### PR TITLE
Workaround for MSBuild reporting duplicate edges

### DIFF
--- a/Public/Src/FrontEnd/MsBuild.Serialization/ProjectWithPredictions.cs
+++ b/Public/Src/FrontEnd/MsBuild.Serialization/ProjectWithPredictions.cs
@@ -48,6 +48,7 @@ namespace BuildXL.FrontEnd.MsBuild.Serialization
         public PredictedTargetsToExecute PredictedTargetsToExecute { get; }
 
         /// <nodoc/>
+        [JsonIgnore()]
         public IReadOnlyCollection<ProjectWithPredictions<TPathType>> ProjectReferences
         {
             get

--- a/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
+++ b/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
@@ -455,6 +455,11 @@ namespace BuildXL.FrontEnd.MsBuild
             processBuilder.AddOutputFile(logDirectory.Combine(PathTable, "msbuild.err"), FileExistence.Optional);
             processBuilder.AddOutputFile(logDirectory.Combine(PathTable, "msbuild.prf"), FileExistence.Optional);
 
+            if (m_resolverSettings?.EnableBinLogTracing == true)
+            {
+                processBuilder.AddOutputFile(logDirectory.Combine(PathTable, "msbuild.binlog"), FileExistence.Optional);
+            }
+
             // Unless the legacy non-isolated mode is explicitly specified, the project builds in isolation, and therefore
             // it produces an output cache file. This file is placed on the (unique) object directory for this project
             if (m_resolverSettings.UseLegacyProjectIsolation != true)

--- a/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
+++ b/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
@@ -195,7 +195,7 @@ namespace BuildXL.FrontEnd.MsBuild
             env[BuildEnvironmentConstants.MsPdbSrvEndpointEnvVar] = mspdbsrvGuid;
 
             // Enable MSBuild debugging if requested
-            if (m_resolverSettings?.EnableEngineTracing == true)
+            if (m_resolverSettings.EnableEngineTracing == true)
             {
                 env[BuildEnvironmentConstants.MsBuildDebug] = "1";
                 env[BuildEnvironmentConstants.MsBuildDebugPath] = logDirectory.ToString(PathTable);
@@ -455,7 +455,7 @@ namespace BuildXL.FrontEnd.MsBuild
             processBuilder.AddOutputFile(logDirectory.Combine(PathTable, "msbuild.err"), FileExistence.Optional);
             processBuilder.AddOutputFile(logDirectory.Combine(PathTable, "msbuild.prf"), FileExistence.Optional);
 
-            if (m_resolverSettings?.EnableBinLogTracing == true)
+            if (m_resolverSettings.EnableBinLogTracing == true)
             {
                 processBuilder.AddOutputFile(logDirectory.Combine(PathTable, "msbuild.binlog"), FileExistence.Optional);
             }
@@ -555,7 +555,7 @@ namespace BuildXL.FrontEnd.MsBuild
             }
 
             // Configure binary logger if specified
-            if (m_resolverSettings?.EnableBinLogTracing == true)
+            if (m_resolverSettings.EnableBinLogTracing == true)
             {
                 using (pipDataBuilder.StartFragment(PipDataFragmentEscaping.NoEscaping, string.Empty))
                 {

--- a/Public/Src/Tools/Tool.MsBuildGraphBuilder/MsBuildGraphBuilder.cs
+++ b/Public/Src/Tools/Tool.MsBuildGraphBuilder/MsBuildGraphBuilder.cs
@@ -351,10 +351,12 @@ namespace MsBuildGraphBuilderTool
             // Reconstruct all references. A two-pass approach avoids needing to do more complicated reconstruction of references that would need traversing the graph
             foreach (var projectWithPredictions in projectNodes)
             {
-                ProjectWithPredictions[] references = nodeWithPredictionsToMsBuildNodes[projectWithPredictions]
+                // TODO: temporarily getting this as a set due to an MSBuild bug where edges are sometimes duplicated. We can just
+                // treat this as an array once the bug is fixed on MSBuild side
+                var references = nodeWithPredictionsToMsBuildNodes[projectWithPredictions]
                     .ProjectReferences
                     .Select(projectReference => msBuildNodesToNodeWithPredictionIndex[projectReference])
-                    .ToArray();
+                    .ToHashSet();
 
                 projectWithPredictions.SetReferences(references);
             }

--- a/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/Utilities/MSBuildProjectBuilder.cs
+++ b/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/Utilities/MSBuildProjectBuilder.cs
@@ -61,6 +61,29 @@ namespace Test.ProjectGraphBuilder.Utilities
         }
 
         /// <summary>
+        /// Writes a collection of projects to disk, where the name and content of the project is already computed
+        /// </summary>
+        /// <remarks>
+        /// The first project of the collection is assumed to be the entry point
+        /// </remarks>
+        public string WriteProjectsWithReferences(params (string projectName, string projectContent)[] projects)
+        {
+            // Create a unique sub-directory to hold all the projects
+            string outputDirectory = Path.Combine(m_outputDirectoryRoot, Guid.NewGuid().ToString());
+            Directory.CreateDirectory(outputDirectory);
+
+            // Write all generated projects to disk
+            foreach (var kvp in projects)
+            {
+                var projectFile = Path.Combine(outputDirectory, kvp.projectName);
+                File.WriteAllText(projectFile, kvp.projectContent);
+            }
+
+            return Path.Combine(outputDirectory, projects[0].projectName);
+        }
+
+
+        /// <summary>
         /// Validates that a <param name="projectGraph"/> is contained by a set of <see cref="projectChains"/>. If <param name="assertEqual"/> is specified,
         /// the graph must match exactly (not just be a sub-graph).
         /// </summary>


### PR DESCRIPTION
MSBuild static graph APIS are sometimes reporting duplicate edges. Temporarily make sure the MSBuild resolver dedups these.