### PR TITLE
Change MsBuildResolver to support multiple entry points

### DIFF
--- a/Public/Sdk/Public/Prelude/Prelude.Configuration.Resolvers.dsc
+++ b/Public/Sdk/Public/Prelude/Prelude.Configuration.Resolvers.dsc
@@ -142,7 +142,7 @@ interface MsBuildResolver extends ResolverBase, UntrackingSettings {
      * Optional file name for the project or solution that should be used to start parsing (under the root traversal)
      * If not provided, BuildXL will try to find a candidate under the root traversal
      */
-    fileNameEntryPoint?: PathAtom;
+    fileNameEntryPoints?: RelativePath[];
     
     /**
      * Targets to execute on the entry point project. If not provided, the default targets are used.

--- a/Public/Sdk/Public/Prelude/Prelude.Configuration.Resolvers.dsc
+++ b/Public/Sdk/Public/Prelude/Prelude.Configuration.Resolvers.dsc
@@ -139,8 +139,11 @@ interface MsBuildResolver extends ResolverBase, UntrackingSettings {
     msBuildSearchLocations?: Directory[];
 
     /**
-     * Optional file name for the project or solution that should be used to start parsing (under the root traversal)
-     * If not provided, BuildXL will try to find a candidate under the root traversal
+     * Optional file paths for the projects or solutions that should be used to start parsing. These are relative 
+     * paths with respect to the root traversal.
+     *
+     * If not provided, BuildXL will attempt to find a candidate under the root traversal. If more than one candidate
+     * is available, the process will fail.
      */
     fileNameEntryPoints?: RelativePath[];
     

--- a/Public/Src/FrontEnd/MsBuild.Serialization/MSBuildGraphBuilderArguments.cs
+++ b/Public/Src/FrontEnd/MsBuild.Serialization/MSBuildGraphBuilderArguments.cs
@@ -22,7 +22,7 @@ namespace BuildXL.FrontEnd.MsBuild.Serialization
         /// <summary>
         /// Path to the entry point project to parse
         /// </summary>
-        public string ProjectToParse { get; }
+        public IReadOnlyCollection<string> ProjectToParse { get; }
 
         /// <summary>
         /// Path to the file were the graph will be serialized to
@@ -54,15 +54,15 @@ namespace BuildXL.FrontEnd.MsBuild.Serialization
 
         /// <nodoc/>
         public MSBuildGraphBuilderArguments(
-            string enlistmentRoot, 
-            string projectToParse, 
+            string enlistmentRoot,
+            IReadOnlyCollection<string> projectToParse, 
             string outputPath, 
             IReadOnlyDictionary<string, string> globalProperties, 
             IReadOnlyCollection<string> mSBuildSearchLocations, 
             IReadOnlyCollection<string> entryPointTargets)
         {
             Contract.Requires(!string.IsNullOrEmpty(enlistmentRoot));
-            Contract.Requires(!string.IsNullOrEmpty(projectToParse));
+            Contract.Requires(projectToParse != null);
             Contract.Requires(!string.IsNullOrEmpty(outputPath));
             Contract.Requires(mSBuildSearchLocations != null);
             Contract.Requires(entryPointTargets != null);
@@ -80,7 +80,7 @@ namespace BuildXL.FrontEnd.MsBuild.Serialization
         {
             return 
 $@"Enlistment root: {EnlistmentRoot}
-Project entry point: {ProjectToParse}
+Project entry point: {string.Join(" ", ProjectToParse)}
 Serialized graph path: {OutputPath}
 Global properties: {(GlobalProperties == null ? "null" : string.Join(" ", GlobalProperties.Select(kvp => $"[{kvp.Key}]={kvp.Value}")))}
 Search locations: {string.Join(" ", MSBuildSearchLocations)}";

--- a/Public/Src/FrontEnd/MsBuild.Serialization/MSBuildGraphBuilderArguments.cs
+++ b/Public/Src/FrontEnd/MsBuild.Serialization/MSBuildGraphBuilderArguments.cs
@@ -20,7 +20,8 @@ namespace BuildXL.FrontEnd.MsBuild.Serialization
         public string EnlistmentRoot { get; }
 
         /// <summary>
-        /// Paths to the entry point projects to parse
+        /// Optional file paths for the projects or solutions that should be used to start parsing. These are relative
+        /// paths with respect to the enlistment root.
         /// </summary>
         public IReadOnlyCollection<string> ProjectsToParse { get; }
 
@@ -62,7 +63,7 @@ namespace BuildXL.FrontEnd.MsBuild.Serialization
             IReadOnlyCollection<string> entryPointTargets)
         {
             Contract.Requires(!string.IsNullOrEmpty(enlistmentRoot));
-            Contract.Requires(projectsToParse != null && projectsToParse.Count > 0);
+            Contract.Requires(projectsToParse?.Count > 0);
             Contract.Requires(!string.IsNullOrEmpty(outputPath));
             Contract.Requires(mSBuildSearchLocations != null);
             Contract.Requires(entryPointTargets != null);
@@ -80,7 +81,7 @@ namespace BuildXL.FrontEnd.MsBuild.Serialization
         {
             return 
 $@"Enlistment root: {EnlistmentRoot}
-Project entry point: {string.Join(" ", ProjectsToParse)}
+Project entry points: [{string.Join(", ", ProjectsToParse)}]
 Serialized graph path: {OutputPath}
 Global properties: {(GlobalProperties == null ? "null" : string.Join(" ", GlobalProperties.Select(kvp => $"[{kvp.Key}]={kvp.Value}")))}
 Search locations: {string.Join(" ", MSBuildSearchLocations)}";

--- a/Public/Src/FrontEnd/MsBuild.Serialization/MSBuildGraphBuilderArguments.cs
+++ b/Public/Src/FrontEnd/MsBuild.Serialization/MSBuildGraphBuilderArguments.cs
@@ -20,7 +20,7 @@ namespace BuildXL.FrontEnd.MsBuild.Serialization
         public string EnlistmentRoot { get; }
 
         /// <summary>
-        /// Path to the entry point project to parse
+        /// Paths to the entry point projects to parse
         /// </summary>
         public IReadOnlyCollection<string> ProjectsToParse { get; }
 

--- a/Public/Src/FrontEnd/MsBuild.Serialization/MSBuildGraphBuilderArguments.cs
+++ b/Public/Src/FrontEnd/MsBuild.Serialization/MSBuildGraphBuilderArguments.cs
@@ -22,7 +22,7 @@ namespace BuildXL.FrontEnd.MsBuild.Serialization
         /// <summary>
         /// Path to the entry point project to parse
         /// </summary>
-        public IReadOnlyCollection<string> ProjectToParse { get; }
+        public IReadOnlyCollection<string> ProjectsToParse { get; }
 
         /// <summary>
         /// Path to the file were the graph will be serialized to
@@ -48,27 +48,27 @@ namespace BuildXL.FrontEnd.MsBuild.Serialization
         /// Collection of target entry points.
         /// </summary>
         /// <remarks>
-        /// Can be empty, in which case the default target of <see cref="ProjectToParse"/> will be used
+        /// Can be empty, in which case the default target of <see cref="ProjectsToParse"/> will be used
         /// </remarks>
         public IReadOnlyCollection<string> EntryPointTargets { get; }
 
         /// <nodoc/>
         public MSBuildGraphBuilderArguments(
             string enlistmentRoot,
-            IReadOnlyCollection<string> projectToParse, 
+            IReadOnlyCollection<string> projectsToParse, 
             string outputPath, 
             IReadOnlyDictionary<string, string> globalProperties, 
             IReadOnlyCollection<string> mSBuildSearchLocations, 
             IReadOnlyCollection<string> entryPointTargets)
         {
             Contract.Requires(!string.IsNullOrEmpty(enlistmentRoot));
-            Contract.Requires(projectToParse != null);
+            Contract.Requires(projectsToParse != null && projectsToParse.Count > 0);
             Contract.Requires(!string.IsNullOrEmpty(outputPath));
             Contract.Requires(mSBuildSearchLocations != null);
             Contract.Requires(entryPointTargets != null);
 
             EnlistmentRoot = enlistmentRoot;
-            ProjectToParse = projectToParse;
+            ProjectsToParse = projectsToParse;
             OutputPath = outputPath;
             GlobalProperties = globalProperties;
             MSBuildSearchLocations = mSBuildSearchLocations;
@@ -80,7 +80,7 @@ namespace BuildXL.FrontEnd.MsBuild.Serialization
         {
             return 
 $@"Enlistment root: {EnlistmentRoot}
-Project entry point: {string.Join(" ", ProjectToParse)}
+Project entry point: {string.Join(" ", ProjectsToParse)}
 Serialized graph path: {OutputPath}
 Global properties: {(GlobalProperties == null ? "null" : string.Join(" ", GlobalProperties.Select(kvp => $"[{kvp.Key}]={kvp.Value}")))}
 Search locations: {string.Join(" ", MSBuildSearchLocations)}";

--- a/Public/Src/FrontEnd/MsBuild/MsBuildWorkspaceResolver.cs
+++ b/Public/Src/FrontEnd/MsBuild/MsBuildWorkspaceResolver.cs
@@ -279,7 +279,7 @@ namespace BuildXL.FrontEnd.MsBuild
 
         private bool TryRetrieveParsingEntryPoint(out IEnumerable<AbsolutePath> parsingEntryPoints)
         {
-            if (m_resolverSettings.FileNameEntryPoints != null && m_resolverSettings.FileNameEntryPoints.Count > 0)
+            if (m_resolverSettings.FileNameEntryPoints?.Count > 0)
             {
                 parsingEntryPoints = m_resolverSettings.FileNameEntryPoints.Select(entryPoint => m_resolverSettings.RootTraversal.Combine(Context.PathTable, entryPoint));
                 return true;

--- a/Public/Src/FrontEnd/MsBuild/MsBuildWorkspaceResolver.cs
+++ b/Public/Src/FrontEnd/MsBuild/MsBuildWorkspaceResolver.cs
@@ -240,7 +240,7 @@ namespace BuildXL.FrontEnd.MsBuild
                     return new MsBuildGraphConstructionFailure(m_resolverSettings, Context.PathTable);
                 }
 
-                if (!TryRetrieveParsingEntryPoint(out AbsolutePath parsingEntryPoint))
+                if (!TryRetrieveParsingEntryPoint(out IEnumerable<AbsolutePath> parsingEntryPoints))
                 {
                     // Errors should have been logged
                     return new MsBuildGraphConstructionFailure(m_resolverSettings, Context.PathTable);
@@ -248,7 +248,7 @@ namespace BuildXL.FrontEnd.MsBuild
 
                 BuildParameters.IBuildParameters buildParameters = RetrieveBuildParameters();
 
-                m_projectGraph = await TryComputeBuildGraphAsync(searchLocations, parsingEntryPoint, buildParameters);
+                m_projectGraph = await TryComputeBuildGraphAsync(searchLocations, parsingEntryPoints, buildParameters);
             }
 
             return m_projectGraph.Value;
@@ -277,11 +277,11 @@ namespace BuildXL.FrontEnd.MsBuild
             return buildParameters;
         }
 
-        private bool TryRetrieveParsingEntryPoint(out AbsolutePath parsingEntryPoint)
+        private bool TryRetrieveParsingEntryPoint(out IEnumerable<AbsolutePath> parsingEntryPoints)
         {
-            if (m_resolverSettings.FileNameEntryPoint.HasValue)
+            if (m_resolverSettings.FileNameEntryPoints != null && m_resolverSettings.FileNameEntryPoints.Count > 0)
             {
-                parsingEntryPoint = m_resolverSettings.RootTraversal.Combine(Context.PathTable, m_resolverSettings.FileNameEntryPoint.Value);
+                parsingEntryPoints = m_resolverSettings.FileNameEntryPoints.Select(entryPoint => m_resolverSettings.RootTraversal.Combine(Context.PathTable, entryPoint));
                 return true;
             }
 
@@ -298,7 +298,7 @@ namespace BuildXL.FrontEnd.MsBuild
             // If there is a single element, that's the one
             if (filesInRootTraversal.Count == 1)
             {
-                parsingEntryPoint = filesInRootTraversal.First();
+                parsingEntryPoints = filesInRootTraversal;
                 return true;
             }
 
@@ -314,7 +314,7 @@ namespace BuildXL.FrontEnd.MsBuild
                 Tracing.Logger.Log.TooManyParsingEntryPointCandidates(Context.LoggingContext, m_resolverSettings.Location(Context.PathTable), m_resolverSettings.RootTraversal.ToString(Context.PathTable), candidates);
             }
             
-            parsingEntryPoint = AbsolutePath.Invalid;
+            parsingEntryPoints = null;
             return false;
 
         }
@@ -322,7 +322,7 @@ namespace BuildXL.FrontEnd.MsBuild
         /// <summary>
         /// TODO: this needs to be qualifier-specific
         /// </summary>
-        private async Task<Possible<ProjectGraphResult>> TryComputeBuildGraphAsync(IEnumerable<AbsolutePath> searchLocations, AbsolutePath parsingEntryPoint, BuildParameters.IBuildParameters buildParameters)
+        private async Task<Possible<ProjectGraphResult>> TryComputeBuildGraphAsync(IEnumerable<AbsolutePath> searchLocations, IEnumerable<AbsolutePath> parsingEntryPoints, BuildParameters.IBuildParameters buildParameters)
         {
             // We create a unique output file on the obj folder associated with the current front end, and using a GUID as the file name
             AbsolutePath outputDirectory = FrontEndHost.GetFolderForFrontEnd(m_frontEnd.Name);
@@ -333,7 +333,7 @@ namespace BuildXL.FrontEnd.MsBuild
             // Make sure the directories are there
             FileUtilities.CreateDirectory(outputDirectory.ToString(Context.PathTable));
 
-            Possible<ProjectGraphWithPredictionsResult<AbsolutePath>> maybeProjectGraphResult = await ComputeBuildGraphAsync(responseFile, parsingEntryPoint, outputFile, searchLocations, buildParameters);
+            Possible<ProjectGraphWithPredictionsResult<AbsolutePath>> maybeProjectGraphResult = await ComputeBuildGraphAsync(responseFile, parsingEntryPoints, outputFile, searchLocations, buildParameters);
 
             if (!maybeProjectGraphResult.Succeeded)
             {
@@ -428,12 +428,12 @@ namespace BuildXL.FrontEnd.MsBuild
 
         private async Task<Possible<ProjectGraphWithPredictionsResult<AbsolutePath>>> ComputeBuildGraphAsync(
             AbsolutePath responseFile,
-            AbsolutePath projectEntryPoint, 
+            IEnumerable<AbsolutePath> projectEntryPoints, 
             AbsolutePath outputFile, 
             IEnumerable<AbsolutePath> searchLocations, 
             BuildParameters.IBuildParameters buildParameters)
         {
-            SandboxedProcessResult result = await RunMsBuildGraphBuilderAsync(responseFile, projectEntryPoint, outputFile, searchLocations, buildParameters);
+            SandboxedProcessResult result = await RunMsBuildGraphBuilderAsync(responseFile, projectEntryPoints, outputFile, searchLocations, buildParameters);
 
             string standardError = result.StandardError.CreateReader().ReadToEndAsync().GetAwaiter().GetResult();
 
@@ -505,7 +505,7 @@ namespace BuildXL.FrontEnd.MsBuild
 
         private Task<SandboxedProcessResult> RunMsBuildGraphBuilderAsync(
             AbsolutePath responseFile,
-            AbsolutePath projectEntryPoint, 
+            IEnumerable<AbsolutePath> projectEntryPoints, 
             AbsolutePath outputFile, 
             IEnumerable<AbsolutePath> searchLocations, 
             BuildParameters.IBuildParameters buildParameters)
@@ -519,7 +519,7 @@ namespace BuildXL.FrontEnd.MsBuild
                 
             var arguments = new MSBuildGraphBuilderArguments(
                 enlistmentRoot,
-                projectEntryPoint.ToString(Context.PathTable),
+                projectEntryPoints.Select(entryPoint => entryPoint.ToString(Context.PathTable)).ToList(),
                 outputFileString,
                 m_resolverSettings.GlobalProperties,
                 searchLocations.Select(location => location.ToString(Context.PathTable)).ToList(),

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/ExecutionTests/MsBuildIntegrationTests.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/ExecutionTests/MsBuildIntegrationTests.cs
@@ -85,7 +85,7 @@ namespace Test.BuildXL.FrontEnd.MsBuild
             var pathToTestProj2 = R("public", "dir2", TestProj2);
 
             const string Dirs = "dirs.proj";
-            var config = (CommandLineConfiguration)Build($"fileNameEntryPoint: a`{Dirs}`")
+            var config = (CommandLineConfiguration)Build($"fileNameEntryPoints: [ r`{Dirs}` ]")
                     .AddSpec(Dirs, CreateDirsProject(pathToTestProj1, pathToTestProj2))
                     .AddSpec(pathToTestProj1, CreateWriteFileTestProject("MyFile1.txt"))
                     .AddSpec(pathToTestProj2, CreateWriteFileTestProject("MyFile2.txt", projectReference: pathToTestProj1))

--- a/Public/Src/Tools/Tool.MsBuildGraphBuilder/MsBuildGraphBuilder.cs
+++ b/Public/Src/Tools/Tool.MsBuildGraphBuilder/MsBuildGraphBuilder.cs
@@ -127,7 +127,7 @@ namespace MsBuildGraphBuilderTool
             GraphBuilderReporter reporter,
             IReadOnlyDictionary<string, string> assemblyPathsToLoad,
             string locatedMsBuildPath,
-            string projectEntryPoint,
+            IReadOnlyCollection<string> projectEntryPoints,
             string enlistmentRoot,
             IReadOnlyDictionary<string, string> globalProperties,
             IReadOnlyCollection<string> entryPointTargets,
@@ -138,9 +138,10 @@ namespace MsBuildGraphBuilderTool
                 reporter.ReportMessage("Parsing MSBuild specs and constructing the build graph...");
 
                 var projectInstanceToProjectCache = new ConcurrentDictionary<ProjectInstance, Project>();
-                var thisQualifierProjectCollection = new ProjectCollection(globalProperties: globalProperties?.ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
+                var globalPropertiesDict = globalProperties?.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+                var thisQualifierProjectCollection = new ProjectCollection(globalProperties: globalPropertiesDict);
                 var projectGraph = new ProjectGraph(
-                    projectEntryPoint, 
+                    projectEntryPoints.Select(entryPoint => new ProjectGraphEntryPoint(entryPoint, globalPropertiesDict)), 
                     thisQualifierProjectCollection, 
                     (projectPath, globalProps, projectCollection) => ProjectInstanceFactory(projectPath, globalProps, projectCollection, projectInstanceToProjectCache));
 

--- a/Public/Src/Tools/Tool.MsBuildGraphBuilder/MsBuildGraphBuilder.cs
+++ b/Public/Src/Tools/Tool.MsBuildGraphBuilder/MsBuildGraphBuilder.cs
@@ -113,7 +113,7 @@ namespace MsBuildGraphBuilderTool
                 reporter,
                 locatedAssemblyPaths,
                 locatedMsBuildPath,
-                arguments.ProjectToParse,
+                arguments.ProjectsToParse,
                 arguments.EnlistmentRoot,
                 arguments.GlobalProperties,
                 arguments.EntryPointTargets,

--- a/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphConstructionTests.cs
+++ b/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphConstructionTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using BuildXL.FrontEnd.MsBuild.Serialization;
 using MsBuildGraphBuilderTool;
@@ -50,7 +51,7 @@ namespace Test.ProjectGraphBuilder
             var entryPointPath = m_builder.WriteProjectsWithReferences(projectChains);
 
             // Parse the projects, build the graph, serialize it to disk and deserialize it back
-            var projectGraphWithPredictionsResult = BuildGraphAndDeserialize(entryPointPath);
+            var projectGraphWithPredictionsResult = BuildGraphAndDeserialize(new[] { entryPointPath });
 
             Assert.True(projectGraphWithPredictionsResult.Succeeded);
 
@@ -58,14 +59,14 @@ namespace Test.ProjectGraphBuilder
             m_builder.ValidateGraphIsSubgraphOfChains(projectGraphWithPredictionsResult.Result, exactMatch, projectChains);
         }
 
-        private ProjectGraphWithPredictionsResult<string> BuildGraphAndDeserialize(string projectEntryPoint)
+        private ProjectGraphWithPredictionsResult<string> BuildGraphAndDeserialize(IReadOnlyCollection<string> projectEntryPoints)
         {
             string outputFile = Path.Combine(TemporaryDirectory, Guid.NewGuid().ToString());
 
             MsBuildGraphBuilder.BuildGraphAndSerialize(
                 new MSBuildGraphBuilderArguments(
                     TestOutputDirectory,
-                    projectEntryPoint,
+                    projectEntryPoints,
                     outputFile,
                     globalProperties: null,
                     mSBuildSearchLocations: new[] {TestDeploymentDir},

--- a/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphDecorationTests.cs
+++ b/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphDecorationTests.cs
@@ -79,7 +79,7 @@ namespace Test.ProjectGraphBuilder
             {
                 var arguments = new MSBuildGraphBuilderArguments(
                     TemporaryDirectory,
-                    entryPoint,
+                    new[] { entryPoint },
                     outputFile,
                     globalProperties: null,
                     mSBuildSearchLocations: new string[] {TestDeploymentDir},

--- a/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphProgressTests.cs
+++ b/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphProgressTests.cs
@@ -71,7 +71,7 @@ namespace Test.ProjectGraphBuilder
             string outputFile = Path.Combine(TemporaryDirectory, Guid.NewGuid().ToString());
             var arguments = new MSBuildGraphBuilderArguments(
                 TestOutputDirectory,
-                m_entryPoint,
+                new[] { m_entryPoint },
                 outputFile,
                 globalProperties: null,
                 mSBuildSearchLocations: new[] {TestDeploymentDir},

--- a/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphStaticPredictionTests.cs
+++ b/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphStaticPredictionTests.cs
@@ -46,7 +46,7 @@ namespace Test.ProjectGraphBuilder
             MsBuildGraphBuilder.BuildGraphAndSerialize(
                 new MSBuildGraphBuilderArguments(
                     TestOutputDirectory,
-                    entryPoint,
+                    new[] { entryPoint },
                     outputFile,
                     globalProperties: null,
                     mSBuildSearchLocations: new[] {TestDeploymentDir},
@@ -73,7 +73,7 @@ namespace Test.ProjectGraphBuilder
             {
                 var arguments = new MSBuildGraphBuilderArguments(
                     TestOutputDirectory,
-                    entryPoint,
+                    new[] { entryPoint },
                     outputFile,
                     globalProperties: null,
                     mSBuildSearchLocations: new[] {TestDeploymentDir},

--- a/Public/Src/Utilities/Configuration/Resolvers/IMsBuildResolverSettings.cs
+++ b/Public/Src/Utilities/Configuration/Resolvers/IMsBuildResolverSettings.cs
@@ -55,10 +55,12 @@ namespace BuildXL.Utilities.Configuration
         IReadOnlyList<DirectoryArtifact> MsBuildSearchLocations { get; }
 
         /// <summary>
-        /// Optional file name for the project or solution that should be used to start parsing (under the root traversal)
+        /// Optional file paths for the projects or solutions that should be used to start parsing. These are relative 
+        /// paths with respect to the root traversal.
         /// </summary>
         /// <remarks>
-        /// If not provided, BuildXL will try to find a candidate under the root traversal
+        /// If not provided, BuildXL will attempt to find a candidate under the root traversal. If more than one 
+        /// candidate is available, the process will fail.
         /// </remarks>
         IReadOnlyList<RelativePath> FileNameEntryPoints { get; }
 

--- a/Public/Src/Utilities/Configuration/Resolvers/IMsBuildResolverSettings.cs
+++ b/Public/Src/Utilities/Configuration/Resolvers/IMsBuildResolverSettings.cs
@@ -60,7 +60,7 @@ namespace BuildXL.Utilities.Configuration
         /// <remarks>
         /// If not provided, BuildXL will try to find a candidate under the root traversal
         /// </remarks>
-        PathAtom? FileNameEntryPoint { get; }
+        IReadOnlyList<RelativePath> FileNameEntryPoints { get; }
 
         /// <summary>
         /// Targets to execute on the entry point project.

--- a/Public/Src/Utilities/Configuration/Resolvers/Mutable/MsBuildResolverSettings.cs
+++ b/Public/Src/Utilities/Configuration/Resolvers/Mutable/MsBuildResolverSettings.cs
@@ -34,7 +34,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             UntrackedDirectories = resolverSettings.UntrackedDirectories;
             RunInContainer = resolverSettings.RunInContainer;
             MsBuildSearchLocations = resolverSettings.MsBuildSearchLocations;
-            FileNameEntryPoint = resolverSettings.FileNameEntryPoint;
+            FileNameEntryPoints = resolverSettings.FileNameEntryPoints;
             InitialTargets = resolverSettings.InitialTargets;
             Environment = resolverSettings.Environment;
             GlobalProperties = resolverSettings.GlobalProperties;
@@ -73,7 +73,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
         public IReadOnlyList<DirectoryArtifact> MsBuildSearchLocations { get; set; }
 
         /// <inheritdoc/>
-        public PathAtom? FileNameEntryPoint { get; set; }
+        public IReadOnlyList<RelativePath> FileNameEntryPoints { get; set; }
 
         /// <inheritdoc/>
         public IReadOnlyList<string> InitialTargets { get; set; }


### PR DESCRIPTION
Enabling multiple entry points in the MSBuildResolver is required to support the VcPkg integration.

This functionality breaks anyone using the MSBuildResolver and the `fileNameEntryPoint` setting, as these are now relative paths to the root of the project instead of atoms. The name has been changed as well.
