### PR TITLE
Remove factory methods for ServiceClientRpcConfiguration

### DIFF
--- a/Public/Src/Cache/ContentStore/Library/Sessions/ServiceClientRpcConfiguration.cs
+++ b/Public/Src/Cache/ContentStore/Library/Sessions/ServiceClientRpcConfiguration.cs
@@ -19,23 +19,7 @@ namespace BuildXL.Cache.ContentStore.Sessions
         /// Gets the GRPC port.
         /// </summary>
         public int GrpcPort { get; }
-
-        /// <summary>
-        /// Creates a configuration based on grpc.
-        /// </summary>
-        public static ServiceClientRpcConfiguration CreateGrpc(int grpcPort, TimeSpan? heartbeatInterval = null)
-        {
-            return new ServiceClientRpcConfiguration(grpcPort, heartbeatInterval);
-        }
-
-        /// <summary>
-        /// Creates a configuration based on grpc.
-        /// The method left for backward compatibility.
-        /// </summary>
-        public static ServiceClientRpcConfiguration CreateGrpc(uint grpcPort, TimeSpan? heartbeatInterval = null)
-        {
-            return CreateGrpc((int)grpcPort, heartbeatInterval);
-        }
+        
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ServiceClientRpcConfiguration"/> class.

--- a/Public/Src/Cache/ContentStore/Test/Stores/TestInProcessServiceClientContentStore.cs
+++ b/Public/Src/Cache/ContentStore/Test/Stores/TestInProcessServiceClientContentStore.cs
@@ -41,7 +41,7 @@ namespace ContentStoreTest.Stores
         {
             return new ServiceClientContentStoreConfiguration(
                        cacheName,
-                       ServiceClientRpcConfiguration.CreateGrpc((int)serviceConfiguration.GrpcPort),
+                       new ServiceClientRpcConfiguration((int)serviceConfiguration.GrpcPort),
                        scenario)
                    {
                         RetryCount = retryCount,

--- a/Public/Src/Cache/MemoizationStore/Test/Sessions/InProcessServiceLocalCacheTests.cs
+++ b/Public/Src/Cache/MemoizationStore/Test/Sessions/InProcessServiceLocalCacheTests.cs
@@ -46,7 +46,7 @@ namespace BuildXL.Cache.MemoizationStore.Test.Sessions
             {
                 GrpcPortFileName = null, // Port is well known at configuration time, no need to expose it.
             };
-            var serviceClientConfiguration = new ServiceClientContentStoreConfiguration(CacheName, ServiceClientRpcConfiguration.CreateGrpc(serverConfiguration.GrpcPort), "Scenario-" + Guid.NewGuid());
+            var serviceClientConfiguration = new ServiceClientContentStoreConfiguration(CacheName, new ServiceClientRpcConfiguration(serverConfiguration.GrpcPort), "Scenario-" + Guid.NewGuid());
             Func<AbsolutePath, ICache> contentStoreFactory = CreateBackendCache;
             var serviceClient = new TestInProcessServiceClientCache(Logger, FileSystem, contentStoreFactory, serverConfiguration, serviceClientConfiguration);
             return serviceClient;

--- a/Public/Src/Cache/VerticalStore/BuildCacheAdapter/BuildCacheUtils.cs
+++ b/Public/Src/Cache/VerticalStore/BuildCacheAdapter/BuildCacheUtils.cs
@@ -80,7 +80,7 @@ namespace BuildXL.Cache.BuildCacheAdapter
                 ServiceClientRpcConfiguration rpcConfiguration;
                 if (cacheConfig.GrpcPort != 0)
                 {
-                    rpcConfiguration = ServiceClientRpcConfiguration.CreateGrpc((int)cacheConfig.GrpcPort);
+                    rpcConfiguration = new ServiceClientRpcConfiguration((int)cacheConfig.GrpcPort);
                 }
                 else
                 {

--- a/Public/Src/Cache/VerticalStore/MemoizationStoreAdapter/CloudStoreLocalCacheServiceFactory.cs
+++ b/Public/Src/Cache/VerticalStore/MemoizationStoreAdapter/CloudStoreLocalCacheServiceFactory.cs
@@ -179,7 +179,7 @@ namespace BuildXL.Cache.MemoizationStoreAdapter
                 ServiceClientRpcConfiguration rpcConfiguration;
                 if (cacheConfig.GrpcPort != 0)
                 {
-                    rpcConfiguration = ServiceClientRpcConfiguration.CreateGrpc((int)cacheConfig.GrpcPort);
+                    rpcConfiguration = new ServiceClientRpcConfiguration((int)cacheConfig.GrpcPort);
                 }
                 else
                 {


### PR DESCRIPTION
Removed factory methods that were designed to create either gRPC or named-pipes configuration, since only gRPC is available now.