### PR TITLE
Hide exception on console when concurrent invocations overlap output directories

### DIFF
--- a/Public/Src/Engine/Dll/Engine.cs
+++ b/Public/Src/Engine/Dll/Engine.cs
@@ -2130,7 +2130,7 @@ namespace BuildXL.Engine
             }
             catch (BuildXLException ex)
             {
-                Logger.Log.FailedToAcquireDirectoryDeletionLock(loggingContext, ex.ToStringDemystified());
+                Logger.Log.FailedToAcquireDirectoryDeletionLock(loggingContext, ex.Message);
             }
             finally
             {

--- a/Public/Src/Engine/Dll/Tracing/Log.cs
+++ b/Public/Src/Engine/Dll/Tracing/Log.cs
@@ -1399,8 +1399,8 @@ If you can't update and need this feature after July 2018 please reach out to th
             EventLevel = Level.Error,
             Keywords = (int)(Events.Keywords.UserMessage | Events.Keywords.InfrastructureError),
             EventTask = (int)Events.Tasks.Engine,
-            Message = "Failed to acquire a lock to prevent directory deletion: {0}")]
-        public abstract void FailedToAcquireDirectoryDeletionLock(LoggingContext context, string innerException);
+            Message = "Failed to acquire a lock to prevent directory deletion. This may be due to invoking concurrent builds with overlapping directories. Error: {0}")]
+        public abstract void FailedToAcquireDirectoryDeletionLock(LoggingContext context, string message);
 
         [GeneratedEvent(
             (int)LogEventId.FailedToAcquireDirectoryLock,
@@ -1703,14 +1703,29 @@ If you can't update and need this feature after July 2018 please reach out to th
             Message = "{ShortProductName} failed to run because only 'case-insensitive' file-systems are currently supported on non-windows hosts.")]
         public abstract void ErrorCaseSensitiveFileSystemDetected(LoggingContext context);
 
+        public void BusyOrUnavailableOutputDirectories(LoggingContext context, string objectDirectoryPath, string exception)
+        {
+            BusyOrUnavailableOutputDirectories(context, objectDirectoryPath);
+            BusyOrUnavailableOutputDirectoriesException(context, objectDirectoryPath, exception);
+        }
+
         [GeneratedEvent(
             (int)EventId.BusyOrUnavailableOutputDirectories,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Error,
             Keywords = (int)(Events.Keywords.UserMessage | Events.Keywords.InfrastructureError),
             EventTask = (int)Events.Tasks.Engine,
-            Message = "Concurrent builds using the same output directories are not supported. Directory already in use or not reachable {0}. Exception: {1}")]
-        public abstract void BusyOrUnavailableOutputDirectories(LoggingContext context, string objectDirectoryPath, string exception);
+            Message = "Concurrent builds using the same output directories are not supported. Directory already in use or not reachable {0}.")]
+        public abstract void BusyOrUnavailableOutputDirectories(LoggingContext context, string objectDirectoryPath);
+
+        [GeneratedEvent(
+            (int)LogEventId.BusyOrUnavailableOutputDirectoriesException,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Verbose,
+            Keywords = (int)Events.Keywords.UserMessage,
+            EventTask = (int)Events.Tasks.Engine,
+            Message = "Directory {0} lock exception: {1}")]
+        public abstract void BusyOrUnavailableOutputDirectoriesException(LoggingContext context, string objectDirectoryPath, string exception);
 
         [GeneratedEvent(
             (int)EventId.BusyOrUnavailableOutputDirectoriesRetry,

--- a/Public/Src/Engine/Dll/Tracing/LogEventId.cs
+++ b/Public/Src/Engine/Dll/Tracing/LogEventId.cs
@@ -214,6 +214,7 @@ namespace BuildXL.Engine.Tracing
         UsingRedirectedUserProfile = 7117,
         FailedToRedirectUserProfile = 7118,
         ResourceBasedCancellationIsEnabledWithSharedOpaquesPresent = 7119,
+        BusyOrUnavailableOutputDirectoriesException = 7120,
         // max 7200
     }
 }


### PR DESCRIPTION
Exception stack is moved to the log file for sake of debugging. Generally it's sufficient to just tell users they are invoking two concurrent builds with overlapping output directories. 

Fixes [AB#1469779](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1469779)