### PR TITLE
Fix reporting of composite opaque content

### DIFF
--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -5109,7 +5109,8 @@ namespace BuildXL.Scheduler
                         aggregatedContent.AddRange(memberContents);
                     }
 
-                    m_fileContentManager.ReportDynamicDirectoryContents(pip.Directory, aggregatedContent, PipOutputOrigin.UpToDate);
+                    // the directory artifacts that this composite shared opaque consists of might or might not be materialized
+                    m_fileContentManager.ReportDynamicDirectoryContents(pip.Directory, aggregatedContent, PipOutputOrigin.NotMaterialized);
                 }
             }
         }

--- a/Public/Src/Utilities/UnitTests/Executables/TestProcess/Operation.cs
+++ b/Public/Src/Utilities/UnitTests/Executables/TestProcess/Operation.cs
@@ -95,6 +95,11 @@ namespace Test.BuildXL.Executables.TestProcess
             ReadFile,
 
             /// <summary>
+            /// Type for reading a file (fails if a file does not exist)
+            /// </summary>
+            ReadRequiredFile,
+
+            /// <summary>
             /// Type for copying a file
             /// </summary>
             CopyFile,
@@ -294,6 +299,9 @@ namespace Test.BuildXL.Executables.TestProcess
                     case Type.ReadFile:
                         DoReadFile();
                         return;
+                    case Type.ReadRequiredFile:
+                        DoReadRequiredFile();
+                        return;
                     case Type.CopyFile:
                         DoCopyFile();
                         return;
@@ -436,6 +444,14 @@ namespace Test.BuildXL.Executables.TestProcess
         public static Operation ReadFile(FileArtifact path, bool doNotInfer = false)
         {
             return new Operation(Type.ReadFile, path, doNotInfer: doNotInfer);
+        }
+
+        /// <summary>
+        /// Creates a read file operation (fails if a file does not exist)
+        /// </summary>
+        public static Operation ReadRequiredFile(FileArtifact path, bool doNotInfer = false)
+        {
+            return new Operation(Type.ReadRequiredFile, path, doNotInfer: doNotInfer);
         }
 
         /// <summary>
@@ -689,6 +705,11 @@ namespace Test.BuildXL.Executables.TestProcess
             {
                 // Ignore tests for denied file access policies
             }
+        }
+
+        private void DoReadRequiredFile()
+        {
+            File.ReadAllText(FileOrDirectoryToString(Path));
         }
 
         private void DoCopyFile()


### PR DESCRIPTION
Prior to this PR, we were reporting the content of shared composite opaques as 'UpToDate'. This potetntially might lead to us not materializing all dependencies in some cases. 

Consider the following example:
pipA -> dirA (worker#1)
pipB -> dirB (worker#1)
compositeDir  = {dirA, dirB}
compositeDir -> pipC (worker#2)

Since pipA and pipB ran on a different worker, their outputs are absent from worker#2. compositeDir is marked as materialized, so BXL would not attempt to materialize the files. Now when pipC actually runs, its inputs will not be ready.