### PR TITLE
Update CommandLineEscaping to escape semicolons on non-Windows platforms

### DIFF
--- a/Public/Sdk/Public/Managed/Tools/Csc/csc.dsc
+++ b/Public/Sdk/Public/Managed/Tools/Csc/csc.dsc
@@ -76,7 +76,10 @@ export function compile(inputArgs: Arguments) : Result {
 
         Cmd.option("/langversion:", args.languageVersion),
 
-        Cmd.option("/define:",       args.defines ? args.defines.join(";")    : undefined),
+        // TODO: uncoment the following line and delete the line after it once a new LKG is published
+        // Cmd.option("/define:",       args.defines ? args.defines.join(";") : undefined), 
+        ...addIf((args.defines || []).length > 0, Cmd.rawArgument(`/define:"${args.defines.join(';')}"`)),
+
         Cmd.option("/nowarn:",       args.noWarnings ? args.noWarnings.map(n => n.toString()).join(",") : undefined),
         Cmd.flag("/warnaserror",     args.treatWarningsAsErrors),
         Cmd.option("/warnaserror-:", (args.treatWarningsAsErrors && args.warningsNotAsErrors) ? args.warningsNotAsErrors.join(",") : undefined),

--- a/Public/Src/Utilities/UnitTests/Utilities/CommandLineEscapingTests.cs
+++ b/Public/Src/Utilities/UnitTests/Utilities/CommandLineEscapingTests.cs
@@ -49,8 +49,19 @@ namespace Test.BuildXL.Utilities
             Case(@"x\\\""y\\\""x", asWord: @"x\\\\\\\""y\\\\\\\""x", asApplicationName: Invalid),
         };
 
+
         public CommandLineEscapingTests(ITestOutputHelper output)
             : base(output) { }
+
+        [Theory]
+        [InlineData("DEBUG;TRACE;DEFTEMP", "\"DEBUG;TRACE;DEFTEMP\"", "DEBUG;TRACE;DEFTEMP")]
+        public void TestPlatformSpecificWordEscaping(string value, string asWordOnUnix, string asWordOnWindows)
+        {
+            var expected = OperatingSystemHelper.IsUnixOS
+                ? asWordOnUnix
+                : asWordOnWindows;
+            XAssertEscapingCase(expected, value, CommandLineEscaping.EscapeAsCommandLineWord);
+        }
 
         [Fact]
         public void TestCommandLineWordEscaping()

--- a/Public/Src/Utilities/Utilities/CommandLineEscaping.cs
+++ b/Public/Src/Utilities/Utilities/CommandLineEscaping.cs
@@ -235,13 +235,26 @@ namespace BuildXL.Utilities
 
         private static bool ContainsDelimiter(string s)
         {
-            foreach (char c in s)
+            if (OperatingSystemHelper.IsUnixOS)
             {
-                if (c <= ' ')
+                foreach (char c in s)
                 {
-                    if (c == ' ' || c == '\t')
+                    if (c == ' ' || c == '\t' || c == ';')
                     {
                         return true;
+                    }
+                }
+            }
+            else
+            {
+                foreach (char c in s)
+                {
+                    if (c <= ' ')
+                    {
+                        if (c == ' ' || c == '\t')
+                        {
+                            return true;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Some tools receive arguments in the form of semicolon-separated values.  For example, `csc`'s `/define:` switch:
```
csc.exe /define:DEBUG;TRACE
```
When running on a non-Windows platform, such values must be escaped because the semicolon ends the current command, i.e.,
```bash
dotnet csc.dll /define:"DEBUG;TRACE"
```
This PR:
  - [x] updates the `CommandLineEscaping` class to handle this case, and
  - [x] updates the csc runner (`csc.dsc`) to temporarily manually add quotes around the value for the `/define:` switch