### PR TITLE
Invoke scrubber for integration tests

### DIFF
--- a/Public/Src/Engine/Dll/Engine.cs
+++ b/Public/Src/Engine/Dll/Engine.cs
@@ -2851,57 +2851,7 @@ namespace BuildXL.Engine
 
         private IReadOnlyList<string> GetNonScrubbablePaths()
         {
-            var nonScrubbablePaths = new List<string>
-            {
-                // Don't scrub the object directory lock file
-                FolderLock.GetLockPath(Configuration.Layout.ObjectDirectory.ToString(Context.PathTable)),
-
-                // Don't scrub the temp directory used for file move-delete
-                // TempCleaner is responsible for cleaning this
-                m_tempCleaner.TempDirectory,
-            };
-
-            AddToNonScrubbableAbsolutePaths(new[]
-            {
-                // Don't scrub the engine cache in the object directory
-                Configuration.Layout.EngineCacheDirectory,
-
-                // Don't scrub the cache directory
-                Configuration.Layout.CacheDirectory,
-
-                // Don't scrub log directories.
-                Configuration.Logging.LogsDirectory,
-                Configuration.Logging.RedirectedLogsDirectory
-            });
-
-            if (OperatingSystemHelper.IsUnixOS)
-            {
-                // Don't scrub the .NET Core lock file when running the CoreCLR on Unix even if its parent directory is specified as scrubabble. 
-                // Some build tools use the '/tmp' folder as temporary file location (e.g. xcodebuild, clang, etc.) for dumping state and reports. 
-                // Unfortunately scrubbing the dotnet state files can lead to a missbehaving CoreCLR in subsequent or parallel runs where several 
-                // dotnet invocations happen, so lets avoid scrubbing that folder explicitly!
-                nonScrubbablePaths.AddRange(new []
-                {
-                    "/tmp/.dotnet/",
-                    "/private/tmp/.dotnet/",
-                });
-            }
-
-            // Don't scrub any of the paths flagged as non-scrubbable
-            nonScrubbablePaths.AddRange(FrontEndController.GetNonScrubbablePaths());
-
-            void AddToNonScrubbableAbsolutePaths(AbsolutePath[] paths)
-            {
-                foreach (AbsolutePath path in paths)
-                {
-                    if (path.IsValid)
-                    {
-                        nonScrubbablePaths.Add(path.ToString(Context.PathTable));
-                    }
-                }
-            }
-
-            return nonScrubbablePaths;
+            return EngineSchedule.GetNonScrubbablePaths(Context.PathTable, Configuration, FrontEndController.GetNonScrubbablePaths(), m_tempCleaner);
         }
 
         private void LogFrontEndStats(LoggingContext loggingContext)

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/DirectorySymlinkTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/DirectorySymlinkTests.cs
@@ -313,12 +313,7 @@ Versions/sym-sym-A -> sym-A
 
             // invalidate producer pip, rerun, expect all cache misses
             InvalidatePip(producerPip);
-            if (dirKind == SealDirectoryKind.SharedOpaque)
-            {
-                // shared opaque dir content must be scrubbed before rerunning
-                FileUtilities.DeleteDirectoryContents(rootDir, deleteRootDirectory: true);
-            }
-            var result = RunSchedulerAndValidateProducedLayout().AssertCacheMiss(allPipIds);
+            RunSchedulerAndValidateProducedLayout().AssertCacheMiss(allPipIds);
 
             // -------------------------------- local functions ---------------------------------
 

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/OpaqueDirectoryTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/OpaqueDirectoryTests.cs
@@ -208,8 +208,6 @@ namespace IntegrationTest.BuildXL.Scheduler
             // first run -- cache PipA
             RunScheduler().AssertFailure();
 
-            // scrub the outputs
-            File.Delete(outputFilePipA.Path.ToString(Context.PathTable));
             FileUtilities.DeleteDirectoryContents(opaqueDir, deleteRootDirectory: true);
 
             // second run - PipA should come from cache, PipB should run, but hit the same violation

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SchedulerIntegrationTestBase.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SchedulerIntegrationTestBase.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.ContractsLight;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using BuildXL.Cache.ContentStore.Hashing;
 using BuildXL;
 using BuildXL.Engine.Cache;
@@ -31,7 +32,6 @@ using Test.BuildXL.TestUtilities.Xunit;
 using Xunit.Abstractions;
 using AssemblyHelper = BuildXL.Utilities.AssemblyHelper;
 using ProcessOutputs = BuildXL.Pips.Builders.ProcessOutputs;
-using System.Threading;
 
 namespace Test.BuildXL.Scheduler
 {

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SchedulerIntegrationTestBase.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SchedulerIntegrationTestBase.cs
@@ -31,6 +31,7 @@ using Test.BuildXL.TestUtilities.Xunit;
 using Xunit.Abstractions;
 using AssemblyHelper = BuildXL.Utilities.AssemblyHelper;
 using ProcessOutputs = BuildXL.Pips.Builders.ProcessOutputs;
+using System.Threading;
 
 namespace Test.BuildXL.Scheduler
 {
@@ -413,6 +414,11 @@ namespace Test.BuildXL.Scheduler
                 directoryTranslator: DirectoryTranslator,
                 testHooks: testHooks))
             {
+                MountPathExpander mountPathExpander = null;
+                var frontEndNonScrubbablePaths = CollectionUtilities.EmptyArray<string>();
+                var nonScrubbablePaths = EngineSchedule.GetNonScrubbablePaths(Context.PathTable, config, frontEndNonScrubbablePaths, tempCleaner);
+                EngineSchedule.ScrubExtraneousFilesAndDirectories(mountPathExpander, testScheduler, LoggingContext, config, nonScrubbablePaths, tempCleaner);
+
                 if (filter == null)
                 {
                     EngineSchedule.TryGetPipFilter(LoggingContext, Context, config, config, Expander.TryGetRootByMountName, out filter);


### PR DESCRIPTION
Scrubber is always invoked in regular builds, so it should be invoked by the integration test setup too.

[AB#1411172](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1411172)