### PR TITLE
Update CacheFactory to ignore invalid JSON fields in config

### DIFF
--- a/Public/Src/Cache/VerticalStore/Interfaces/CacheFactory.cs
+++ b/Public/Src/Cache/VerticalStore/Interfaces/CacheFactory.cs
@@ -290,6 +290,8 @@ namespace BuildXL.Cache.Interfaces
                 }
             }
 
+            // We used to validate that the JSON config had no fields that did not correspond to a field in our config, but this caused issues when we added new flags, since old versions of the cache would break
+            //  when used with newer configs. Because of that, we removed that validation.
             return target;
         }
     }

--- a/Public/Src/Cache/VerticalStore/Interfaces/CacheFactory.cs
+++ b/Public/Src/Cache/VerticalStore/Interfaces/CacheFactory.cs
@@ -290,24 +290,6 @@ namespace BuildXL.Cache.Interfaces
                 }
             }
 
-            foreach (string key in cacheData.Keys)
-            {
-                switch (key)
-                {
-                    case DictionaryKeyFactoryTypeName:
-                    case DictionaryKeyFactoryAssemblyName:
-                        break;
-                    default:
-
-                        if (target.GetType().GetProperty(key) == null)
-                        {
-                            return new IncorrectJsonConfigDataFailure("{0} does not support setting '{1}' in Json configuration data", configName, key);
-                        }
-
-                        break;
-                }
-            }
-
             return target;
         }
     }

--- a/Public/Src/Cache/VerticalStore/UnitTests/Interfaces/TestCacheFactory.cs
+++ b/Public/Src/Cache/VerticalStore/UnitTests/Interfaces/TestCacheFactory.cs
@@ -403,7 +403,7 @@ namespace BuildXL.Cache.Tests
         }
 
         /// <summary>
-        /// Verifies that InitializeCache returns a valid Failure when a Json string contains fields that do not exist in the factory's config structure
+        /// Verifies that InitializeCache returns a valid cache when a Json string contains fields that do not exist in the factory's config structure
         /// </summary>
         [Fact]
         public async Task TestInvalidJsonField()
@@ -415,17 +415,20 @@ namespace BuildXL.Cache.Tests
                     { "StringWithNoDefaultValue", "Value_of_StringWithNoDefaultValue" },
                 });
 
-            // this Json string will produce a failure and there will be no results to validate. We will set the result validation to null here
-            resultValidationLambda = null;
+            // set up the result validation lambda
+            resultValidationLambda = (obj1) =>
+            {
+                XAssert.AreEqual("Value_of_StringWithDefaultValue", obj1.StringWithDefaultValue);
+
+                // the lambda assigned to resultValidationLambda is static and each test should set it. We will set it to null to make sure that no other tests use this lambda accidentally.
+                resultValidationLambda = null;
+            };
 
             // call InitializeCache, there should be no exception
             Possible<ICache, Failure> cache = await InitializeCacheAsync(jsonString);
 
             // make sure that we do not get a cache
-            Assert.False(cache.Succeeded);
-
-            // validate the returned error message
-            XAssert.AreEqual("BuildXL.Cache.Tests.TestCacheFactory does not support setting 'InvalidFieldName' in Json configuration data", cache.Failure.Describe());
+            Assert.True(cache.Succeeded);
         }
 
         /// <summary>

--- a/Public/Src/Cache/VerticalStore/UnitTests/Interfaces/TestInMemory.cs
+++ b/Public/Src/Cache/VerticalStore/UnitTests/Interfaces/TestInMemory.cs
@@ -33,10 +33,9 @@ namespace BuildXL.Cache.Tests
 
         // This is a config string that should cause the in-memory cache to fail to get constructed
         private static readonly string inMemoryCacheConfigFailureJSONData = @"{{ 
-            ""Assembly"":""BuildXL.Cache.InMemory"",
+            ""Assembly"":""BadAssemblyNameShouldFail"",
             ""Type"":""BuildXL.Cache.InMemory.MemCacheFactory"", 
             ""CacheId"":""{0}"",
-            ""BadOption"":""SouldNeverWork"",
             ""StrictMetadataCasCoupling"":{1},
             ""IsAuthoritative"":{2}
         }}";


### PR DESCRIPTION
A problem arose when an old version of cache received a config file from a new version of GBR which emitted a config flag that didn't exist in the old cache bits.

To fix this, we will now ignore invalid fields in the cache config.