### PR TITLE
Copy between separate Win machines

### DIFF
--- a/Public/Src/Cache/ContentStore/App/BuildXL.Cache.ContentStore.App.dsc
+++ b/Public/Src/Cache/ContentStore/App/BuildXL.Cache.ContentStore.App.dsc
@@ -19,6 +19,7 @@ namespace App {
                 : [importFrom("CLAP").pkg]
             ),
             UtilitiesCore.dll,
+            Grpc.dll,
             Hashing.dll,
             Library.dll,
             Distributed.dll,
@@ -26,6 +27,10 @@ namespace App {
             importFrom("BuildXL.Cache.MemoizationStore").Distributed.dll,
             importFrom("BuildXL.Cache.DistributedCache.Host").Service.dll,
             importFrom("BuildXL.Cache.DistributedCache.Host").Configuration.dll,
+
+            importFrom("Grpc.Core").pkg,
+            importFrom("Google.Protobuf").pkg,
+
             ManagedSdk.Factory.createBinary(importFrom("TransientFaultHandling.Core").Contents.all, r`lib/NET4/Microsoft.Practices.TransientFaultHandling.Core.dll`),
         ],
         tools: {

--- a/Public/Src/Cache/ContentStore/App/DistributedService.cs
+++ b/Public/Src/Cache/ContentStore/App/DistributedService.cs
@@ -28,7 +28,8 @@ namespace BuildXL.Cache.ContentStore.App
             (
             [Description("Cache name")] string cacheName,
             [Description("Cache root path")] string cachePath,
-            [DefaultValue(ServiceConfiguration.GrpcDisabledPort), Description(GrpcPortDescription)] uint grpcPort,
+            [DefaultValue(ServiceConfiguration.GrpcDisabledPort), Description(GrpcPortDescription)] int grpcPort,
+            [Description("Name of the memory mapped file used to share GRPC port. 'CASaaS GRPC port' if not specified.")] string grpcPortFileName,
             [DefaultValue(null), Description("Writable directory for service operations (use CWD if null)")] string dataRootPath,
             [DefaultValue(null), Description("Identifier for the stamp this service will run as")] string stampId,
             [DefaultValue(null), Description("Identifier for the ring this service will run as")] string ringId,
@@ -48,13 +49,18 @@ namespace BuildXL.Cache.ContentStore.App
 
                 var host = new HostInfo(stampId, ringId, new List<string>());
 
+                if (grpcPort == 0)
+                {
+                    grpcPort = Helpers.GetGrpcPortFromFile(_logger, grpcPortFileName);
+                }
+
                 var arguments = CreateDistributedCacheServiceArguments(
-                    copier: useDistributedGrpc ? new GrpcFileCopier(new Interfaces.Tracing.Context(_logger), (int)grpcPort) : (IAbsolutePathFileCopier)new DistributedCopier(),
+                    copier: useDistributedGrpc ? new GrpcFileCopier(new Interfaces.Tracing.Context(_logger), grpcPort) : (IAbsolutePathFileCopier)new DistributedCopier(),
                     pathTransformer: useDistributedGrpc ? new GrpcDistributedPathTransformer() : (IAbsolutePathTransformer)new DistributedPathTransformer(),
                     host: host,
                     cacheName: cacheName,
                     cacheRootPath: cachePath,
-                    grpcPort: grpcPort,
+                    grpcPort: (uint)grpcPort,
                     maxSizeQuotaMB: maxSizeQuotaMB,
                     dataRootPath: dataRootPath,
                     ct: cancellationTokenSource.Token);

--- a/Public/Src/Cache/ContentStore/App/Hello.cs
+++ b/Public/Src/Cache/ContentStore/App/Hello.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using BuildXL.Cache.ContentStore.Exceptions;
+using BuildXL.Cache.ContentStore.Hashing;
+using BuildXL.Cache.ContentStore.Interfaces.FileSystem;
+using BuildXL.Cache.ContentStore.Interfaces.Tracing;
+using BuildXL.Cache.ContentStore.Service;
+using BuildXL.Cache.ContentStore.Service.Grpc;
+using Microsoft.Practices.TransientFaultHandling;
+using CLAP;
+using BuildXL.Cache.ContentStore.Sessions;
+using Grpc.Core;
+using ContentStore.Grpc;
+using System.Linq;
+
+namespace BuildXL.Cache.ContentStore.App
+{
+    internal sealed partial class Application
+    {
+        public static ChannelOption[] DefaultChannelOptions = new ChannelOption[] { new ChannelOption(ChannelOptions.MaxSendMessageLength, -1), new ChannelOption(ChannelOptions.MaxReceiveMessageLength, -1) };
+
+        /// <summary>
+        /// Attempt to connect to a grpc port and send 'Hello'
+        /// </summary>
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [Verb(Description = "Send 'Hello' to another CASaaS")]
+        internal void Hello(
+            string hash,
+            [Required, Description("Machine to copy from")] string host,
+            [Description("The GRPC port"), DefaultValue(0)] int grpcPort)
+        {
+            Initialize();
+
+            if (grpcPort <= 0)
+            {
+                throw new Exception("Must define grpc port greater than 0");
+            }
+
+            var _channel = new Channel(host, grpcPort, ChannelCredentials.Insecure, DefaultChannelOptions);
+            var _client = new ContentServer.ContentServerClient(_channel);
+            var helloResponse = _client.Hello(new HelloRequest(), new CallOptions(deadline: DateTime.UtcNow + TimeSpan.FromSeconds(2)));
+
+            Console.WriteLine(helloResponse.ToString());
+        }
+    }
+}

--- a/Public/Src/Cache/ContentStore/App/Hello.cs
+++ b/Public/Src/Cache/ContentStore/App/Hello.cs
@@ -30,8 +30,8 @@ namespace BuildXL.Cache.ContentStore.App
         [Verb(Description = "Send 'Hello' to another CASaaS")]
         internal void Hello(
             string hash,
-            [Required, Description("Machine to copy from")] string host,
-            [Description("The GRPC port"), DefaultValue(0)] int grpcPort)
+            [Required, Description("Machine to send Hello request to")] string host,
+            [Description("GRPC port on the target machine"), DefaultValue(0)] int grpcPort)
         {
             Initialize();
 

--- a/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcDistributedPathTransformer.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcDistributedPathTransformer.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.IO;
-using System.Linq;
-using System.Net;
 using System.Text;
 using BuildXL.Cache.ContentStore.Hashing;
 using BuildXL.Cache.ContentStore.Interfaces.Distributed;

--- a/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcDistributedPathTransformer.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcDistributedPathTransformer.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.IO;
+using System.Linq;
+using System.Net;
 using System.Text;
 using BuildXL.Cache.ContentStore.Hashing;
 using BuildXL.Cache.ContentStore.Interfaces.Distributed;
@@ -16,7 +18,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Utilities
     /// </summary>
     public class GrpcDistributedPathTransformer : IAbsolutePathTransformer
     {
-        private static readonly string _localMachineName = Environment.MachineName;
+        private static readonly string _localIpAddress = Dns.GetHostEntry(Dns.GetHostName()).AddressList.FirstOrDefault(ip => ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork).ToString();
         internal const string BlobFileExtension = ".blob";
 
         /// <inheritdoc />
@@ -44,7 +46,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Utilities
 
             return
                 Encoding.UTF8.GetBytes(
-                    Path.Combine(@"\\" + _localMachineName, networkPathRoot).ToUpperInvariant());
+                    Path.Combine(@"\\" + _localIpAddress, networkPathRoot).ToUpperInvariant());
         }
 
         /// <inheritdoc />

--- a/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcDistributedPathTransformer.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcDistributedPathTransformer.cs
@@ -18,7 +18,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Utilities
     /// </summary>
     public class GrpcDistributedPathTransformer : IAbsolutePathTransformer
     {
-        private static readonly string _localIpAddress = Dns.GetHostEntry(Dns.GetHostName()).AddressList.FirstOrDefault(ip => ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork).ToString();
+        private static readonly string _localMachineName = Environment.MachineName;
         internal const string BlobFileExtension = ".blob";
 
         /// <inheritdoc />
@@ -46,7 +46,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Utilities
 
             return
                 Encoding.UTF8.GetBytes(
-                    Path.Combine(@"\\" + _localIpAddress, networkPathRoot).ToUpperInvariant());
+                    Path.Combine(@"\\" + _localMachineName, networkPathRoot).ToUpperInvariant());
         }
 
         /// <inheritdoc />

--- a/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcFileCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcFileCopier.cs
@@ -49,7 +49,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Utilities
 
             CopyFileResult copyFileResult = null;
             // Contact hard-coded port on source
-            using (var client = GrpcCopyClient.Create(System.Net.IPAddress.Any.ToString(), DefaultGrpcPort))
+            using (var client = GrpcCopyClient.Create(host, DefaultGrpcPort))
             {
                 copyFileResult = await client.CopyFileAsync(_context, contentHash, destinationPath, cancellationToken);
             }
@@ -92,7 +92,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Utilities
 
             CopyFileResult copyFileResult = null;
             // Contact hard-coded port on source
-            using (var client = GrpcCopyClient.Create(System.Net.IPAddress.Any.ToString(), DefaultGrpcPort))
+            using (var client = GrpcCopyClient.Create(host, DefaultGrpcPort))
             {
                 copyFileResult = await client.CopyToAsync(_context, contentHash, destinationStream, cancellationToken);
             }

--- a/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcCopyClient.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcCopyClient.cs
@@ -54,7 +54,7 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
         private GrpcCopyClient(string host, int grpcPort)
         {
             GrpcEnvironment.InitializeIfNeeded();
-            _channel = new Channel(host, (int)grpcPort, ChannelCredentials.Insecure);
+            _channel = new Channel(host, grpcPort, ChannelCredentials.Insecure);
             _client = new ContentServer.ContentServerClient(_channel);
             _host = host;
             _grpcPort = grpcPort;
@@ -121,7 +121,7 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
 
                 AsyncServerStreamingCall<CopyFileResponse> response = _client.CopyFile(request);
 
-                Metadata headers = await response.ResponseHeadersAsync.ConfigureAwait(false);
+                Metadata headers = await response.ResponseHeadersAsync;
 
                 // If the remote machine couldn't be contacted, GRPC returns an empty
                 // header collection. GRPC would throw an RpcException when we tried

--- a/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcServerFactory.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcServerFactory.cs
@@ -5,6 +5,7 @@
 // --------------------------------------------------------------------
 
 using System.Diagnostics.ContractsLight;
+using System.Net;
 using Grpc.Core;
 
 namespace BuildXL.Cache.ContentStore.Service.Grpc
@@ -23,7 +24,7 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
             return new Server
             {
                 Services = { service },
-                Ports = { new ServerPort(System.Net.IPAddress.Any.ToString(), grpcPort, ServerCredentials.Insecure) },
+                Ports = { new ServerPort(IPAddress.Any.ToString(), grpcPort, ServerCredentials.Insecure) },
                 // need a higher number here to avoid throttling: 7000 worked for initial experiments.
                 RequestCallTokensPerCompletionQueue = requestCallTokensPerCompletionQueue ?? LocalServerConfiguration.DefaultRequestCallTokensPerCompletionQueue,
             };
@@ -37,7 +38,7 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
             GrpcEnvironment.InitializeIfNeeded();
             var server = new Server
             {
-                Ports = { new ServerPort(System.Net.IPAddress.Any.ToString(), grpcPort, ServerCredentials.Insecure) },
+                Ports = { new ServerPort(IPAddress.Any.ToString(), grpcPort, ServerCredentials.Insecure) },
                 // need a higher number here to avoid throttling: 7000 worked for initial experiments.
                 RequestCallTokensPerCompletionQueue = requestCallTokensPerCompletionQueue
             };

--- a/Public/Src/Cache/ContentStore/Library/Service/LocalContentServerBase.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/LocalContentServerBase.cs
@@ -7,23 +7,24 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.ContractsLight;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using BuildXL.Cache.ContentStore.Extensions;
+using BuildXL.Cache.ContentStore.Hashing;
 using BuildXL.Cache.ContentStore.Interfaces.FileSystem;
+using BuildXL.Cache.ContentStore.Interfaces.Logging;
 using BuildXL.Cache.ContentStore.Interfaces.Results;
+using BuildXL.Cache.ContentStore.Interfaces.Sessions;
 using BuildXL.Cache.ContentStore.Interfaces.Stores;
 using BuildXL.Cache.ContentStore.Interfaces.Tracing;
+using BuildXL.Cache.ContentStore.Service.Grpc;
 using BuildXL.Cache.ContentStore.Sessions;
+using BuildXL.Cache.ContentStore.Stores;
 using BuildXL.Cache.ContentStore.Synchronization;
 using BuildXL.Cache.ContentStore.Timers;
 using BuildXL.Cache.ContentStore.Tracing.Internal;
 using BuildXL.Cache.ContentStore.Utils;
-using BuildXL.Cache.ContentStore.Hashing;
-using BuildXL.Cache.ContentStore.Interfaces.Logging;
-using BuildXL.Cache.ContentStore.Interfaces.Sessions;
-using BuildXL.Cache.ContentStore.Service.Grpc;
-using BuildXL.Cache.ContentStore.Stores;
 using BuildXL.Cache.ContentStore.UtilitiesCore;
 using Grpc.Core;
 using GrpcEnvironment = BuildXL.Cache.ContentStore.Service.Grpc.GrpcEnvironment;
@@ -249,7 +250,7 @@ namespace BuildXL.Cache.ContentStore.Service
             GrpcEnvironment.InitializeIfNeeded();
             _grpcServer = new Server
                           {
-                              Ports = { new ServerPort(GrpcEnvironment.Localhost, grpcPort, ServerCredentials.Insecure) },
+                              Ports = { new ServerPort(IPAddress.Any.ToString(), grpcPort, ServerCredentials.Insecure) },
 
                               // need a higher number here to avoid throttling: 7000 worked for initial experiments.
                               RequestCallTokensPerCompletionQueue = requestCallTokensPerCompletionQueue,

--- a/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
@@ -141,6 +141,12 @@ namespace BuildXL.Cache.Host.Configuration
         [DataMember]
         public long MaxBlobCapacity { get; set; } = 1024 * 1024 * 1024;
 
+        /// <summary>
+        /// Use GRPC for file copies between CASaaS.
+        /// </summary>
+        [DataMember]
+        public bool IsGrpcCopierEnabled { get; set; } = false;
+
         #region Distributed Eviction
         [DataMember]
         public bool IsDistributedEvictionEnabled { get; set; } = false;


### PR DESCRIPTION
Open GRPC server to listen to all external requests.

[AB#1504491](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1504491)

When attempting to copy files between separate Windows machines, the GRPC client failed to connect to the GRPC server. The connection succeeded when using "localhost" as the target host, but failed when using the server's machine name or ip address. To investigate, a simple "Hello" verb was added to test client-server connections.

In the end, the error was in the construction of the ServerPort. It was previously only exposed to local communication. With this change, the server can respond to communication from external sources.