### PR TITLE
Add try finally block to reset m_isSerializationInProgress

### DIFF
--- a/Public/Src/Utilities/Utilities/HierarchicalNameTable.cs
+++ b/Public/Src/Utilities/Utilities/HierarchicalNameTable.cs
@@ -1878,16 +1878,22 @@ namespace BuildXL.Utilities
             m_isSerializationInProgress = true;
             // Actual serialization done in a static method with a snapshot of internal state to ensure nothing is
             // written that isn't accessible during deserialization
-            Serialize(
-                writer,
-                new SerializedState()
-                {
-                    DebugTag = DebugTag,
-                    IgnoreCase = m_ignoreCase,
-                    NodeCount = Count,
-                    NodeMap = m_nodeMap,
-                });
-            m_isSerializationInProgress = false;
+            try
+            {
+                Serialize(
+                    writer,
+                    new SerializedState()
+                    {
+                        DebugTag = DebugTag,
+                        IgnoreCase = m_ignoreCase,
+                        NodeCount = Count,
+                        NodeMap = m_nodeMap,
+                    });
+            }
+            finally
+            {
+                m_isSerializationInProgress = false;
+            }
         }
 
         /// <summary>

--- a/Public/Src/Utilities/Utilities/StringTable.cs
+++ b/Public/Src/Utilities/Utilities/StringTable.cs
@@ -1100,14 +1100,14 @@ namespace BuildXL.Utilities
             try
             {
                 Serialize(
-                writer,
-                new SerializedState()
-                {
-                    Count = Count,
-                    NextId = m_nextId,
-                    StringSet = m_stringSet,
-                    ByteBuffers = m_byteBuffers,
-                });
+                    writer,
+                    new SerializedState()
+                    {
+                        Count = Count,
+                        NextId = m_nextId,
+                        StringSet = m_stringSet,
+                        ByteBuffers = m_byteBuffers,
+                    });
             }
             finally
             {

--- a/Public/Src/Utilities/Utilities/StringTable.cs
+++ b/Public/Src/Utilities/Utilities/StringTable.cs
@@ -1097,7 +1097,9 @@ namespace BuildXL.Utilities
 
             m_isSerializationInProgress = true;
             // Call a static method to do the actual serialization to ensure not state outside of SerializedState is used
-            Serialize(
+            try
+            {
+                Serialize(
                 writer,
                 new SerializedState()
                 {
@@ -1106,7 +1108,11 @@ namespace BuildXL.Utilities
                     StringSet = m_stringSet,
                     ByteBuffers = m_byteBuffers,
                 });
-            m_isSerializationInProgress = false;
+            }
+            finally
+            {
+                m_isSerializationInProgress = false;
+            }         
         }
 
         private static void Serialize(BuildXLWriter writer, SerializedState state)


### PR DESCRIPTION
When exception happens during the serialization, m_isSerializationInProgress can't be reset. So the table will stay in the state of SerializationInProgress and no new item can be added to it. The crash in the bug happened in this case. Adding the finally block can reset the m_isSerializationInProgress and solve the problem.

Fixes [AB#1419013](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1419013)