### PR TITLE
Remove diagnostic flag from bxl.sh for mac

### DIFF
--- a/bxl.sh
+++ b/bxl.sh
@@ -54,7 +54,6 @@ function setInternal() {
 function compileWithBxl() {
     local args=(
         --config "$MY_DIR/config.dsc"
-        /p:[Sdk.Deployment]Diagnostics.enabled=true
         /fancyConsoleMaxStatusPips:10
         /nowarn:11319 # DX11319: nuget version mismatch
         "$@"


### PR DESCRIPTION
This is slowing down evaluation of DScript on the mac where it should only be passed when you have a double-deploy validation error. The error message clearly hints to adding this flag to include extra diagnostics on failure.