### PR TITLE
Dynamically adjust the cpu and cachelookup slots on master in distributed builds

### DIFF
--- a/Public/Src/Engine/Dll/Engine.cs
+++ b/Public/Src/Engine/Dll/Engine.cs
@@ -1003,17 +1003,6 @@ namespace BuildXL.Engine
                 // Disable viewer
                 mutableConfig.Viewer = ViewerMode.Disable;
 
-                // If CacheLookup and CPU multiplier is not given by the dev, set them to 0 in CloudBuild to reduce the master overhead.
-                if (!mutableConfig.Schedule.MasterCacheLookupMultiplier.HasValue)
-                {
-                    mutableConfig.Schedule.MasterCacheLookupMultiplier = 0;
-                }
-
-                if (!mutableConfig.Schedule.MasterCpuMultiplier.HasValue)
-                {
-                    mutableConfig.Schedule.MasterCpuMultiplier = 0;
-                }
-
                 // Enable historic ram based throttling in CloudBuild by default if it is not explicitly disabled.
                 mutableConfig.Schedule.UseHistoricalRamUsageInfo = initialCommandLineConfiguration.Schedule.UseHistoricalRamUsageInfo ?? true;
 


### PR DESCRIPTION
Master is configured to do nothing when a remote worker is connected due to some overhead. However, there are some queues with only 2 workers and minimal distribution overhead; which turns out to be 1-worker builds. If we do not set masterCpuMultiplier or masterCacheLookupMultiplier to 0, the master slots will be adjusted automatically based on the number of available workers. For instance, if there are 4 available workers, the master cpu slots will be maxProcs/4. 

Fixes AB#1492499

@olkononenko WDG will benefit from this change because in their 4-worker builds, the master can concurrently execute cpuSlots/4 pips instead of doing nothing. 