### PR TITLE
Bump minimum required version of MSBuild

### DIFF
--- a/Public/Src/Tools/Tool.MsBuildGraphBuilder/MsBuildAssemblyLoader.cs
+++ b/Public/Src/Tools/Tool.MsBuildGraphBuilder/MsBuildAssemblyLoader.cs
@@ -22,7 +22,7 @@ namespace MsBuildGraphBuilderTool
         private const string DotNetPublicToken = "cc7b13ffcd2ddd51";
 
         private static readonly Version s_minimumRequiredMsBuildAssemblyVersion = new Version("15.1.0.0");
-        private static readonly Version s_minimumRequiredMsBuildFileVersion = new Version("16.0.439.61203");
+        private static readonly Version s_minimumRequiredMsBuildFileVersion = new Version("16.1.42.55196");
 
         // List of required assemblies
         private const string MicrosoftBuild = "Microsoft.Build.dll";


### PR DESCRIPTION
Bump the minimum required version of MSBuild for BuildXL so it matches the latest API/cross targeting functionality