### PR TITLE
Fix fingerprint comparison when reusing packages from disk

### DIFF
--- a/Public/Src/FrontEnd/Core/FrontEndHostController.Nuget.cs
+++ b/Public/Src/FrontEnd/Core/FrontEndHostController.Nuget.cs
@@ -199,7 +199,7 @@ namespace BuildXL.FrontEnd.Core
 
             // .NET Core builds do not support nuget at all, so we use files from disk regardless of their correctness
             // Reuse package from disk when fingerprint matches or when the fingeprint check is disabled.
-            if (FrontEndConfiguration.RespectWeakFingerprintForNugetUpToDateCheck() && packageHash.Value.FingerprintHash != weakPackageFingerprint)
+            if (FrontEndConfiguration.RespectWeakFingerprintForNugetUpToDateCheck() && packageHash.Value.FingerprintText != weakPackageFingerprint)
             {
                 m_logger.CanNotReusePackageHashFile(
                     LoggingContext,


### PR DESCRIPTION
Change FingerprintHash to FingerprintText when comparing with the weakPackageFingerprint, since that is what is actually passed down.