### PR TITLE
Failed USN read gracefully when read request not supported

### DIFF
--- a/Public/Src/Utilities/Native/IO/Windows/FileSystem.Win.cs
+++ b/Public/Src/Utilities/Native/IO/Windows/FileSystem.Win.cs
@@ -1167,7 +1167,8 @@ namespace BuildXL.Native.IO.Windows
                     error == NativeIOConstants.ErrorJournalNotActive ||
                     error == NativeIOConstants.ErrorInvalidFunction ||
                     error == NativeIOConstants.ErrorOnlyIfConnected ||
-                    error == NativeIOConstants.ErrorAccessDenied)
+                    error == NativeIOConstants.ErrorAccessDenied ||
+                    error == NativeIOConstants.ErrorNotSupported)
                 {
                     return null;
                 }


### PR DESCRIPTION
When read request is not supported because 
**journal query error 'FailedToOpenVolumeHandle': Failed to open a volume handle for the volume '\\?\Volume{15467674-7855-44df-a9a2-e27782706177}\'**

USN read request on that volume results in a catastrophic error:
**Exception:BuildXL.Native.IO.NativeWin32Exception (0x80070032): Native: DeviceIoControl(FSCTL_READ_FILE_USN_DATA) for ReadFileUsnByHandle failed (0x32: The request is not supported)**

With this change, we simply failed gracefully, by returning null. Consequently, the tracker will stop tracking because missing to track a single important file can result in unfaithful data in the tracker state.

[AB#1496397](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1496397)