### PR TITLE
Fixed the VS workloads needed to build the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Check out these [demos](docs/demos.md) to learn the basics about BuildXL sandbox
 # Building the Code
 
 ## Windows
-You should use [Visual Studio](https://visualstudio.microsoft.com/vs/), e.g. Community Edition, to build to code with MSBuild. You need to install the C# and C++ workloads. Additionally, the Windows code in this release contains a hard-coded, required dependency on Windows SDK version 10.0.10240.0. The BuildXL team will be updating the SDK version over time, but upgrading the SDK now will result in build errors.
+You should use [Visual Studio](https://visualstudio.microsoft.com/vs/), e.g. Community Edition, to build to code with MSBuild. You need to install the ".NET desktop development", "Desktop development with C++" and ".NET core cross-platform development" workloads. Additionally, the Windows code in this release contains a hard-coded, required dependency on Windows SDK version 10.0.10240.0. The BuildXL team will be updating the SDK version over time, but upgrading the SDK now will result in build errors.
 
 To install this SDK version in Visual Studio:
 


### PR DESCRIPTION
Changing names of the workloads to match what you get in the Visual Studio installer.

It turns out .NET core is also needed for some projects.