### PR TITLE
Move runtime cache miss FingerprintStore to Logs\FingerprintStore

### DIFF
--- a/Public/Src/Engine/Dll/Engine.cs
+++ b/Public/Src/Engine/Dll/Engine.cs
@@ -703,15 +703,19 @@ namespace BuildXL.Engine
                 logging.EngineCacheCorruptFilesLogDirectory = logging.EngineCacheLogDirectory.Combine(pathTable, EngineSerializer.CorruptFilesLogLocation);
             }
 
-            var fingerprintsLogDirectory = logging.LogsDirectory.Combine(pathTable, LogFileExtensions.FingerprintsLogDirectory);
-            if (!logging.FingerprintStoreLogDirectory.IsValid)
+            if (!logging.FingerprintsLogDirectory.IsValid)
             {
-                logging.FingerprintStoreLogDirectory = fingerprintsLogDirectory.Combine(pathTable, Scheduler.Scheduler.FingerprintStoreDirectory);
+                logging.FingerprintsLogDirectory = logging.LogsDirectory.Combine(pathTable, LogFileExtensions.FingerprintsLogDirectory);
+            }
+
+            if (!logging.ExecutionFingerprintStoreLogDirectory.IsValid)
+            {
+                logging.ExecutionFingerprintStoreLogDirectory = logging.FingerprintsLogDirectory.Combine(pathTable, Scheduler.Scheduler.FingerprintStoreDirectory);
             }
 
             if (!logging.CacheLookupFingerprintStoreLogDirectory.IsValid)
             {
-                logging.CacheLookupFingerprintStoreLogDirectory = fingerprintsLogDirectory.Combine(pathTable, Scheduler.Scheduler.FingerprintStoreDirectory + LogFileExtensions.CacheLookupFingerprintStore);
+                logging.CacheLookupFingerprintStoreLogDirectory = logging.FingerprintsLogDirectory.Combine(pathTable, Scheduler.Scheduler.FingerprintStoreDirectory + LogFileExtensions.CacheLookupFingerprintStore);
             }
 
             if (mutableConfig.Cache.HistoricMetadataCache == true && !logging.HistoricMetadataCacheLogDirectory.IsValid)

--- a/Public/Src/Engine/Dll/EngineSchedule.cs
+++ b/Public/Src/Engine/Dll/EngineSchedule.cs
@@ -590,7 +590,7 @@ namespace BuildXL.Engine
                 {
                     var storeResult = await m_cache.TrySaveFingerprintStoreAsync(
                         loggingContext,
-                        configuration.Logging.FingerprintStoreLogDirectory,
+                        configuration.Logging.ExecutionFingerprintStoreLogDirectory,
                         Context.PathTable,
                         storeKey,
                         configuration.Schedule.EnvironmentFingerprint);

--- a/Public/Src/Engine/Scheduler/Tracing/FingerprintStore.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/FingerprintStore.cs
@@ -1506,7 +1506,7 @@ namespace BuildXL.Scheduler.Tracing
         {
             using (counters?.StartStopwatch(FingerprintStoreCounters.SnapshotTime))
             {
-                var logDirectory = configuration.Logging.FingerprintStoreLogDirectory.ToString(pathTable);
+                var logDirectory = configuration.Logging.ExecutionFingerprintStoreLogDirectory.ToString(pathTable);
                 var filesToCopy = new List<Task<bool>>();
                 var hardLinkFailureSeen = false;
 

--- a/Public/Src/Engine/Scheduler/Tracing/RuntimeCacheMissAnalyzer.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/RuntimeCacheMissAnalyzer.cs
@@ -67,7 +67,7 @@ namespace BuildXL.Scheduler.Tracing
                         Contract.Assert(option.Mode == CacheMissMode.Remote);
                         foreach (var key in option.Keys)
                         {
-                            var cacheSavePath = configuration.Logging.FingerprintStoreLogDirectory
+                            var cacheSavePath = configuration.Logging.FingerprintsLogDirectory
                                 .Combine(context.PathTable, Scheduler.FingerprintStoreDirectory + "." + key);
 #pragma warning disable AsyncFixer02 // This should explicitly happen synchronously since it interacts with the PathTable and StringTable
                             var result = cache.TryRetrieveFingerprintStoreAsync(loggingContext, cacheSavePath, context.PathTable, key, configuration.Schedule.EnvironmentFingerprint).Result;

--- a/Public/Src/Engine/Scheduler/Tracing/RuntimeCacheMissAnalyzer.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/RuntimeCacheMissAnalyzer.cs
@@ -67,8 +67,8 @@ namespace BuildXL.Scheduler.Tracing
                         Contract.Assert(option.Mode == CacheMissMode.Remote);
                         foreach (var key in option.Keys)
                         {
-                            var cacheSavePath = configuration.Logging.EngineCacheLogDirectory
-                                .Combine(context.PathTable, Scheduler.FingerprintStoreDirectory + "_" + key);
+                            var cacheSavePath = configuration.Logging.FingerprintStoreLogDirectory
+                                .Combine(context.PathTable, Scheduler.FingerprintStoreDirectory + "." + key);
 #pragma warning disable AsyncFixer02 // This should explicitly happen synchronously since it interacts with the PathTable and StringTable
                             var result = cache.TryRetrieveFingerprintStoreAsync(loggingContext, cacheSavePath, context.PathTable, key, configuration.Schedule.EnvironmentFingerprint).Result;
 #pragma warning restore AsyncFixer02

--- a/Public/Src/Engine/UnitTests/FingerprintStore/FingerprintStoreTests.cs
+++ b/Public/Src/Engine/UnitTests/FingerprintStore/FingerprintStoreTests.cs
@@ -464,7 +464,7 @@ namespace Test.BuildXL.FingerprintStore
             var build = RunScheduler().AssertSuccess();
 
             // No logs should have been recorded
-            XAssert.IsFalse(Directory.Exists(build.Config.Logging.FingerprintStoreLogDirectory.ToString(Context.PathTable)));
+            XAssert.IsFalse(Directory.Exists(build.Config.Logging.ExecutionFingerprintStoreLogDirectory.ToString(Context.PathTable)));
 
             // No directory should have been created
             var fingerprintStoreDirectory = build.Config.Layout.FingerprintStoreDirectory;
@@ -1302,7 +1302,7 @@ namespace Test.BuildXL.FingerprintStore
 
         private string ResultToStoreDirectory(ScheduleRunResult result, bool cacheLookupStore = false)
         {
-            return cacheLookupStore ? result.Config.Logging.CacheLookupFingerprintStoreLogDirectory.ToString(Context.PathTable) : result.Config.Logging.FingerprintStoreLogDirectory.ToString(Context.PathTable);
+            return cacheLookupStore ? result.Config.Logging.CacheLookupFingerprintStoreLogDirectory.ToString(Context.PathTable) : result.Config.Logging.ExecutionFingerprintStoreLogDirectory.ToString(Context.PathTable);
         }
 
         /// <summary>
@@ -1345,7 +1345,7 @@ namespace Test.BuildXL.FingerprintStore
         public static ScheduleRunResult AssertCacheMissWithFingerprintStore(this ScheduleRunResult result, PathTable pathTable, PathExpander pathExpander, params PipId[] pipIds)
         {
             var misses = new HashSet<PipId>();
-            FingerprintStoreTests.FingerprintStoreSession(result.Config.Logging.FingerprintStoreLogDirectory.ToString(pathTable), store =>
+            FingerprintStoreTests.FingerprintStoreSession(result.Config.Logging.ExecutionFingerprintStoreLogDirectory.ToString(pathTable), store =>
             {
                 XAssert.IsTrue(store.TryGetCacheMissList(out var cacheMissList));
                 foreach (var miss in cacheMissList)

--- a/Public/Src/Tools/UnitTests/Analyzers/FingerprintStoreAnalyzerTests.cs
+++ b/Public/Src/Tools/UnitTests/Analyzers/FingerprintStoreAnalyzerTests.cs
@@ -771,7 +771,7 @@ namespace Test.Tool.Analyzers
 
         private string ResultToStoreDirectory(ScheduleRunResult result, bool cacheLookupStore = false)
         {
-            return cacheLookupStore ? result.Config.Logging.CacheLookupFingerprintStoreLogDirectory.ToString(Context.PathTable) : result.Config.Logging.FingerprintStoreLogDirectory.ToString(Context.PathTable);
+            return cacheLookupStore ? result.Config.Logging.CacheLookupFingerprintStoreLogDirectory.ToString(Context.PathTable) : result.Config.Logging.ExecutionFingerprintStoreLogDirectory.ToString(Context.PathTable);
         }
 
         /// <summary>

--- a/Public/Src/Utilities/Configuration/ILoggingConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/ILoggingConfiguration.cs
@@ -95,10 +95,15 @@ namespace BuildXL.Utilities.Configuration
         int FingerprintStoreMaxEntryAgeMinutes { get; }
 
         /// <summary>
+        /// Specifies the path to the fingerprints log directory which contains FingerprintStores.
+        /// </summary>
+        AbsolutePath FingerprintsLogDirectory { get; }
+
+        /// <summary>
         /// Specifies the path to the fingerprint store log directory. The log directory represents a snapshot of the persistent fingerprint store at the
         /// end of a particular build.
         /// </summary>
-        AbsolutePath FingerprintStoreLogDirectory { get; }
+        AbsolutePath ExecutionFingerprintStoreLogDirectory { get; }
 
         /// <summary>
         /// Specifies the path to the cache lookup fingerprint store log directory. This is a per-build store and does not persist build-over-build.

--- a/Public/Src/Utilities/Configuration/Mutable/LoggingConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/LoggingConfiguration.cs
@@ -30,7 +30,8 @@ namespace BuildXL.Utilities.Configuration.Mutable
             FingerprintStoreMaxEntryAgeMinutes = 4320; // 3 days
             EngineCacheLogDirectory = AbsolutePath.Invalid;
             EngineCacheCorruptFilesLogDirectory = AbsolutePath.Invalid;
-            FingerprintStoreLogDirectory = AbsolutePath.Invalid;
+            FingerprintsLogDirectory = AbsolutePath.Invalid;
+            ExecutionFingerprintStoreLogDirectory = AbsolutePath.Invalid;
             CacheLookupFingerprintStoreLogDirectory = AbsolutePath.Invalid;
             HistoricMetadataCacheLogDirectory = AbsolutePath.Invalid;
             ReplayWarnings = true;
@@ -63,7 +64,8 @@ namespace BuildXL.Utilities.Configuration.Mutable
             StoreFingerprints = template.StoreFingerprints;
             FingerprintStoreMode = template.FingerprintStoreMode;
             FingerprintStoreMaxEntryAgeMinutes = template.FingerprintStoreMaxEntryAgeMinutes;
-            FingerprintStoreLogDirectory = pathRemapper.Remap(template.FingerprintStoreLogDirectory);
+            FingerprintsLogDirectory = pathRemapper.Remap(template.FingerprintsLogDirectory)
+            ExecutionFingerprintStoreLogDirectory = pathRemapper.Remap(template.ExecutionFingerprintStoreLogDirectory);
             CacheLookupFingerprintStoreLogDirectory = pathRemapper.Remap(template.CacheLookupFingerprintStoreLogDirectory);
             HistoricMetadataCacheLogDirectory = pathRemapper.Remap(template.HistoricMetadataCacheLogDirectory);
             EngineCacheLogDirectory = pathRemapper.Remap(template.EngineCacheLogDirectory);
@@ -170,7 +172,10 @@ namespace BuildXL.Utilities.Configuration.Mutable
         public int FingerprintStoreMaxEntryAgeMinutes { get; set; }
 
         /// <inheritdoc />
-        public AbsolutePath FingerprintStoreLogDirectory { get; set; }
+        public AbsolutePath FingerprintsLogDirectory { get; set; }
+
+        /// <inheritdoc />
+        public AbsolutePath ExecutionFingerprintStoreLogDirectory { get; set; }
 
         /// <inheritdoc />
         public AbsolutePath CacheLookupFingerprintStoreLogDirectory { get; set; }

--- a/Public/Src/Utilities/Configuration/Mutable/LoggingConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/LoggingConfiguration.cs
@@ -64,7 +64,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             StoreFingerprints = template.StoreFingerprints;
             FingerprintStoreMode = template.FingerprintStoreMode;
             FingerprintStoreMaxEntryAgeMinutes = template.FingerprintStoreMaxEntryAgeMinutes;
-            FingerprintsLogDirectory = pathRemapper.Remap(template.FingerprintsLogDirectory)
+            FingerprintsLogDirectory = pathRemapper.Remap(template.FingerprintsLogDirectory);
             ExecutionFingerprintStoreLogDirectory = pathRemapper.Remap(template.ExecutionFingerprintStoreLogDirectory);
             CacheLookupFingerprintStoreLogDirectory = pathRemapper.Remap(template.CacheLookupFingerprintStoreLogDirectory);
             HistoricMetadataCacheLogDirectory = pathRemapper.Remap(template.HistoricMetadataCacheLogDirectory);


### PR DESCRIPTION
For remote cache miss mode, if a FingerprintStore is downloaded, moves the store from Logs/BuildXL/FingerprintStore_<key name> to Logs/FingerprintStore/FingerprintStore.<key name>

The Logs/FingerprintStore directory is also where the standard "FingerprintStore" and "FingerprintStore.CacheLookup" live.