### PR TITLE
Better unauthorized access

### DIFF
--- a/Public/Src/Cache/ContentStore/Library/FileSystem/PassThroughFileSystem.cs
+++ b/Public/Src/Cache/ContentStore/Library/FileSystem/PassThroughFileSystem.cs
@@ -146,7 +146,7 @@ namespace BuildXL.Cache.ContentStore.FileSystem
 
                 if (!createOrOpenResult.Succeeded)
                 {
-                    throw ThrowLastWin32Error($"Failed to create or open file {path.ToString()} to get its ID. Status: {createOrOpenResult.Status}");
+                    throw ThrowLastWin32Error(path.ToString(), $"Failed to create or open file {path} to get its ID. Status: {createOrOpenResult.Status}");
                 }
 
                 return (ulong)handle.DangerousGetHandle().ToInt64();
@@ -171,7 +171,7 @@ namespace BuildXL.Cache.ContentStore.FileSystem
 
                     if (!NativeMethods.GetFileInformationByHandle(sourceFileHandle, out var handleInfo))
                     {
-                        throw ThrowLastWin32Error(errorMessage);
+                        throw ThrowLastWin32Error(path.Path, errorMessage);
                     }
 
                     return (((ulong)handleInfo.FileIndexHigh) << 32) | handleInfo.FileIndexLow;
@@ -208,7 +208,7 @@ namespace BuildXL.Cache.ContentStore.FileSystem
 
                     if (!NativeMethods.GetFileInformationByHandle(sourceFileHandle, out var handleInfo))
                     {
-                        throw ThrowLastWin32Error(errorMessage);
+                        throw ThrowLastWin32Error(path.Path, errorMessage);
                     }
 
                     return checked((int)handleInfo.NumberOfLinks);
@@ -279,7 +279,11 @@ namespace BuildXL.Cache.ContentStore.FileSystem
                 // 0x20 is shared violation.
                 if (e.InnerException is NativeWin32Exception win32 && win32.ErrorCode == 0x20)
                 {
-                    throw new UnauthorizedAccessException(e.Message, e);
+                    var extraMessage = FileUtilities.TryFindOpenHandlesToFile(path.ToString(), out var info, printCurrentFilePath: false)
+                        ? info
+                        : "Attempt to find processes with open handles to the file failed.";
+
+                    throw new UnauthorizedAccessException($"{e.Message} {extraMessage}", e);
                 }
             }
         }
@@ -315,6 +319,7 @@ namespace BuildXL.Cache.ContentStore.FileSystem
                     replaceExisting ? NativeMethods.MoveFileOption.MOVEFILE_REPLACE_EXISTING : 0))
                 {
                     throw ThrowLastWin32Error(
+                        destinationFilePath.Path,
                         string.Format(
                             CultureInfo.InvariantCulture,
                             "Unable to move file from '{0}' to '{1}'.",
@@ -498,12 +503,14 @@ namespace BuildXL.Cache.ContentStore.FileSystem
                         case NativeMethods.ERROR_PATH_NOT_FOUND:
                             return (Stream)null;
                         default:
-                            throw ThrowLastWin32Error(string.Format(
-                                CultureInfo.InvariantCulture,
-                                "Unable to open a handle to '{0}' as {1} with {2}.",
+                            throw ThrowLastWin32Error(
                                 path.Path,
-                                mode,
-                                accessMode));
+                                string.Format(
+                                    CultureInfo.InvariantCulture,
+                                    "Unable to open a handle to '{0}' as {1} with {2}.",
+                                    path.Path,
+                                    mode,
+                                    accessMode));
                     }
                 }
 
@@ -679,20 +686,24 @@ namespace BuildXL.Cache.ContentStore.FileSystem
                 {
                     if (handle.IsInvalid)
                     {
-                        throw ThrowLastWin32Error(string.Format(
-                            CultureInfo.InvariantCulture,
-                            "Unable to open a handle for SetFileTime at '{0}' to '{1}'.",
+                        throw ThrowLastWin32Error(
                             path,
-                            lastAccessTimeUtc));
+                            string.Format(
+                                CultureInfo.InvariantCulture,
+                                "Unable to open a handle for SetFileTime at '{0}' to '{1}'.",
+                                path,
+                                lastAccessTimeUtc));
                     }
 
                     if (!NativeMethods.SetFileTime(handle, null, &time, null))
                     {
-                        throw ThrowLastWin32Error(string.Format(
-                            CultureInfo.InvariantCulture,
-                            "Unable to SetFileTime at '{0}' to '{1}'.",
+                        throw ThrowLastWin32Error(
                             path,
-                            lastAccessTimeUtc));
+                            string.Format(
+                                CultureInfo.InvariantCulture,
+                                "Unable to SetFileTime at '{0}' to '{1}'.",
+                                path,
+                                lastAccessTimeUtc));
                     }
                 }
             }
@@ -765,7 +776,7 @@ namespace BuildXL.Cache.ContentStore.FileSystem
                         case OpenFileStatus.AccessDenied:
                         case OpenFileStatus.UnknownError:
                         default:
-                            throw ThrowLastWin32Error($"Failed to create or open file {sourceFileName.Path} to create hard link. Status: {createOrOpenResult.Status}");
+                            throw ThrowLastWin32Error(destinationFileName.Path, $"Failed to create or open file {sourceFileName.Path} to create hard link. Status: {createOrOpenResult.Status}");
                     }
                 }
             }
@@ -802,7 +813,7 @@ namespace BuildXL.Cache.ContentStore.FileSystem
             }
             else
             {
-                throw ThrowLastWin32Error($"Failed to create hard link for file {sourceFileName.Path} with unknown error: {createHardLinkResult.ToString()}");
+                throw ThrowLastWin32Error(sourceFileName.Path, $"Failed to create hard link for file {sourceFileName.Path} with unknown error: {createHardLinkResult.ToString()}");
             }
         }
 
@@ -1001,15 +1012,17 @@ namespace BuildXL.Cache.ContentStore.FileSystem
                 {
                     if (volumeHandle.IsInvalid)
                     {
-                        throw ThrowLastWin32Error(string.Format(
-                            CultureInfo.InvariantCulture,
-                            "Could not open volume handle to '{0}'.  Elevated administrator access is required.",
-                            volumePath));
+                        throw ThrowLastWin32Error(
+                            path: null,
+                            string.Format(
+                                CultureInfo.InvariantCulture,
+                                "Could not open volume handle to '{0}'.  Elevated administrator access is required.",
+                                volumePath));
                     }
 
                     if (!NativeMethods.FlushFileBuffers(volumeHandle))
                     {
-                        throw ThrowLastWin32Error("Could not flush volume " + volumePath + ".");
+                        throw ThrowLastWin32Error(path: null, "Could not flush volume " + volumePath + ".");
                     }
                 }
             }
@@ -1039,7 +1052,7 @@ namespace BuildXL.Cache.ContentStore.FileSystem
             FileUtilities.SetFileAccessControl(path.Path, fileSystemRights, accessControlType == AccessControlType.Allow);
         }
 
-        private static Exception ThrowLastWin32Error(string message)
+        private static Exception ThrowLastWin32Error(string path, string message)
         {
             if (BuildXL.Utilities.OperatingSystemHelper.IsUnixOS)
             {
@@ -1059,7 +1072,17 @@ namespace BuildXL.Cache.ContentStore.FileSystem
                         throw new DirectoryNotFoundException(message);
                     case NativeMethods.ERROR_ACCESS_DENIED:
                     case NativeMethods.ERROR_SHARING_VIOLATION:
-                        throw new UnauthorizedAccessException(message);
+
+                        string extraMessage = string.Empty;
+
+                        if (path != null)
+                        {
+                            extraMessage = " " + (FileUtilities.TryFindOpenHandlesToFile(path, out var info, printCurrentFilePath: false)
+                                ? info
+                                : "Attempt to find processes with open handles to the file failed.");
+                        }
+
+                        throw new UnauthorizedAccessException($"{message}.{extraMessage}");
                     default:
                         throw new IOException(message, Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error()));
                 }

--- a/Public/Src/Cache/ContentStore/Test/FileSystem/PassThroughFileSystemTests.cs
+++ b/Public/Src/Cache/ContentStore/Test/FileSystem/PassThroughFileSystemTests.cs
@@ -13,6 +13,7 @@ using ContentStoreTest.Test;
 using BuildXL.Native.IO;
 using Xunit;
 using BuildXL.Cache.ContentStore.UtilitiesCore;
+using FluentAssertions;
 
 namespace ContentStoreTest.FileSystem
 {
@@ -134,7 +135,8 @@ namespace ContentStoreTest.FileSystem
                                        }
                                    };
 
-                    await Assert.ThrowsAsync<UnauthorizedAccessException>(a);
+                    var exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(a);
+                    exception.Message.Should().Contain("Handle was used by");
                 }
             }
         }

--- a/Public/Src/Cache/ContentStore/Test/FileSystem/PassThroughFileSystemTests.cs
+++ b/Public/Src/Cache/ContentStore/Test/FileSystem/PassThroughFileSystemTests.cs
@@ -136,7 +136,7 @@ namespace ContentStoreTest.FileSystem
                                    };
 
                     var exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(a);
-                    exception.Message.Should().Contain("Handle was used by");
+                    exception.Message.Should().ContainAny("Handle was used by", "Did not find any actively running processes using the handle");
                 }
             }
         }

--- a/Public/Src/Utilities/Native/IO/FileUtilities.cs
+++ b/Public/Src/Utilities/Native/IO/FileUtilities.cs
@@ -387,8 +387,9 @@ namespace BuildXL.Native.IO
             Func<SafeFileHandle, bool> predicate = null,
             Action<SafeFileHandle> onCompletion = null) => s_fileUtilities.WriteAllBytesAsync(filePath, bytes, predicate, onCompletion);
 
-        /// <see cref="IFileUtilities.TryFindOpenHandlesToFile(string, out string)"/>
-        public static bool TryFindOpenHandlesToFile(string filePath, out string diagnosticInfo) => s_fileUtilities.TryFindOpenHandlesToFile(filePath, out diagnosticInfo);
+        /// <see cref="IFileUtilities.TryFindOpenHandlesToFile"/>
+        public static bool TryFindOpenHandlesToFile(string filePath, out string diagnosticInfo, bool printCurrentFilePath = true) 
+            => s_fileUtilities.TryFindOpenHandlesToFile(filePath, out diagnosticInfo, printCurrentFilePath);
 
         /// <see cref="IFileUtilities.GetHardLinkCount(string)"/>
         public static uint GetHardLinkCount(string path) => s_fileUtilities.GetHardLinkCount(path);

--- a/Public/Src/Utilities/Native/IO/IFileUtilities.cs
+++ b/Public/Src/Utilities/Native/IO/IFileUtilities.cs
@@ -264,8 +264,9 @@ namespace BuildXL.Native.IO
         /// </summary>
         /// <param name="filePath">The absolute path to the file</param>
         /// <param name="diagnosticInfo">Diagnostic information for what might have an open handle to the file</param>
+        /// <param name="printCurrentFilePath">If true, the output message would contain a path to a current file.</param>
         /// <returns>true if diagnostic info is available</returns>
-        bool TryFindOpenHandlesToFile(string filePath, out string diagnosticInfo);
+        bool TryFindOpenHandlesToFile(string filePath, out string diagnosticInfo, bool printCurrentFilePath = true);
 
         /// <summary>
         /// Gets hard link count.

--- a/Public/Src/Utilities/Native/IO/Unix/FileUtilities.Unix.cs
+++ b/Public/Src/Utilities/Native/IO/Unix/FileUtilities.Unix.cs
@@ -551,7 +551,7 @@ namespace BuildXL.Native.IO.Unix
         }
 
         /// <inheritdoc />
-        public bool TryFindOpenHandlesToFile(string filePath, out string diagnosticInfo) => throw new NotImplementedException();
+        public bool TryFindOpenHandlesToFile(string filePath, out string diagnosticInfo, bool printCurrentFilePath) => throw new NotImplementedException();
 
         /// <inheritdoc />
         public uint GetHardLinkCount(string path)


### PR DESCRIPTION
Today, if the CASaaS operation fails with `UnauthorizedAccessException` it is hard to tell which process is to blame.

Here is an example of the error:

```
b0f230db-0c02-4492-b7ac-4187db9caf45 Critical error occurred: DistributedContentSession.PutFileAsync stop 99.6744ms. result=[Error=[UnauthorizedAccessException: System.UnauthorizedAccessException: Unable to open a handle to 'd:\dbs\el\dF\Build\MetaBuild\oacrEnvironment\math_solverengine_x64_ship.json' as Open with Read. last error: [The process cannot access the file because it is being used by another process.] (error code 32)
```

This PR changes the code that throws `UnauthorizedAccessException` from `PassThroughFileSystem` members to also include a process that holds a handle to a file (if possible).

In this case the error message looks like this:

```
"Unable to open a handle to 'C:\Users\seteplia\AppData\Local\Temp\CloudStore\36aa81cc69ea\parent2\dst' as Create with Write. last error: [The process cannot access the file because it is being used by another process.] (error code 32). Handle was used by 'MyProcess' with PID '15852'.
```

Bug in AzDev: #1478669