### PR TITLE
Add process "weight" to control scheduling parallel processes

### DIFF
--- a/Public/Sdk/Public/Transformers/Transformer.Execute.dsc
+++ b/Public/Sdk/Public/Transformers/Transformer.Execute.dsc
@@ -126,7 +126,7 @@ namespace Transformer {
          * Default is globally controlled by the sandbox configuration
          * TODO: input isolation is not implemented
          */
-         containerIsolationLevel?: ContainerIsolationLevel;
+        containerIsolationLevel?: ContainerIsolationLevel;
 
         /**
          * The policy to apply when a double write occurs.

--- a/Public/Sdk/Public/Transformers/Transformer.Execute.dsc
+++ b/Public/Sdk/Public/Transformers/Transformer.Execute.dsc
@@ -163,10 +163,11 @@ namespace Transformer {
         disableCacheLookup?: boolean;
 
         /**
-         * The weighted value of this pip when limiting concurrency of process pips.
-         * The default weight for a process pip is 1, and the max valid weight is the max concurrent processes allowed in the build.
-         * The higher the weight, the fewer process pips that can run in parallel.
-         * No additional processes can be run concurrently while the sum of weights of all running processes is >= the build's weight limit (which is the max valid weight).
+         * The # of process slots this process requires when limiting concurrency of process pips.
+         * The total weight of all proceses running concurrently must be less than or equal to the # of available process slots.
+         * The # of available process slots is typically a function of the number of cores on the machine, but can also be limited by runtime resource exhaustion or be set per-build by configuration.
+         * Valid input range for the weight is [min Int32, max Int32] though all values will be effectively coerced to fit within [1, # of process slots]
+         * If a given weight is greater than or equal to # of available process slots, the process will run alone.
          */
         weight?: number;
     }

--- a/Public/Sdk/Public/Transformers/Transformer.Execute.dsc
+++ b/Public/Sdk/Public/Transformers/Transformer.Execute.dsc
@@ -10,21 +10,21 @@ namespace Transformer {
 
     @@public
     export interface ExecuteArguments extends ExecuteArgumentsCommon {
-        /** Regular process pips that make calls to one or more service
+        /** Regular process pips that make calls to one or more service 
           * pips should use this field to declare those dependencies
           * (so that they don't get scheduled for execution before all
           * the services have started). */
         servicePipDependencies?: ServiceId[];
 
-        /** Whether to grant the read/write permissions of this pip to
-          * the declared service pips (permissions are granted only
+        /** Whether to grant the read/write permissions of this pip to 
+          * the declared service pips (permissions are granted only 
           * throughout the lifetime of this pip). */
         delegatePermissionsToServicePips?: PermissionDelegationMode;
     }
-
+    
     /** Different options for delegating permissions of a process to a service pip. */
     @@public
-    export const enum PermissionDelegationMode {
+    export const enum PermissionDelegationMode { 
         /** Don't grant any permissions at all. */
         none,
 
@@ -33,7 +33,7 @@ namespace Transformer {
 
         /** Grant permissions permanently, i.e., until the service pip terminates. */
         permanent
-    }
+    } 
 
     @@public
     export interface ExecuteArgumentsCommon extends ExecuteArgumentsComposible {
@@ -83,7 +83,7 @@ namespace Transformer {
 
         /** Regex that would be used to extract warnings from the output. */
         warningRegex?: string;
-
+        
         /** Regex that would be used to extract errors from the output. */
         errorRegex?: string;
 
@@ -116,7 +116,7 @@ namespace Transformer {
 
         /** Whether this process should run in an isolated container (i.e. filesystem isolation)
          * When running in a container, the isolation level can be controlled by 'containerIsolationLevel' field.
-         * Note: this is an experimental feature for now, use at your own risk
+         * Note: this is an experimental feature for now, use at your own risk 
          * Default is globally controlled by the sandbox configuration
          */
         runInContainer?: boolean;
@@ -126,7 +126,7 @@ namespace Transformer {
          * Default is globally controlled by the sandbox configuration
          * TODO: input isolation is not implemented
          */
-        containerIsolationLevel?: ContainerIsolationLevel;
+         containerIsolationLevel?: ContainerIsolationLevel;
 
         /**
          * The policy to apply when a double write occurs.
@@ -134,12 +134,12 @@ namespace Transformer {
          */
         doubleWritePolicy?: DoubleWritePolicy;
 
-        /** Whether this process should allow undeclared reads from source files. A source
+        /** Whether this process should allow undeclared reads from source files. A source 
          * file is considered to be a file that is not written during the build.
          * Note: this option turns static enforcements based on source file declarations into dynamic
          * ones. The downside is that potential build errors will be reported later in time, during the
          * execution phase, and only based on runtime observations. This means that even if there is something
-         * wrong, BuildXL may not see it if the running build doesn't hit it. The advise is: statically declare all
+         * wrong, BuildXL may not see it if the running build doesn't hit it. The advise is: statically declare all 
          * sources if possible, and only use this option for the sources where static predictions are not available. */
         allowUndeclaredSourceReads?: boolean;
 
@@ -161,6 +161,14 @@ namespace Transformer {
          * for a pip. The pip will still be stored to the cache for sake of supporting distribution.
          */
         disableCacheLookup?: boolean;
+
+        /**
+         * The weighted value of this pip when limiting concurrency of process pips.
+         * The default weight for a process pip is 1, and the max valid weight is the max concurrent processes allowed in the build.
+         * The higher the weight, the fewer process pips that can run in parallel.
+         * No additional processes can be run concurrently while the sum of weights of all running processes is >= the build's weight limit (which is the max valid weight).
+         */
+        weight?: number;
     }
 
     @@public
@@ -186,7 +194,7 @@ namespace Transformer {
         zeroIsSuccess = 1,
         zeroOr255IsSuccess,
     }
-
+    
     @@public
     export interface UnsafeExecuteArguments {
         untrackedPaths?: (File | Directory)[];

--- a/Public/Src/Engine/Scheduler/Distribution/Worker.cs
+++ b/Public/Src/Engine/Scheduler/Distribution/Worker.cs
@@ -421,7 +421,7 @@ namespace BuildXL.Scheduler.Distribution
                 loadFactor = 1;
             }
 
-            var processRunnablePip = runnablePip as ProcessRunnablePip;
+            var processRunnablePip = (ProcessRunnablePip) runnablePip;
             var acquiredSlots = m_acquiredProcessSlots;
             var totalSlotsNeeded = acquiredSlots + processRunnablePip.Process.Weight;
 

--- a/Public/Src/Engine/Scheduler/PipExecutor.cs
+++ b/Public/Src/Engine/Scheduler/PipExecutor.cs
@@ -2061,10 +2061,22 @@ namespace BuildXL.Scheduler
                     Contract.Assert(pipCacheMiss.Value.CacheMissType != PipCacheMissType.Invalid, "Must have valid cache miss reason");
                     environment.Counters.IncrementCounter((PipExecutorCounter)pipCacheMiss.Value.CacheMissType);
 
-                    Logger.Log.ScheduleProcessPipCacheMiss(
-                        operationContext,
-                        cacheableProcess.Description,
-                        runnableFromCacheResult.Fingerprint.ToString());
+                    if (processRunnable.Process.Weight > 1)
+                    {
+                        Logger.Log.ProcessPipCacheMissWithProcessWeight(
+                            operationContext,
+                            cacheableProcess.Description,
+                            runnableFromCacheResult.Fingerprint.ToString(),
+                            processRunnable.Process.Weight.ToString());
+                    }
+                    else
+                    {
+                        Logger.Log.ScheduleProcessPipCacheMiss(
+                            operationContext,
+                            cacheableProcess.Description,
+                            runnableFromCacheResult.Fingerprint.ToString());
+                    }
+
                     environment.State.ExecutionLog?.PipCacheMiss(pipCacheMiss.Value);
                 }
 

--- a/Public/Src/Engine/Scheduler/PipExecutor.cs
+++ b/Public/Src/Engine/Scheduler/PipExecutor.cs
@@ -2061,22 +2061,10 @@ namespace BuildXL.Scheduler
                     Contract.Assert(pipCacheMiss.Value.CacheMissType != PipCacheMissType.Invalid, "Must have valid cache miss reason");
                     environment.Counters.IncrementCounter((PipExecutorCounter)pipCacheMiss.Value.CacheMissType);
 
-                    if (processRunnable.Process.Weight > 1)
-                    {
-                        Logger.Log.ProcessPipCacheMissWithProcessWeight(
-                            operationContext,
-                            cacheableProcess.Description,
-                            runnableFromCacheResult.Fingerprint.ToString(),
-                            processRunnable.Process.Weight.ToString());
-                    }
-                    else
-                    {
-                        Logger.Log.ScheduleProcessPipCacheMiss(
-                            operationContext,
-                            cacheableProcess.Description,
-                            runnableFromCacheResult.Fingerprint.ToString());
-                    }
-
+                    Logger.Log.ScheduleProcessPipCacheMiss(
+                        operationContext,
+                        cacheableProcess.Description,
+                        runnableFromCacheResult.Fingerprint.ToString());
                     environment.State.ExecutionLog?.PipCacheMiss(pipCacheMiss.Value);
                 }
 

--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -3384,6 +3384,12 @@ namespace BuildXL.Scheduler
                     {
                         MarkPipStartExecuting();
 
+                        if (processRunnable.Process.Weight > 1)
+                        {
+                            // Only log for pips with non-standard process weights
+                            Logger.Log.ProcessPipProcessWeight(loggingContext, processRunnable.Description, processRunnable.Process.Weight);
+                        }
+
                         processRunnable.Executed = true;
                         var executionResult = await worker.ExecuteProcessAsync(processRunnable);
 

--- a/Public/Src/Engine/Scheduler/SchedulerTestHooks.cs
+++ b/Public/Src/Engine/Scheduler/SchedulerTestHooks.cs
@@ -45,5 +45,11 @@ namespace BuildXL.Scheduler
         /// Test hooks for the <see cref="FingerprintStore"/>.
         /// </summary>
         public FingerprintStoreTestHooks FingerprintStoreTestHooks { get; set; }
+
+        /// <summary>
+        /// Whether <see cref="Scheduler.LogStats(Utilities.Instrumentation.Common.LoggingContext)"/> should be called after the
+        /// scheduler run is completed.
+        /// </summary>
+        public bool LogSchedulerStats = false;
     }
 }

--- a/Public/Src/Engine/Scheduler/Tracing/Log.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/Log.cs
@@ -264,6 +264,15 @@ namespace BuildXL.Scheduler.Tracing
         internal abstract void ScheduleProcessPipCacheMiss(LoggingContext loggingContext, string pipDescription, string fingerprint);
 
         [GeneratedEvent(
+            (ushort)EventId.ProcessPipCacheMissWithProcessWeight,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Verbose,
+            Keywords = (int)Events.Keywords.UserMessage,
+            EventTask = (ushort)Events.Tasks.Storage,
+            Message = "[{pipDescription}] Cache miss (fingerprint '{fingerprint}'): Process will be executed. Process weight: {weight}.")]
+        internal abstract void ProcessPipCacheMissWithProcessWeight(LoggingContext loggingContext, string pipDescription, string fingerprint, string weight);
+
+        [GeneratedEvent(
             (ushort)EventId.ProcessPipCacheHit,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,

--- a/Public/Src/Engine/Scheduler/Tracing/Log.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/Log.cs
@@ -264,13 +264,13 @@ namespace BuildXL.Scheduler.Tracing
         internal abstract void ScheduleProcessPipCacheMiss(LoggingContext loggingContext, string pipDescription, string fingerprint);
 
         [GeneratedEvent(
-            (ushort)EventId.ProcessPipCacheMissWithProcessWeight,
+            (ushort)EventId.ProcessPipProcessWeight,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,
             Keywords = (int)Events.Keywords.UserMessage,
             EventTask = (ushort)Events.Tasks.Storage,
-            Message = "[{pipDescription}] Cache miss (fingerprint '{fingerprint}'): Process will be executed. Process weight: {weight}.")]
-        internal abstract void ProcessPipCacheMissWithProcessWeight(LoggingContext loggingContext, string pipDescription, string fingerprint, string weight);
+            Message = "[{pipDescription}] Executing process with process weight: {weight}.")]
+        internal abstract void ProcessPipProcessWeight(LoggingContext loggingContext, string pipDescription, int weight);
 
         [GeneratedEvent(
             (ushort)EventId.ProcessPipCacheHit,

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/IncrementalSchedulingTests/ProcessWeightTests_IncrementalScheduling.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/IncrementalSchedulingTests/ProcessWeightTests_IncrementalScheduling.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Test.BuildXL.TestUtilities.Xunit;
+using Xunit.Abstractions;
+
+namespace IntegrationTest.BuildXL.Scheduler.IncrementalSchedulingTests
+{
+    [TestClassIfSupported(requiresJournalScan: true)]
+    public class ProcessWeightTests_IncrementalScheduling : ProcessWeightTests
+    {
+        public ProcessWeightTests_IncrementalScheduling(ITestOutputHelper output) : base(output)
+        {
+            Configuration.Schedule.IncrementalScheduling = true;
+            Configuration.Schedule.SkipHashSourceFile = false;
+        }
+    }
+}

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/ProcessWeightTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/ProcessWeightTests.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using BuildXL.Scheduler.Distribution;
+using Test.BuildXL.Executables.TestProcess;
+using Test.BuildXL.Scheduler;
+using Test.BuildXL.TestUtilities.Xunit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace IntegrationTest.BuildXL.Scheduler
+{
+    public class ProcessWeightTests : SchedulerIntegrationTestBase
+    {
+        public ProcessWeightTests(ITestOutputHelper output) : base(output)
+        {
+            // Turns on logging for most scheduler stats, including the limiting resource stat looked for by these tests
+            ShouldLogSchedulerStats = true;
+        }
+
+        [Theory]
+        [InlineData(-1)] // Make sure a weights of < 1 are treated the same as a weight of 1
+        [InlineData(0)]
+        [InlineData(1)]
+        public void CanRunUpToMaxProcessesInParallel(int defaultWeight)
+        {
+            CreateAndScheduleProcessWithWeight(defaultWeight, numProcesses: Configuration.Schedule.MaxProcesses);
+
+            RunScheduler().AssertSuccess();
+            AssertProcessConcurrencyWeightLimited(false);
+        }
+
+        [Theory]
+        [InlineData(-1)] // Make sure a weights of < 1 are treated the same as a weight of 1
+        [InlineData(0)]
+        [InlineData(1)]
+        public void CannotRunGreaterThanMaxProcessesInParallel(int defaultWeight)
+        {
+            // Schedule one over max concurrent processes
+            CreateAndScheduleProcessWithWeight(defaultWeight, numProcesses: Configuration.Schedule.MaxProcesses + 1);
+
+            RunScheduler().AssertSuccess();
+            AssertProcessConcurrencyWeightLimited(true);
+        }
+
+        [Fact]
+        public void UseProcessWeightToRunAlone()
+        {
+            CreateAndScheduleProcessWithWeight(Configuration.Schedule.MaxProcesses);
+            CreateAndScheduleProcessWithWeight(1);
+
+            RunScheduler().AssertSuccess();
+            AssertProcessConcurrencyWeightLimited(true);
+        }
+
+        [Fact]
+        public void GreaterThanMaxWeightStillRuns()
+        {
+            CreateAndScheduleProcessWithWeight(Configuration.Schedule.MaxProcesses * 2);
+            CreateAndScheduleProcessWithWeight(1);
+
+            RunScheduler().AssertSuccess();
+            AssertProcessConcurrencyWeightLimited(true);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+
+        public void TestVaryingWeights(bool shouldOverSchedule)
+        {
+            int sum = 0;
+            int w = 1;
+            int limit = 0;
+
+            // Schedules pips with monotonically increasing weights of (e.g. 1, 2, 3, ... n)
+            while (limit <= Configuration.Schedule.MaxProcesses)
+            {
+                CreateAndScheduleProcessWithWeight(w);
+
+                sum += w;
+                w++;
+
+                limit = shouldOverSchedule ? sum : sum + w;
+            }
+
+            RunScheduler().AssertSuccess();
+            AssertProcessConcurrencyWeightLimited(shouldOverSchedule);
+        }
+
+        [Fact]
+        public void TotalAllowedWeightIsLimitedByConfigurationMaxProcesses()
+        {
+            var maxProcesses = 1;
+            Configuration.Schedule.MaxProcesses = maxProcesses;
+            CreateAndScheduleProcessWithWeight(1, numProcesses: maxProcesses + 1);
+
+            RunScheduler().AssertSuccess();
+            AssertProcessConcurrencyWeightLimited(true);
+        }
+
+        private void CreateAndScheduleProcessWithWeight(int weight, int numProcesses = 1)
+        {
+            for (int i = 0; i < numProcesses; ++i)
+            {
+                var builder = CreatePipBuilder(new Operation[]
+                {
+                    Operation.WriteFile(CreateOutputFileArtifact())
+                });
+
+                builder.Weight = weight;
+                SchedulePipBuilder(builder);
+            }
+        }
+
+        private void AssertProcessConcurrencyWeightLimited(bool isWeightLimited)
+        {
+            var log = EventListener.GetLog();
+            XAssert.AreEqual(isWeightLimited, log.Contains(WorkerResource.AvailableProcessSlots.Name));
+        }
+    }
+}

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SchedulerIntegrationTestBase.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SchedulerIntegrationTestBase.cs
@@ -53,6 +53,11 @@ namespace Test.BuildXL.Scheduler
 
         private JournalState m_journalState;
 
+        /// <summary>
+        /// Whether the scheduler should log all of its statistics at the end of every run.
+        /// </summary>
+        public bool ShouldLogSchedulerStats { get; set; } = false;
+
         /// <nodoc/>
         public SchedulerIntegrationTestBase(ITestOutputHelper output) : base(output)
         {
@@ -409,6 +414,15 @@ namespace Test.BuildXL.Scheduler
                 bool success = testScheduler.WhenDone().GetAwaiter().GetResult();
                 testScheduler.SaveFileChangeTrackerAsync(LoggingContext).Wait();
 
+                if (ShouldLogSchedulerStats)
+                {
+                    // Logs are not written out normally during these tests, but LogStats depends on the existence of the logs directory
+                    // to write out the stats perf JSON file
+                    var logsDir = config.Logging.LogsDirectory.ToString(Context.PathTable);
+                    Directory.CreateDirectory(logsDir);
+                    testScheduler.LogStats(LoggingContext);
+                }
+
                 return new ScheduleRunResult
                 {
                     Graph = graph,
@@ -420,7 +434,7 @@ namespace Test.BuildXL.Scheduler
                     ProcessPipCountersByFilter = testScheduler.ProcessPipCountersByFilter,
                     ProcessPipCountersByTelemetryTag = testScheduler.ProcessPipCountersByTelemetryTag,
                     SchedulerState = new SchedulerState(testScheduler)
-                };               
+                };
             }
         }
 

--- a/Public/Src/FrontEnd/Script/Ambients/Transformers/AmbientTransformer.Process.cs
+++ b/Public/Src/FrontEnd/Script/Ambients/Transformers/AmbientTransformer.Process.cs
@@ -124,6 +124,7 @@ namespace BuildXL.FrontEnd.Script.Ambients.Transformers
         private SymbolAtom m_toolDependsOnAppDataDirectory;
         private SymbolAtom m_toolPrepareTempDirectory;
         private SymbolAtom m_toolDescription;
+        private SymbolAtom m_weight;
         
         private SymbolAtom m_runtimeEnvironmentMinimumOSVersion;
         private SymbolAtom m_runtimeEnvironmentMaximumOSVersion;
@@ -230,6 +231,7 @@ namespace BuildXL.FrontEnd.Script.Ambients.Transformers
             m_executeErrorRegex = Symbol("errorRegex");
             m_executeAllowedSurvivingChildProcessNames = Symbol("allowedSurvivingChildProcessNames");
             m_executeNestedProcessTerminationTimeoutMs = Symbol("nestedProcessTerminationTimeoutMs");
+            m_weight = Symbol("weight");
 
             m_argN = Symbol("n");
             m_argV = Symbol("v");
@@ -436,6 +438,13 @@ namespace BuildXL.FrontEnd.Script.Ambients.Transformers
             }
 
             // TODO: Regex. Should we follow ECMA, C#, JavaScript?
+
+            // Weight.
+            var weight = Converter.ExtractInt(obj, m_weight);
+            if (weight != null)
+            {
+                processBuilder.Weight = weight.Value;
+            }
 
             // Acquired semaphores.
             var acquireSemaphores = Converter.ExtractArrayLiteral(obj, m_executeAcquireSemaphores, allowUndefined: true);

--- a/Public/Src/FrontEnd/Script/Ambients/Transformers/AmbientTransformer.Process.cs
+++ b/Public/Src/FrontEnd/Script/Ambients/Transformers/AmbientTransformer.Process.cs
@@ -440,7 +440,7 @@ namespace BuildXL.FrontEnd.Script.Ambients.Transformers
             // TODO: Regex. Should we follow ECMA, C#, JavaScript?
 
             // Weight.
-            var weight = Converter.ExtractInt(obj, m_weight);
+            var weight = Converter.ExtractOptionalInt(obj, m_weight);
             if (weight != null)
             {
                 processBuilder.Weight = weight.Value;

--- a/Public/Src/Pips/Dll/Builders/ProcessBuilder.cs
+++ b/Public/Src/Pips/Dll/Builders/ProcessBuilder.cs
@@ -56,7 +56,7 @@ namespace BuildXL.Pips.Builders
         public FileArtifact ResponseFile { get; set; }
 
         private ResponseFileSpecification m_responseFileSpecification;
-        
+
         /// <nodoc />
         public PipData ResponseFileData { get; set; }
 
@@ -102,6 +102,12 @@ namespace BuildXL.Pips.Builders
         public ReadOnlyArray<int> RetryExitCodes { get; set; } = ReadOnlyArray<int>.Empty;
 
         private Dictionary<StringId, ProcessSemaphoreInfo> m_semaphores;
+
+        /// <summary>
+        /// The weighted value of this pip when limiting concurrency of process pips.
+        /// The higher the weight, the fewer process pips that can run in parallel.
+        /// </summary>
+        public int Weight { get; set; } = 1;
 
         /// <nodoc />
         public TimeSpan? Timeout { get; set; }
@@ -650,7 +656,8 @@ namespace BuildXL.Pips.Builders
                 nestedProcessTerminationTimeout: NestedProcessTerminationTimeout,
                 doubleWritePolicy: DoubleWritePolicy,
                 containerIsolationLevel: ContainerIsolationLevel,
-                absentPathProbeMode: AbsentPathProbeUnderOpaquesMode
+                absentPathProbeMode: AbsentPathProbeUnderOpaquesMode,
+                weight: Weight
             );
 
             return true;

--- a/Public/Src/Pips/Dll/Builders/ProcessBuilder.cs
+++ b/Public/Src/Pips/Dll/Builders/ProcessBuilder.cs
@@ -107,7 +107,7 @@ namespace BuildXL.Pips.Builders
         /// The weighted value of this pip when limiting concurrency of process pips.
         /// The higher the weight, the fewer process pips that can run in parallel.
         /// </summary>
-        public int Weight { get; set; } = 1;
+        public int? Weight { get; set; } = null;
 
         /// <nodoc />
         public TimeSpan? Timeout { get; set; }

--- a/Public/Src/Pips/Dll/Operations/Process.cs
+++ b/Public/Src/Pips/Dll/Operations/Process.cs
@@ -277,10 +277,11 @@ namespace BuildXL.Pips.Operations
         public ServiceInfo ServiceInfo { get; }
 
         /// <summary>
-        /// The weighted value of this pip when limiting concurrency of process pips.
-        /// The default weight for a process pip is 1, and the max valid weight is <see cref="IScheduleConfiguration.MaxProcesses"/>.
-        /// The higher the weight, the fewer process pips that can run in parallel.
-        /// No additional processes can be run concurrently while the sum of weights of all running processes is >= the build's weight limit (which is the max valid weight).
+        /// The # of process slots this process requires when limiting concurrency of process pips.
+        /// The total weight of all proceses running concurrently must be less than or equal to the number of available process slots.
+        /// The # of available process slots is typically a function of the number of cores on the machine, but can also be limited by runtime resource exhaustion or be set per-build by configuration.
+        /// Valid input range for the weight is [min Int32, max Int32] though all values will be effectively coerced to fit within [1, # of process slots]
+        /// If a given weight is greater than or equal to # of available process slots, the process will run alone.
         /// </summary>
         [PipCaching(FingerprintingRole = FingerprintingRole.None)]
         public int Weight { get; }

--- a/Public/Src/Pips/Dll/Operations/Process.cs
+++ b/Public/Src/Pips/Dll/Operations/Process.cs
@@ -339,7 +339,7 @@ namespace BuildXL.Pips.Operations
             AbsentPathProbeInUndeclaredOpaquesMode absentPathProbeMode = AbsentPathProbeInUndeclaredOpaquesMode.Unsafe,
             DoubleWritePolicy doubleWritePolicy = DoubleWritePolicy.DoubleWritesAreErrors,
             ContainerIsolationLevel containerIsolationLevel = ContainerIsolationLevel.None,
-            int weight = 1)
+            int? weight = null)
         {
             Contract.Requires(executable.IsValid);
             Contract.Requires(workingDirectory.IsValid);
@@ -369,6 +369,7 @@ namespace BuildXL.Pips.Operations
             Contract.Requires(tags.IsValid);
             // If the process needs to run in a container, the redirected directory has to be set
             Contract.Requires((options & Options.NeedsToRunInContainer) == Options.None || uniqueRedirectedDirectoryRoot.IsValid);
+            Contract.Requires(!weight.HasValue || weight.Value > 0, "Process weight values must be positive.");
 
 #if DEBUG   // a little too expensive for release builds
             Contract.Requires(Contract.Exists(dependencies, d => d == executable), "The executable must be declared as a dependency");
@@ -438,7 +439,7 @@ namespace BuildXL.Pips.Operations
             ProcessAbsentPathProbeInUndeclaredOpaquesMode = absentPathProbeMode;
             DoubleWritePolicy = doubleWritePolicy;
             ContainerIsolationLevel = containerIsolationLevel;
-            Weight = weight > 0 ? weight : 1;
+            Weight = weight.HasValue ? weight.Value: 1;
         }
 
         /// <summary>
@@ -484,7 +485,7 @@ namespace BuildXL.Pips.Operations
             AbsentPathProbeInUndeclaredOpaquesMode absentPathProbeMode = AbsentPathProbeInUndeclaredOpaquesMode.Unsafe,
             DoubleWritePolicy doubleWritePolicy = DoubleWritePolicy.DoubleWritesAreErrors,
             ContainerIsolationLevel containerIsolationLevel = ContainerIsolationLevel.None,
-            int weight = 1)
+            int? weight = null)
         {
             return new Process(
                 executable ?? Executable,
@@ -526,7 +527,7 @@ namespace BuildXL.Pips.Operations
                 absentPathProbeMode,
                 doubleWritePolicy,
                 containerIsolationLevel,
-                weight > 0 ? weight : 1);
+                weight);
         }
 
         /// <inheritdoc />
@@ -745,7 +746,7 @@ namespace BuildXL.Pips.Operations
                 absentPathProbeMode: (AbsentPathProbeInUndeclaredOpaquesMode)reader.ReadByte(),
                 doubleWritePolicy: (DoubleWritePolicy)reader.ReadByte(),
                 containerIsolationLevel: (ContainerIsolationLevel)reader.ReadByte(),
-                weight: reader.ReadInt32()
+                weight: reader.ReadInt32Compact()
                 );
         }
 
@@ -790,7 +791,7 @@ namespace BuildXL.Pips.Operations
             writer.Write((byte)ProcessAbsentPathProbeInUndeclaredOpaquesMode);
             writer.Write((byte)DoubleWritePolicy);
             writer.Write((byte)ContainerIsolationLevel);
-            writer.Write(Weight);
+            writer.WriteCompact(Weight);
         }
         #endregion
     }

--- a/Public/Src/Pips/Dll/Operations/Process.cs
+++ b/Public/Src/Pips/Dll/Operations/Process.cs
@@ -370,7 +370,6 @@ namespace BuildXL.Pips.Operations
             Contract.Requires(tags.IsValid);
             // If the process needs to run in a container, the redirected directory has to be set
             Contract.Requires((options & Options.NeedsToRunInContainer) == Options.None || uniqueRedirectedDirectoryRoot.IsValid);
-            Contract.Requires(!weight.HasValue || weight.Value > 0, "Process weight values must be positive.");
 
 #if DEBUG   // a little too expensive for release builds
             Contract.Requires(Contract.Exists(dependencies, d => d == executable), "The executable must be declared as a dependency");
@@ -440,7 +439,7 @@ namespace BuildXL.Pips.Operations
             ProcessAbsentPathProbeInUndeclaredOpaquesMode = absentPathProbeMode;
             DoubleWritePolicy = doubleWritePolicy;
             ContainerIsolationLevel = containerIsolationLevel;
-            Weight = weight.HasValue ? weight.Value: 1;
+            Weight = weight.HasValue && weight.Value > 0 ? weight.Value : 1;
         }
 
         /// <summary>

--- a/Public/Src/Utilities/Utilities/Tracing/EventId.cs
+++ b/Public/Src/Utilities/Utilities/Tracing/EventId.cs
@@ -287,7 +287,7 @@ namespace BuildXL.Utilities.Tracing
         InvalidInputSinceSourceFileCannotBeInsideOutputDirectory = 299,
         ScheduleProcessConfiguredUncacheable = 300,
 
-        ProcessPipCacheMissWithProcessWeight = 301,
+        ProcessPipProcessWeight = 301,
 
         // Reserved = 306,
         // Reserved = 307,

--- a/Public/Src/Utilities/Utilities/Tracing/EventId.cs
+++ b/Public/Src/Utilities/Utilities/Tracing/EventId.cs
@@ -287,6 +287,8 @@ namespace BuildXL.Utilities.Tracing
         InvalidInputSinceSourceFileCannotBeInsideOutputDirectory = 299,
         ScheduleProcessConfiguredUncacheable = 300,
 
+        ProcessPipCacheMissWithProcessWeight = 301,
+
         // Reserved = 306,
         // Reserved = 307,
         PipFailSymlinkCreation = 308,


### PR DESCRIPTION
BuildXL has a limited number of process slots that determine how many processes can run concurrently during the build. Previously, all process pips took up one slot, no matter how resource-heavy the process was. 

This PR adds the concept of process "weight" that processes can use to indicate they require more resources/slots than average and should not be run in parallel with as many other processes.

Changes
- Add "weight" field to Process, which represents how many process slots that process needs to run
- The total "weight" of all processes running concurrently must be less than the number of available process slots (dictated by /maxproc and possibly RAM available)
- "weight" defaults to 1, converts values < 1 to 1, and considers values >= available process slots to mean the process should run alone

[AB#1469609](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1469609)