### PR TITLE
Store per-build cache lookup fingerprints to improve strong fingerprint cache miss analysis

### DIFF
--- a/Public/Src/App/Bxl/HelpText.cs
+++ b/Public/Src/App/Bxl/HelpText.cs
@@ -296,7 +296,7 @@ namespace BuildXL
                 HelpLevel.Verbose);
 
             hw.WriteOption(
-                "/storeFingerprints:<Default|IgnoreExistingEntries>",
+                "/storeFingerprints:<Default|ExecutionFingerprintsOnly|IgnoreExistingEntries>",
                 Strings.HelpText_DisplayHelp_StoreFingerprintsWithMode,
                 HelpLevel.Verbose);
 

--- a/Public/Src/App/Bxl/Strings.resx
+++ b/Public/Src/App/Bxl/Strings.resx
@@ -878,7 +878,7 @@ Example: ad2d42d2ec5d2ca0c0b7ad65402d07c7ef40b91e</value>
     <value>When enabled, {ShortProductName} will not flag as violations absent path probes that coexist with writes under output directories for those same paths.</value>
   </data>
   <data name="HelpText_DisplayHelp_StoreFingerprintsWithMode" xml:space="preserve">
-    <value>Stores fingerprint computation information for each pip seen in the build in a peristent key-value store that can be accessed from the logs. "Default" mode will check for pre-existing entries before overwriting entries. "IgnoreExistingEntries" mode will overwrite entries without doing any (random) reads, this is only recommended on spin drives experiencing slowdowns. </value>
+    <value>Stores fingerprint computation information for each pip seen in the build in a peristent key-value store that can be accessed from the logs. "Default" mode will check for pre-existing entries before overwriting entries. "ExecutionFingerprintsOnly" mode will only store fingerprints computed when a pip executes. On strong fingerprint cache misses, setting this will SKIP storing fingerprints computed at cache lookup time, which are useful for analyzing strong fingerprint misses. "IgnoreExistingEntries" mode will overwrite entries without doing any (random) reads, this is only recommended on spin drives experiencing slowdowns. </value>
   </data>
   <data name="HelpText_DisplayHelp_UseFileContentTable" xml:space="preserve">
     <value>When enabled, use file content table. Defaults to on on Windows, but off on Unix</value>

--- a/Public/Src/Engine/Dll/Engine.cs
+++ b/Public/Src/Engine/Dll/Engine.cs
@@ -703,9 +703,15 @@ namespace BuildXL.Engine
                 logging.EngineCacheCorruptFilesLogDirectory = logging.EngineCacheLogDirectory.Combine(pathTable, EngineSerializer.CorruptFilesLogLocation);
             }
 
+            var fingerprintsLogDirectory = logging.LogsDirectory.Combine(pathTable, LogFileExtensions.FingerprintsLogDirectory);
             if (!logging.FingerprintStoreLogDirectory.IsValid)
             {
-                logging.FingerprintStoreLogDirectory = logging.EngineCacheLogDirectory.Combine(pathTable, Scheduler.Scheduler.FingerprintStoreDirectory);
+                logging.FingerprintStoreLogDirectory = fingerprintsLogDirectory.Combine(pathTable, Scheduler.Scheduler.FingerprintStoreDirectory);
+            }
+
+            if (!logging.CacheLookupFingerprintStoreLogDirectory.IsValid)
+            {
+                logging.CacheLookupFingerprintStoreLogDirectory = fingerprintsLogDirectory.Combine(pathTable, Scheduler.Scheduler.FingerprintStoreDirectory + LogFileExtensions.CacheLookupFingerprintStore);
             }
 
             if (mutableConfig.Cache.HistoricMetadataCache == true && !logging.HistoricMetadataCacheLogDirectory.IsValid)
@@ -2890,7 +2896,7 @@ namespace BuildXL.Engine
 
             // Don't scrub any of the paths flagged as non-scrubbable
             nonScrubbablePaths.AddRange(FrontEndController.GetNonScrubbablePaths());
-            
+
             void AddToNonScrubbableAbsolutePaths(AbsolutePath[] paths)
             {
                 foreach (AbsolutePath path in paths)

--- a/Public/Src/Engine/Scheduler/Fingerprints/ObservedInput.cs
+++ b/Public/Src/Engine/Scheduler/Fingerprints/ObservedInput.cs
@@ -76,6 +76,31 @@ namespace BuildXL.Scheduler.Fingerprints
         /// Hashing label for collection of <see cref="ObservedInput"/>
         /// </summary>
         public const string ObservedInputs = "ObservedInputs";
+
+        /// <summary>
+        /// Helper function to convert from abbreviated strings to full type strings.
+        /// </summary>
+        /// <returns>
+        /// If the input string is an abbreviated observed input type, the expanded form; otherwise, the input string unaltered.
+        /// </returns>
+        public static string ToExpandedString(string observedInputConstant)
+        {
+            switch (observedInputConstant)
+            {
+                case ObservedInputConstants.AbsentPathProbe:
+                    return ObservedInputType.AbsentPathProbe.ToString();
+                case ObservedInputConstants.FileContentRead:
+                    return ObservedInputType.FileContentRead.ToString();
+                case ObservedInputConstants.DirectoryEnumeration:
+                    return ObservedInputType.DirectoryEnumeration.ToString();
+                case ObservedInputConstants.ExistingDirectoryProbe:
+                    return ObservedInputType.ExistingDirectoryProbe.ToString();
+                case ObservedInputConstants.ExistingFileProbe:
+                    return ObservedInputType.ExistingFileProbe.ToString();
+                default:
+                    return observedInputConstant;
+            }
+        }
     }
 
     /// <summary>

--- a/Public/Src/Engine/Scheduler/Tracing/FingerprintStoreCounters.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/FingerprintStoreCounters.cs
@@ -22,19 +22,19 @@ namespace BuildXL.Scheduler.Tracing
         NumDirectoryMembershipEvents,
 
         /// <summary>
-        /// The number of <see cref="ProcessFingerprintComputationEventData"/> skipped due to the
-        /// a weak fingerprint miss. Fingerprint computation for misses will be recorded at execution time.
+        /// The number of <see cref="ProcessFingerprintComputationEventData"/> computed at cache lookup time that are skipped.
+        /// Fingerprint computation information for weak fingerprint misses are only recorded at execution time.
         /// </summary>
         /// <note>
         /// This count can include non-cacheable pips.
         /// </note>
-        NumFingerprintComputationSkippedWeakFingerprintMiss,
+        NumCacheLookupFingerprintComputationSkipped,
 
         /// <summary>
-        /// The number of <see cref="ProcessFingerprintComputationEventData"/> skipped due to the
-        /// a strong fingerprint miss. Fingerprint computation for misses will be recorded at execution time.
+        /// The number of <see cref="ProcessFingerprintComputationEventData"/> stored in the <see cref="FingerprintStoreExecutionLogTarget.CacheLookupFingerprintStore"/>.
+        /// To prevent redundancy, only strong fingerprint misses are stored in the cache lookup store. Fingerprint computation information for weak fingerprint misses are only recorded at execution time.
         /// </summary>
-        NumFingerprintComputationSkippedStrongFingerprintMiss,
+        NumCacheLookupFingerprintComputationStored,
 
         /// <summary>
         /// The number of <see cref="ProcessFingerprintComputationEventData"/> skipped due to

--- a/Public/Src/Engine/Scheduler/Tracing/FingerprintStoreExecutionLogTarget.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/FingerprintStoreExecutionLogTarget.cs
@@ -382,7 +382,7 @@ namespace BuildXL.Scheduler.Tracing
             }
             
             var strongFingerprintData = maybeStrongFingerprintData.Value;
-            if (strongFingerprintData.Succeeded)
+            if (!strongFingerprintData.Succeeded)
             {
                 // Something went wrong when computing the strong fingerprint
                 // Don't bother attempting to store or analyze data since the data may be partial and cause failures

--- a/Public/Src/Engine/UnitTests/FingerprintStore/FingerprintStoreTests.cs
+++ b/Public/Src/Engine/UnitTests/FingerprintStore/FingerprintStoreTests.cs
@@ -25,6 +25,7 @@ using System.Threading.Tasks;
 using System.Linq;
 using System.Threading;
 using BuildXL.Engine.Cache.KeyValueStores;
+using BuildXL.Utilities.Configuration;
 
 namespace Test.BuildXL.FingerprintStore
 {
@@ -34,6 +35,8 @@ namespace Test.BuildXL.FingerprintStore
             : base(output)
         {
             Configuration.Logging.StoreFingerprints = true;
+            // Forces unique, time-stamped logs directory between different scheduler runs within the same test
+            Configuration.Logging.LogsToRetain = int.MaxValue;
         }
 
         [Fact]
@@ -78,7 +81,7 @@ namespace Test.BuildXL.FingerprintStore
                 entry.PipToFingerprintKeys.Key,
                 keys.WeakFingerprint,
                 keys.StrongFingerprint,
-                keys.PathSetHash
+                keys.FormattedPathSetHash
             };
 
             foreach (var str in pipToFingerprintKeysStrings)
@@ -886,6 +889,98 @@ namespace Test.BuildXL.FingerprintStore
             XAssert.AreEqual(passSfInputs, failSfInputs);
         }
 
+        /// <summary>
+        /// Helper function for verifying build results in <see cref="OnlyWriteToCacheLookupStoreOnStrongFingerprintMiss(FingerprintStoreMode)"/>.
+        /// </summary>
+        private void VerifyNoCacheLookupStore(FingerprintStoreMode mode, CounterCollection<FingerprintStoreCounters> counters, ScheduleRunResult result, Pip pipCacheMiss)
+        {
+            XAssert.AreEqual(counters.GetCounterValue(FingerprintStoreCounters.NumCacheLookupFingerprintComputationStored), 0);
+
+            if (mode == FingerprintStoreMode.ExecutionFingerprintsOnly)
+            {
+                XAssert.IsFalse(Directory.Exists(ResultToStoreDirectory(result, cacheLookupStore: true)));
+            }
+            else
+            {
+                FingerprintStoreSession(ResultToStoreDirectory(result, cacheLookupStore: true), store =>
+                {
+                    XAssert.IsFalse(store.TryGetFingerprintStoreEntryBySemiStableHash(pipCacheMiss.FormattedSemiStableHash, out var entry));
+                });
+            }
+        }
+
+        [Theory]
+        [InlineData(FingerprintStoreMode.Default)]
+        [InlineData(FingerprintStoreMode.ExecutionFingerprintsOnly)]
+        public void OnlyWriteToCacheLookupStoreOnStrongFingerprintMiss(FingerprintStoreMode fingerprintStoreMode)
+        {
+            Configuration.Logging.FingerprintStoreMode = fingerprintStoreMode;
+            var testHooks = new SchedulerTestHooks()
+            {
+                FingerprintStoreTestHooks = new FingerprintStoreTestHooks()
+            };
+
+            var srcFile = CreateSourceFile();
+            var dir = CreateUniqueDirectoryArtifact(ReadonlyRoot);
+            var pip = CreateAndSchedulePipBuilder(new Operation[]
+            {
+                Operation.ReadFile(srcFile),
+                Operation.EnumerateDir(dir),
+                Operation.WriteFile(CreateOutputFileArtifact()),
+            }).Process;
+
+            var build1 = RunScheduler(testHooks).AssertCacheMiss(pip.PipId);
+            var counters1 = testHooks.FingerprintStoreTestHooks.Counters;
+            // One put in execution fingerprint store
+            XAssert.AreEqual(counters1.GetCounterValue(FingerprintStoreCounters.NumPipFingerprintEntriesPut), 1);
+            VerifyNoCacheLookupStore(fingerprintStoreMode, counters1, build1, pip);
+
+            var build2 = RunScheduler(testHooks).AssertCacheHit(pip.PipId);
+            
+            // Fully cache hit is no puts in either execution or cache lookup fingerprint store
+            var counters2 = testHooks.FingerprintStoreTestHooks.Counters;
+            XAssert.AreEqual(counters2.GetCounterValue(FingerprintStoreCounters.NumPipFingerprintEntriesPut), 0);
+            VerifyNoCacheLookupStore(fingerprintStoreMode, counters2, build2, pip);
+
+
+            // Cause a weak fingerprint miss
+            File.WriteAllText(ArtifactToString(srcFile), "asdf");
+
+            var build3 = RunScheduler(testHooks).AssertCacheMiss(pip.PipId);
+            
+            // One put in execution fingerprint store (overwrite)
+            var counters3 = testHooks.FingerprintStoreTestHooks.Counters;
+            XAssert.AreEqual(counters3.GetCounterValue(FingerprintStoreCounters.NumPipFingerprintEntriesPut), 1);
+            VerifyNoCacheLookupStore(fingerprintStoreMode, counters3, build1, pip);
+
+            // Cause a strong fingerprint miss
+            CreateSourceFile(ArtifactToString(dir));
+            var build4 = RunScheduler(testHooks).AssertCacheMiss(pip.PipId);
+            // One put in execution fingerprint store (overwrite), one put in cache lookup fingerprint store
+            var counters4 = testHooks.FingerprintStoreTestHooks.Counters;
+            if (fingerprintStoreMode == FingerprintStoreMode.ExecutionFingerprintsOnly)
+            {
+                XAssert.AreEqual(counters4.GetCounterValue(FingerprintStoreCounters.NumPipFingerprintEntriesPut), 1);
+                VerifyNoCacheLookupStore(fingerprintStoreMode, counters4, build4, pip);
+            }
+            else
+            {
+                XAssert.AreEqual(counters4.GetCounterValue(FingerprintStoreCounters.NumPipFingerprintEntriesPut), 2);
+                XAssert.AreEqual(counters4.GetCounterValue(FingerprintStoreCounters.NumCacheLookupFingerprintComputationStored), 1);
+                
+                // Cache lookup store should be populated on strong fingerprint misses
+                FingerprintStoreSession(ResultToStoreDirectory(build4, cacheLookupStore: true), store =>
+                {
+                    XAssert.IsTrue(store.TryGetFingerprintStoreEntryBySemiStableHash(pip.FormattedSemiStableHash, out var entry));
+                });
+            }
+
+            // No persistence build-over-build
+            var build5 = RunScheduler(testHooks).AssertCacheHit(pip.PipId);
+            var counters5 = testHooks.FingerprintStoreTestHooks.Counters;
+            VerifyNoCacheLookupStore(fingerprintStoreMode, counters5, build5, pip);
+        }
+
         [Fact]
         public void RoundTripCacheMissList()
         {
@@ -1021,7 +1116,7 @@ namespace Test.BuildXL.FingerprintStore
                 XAssert.AreNotEqual(keys1.WeakFingerprint, keys2.WeakFingerprint);
                 XAssert.AreNotEqual(keys1.StrongFingerprint, keys2.StrongFingerprint);
                 // Path set hash can be shared between different pips, which is why they are not keyed by pip semistablehash.
-                XAssert.AreEqual(keys1.PathSetHash, keys2.PathSetHash);
+                XAssert.AreEqual(keys1.FormattedPathSetHash, keys2.FormattedPathSetHash);
             });
         }
 
@@ -1053,7 +1148,6 @@ namespace Test.BuildXL.FingerprintStore
             // Put a random file in store location to make it impossible to delete the directory
             var dontDeleteFile = Path.Combine(engineCacheStore, "dontdelete");
             File.WriteAllText(dontDeleteFile, "asdf");
-            
             // An invalid format version causes the fingerprint store to delete itself before starting a new one
             // The open filestream will prevent the directory from being deleted and prevent a new store from being created
             // The build should continue without error without the fingerprint store
@@ -1206,9 +1300,9 @@ namespace Test.BuildXL.FingerprintStore
                 counters2.GetCounterValue(FingerprintStoreCounters.NumPipFingerprintEntriesPut));
         }
 
-        private string ResultToStoreDirectory(ScheduleRunResult result)
+        private string ResultToStoreDirectory(ScheduleRunResult result, bool cacheLookupStore = false)
         {
-            return result.Config.Logging.FingerprintStoreLogDirectory.ToString(Context.PathTable);
+            return cacheLookupStore ? result.Config.Logging.CacheLookupFingerprintStoreLogDirectory.ToString(Context.PathTable) : result.Config.Logging.FingerprintStoreLogDirectory.ToString(Context.PathTable);
         }
 
         /// <summary>

--- a/Public/Src/Engine/UnitTests/Scheduler/PipTestBase.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/PipTestBase.cs
@@ -26,7 +26,6 @@ using Xunit.Abstractions;
 
 using static BuildXL.Interop.MacOS.IO;
 using System.Threading;
-using BuildXL.Scheduler;
 
 namespace Test.BuildXL.Scheduler
 {
@@ -512,6 +511,12 @@ namespace Test.BuildXL.Scheduler
             Directory.CreateDirectory(path.ToString(Context.PathTable));
             return path;
         }
+
+        /// <summary>
+        /// Creates a unique directory and wraps it in a <see cref="DirectoryArtifact"/>.
+        /// </summary>
+        protected DirectoryArtifact CreateUniqueDirectoryArtifact(string root = null, string prefix = null) 
+            => DirectoryArtifact.CreateWithZeroPartialSealId(CreateUniqueDirectory(root, prefix));
 
         /// <summary>
         /// Creates a file artifact with the given name under the given root

--- a/Public/Src/Engine/UnitTests/Scheduler/PipTestBase.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/PipTestBase.cs
@@ -26,6 +26,7 @@ using Xunit.Abstractions;
 
 using static BuildXL.Interop.MacOS.IO;
 using System.Threading;
+using BuildXL.Scheduler;
 
 namespace Test.BuildXL.Scheduler
 {

--- a/Public/Src/Tools/UnitTests/Analyzers/FingerprintStoreAnalyzerTests.cs
+++ b/Public/Src/Tools/UnitTests/Analyzers/FingerprintStoreAnalyzerTests.cs
@@ -20,6 +20,9 @@ using Xunit.Abstractions;
 using static BuildXL.ToolSupport.CommandLineUtilities;
 using static Test.Tool.Analyzers.AnalyzerTestBase;
 using BuildXLConfiguration = BuildXL.Utilities.Configuration;
+using System;
+using static BuildXL.Scheduler.Tracing.FingerprintStore;
+using System.Linq;
 
 namespace Test.Tool.Analyzers
 {
@@ -109,7 +112,7 @@ namespace Test.Tool.Analyzers
                 PipCacheMissType.MissForDescriptorsDueToStrongFingerprints,
                 ArtifactToPrint(absentFile),
                 ObservedInputConstants.AbsentPathProbe,
-                ObservedInputConstants.ExistingFileProbe);
+                ObservedInputConstants.FileContentRead);
         }
 
         [Fact]
@@ -401,18 +404,20 @@ namespace Test.Tool.Analyzers
             FileArtifact nestedFile = CreateSourceFile(ArtifactToPrint(dir));
             ScheduleRunResult buildB = RunScheduler().AssertCacheMiss(pip.PipId);
 
-            var fingerprintStoreDirectory = buildB.Config.Logging.FingerprintStoreLogDirectory;
-
-            using (var store = FingerprintStore.Open(fingerprintStoreDirectory.ToString(Context.PathTable)).Result)
+            // On a strong fingerprint miss, both the execution and cache lookup store will store fingerprints
+            using (var executionStore = FingerprintStore.Open(ResultToStoreDirectory(buildB)).Result)
+            using (var cacheLookupStore = FingerprintStore.Open(ResultToStoreDirectory(buildB, cacheLookupStore: true)).Result)
             {
-                XAssert.IsTrue(store.TryGetFingerprintStoreEntryBySemiStableHash(pip.FormattedSemiStableHash, out var entry));
+                XAssert.IsTrue(executionStore.TryGetFingerprintStoreEntryBySemiStableHash(pip.FormattedSemiStableHash, out var entry));
+                XAssert.IsTrue(cacheLookupStore.TryGetFingerprintStoreEntryBySemiStableHash(pip.FormattedSemiStableHash, out var cacheLookupEntry));
 
                 // Parse the entry for the directory membership fingerprint key
                 var reader = new JsonReader(entry.StrongFingerprintEntry.StrongFingerprintToInputs.Value);
                 XAssert.IsTrue(reader.TryGetPropertyValue(ObservedInputConstants.DirectoryEnumeration, out string directoryMembershipFingerprint));
 
                 // Remove the directory memberhsip entry
-                store.RemoveContentHashForTesting(directoryMembershipFingerprint);
+                executionStore.RemoveContentHashForTesting(directoryMembershipFingerprint);
+                cacheLookupStore.RemoveContentHashForTesting(directoryMembershipFingerprint);
             }
 
             var result = RunAnalyzer(buildA, buildB).AssertPipMiss(
@@ -659,6 +664,94 @@ namespace Test.Tool.Analyzers
         }
 
         /// <summary>
+        /// Checks that <see cref="FingerprintStoreExecutionLogTarget.CacheLookupFingerprintStore"/> is used before the <see cref="FingerprintStoreExecutionLogTarget.ExecutionFingerprintStore"/>
+        /// when looking for fingerprints from the newer build.
+        /// </summary>
+        [Fact]
+        public void EnsureCacheLookupStoreIsFirst()
+        {
+            // Read only mount
+            var sealDir = CreateUniqueDirectory(ReadonlyRoot);
+            // Set up absent file under source seal directory
+            var absentFile = CreateSourceFile(sealDir);
+            File.Delete(ArtifactToString(absentFile));
+            var absentFileDir = CreateAndScheduleSealDirectoryArtifact(sealDir, SealDirectoryKind.SourceAllDirectories);
+
+            // Create a pip that will have a strong fingerprint miss if absentFile is created
+            var ops = new Operation[]
+            {
+                Operation.Probe(absentFile, doNotInfer: true),
+                Operation.WriteFile(CreateOutputFileArtifact())
+            };
+
+            var builder = CreatePipBuilder(ops);
+            builder.AddInputDirectory(absentFileDir);
+
+            var pipA = SchedulePipBuilder(builder).Process;
+
+            var srcB = CreateSourceFile();
+            var pipB = CreateAndSchedulePipBuilder(new Operation[]
+            {
+                Operation.ReadFile(srcB),
+                Operation.WriteFile(CreateOutputFileArtifact())
+            }).Process;
+
+            var build1 = RunScheduler().AssertCacheMiss(pipA.PipId);
+
+            // Create /absentFile
+            File.WriteAllText(ArtifactToString(absentFile), "asdf");
+            var build2 = RunScheduler().AssertCacheMiss(pipA.PipId);
+
+            var correctOut1 = RunAnalyzer(build1, build2).AssertPipMiss(
+                pipA,
+                PipCacheMissType.MissForDescriptorsDueToStrongFingerprints,
+                ArtifactToPrint(absentFile),
+                ObservedInputConstants.AbsentPathProbe,
+                ObservedInputConstants.FileContentRead).FileOutput;
+
+            FingerprintStoreEntry pipAEntry = default;
+            FingerprintStoreSession(ResultToStoreDirectory(build2), store =>
+            {
+                // Remove pipA's entry from the execution-time fingerprintStore, and replace it with a dummy entry (pipB's) that will diff incorrectly if used
+                store.TryGetFingerprintStoreEntryBySemiStableHash(pipA.FormattedSemiStableHash, out pipAEntry);
+                store.RemoveFingerprintStoreEntryForTesting(pipAEntry);
+
+                store.TryGetFingerprintStoreEntryBySemiStableHash(pipB.FormattedSemiStableHash, out var pipBEntry);
+                // Route's pipA's key to point to the same fingerprint info as pipB's
+                // If this store is used now to analyze pipA, the analysis will be incorrect
+                pipBEntry.PipToFingerprintKeys = new System.Collections.Generic.KeyValuePair<string, PipFingerprintKeys>(pipA.FormattedSemiStableHash, pipBEntry.PipToFingerprintKeys.Value);
+                store.PutFingerprintStoreEntry(pipBEntry);
+            },
+            readOnly: false);
+
+            // Make sure the diff is still correct, which implies the cache lookup fingerprint store is still being used
+            var correctOut2 = RunAnalyzer(build1, build2).AssertPipMiss(
+                pipA,
+                PipCacheMissType.MissForDescriptorsDueToStrongFingerprints,
+                ArtifactToPrint(absentFile),
+                ObservedInputConstants.AbsentPathProbe,
+                ObservedInputConstants.FileContentRead).FileOutput;
+
+            XAssert.AreEqual(correctOut1, correctOut2);
+
+            // Remove pipA's entry from the cache lookup store
+            FingerprintStoreSession(ResultToStoreDirectory(build2, cacheLookupStore: true), store =>
+            {
+                store.RemoveFingerprintStoreEntryForTesting(pipAEntry);
+            },
+            readOnly: false);
+
+            // Ensure that the analyzer falls-back on the execution-time store when the cache-lookup store is missing entries
+            // srcB from pipB's dependencies will show up in the analysis because of earlier manipulation of the execution-time store
+            var incorrectOut = RunAnalyzer(build1, build2).AssertPipMiss(
+                pipA,
+                PipCacheMissType.MissForDescriptorsDueToStrongFingerprints,
+                ArtifactToPrint(srcB)).FileOutput;
+
+            XAssert.AreNotEqual(correctOut2, incorrectOut);
+        }
+
+        /// <summary>
         /// Matches the string representation of <see cref="FileOrDirectoryArtifact"/> used by the fingerprint store
         /// when serializing to JSON.
         /// </summary>
@@ -671,7 +764,31 @@ namespace Test.Tool.Analyzers
         {
             if (Configuration.Logging.CacheMissAnalysisOption == CacheMissAnalysisOption.LocalMode())
             {
-                AssertLogContains(caseSensitive: false, requiredLogMessages: requiredMessages);
+                var messages = requiredMessages.Select((s) => ObservedInputConstants.ToExpandedString(s));
+                AssertLogContains(caseSensitive: false, requiredLogMessages: messages.ToArray());
+            }
+        }
+
+        private string ResultToStoreDirectory(ScheduleRunResult result, bool cacheLookupStore = false)
+        {
+            return cacheLookupStore ? result.Config.Logging.CacheLookupFingerprintStoreLogDirectory.ToString(Context.PathTable) : result.Config.Logging.FingerprintStoreLogDirectory.ToString(Context.PathTable);
+        }
+
+        /// <summary>
+        /// Encapsulates one "session" with a fingerprint store.
+        /// </summary>
+        /// <param name="storeDirectory">
+        /// Directory of the fingerprint store.
+        /// </param>
+        /// <param name="storeOps">
+        /// The store operations to execute.
+        /// </param>
+        public static CounterCollection<FingerprintStoreCounters> FingerprintStoreSession(string storeDirectory, Action<FingerprintStore> storeOps, bool readOnly = true, FingerprintStoreTestHooks testHooks = null)
+        {
+            using (var fingerprintStore = FingerprintStore.Open(storeDirectory, readOnly: readOnly, testHooks: testHooks).Result)
+            {
+                storeOps(fingerprintStore);
+                return fingerprintStore.Counters;
             }
         }
         protected override void Dispose(bool disposing)
@@ -752,7 +869,7 @@ namespace Test.Tool.Analyzers
         {
             foreach (var message in messages)
             {
-                XAssert.IsTrue(result.FileOutput.Contains(message), "Expected message: \"{0}\" to appear in analyzer output: \"{1}\"", message, result.FileOutput);
+                XAssert.IsTrue(result.FileOutput.Contains(ObservedInputConstants.ToExpandedString(message)), "Expected message: \"{0}\" to appear in analyzer output: \"{1}\"", ObservedInputConstants.ToExpandedString(message), result.FileOutput);
             }
 
             return result;

--- a/Public/Src/Utilities/Configuration/FingerprintStoreMode.cs
+++ b/Public/Src/Utilities/Configuration/FingerprintStoreMode.cs
@@ -28,5 +28,11 @@ namespace BuildXL.Utilities.Configuration
         /// An alternative scheme is to just delete the existing store altogether, but that risks data loss of entries unused in a particular build.
         /// </remarks>
         IgnoreExistingEntries = 2,
+
+        /// <summary>
+        /// Only store fingerprints computed at execution time. 
+        /// This will reduce reads/writes on strong fingerprint cache misses by skipping storing any fingerprints from cache lookup time, which are useful for strong fingerprint analysis.
+        /// </summary>
+        ExecutionFingerprintsOnly = 3,
     }
 }

--- a/Public/Src/Utilities/Configuration/ILoggingConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/ILoggingConfiguration.cs
@@ -95,10 +95,15 @@ namespace BuildXL.Utilities.Configuration
         int FingerprintStoreMaxEntryAgeMinutes { get; }
 
         /// <summary>
-        /// Specifies the path to the fingerprint store log directory. The log directory represents a snapshot of the fingerprint store at the
+        /// Specifies the path to the fingerprint store log directory. The log directory represents a snapshot of the persistent fingerprint store at the
         /// end of a particular build.
         /// </summary>
         AbsolutePath FingerprintStoreLogDirectory { get; }
+
+        /// <summary>
+        /// Specifies the path to the cache lookup fingerprint store log directory. This is a per-build store and does not persist build-over-build.
+        /// </summary>
+        AbsolutePath CacheLookupFingerprintStoreLogDirectory { get; }
 
         /// <summary>
         /// Specifies the path to the historic metadata cache log directory.

--- a/Public/Src/Utilities/Configuration/LogFileExtensions.cs
+++ b/Public/Src/Utilities/Configuration/LogFileExtensions.cs
@@ -67,5 +67,15 @@ namespace BuildXL.Utilities.Configuration
         /// A file containing rpc log entries
         /// </summary>
         public const string RpcLog = ".DistributionRpc.log";
+
+        /// <summary>
+        /// A folder for cache miss information
+        /// </summary>
+        public const string FingerprintsLogDirectory = "Fingerprints";
+
+        /// <summary>
+        /// Suffix for the folder containing the FingerprintStore for cache lookup fingerprints.
+        /// </summary>
+        public const string CacheLookupFingerprintStore = ".CacheLookup";
     }
 }

--- a/Public/Src/Utilities/Configuration/Mutable/LoggingConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/LoggingConfiguration.cs
@@ -31,6 +31,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             EngineCacheLogDirectory = AbsolutePath.Invalid;
             EngineCacheCorruptFilesLogDirectory = AbsolutePath.Invalid;
             FingerprintStoreLogDirectory = AbsolutePath.Invalid;
+            CacheLookupFingerprintStoreLogDirectory = AbsolutePath.Invalid;
             HistoricMetadataCacheLogDirectory = AbsolutePath.Invalid;
             ReplayWarnings = true;
             SubstSource = AbsolutePath.Invalid;
@@ -63,6 +64,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             FingerprintStoreMode = template.FingerprintStoreMode;
             FingerprintStoreMaxEntryAgeMinutes = template.FingerprintStoreMaxEntryAgeMinutes;
             FingerprintStoreLogDirectory = pathRemapper.Remap(template.FingerprintStoreLogDirectory);
+            CacheLookupFingerprintStoreLogDirectory = pathRemapper.Remap(template.CacheLookupFingerprintStoreLogDirectory);
             HistoricMetadataCacheLogDirectory = pathRemapper.Remap(template.HistoricMetadataCacheLogDirectory);
             EngineCacheLogDirectory = pathRemapper.Remap(template.EngineCacheLogDirectory);
             EngineCacheCorruptFilesLogDirectory = pathRemapper.Remap(template.EngineCacheCorruptFilesLogDirectory);
@@ -169,6 +171,9 @@ namespace BuildXL.Utilities.Configuration.Mutable
 
         /// <inheritdoc />
         public AbsolutePath FingerprintStoreLogDirectory { get; set; }
+
+        /// <inheritdoc />
+        public AbsolutePath CacheLookupFingerprintStoreLogDirectory { get; set; }
 
         /// <inheritdoc />
         public AbsolutePath HistoricMetadataCacheLogDirectory { get; set; }


### PR DESCRIPTION
Previously, FingerprintStoreAnalyzer/CacheMissV2 only stored and compared fingerprints that were computed at execution time. Storing fingerprints is relatively expensive as paths are left expanded and pip fingerprints can be large.

This can cause confusing analysis for non-deterministic pips that might change their observed inputs from build-to-build and have different path sets build-to-build. That results in pips computing a different strong fingerprint at cache lookup time when a path set from the cache is used vs. at execution time when the pip is re-run and its path set is re-observed.

BuildXL Changes

- New "FingerprintStore.CacheLookup" store that writes directly into "Logs/Fingerprints/FingerprintStore.CacheLookup"
- -- This is a per-build store that starts empty/non-existent at the beginning of the build and only gets used on strong fingerprint misses
- -- On strong fingerprint misses only, one fingerprint computed at cache lookup time is stored in FingerprintStore.CacheLookup for that pip, the strong fingerprint computed using the path set that matches the path set for that pip from the previous build is preferred
- Moves the copied store "Logs/BuildXL/FingerprintStore" to "Logs/Fingerprints/FingerprintStore", the build-over-build persisted version remains in "EngineCache/FingerprintStore"
- Add "/storeFingerprints:ExecutionFingerprintsOnly" flag to revert back to previous state where only fingerprints computed at execution time were stored

FingerprintStoreAnalyzer Changes

- If a "FingerprintStore.CacheLookup" store exists, whenever a strong fingerprint miss is analyzed, the analyzer will compare the entry from the new build's "CacheLookup" store to the old build's "Execution" store. Assuming pip's are being cached correctly, this is very similar to what actually happens at cache lookup time.
- If "FingerprintStore.CacheLookup" does not exist || weak fingerprint miss || entry missing from "CacheLookup", the analyzer falls back on the execution-time "FingerprintStore"