### PR TITLE
Make purging on startup optional for quota keeper.

### DIFF
--- a/Public/Src/Cache/ContentStore/Library/Stores/ContentStoreSettings.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/ContentStoreSettings.cs
@@ -36,6 +36,11 @@ namespace BuildXL.Cache.ContentStore.Stores
         /// </remarks>
         public bool UseLegacyQuotaKeeperImplementation { get; set; } = true;
 
+        /// <summary>
+        /// If true, then quota keeper will check the current content directory size and start content eviction at startup if the threshold is reached.
+        /// </summary>
+        public bool StartPurgingAtStartup { get; set; } = true;
+
         /// <nodoc />
         public static ContentStoreSettings DefaultSettings { get; } = new ContentStoreSettings();
     }

--- a/Public/Src/Cache/ContentStore/Library/Stores/FileSystemContentStoreInternal.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/FileSystemContentStoreInternal.cs
@@ -1105,9 +1105,9 @@ namespace BuildXL.Cache.ContentStore.Stores
         /// <summary>
         ///     Complete all pending/background operations.
         /// </summary>
-        public async Task SyncAsync(Context context)
+        public async Task SyncAsync(Context context, bool purge = true)
         {
-            await _quotaKeeper.SyncAsync(context);
+            await _quotaKeeper.SyncAsync(context, purge);
 
             // Ensure there are no pending LRU updates.
             await ContentDirectory.SyncAsync();

--- a/Public/Src/Cache/ContentStore/Library/Stores/FileSystemContentStoreInternal.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/FileSystemContentStoreInternal.cs
@@ -672,9 +672,8 @@ namespace BuildXL.Cache.ContentStore.Stores
             var quotaKeeperConfiguration = QuotaKeeperConfiguration.Create(
                 Configuration,
                 _distributedEvictionSettings,
-                size,
-                _settings.StartPurgingAtStartup,
-                _settings.UseLegacyQuotaKeeperImplementation);
+                _settings,
+                size);
             _quotaKeeper = QuotaKeeper.Create(
                 FileSystem,
                 _tracer,

--- a/Public/Src/Cache/ContentStore/Library/Stores/FileSystemContentStoreInternal.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/FileSystemContentStoreInternal.cs
@@ -669,15 +669,18 @@ namespace BuildXL.Cache.ContentStore.Stores
                 GetPinnedSize,
                 _nagleQueue);
 
+            var quotaKeeperConfiguration = QuotaKeeperConfiguration.Create(
+                Configuration,
+                _distributedEvictionSettings,
+                size,
+                _settings.StartPurgingAtStartup,
+                _settings.UseLegacyQuotaKeeperImplementation);
             _quotaKeeper = QuotaKeeper.Create(
                 FileSystem,
                 _tracer,
-                Configuration,
-                size,
                 ShutdownStartedCancellationToken,
                 this,
-                _distributedEvictionSettings,
-                useLegacyQuotaKeeper: _settings.UseLegacyQuotaKeeperImplementation);
+                quotaKeeperConfiguration);
 
             var result = await _quotaKeeper.StartupAsync(context);
 

--- a/Public/Src/Cache/ContentStore/Library/Stores/IContentStoreInternal.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/IContentStoreInternal.cs
@@ -303,7 +303,7 @@ namespace BuildXL.Cache.ContentStore.Stores
         /// <summary>
         ///     Complete all pending/background operations.
         /// </summary>
-        Task SyncAsync(Context context);
+        Task SyncAsync(Context context, bool purge = true);
 
         /// <summary>
         ///     Read pin history.

--- a/Public/Src/Cache/ContentStore/Library/Stores/QuotaManagement/LegacyQuotaKeeper.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/QuotaManagement/LegacyQuotaKeeper.cs
@@ -158,12 +158,12 @@ namespace BuildXL.Cache.ContentStore.Stores
         }
 
         /// <inheritdoc />
-        public override async Task SyncAsync(Context context)
+        public override async Task SyncAsync(Context context, bool purge)
         {
             // Ensure there are no pending requests.
-            var emptyRequest = new Request<QuotaKeeperRequest, string>(QuotaKeeperRequest.Synchronize());
-            _reserveQueue.Add(emptyRequest);
-            await emptyRequest.WaitForCompleteAsync();
+            var request = new Request<QuotaKeeperRequest, string>(purge ? QuotaKeeperRequest.Reserve(0) :QuotaKeeperRequest.Synchronize());
+            _reserveQueue.Add(request);
+            await request.WaitForCompleteAsync();
 
             var purgeTask = _purgeTask;
             if (purgeTask != null)
@@ -515,7 +515,7 @@ namespace BuildXL.Cache.ContentStore.Stores
                 Calibrate,
 
                 /// <summary>
-                ///     Request used by <see cref="QuotaKeeper.SyncAsync(Context)"/>.
+                ///     Request used by <see cref="QuotaKeeper.SyncAsync"/>.
                 /// </summary>
                 Sync
             }

--- a/Public/Src/Cache/ContentStore/Library/Stores/QuotaManagement/LegacyQuotaKeeper.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/QuotaManagement/LegacyQuotaKeeper.cs
@@ -85,6 +85,10 @@ namespace BuildXL.Cache.ContentStore.Stores
                 // over the cache quota if configured.
                 StartPurging();
             }
+            else
+            {
+                _tracer.Debug(context, $"{_tracer.Name}: do not purge at startup based on configuration settings.");
+            }
 
             return BoolResult.Success;
         }

--- a/Public/Src/Cache/ContentStore/Library/Stores/QuotaManagement/QuotaKeeper.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/QuotaManagement/QuotaKeeper.cs
@@ -80,7 +80,7 @@ namespace BuildXL.Cache.ContentStore.Stores
         /// <summary>
         /// Completes all the pending operations (like reservation and/or calibration requests).
         /// </summary>
-        public abstract Task SyncAsync(Context context);
+        public abstract Task SyncAsync(Context context, bool purge);
 
         /// <summary>
         /// Reserve room for specified content size.

--- a/Public/Src/Cache/ContentStore/Library/Stores/QuotaManagement/QuotaKeeperConfiguration.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/QuotaManagement/QuotaKeeperConfiguration.cs
@@ -35,7 +35,9 @@ namespace BuildXL.Cache.ContentStore.Stores
         /// </summary>
         public int? HistoryWindowSize { get; private set; }
 
-        /// <nodoc />
+        /// <summary>
+        /// <see cref="DistributedEvictionSettings"/>.
+        /// </summary>
         public DistributedEvictionSettings DistributedEvictionSettings { get; private set; }
 
         /// <summary>
@@ -62,9 +64,8 @@ namespace BuildXL.Cache.ContentStore.Stores
         public static QuotaKeeperConfiguration Create(
             ContentStoreConfiguration configuration,
             DistributedEvictionSettings evictionSettings,
-            long contentDirectorySize,
-            bool startPurgingAtStartup = true,
-            bool useLegacyQuotaKeeper = false)
+            ContentStoreSettings contentStoreSettings,
+            long contentDirectorySize)
         {
             Contract.Requires(configuration != null);
 
@@ -77,8 +78,8 @@ namespace BuildXL.Cache.ContentStore.Stores
                        HistoryWindowSize = configuration.HistoryWindowSize,
                        DistributedEvictionSettings = evictionSettings,
                        ContentDirectorySize = contentDirectorySize,
-                       StartPurgingAtStartup = startPurgingAtStartup,
-                       UseLegacyQuotaKeeper = useLegacyQuotaKeeper,
+                       StartPurgingAtStartup = contentStoreSettings.StartPurgingAtStartup,
+                       UseLegacyQuotaKeeper = contentStoreSettings.UseLegacyQuotaKeeperImplementation,
                    };
         }
     }

--- a/Public/Src/Cache/ContentStore/Library/Stores/QuotaManagement/QuotaKeeperConfiguration.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/QuotaManagement/QuotaKeeperConfiguration.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.ContractsLight;
+
+namespace BuildXL.Cache.ContentStore.Stores
+{
+    /// <summary>
+    /// Configuration settings for <see cref="QuotaKeeper"/>.
+    /// </summary>
+    public sealed class QuotaKeeperConfiguration
+    {
+        /// <summary>
+        /// <see cref="ContentStoreConfiguration.EnableElasticity"/>.
+        /// </summary>
+        public bool EnableElasticity { get; private set; }
+
+        /// <summary>
+        /// <see cref="ContentStoreConfiguration.MaxSizeQuota"/>.
+        /// </summary>
+        public MaxSizeQuota MaxSizeQuota { get; private set; }
+
+        /// <summary>
+        /// <see cref="ContentStoreConfiguration.DiskFreePercentQuota"/>.
+        /// </summary>
+        public DiskFreePercentQuota DiskFreePercentQuota { get; private set; }
+
+        /// <summary>
+        /// <see cref="ContentStoreConfiguration.InitialElasticSize"/>.
+        /// </summary>
+        public MaxSizeQuota InitialElasticSize { get; private set; }
+
+        /// <summary>
+        /// <see cref="ContentStoreConfiguration.HistoryWindowSize"/>.
+        /// </summary>
+        public int? HistoryWindowSize { get; private set; }
+
+        /// <nodoc />
+        public DistributedEvictionSettings DistributedEvictionSettings { get; private set; }
+
+        /// <summary>
+        /// Initial size of the content directory.
+        /// </summary>
+        public long ContentDirectorySize { get; private set; }
+
+        /// <summary>
+        /// If true, then quota keeper will check the current content directory size and start content eviction at startup if the threshold is reached.
+        /// </summary>
+        public bool StartPurgingAtStartup { get; private set; }
+
+        /// <summary>
+        /// If true, then <see cref="LegacyQuotaKeeper"/> is used, otherwise <see cref="QuotaKeeperV2"/> is used.
+        /// </summary>
+        public bool UseLegacyQuotaKeeper { get; private set; }
+
+        /// <nodoc />
+        private QuotaKeeperConfiguration()
+        {
+        }
+
+        /// <nodoc />
+        public static QuotaKeeperConfiguration Create(
+            ContentStoreConfiguration configuration,
+            DistributedEvictionSettings evictionSettings,
+            long contentDirectorySize,
+            bool startPurgingAtStartup = true,
+            bool useLegacyQuotaKeeper = false)
+        {
+            Contract.Requires(configuration != null);
+
+            return new QuotaKeeperConfiguration()
+                   {
+                       EnableElasticity = configuration.EnableElasticity,
+                       MaxSizeQuota = configuration.MaxSizeQuota,
+                       DiskFreePercentQuota = configuration.DiskFreePercentQuota,
+                       InitialElasticSize = configuration.InitialElasticSize,
+                       HistoryWindowSize = configuration.HistoryWindowSize,
+                       DistributedEvictionSettings = evictionSettings,
+                       ContentDirectorySize = contentDirectorySize,
+                       StartPurgingAtStartup = startPurgingAtStartup,
+                       UseLegacyQuotaKeeper = useLegacyQuotaKeeper,
+                   };
+        }
+    }
+}

--- a/Public/Src/Cache/ContentStore/Library/Stores/QuotaManagement/QuotaKeeperV2.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/QuotaManagement/QuotaKeeperV2.cs
@@ -10,7 +10,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using BuildXL.Cache.ContentStore.Exceptions;
-using BuildXL.Cache.ContentStore.Synchronization;
 using BuildXL.Cache.ContentStore.Tracing;
 using BuildXL.Cache.ContentStore.Tracing.Internal;
 using BuildXL.Cache.ContentStore.Interfaces.Extensions;

--- a/Public/Src/Cache/ContentStore/Library/Stores/QuotaManagement/QuotaKeeperV2.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/QuotaManagement/QuotaKeeperV2.cs
@@ -114,6 +114,10 @@ namespace BuildXL.Cache.ContentStore.Stores
                 const string Operation = "PurgeRequest";
                 SendPurgeRequest(context, "Startup").FireAndForget(context, Operation);
             }
+            else
+            {
+                _tracer.Debug(context, $"{_tracer.Name}: do not purge at startup based on configuration settings.");
+            }
 
             return BoolResult.Success;
         }

--- a/Public/Src/Cache/ContentStore/Library/Stores/QuotaManagement/QuotaRequest.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/QuotaManagement/QuotaRequest.cs
@@ -26,6 +26,9 @@ namespace BuildXL.Cache.ContentStore.Stores
         public static ReserveSpaceRequest Purge() => Reserve(0);
 
         /// <nodoc />
+        public static SynchronizationRequest Synchronize() => SynchronizationRequest.Instance;
+
+        /// <nodoc />
         public Task<BoolResult> CompletionAsync() => _taskSource.Task;
 
         /// <nodoc />
@@ -55,6 +58,18 @@ namespace BuildXL.Cache.ContentStore.Stores
 
         /// <inheritdoc />
         public override string ToString() => $"Reservation request for {ReserveSize} bytes";
+    }
+
+    /// <summary>
+    /// Request to <see cref="QuotaKeeperV2"/> for processing all pending requests.
+    /// </summary>
+    internal sealed class SynchronizationRequest : QuotaRequest
+    {
+        /// <nodoc />
+        public static SynchronizationRequest Instance { get; } = new SynchronizationRequest();
+
+        /// <inheritdoc />
+        public override string ToString() => $"Synchronization";
     }
 
     /// <summary>

--- a/Public/Src/Cache/ContentStore/Library/Stores/QuotaManagement/QuotaRequest.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/QuotaManagement/QuotaRequest.cs
@@ -26,7 +26,7 @@ namespace BuildXL.Cache.ContentStore.Stores
         public static ReserveSpaceRequest Purge() => Reserve(0);
 
         /// <nodoc />
-        public static SynchronizationRequest Synchronize() => SynchronizationRequest.Instance;
+        public static SynchronizationRequest Synchronize() => new SynchronizationRequest();
 
         /// <nodoc />
         public Task<BoolResult> CompletionAsync() => _taskSource.Task;
@@ -65,9 +65,6 @@ namespace BuildXL.Cache.ContentStore.Stores
     /// </summary>
     internal sealed class SynchronizationRequest : QuotaRequest
     {
-        /// <nodoc />
-        public static SynchronizationRequest Instance { get; } = new SynchronizationRequest();
-
         /// <inheritdoc />
         public override string ToString() => $"Synchronization";
     }

--- a/Public/Src/Cache/ContentStore/Test/Stores/DiskFreePercentRuleTests.cs
+++ b/Public/Src/Cache/ContentStore/Test/Stores/DiskFreePercentRuleTests.cs
@@ -401,7 +401,7 @@ namespace ContentStoreTest.Stores
                 throw new NotImplementedException();
             }
 
-            public Task SyncAsync(Context context)
+            public Task SyncAsync(Context context, bool purge = true)
             {
                 throw new NotImplementedException();
             }

--- a/Public/Src/Cache/ContentStore/Test/Stores/FileSystemContentStoreInternalDiskFreePercentPurgeTests.cs
+++ b/Public/Src/Cache/ContentStore/Test/Stores/FileSystemContentStoreInternalDiskFreePercentPurgeTests.cs
@@ -40,7 +40,8 @@ namespace ContentStoreTest.Stores
                 config,
                 contentHashWithSize => ((MyMemoryFileSystem)FileSystem).ContentAdded(contentHashWithSize.Size),
                 contentHashWithSize => ((MyMemoryFileSystem)FileSystem).ContentEvicted(contentHashWithSize.Size),
-                nagleBlock
+                nagleBlock,
+                settings: ContentStoreSettings
                 );
         }
 

--- a/Public/Src/Cache/ContentStore/Test/Stores/FileSystemContentStoreInternalMaxSizePurgeTests.cs
+++ b/Public/Src/Cache/ContentStore/Test/Stores/FileSystemContentStoreInternalMaxSizePurgeTests.cs
@@ -37,7 +37,7 @@ namespace ContentStoreTest.Stores
         protected override TestFileSystemContentStoreInternal Create(AbsolutePath rootPath, ITestClock clock, NagleQueue<ContentHash> nagleBlock = null)
         {
             var config = new ContentStoreConfiguration(_quota);
-            return new TestFileSystemContentStoreInternal(FileSystem, clock, rootPath, config, nagleQueue: nagleBlock);
+            return new TestFileSystemContentStoreInternal(FileSystem, clock, rootPath, config, nagleQueue: nagleBlock, settings: ContentStoreSettings);
         }
 
         protected override int ContentSizeToStartSoftPurging(int numberOfBlobs)

--- a/Public/Src/Cache/ContentStore/Test/Stores/FileSystemContentStoreInternalTestBase.cs
+++ b/Public/Src/Cache/ContentStore/Test/Stores/FileSystemContentStoreInternalTestBase.cs
@@ -31,6 +31,8 @@ namespace ContentStoreTest.Stores
         private static readonly MaxSizeQuota MaxSizeQuota = new MaxSizeQuota(MaxSizeHard, MaxSizeSoft);
         private static readonly ContentStoreConfiguration Config = new ContentStoreConfiguration(MaxSizeQuota);
 
+        protected virtual ContentStoreSettings ContentStoreSettings { get; set; } = null;
+
         protected static readonly char[] Drives = { 'C', 'D' };
 
         protected static int BlobSizeToStartSoftPurging(int numberOfBlobs)
@@ -130,7 +132,7 @@ namespace ContentStoreTest.Stores
 
         protected virtual TestFileSystemContentStoreInternal Create(AbsolutePath rootPath, ITestClock clock, NagleQueue<ContentHash> nagleBlock = null)
         {
-            return new TestFileSystemContentStoreInternal(FileSystem, clock, rootPath, Config, nagleQueue: nagleBlock);
+            return new TestFileSystemContentStoreInternal(FileSystem, clock, rootPath, Config, nagleQueue: nagleBlock, settings: ContentStoreSettings);
         }
 
         protected virtual TestFileSystemContentStoreInternal CreateElastic(
@@ -145,7 +147,7 @@ namespace ContentStoreTest.Stores
             // Some tests rely on maxSizeQuota being set in the configuration although it is ignored if elasticity is enabled.
             var config = new ContentStoreConfiguration(maxSizeQuota: maxSizeQuota, enableElasticity: true, initialElasticSize: maxSizeQuota, historyWindowSize: windowSize);
 
-            return new TestFileSystemContentStoreInternal(FileSystem, clock, rootPath, config, nagleQueue: nagleBlock);
+            return new TestFileSystemContentStoreInternal(FileSystem, clock, rootPath, config, nagleQueue: nagleBlock, settings: ContentStoreSettings);
         }
 
         protected async Task<ElasticSizeRule.LoadQuotaResult> LoadElasticQuotaAsync(AbsolutePath rootPath)

--- a/Public/Src/Cache/ContentStore/Test/Stores/FixedSizeFileSystemContentStoreInternalPurgeTests.cs
+++ b/Public/Src/Cache/ContentStore/Test/Stores/FixedSizeFileSystemContentStoreInternalPurgeTests.cs
@@ -183,7 +183,7 @@ namespace ContentStoreTest.Stores
                     async store =>
                     {
                         // Syncing the store to wait for purging process to finish.
-                        await store.SyncAsync(Context);
+                        await store.SyncAsync(Context, purge: false);
 
                         triggeredEviction.Should().Be(expectedTriggeredEviction, "Eviction should be triggered at startup if configured.");
                     },

--- a/Public/Src/Cache/ContentStore/Test/Stores/FixedSizeFileSystemContentStoreInternalPurgeTests.cs
+++ b/Public/Src/Cache/ContentStore/Test/Stores/FixedSizeFileSystemContentStoreInternalPurgeTests.cs
@@ -2,12 +2,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using BuildXL.Cache.ContentStore.Stores;
 using BuildXL.Cache.ContentStore.Interfaces.FileSystem;
 using BuildXL.Cache.ContentStore.Interfaces.Logging;
 using BuildXL.Cache.ContentStore.Interfaces.Results;
+using BuildXL.Cache.ContentStore.Interfaces.Stores;
 using BuildXL.Cache.ContentStore.InterfacesTest.Results;
 using FluentAssertions;
 using Xunit;
@@ -128,10 +130,71 @@ namespace ContentStoreTest.Stores
                     await pinContext.DisposeAsync();
                 }
 
-                PutResult putAfterReleaseResult = await store.PutRandomAsync(Context, contentSize);
-                ResultTestExtensions.ShouldBeSuccess((BoolResult) putAfterReleaseResult);
+                await store.PutRandomAsync(Context, contentSize).ShouldBeSuccess();
                 triggeredEviction.Should().BeTrue();
             });
+        }
+
+        [Theory]
+        [InlineData(true, true, true)] // useLegacyQuotaKeeper: true, purgeAtStartup: true, expectedTriggeredEviction: true
+        [InlineData(true, false, false)] // useLegacyQuotaKeeper: true, purgeAtStartup: false, expectedTriggeredEviction: false
+        [InlineData(false, true, true)] // useLegacyQuotaKeeper: false, purgeAtStartup: true, expectedTriggeredEviction: true
+        [InlineData(false, false, false)] // useLegacyQuotaKeeper: false, purgeAtStartup: false, expectedTriggeredEviction: false
+        public async Task StartupShouldTriggerPurgeIfConfigured(bool useLegacyQuotaKeeper, bool purgeAtStartup, bool expectedTriggeredEviction)
+        {
+            // This test makes sure that if configured QuotaKeeper starts purging at startup if
+            // the constructed store is full (above soft limit).
+
+            // Using the same test directory for two invocations to reuse the content.
+            using (var directory = new DisposableDirectory(FileSystem))
+            {
+                ContentStoreSettings = new ContentStoreSettings()
+                                       {
+                                           StartPurgingAtStartup = purgeAtStartup,
+                                           UseLegacyQuotaKeeperImplementation = useLegacyQuotaKeeper,
+                                       };
+
+                bool triggeredEviction = false;
+                var contentSize = ContentSizeToStartSoftPurging(3);
+                await TestStore(Context, Clock, directory, async store =>
+                                                {
+                                                    store.OnLruEnumerationWithTime = hashes =>
+                                                                                     {
+                                                                                         // Intentionally returning an empty list to avoid purging the content.
+                                                                                         return Task.FromResult((IReadOnlyList<ContentHashWithLastAccessTimeAndReplicaCount>)new ContentHashWithLastAccessTimeAndReplicaCount[0]);
+                                                                                     };
+
+                                                    using (var pinContext = store.CreatePinContext())
+                                                    {
+                                                        // Putting the content 3 times to reach the soft limit.
+                                                        // The last put will trigger an eviction, but 'OnLruEnumerationWithTime'
+                                                        // returns an empty result to avoid purging.
+                                                        await PutRandomAndPinAsync(store, contentSize, pinContext);
+                                                        await PutRandomAndPinAsync(store, contentSize, pinContext);
+                                                        await PutRandomAndPinAsync(store, contentSize, pinContext);
+                                                    }
+                                                });
+
+                // Running the store for the second time to force purging process to happen during startup.
+                await TestStore(
+                    Context,
+                    Clock,
+                    directory,
+                    async store =>
+                    {
+                        // Syncing the store to wait for purging process to finish.
+                        await store.SyncAsync(Context);
+
+                        triggeredEviction.Should().Be(expectedTriggeredEviction, "Eviction should be triggered at startup if configured.");
+                    },
+                    store =>
+                        store.OnLruEnumerationWithTime = hashes =>
+                                                         {
+                                                             triggeredEviction = true;
+                                                             return Task.FromResult(hashes);
+                                                         }
+                );
+            }
         }
     }
 }

--- a/Public/Src/Cache/ContentStore/Test/Stores/TestFileSystemContentStoreInternal.cs
+++ b/Public/Src/Cache/ContentStore/Test/Stores/TestFileSystemContentStoreInternal.cs
@@ -45,8 +45,9 @@ namespace ContentStoreTest.Stores
             ContentStoreConfiguration configuration,
             Action<ContentHashWithSize> onContentAdded = null,
             Action<ContentHashWithSize> onContentEvicted = null,
-            NagleQueue<ContentHash> nagleQueue = null)
-            : base(fileSystem, clock, rootPath, new ConfigurationModel(configuration), nagleQueue: nagleQueue)
+            NagleQueue<ContentHash> nagleQueue = null,
+            ContentStoreSettings settings = null)
+            : base(fileSystem, clock, rootPath, new ConfigurationModel(configuration), nagleQueue: nagleQueue, settings: settings)
         {
             Contract.Requires(fileSystem != null);
             Contract.Requires(clock != null);

--- a/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
@@ -109,6 +109,12 @@ namespace BuildXL.Cache.Host.Configuration
         public bool UseLegacyQuotaKeeperImplementation { get; set; } = true;
 
         /// <summary>
+        /// If true, then quota keeper will check the current content directory size and start content eviction at startup if the threshold is reached.
+        /// </summary>
+        [DataMember]
+        public bool StartPurgingAtStartup { get; set; } = true;
+
+        /// <summary>
         /// Whether to use native (unmanaged) file enumeration or not.
         /// </summary>
         [DataMember]

--- a/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
@@ -197,6 +197,7 @@ namespace BuildXL.Cache.Host.Service.Internal
                              UseEmptyFileHashShortcut = settings.EmptyFileHashShortcutEnabled,
                              CheckFiles = settings.CheckLocalFiles,
                              UseLegacyQuotaKeeperImplementation = settings.UseLegacyQuotaKeeperImplementation,
+                             StartPurgingAtStartup = settings.StartPurgingAtStartup,
                              UseNativeBlobEnumeration = settings.UseNativeBlobEnumeration,
                          };
         }


### PR DESCRIPTION
If the cache restarts during the build (which is a normal procedure), the cache may decide to start content eviction process at a startup when the cache is full.

Effectively, there is a race condition at startup when one part of the cache reloads the session state and tries to re-pin the content that was used by a previous service instance and another part of the cache tries to evict it. In some cases an important content can be evicted causing the build to fail.

This PR adds mitigation by exposing a configuration option that prevents purging on startup.