### PR TITLE
Increase DownloadResolver timeout and log error when canceled

### DIFF
--- a/Public/Src/FrontEnd/Download/DownloadResolver.cs
+++ b/Public/Src/FrontEnd/Download/DownloadResolver.cs
@@ -327,7 +327,7 @@ namespace BuildXL.FrontEnd.Download
             }
             catch (TaskCanceledException e)
             {
-                string message = m_context.CancellationToken.IsCancellationRequested ? "Download manually canceled" : e.Message;
+                string message = m_context.CancellationToken.IsCancellationRequested ? "Download manually canceled." : e.Message;
                 m_logger.DownloadFailed(m_context.LoggingContext, downloadData.Settings.ModuleName, downloadData.Settings.Url, message);
                 return EvaluationResult.Canceled;
             }

--- a/Public/Src/FrontEnd/Download/DownloadResolver.cs
+++ b/Public/Src/FrontEnd/Download/DownloadResolver.cs
@@ -307,6 +307,7 @@ namespace BuildXL.FrontEnd.Download
             {
                 using (var httpClient = new HttpClient())
                 {
+                    httpClient.Timeout = TimeSpan.FromMinutes(10);
                     var response = await httpClient.GetAsync((Uri)downloadData.DownloadUri, m_context.CancellationToken);
                     response.EnsureSuccessStatusCode();
                     var stream = await response.Content.ReadAsStreamAsync();
@@ -324,8 +325,10 @@ namespace BuildXL.FrontEnd.Download
                         new FileInfo(downloadFilePathAsString).Length);
                 }
             }
-            catch (TaskCanceledException)
+            catch (TaskCanceledException e)
             {
+                string message = m_context.CancellationToken.IsCancellationRequested ? "Download manually canceled" : e.Message;
+                m_logger.DownloadFailed(m_context.LoggingContext, downloadData.Settings.ModuleName, downloadData.Settings.Url, message);
                 return EvaluationResult.Canceled;
             }
             catch (HttpRequestException e)


### PR DESCRIPTION
Fixes the issue where the public builds fails when the download resolver times out or is canceled during evaluation phase.