### PR TITLE
Ensure InputTracker tracks changing mount paths

### DIFF
--- a/Public/Src/Engine/Dll/Engine.FrontEnd.cs
+++ b/Public/Src/Engine/Dll/Engine.FrontEnd.cs
@@ -226,6 +226,7 @@ namespace BuildXL.Engine
                         serializer,
                         graphFingerprint: graphFingerprint,
                         availableEnvironmentVariables: effectiveEnvironmentVariables,
+                        availableMounts: availableMounts,
                         journalState: journalState,
                         maxDegreeOfParallelism: maxDegreeOfParallelism);
                     cacheGraphStats.ObjectDirectoryHit = engineCacheMatchResult.Matches;

--- a/Public/Src/Engine/Dll/Engine.cs
+++ b/Public/Src/Engine/Dll/Engine.cs
@@ -3125,7 +3125,9 @@ namespace BuildXL.Engine
                         GraphCacheFile.PreviousInputs,
                         writer => inputTracker.WriteToFile(
                             writer,
+                            Context.PathTable,
                             envVarsImpactingBuild,
+                            mountsImpactingBuild,
                             serializer.PreviousInputsJournalCheckpoint),
                         overrideName: EngineSerializer.PreviousInputsIntermediateFile);
 
@@ -3239,6 +3241,7 @@ namespace BuildXL.Engine
             EngineSerializer serializer,
             GraphFingerprint graphFingerprint,
             IBuildParameters availableEnvironmentVariables,
+            MountsTable availableMounts,
             JournalState journalState,
             int maxDegreeOfParallelism)
         {
@@ -3249,6 +3252,7 @@ namespace BuildXL.Engine
                 fileContentTable: FileContentTable,
                 graphFingerprint: graphFingerprint,
                 availableEnvironmentVariables: availableEnvironmentVariables,
+                availableMounts: availableMounts,
                 journalState: journalState,
                 timeLimitForJournalScanning:
                     Configuration.Engine.ScanChangeJournalTimeLimitInSec < 0

--- a/Public/Src/Engine/Dll/GraphFingerprinter.cs
+++ b/Public/Src/Engine/Dll/GraphFingerprinter.cs
@@ -38,7 +38,7 @@ namespace BuildXL.Engine
     /// </remarks>
     public static class GraphFingerprinter
     {
-        internal const int GraphFingerprintVersion = 7;
+        internal const int GraphFingerprintVersion = 8;
 
         /// <summary>
         /// Computes a fingerprint for looking up a reloadable build graph. Null indicates failure

--- a/Public/Src/Engine/Dll/InputTracker.cs
+++ b/Public/Src/Engine/Dll/InputTracker.cs
@@ -532,7 +532,7 @@ namespace BuildXL.Engine
             BinaryWriter writer,
             PathTable pathTable,
             IReadOnlyDictionary<string, string> buildParametersImpactingBuild,
-            IReadOnlyDictionary<string, IMount> mountsImpactingBuild,
+            [CanBeNull] IReadOnlyDictionary<string, IMount> mountsImpactingBuild,
             string changeTrackingStatePath)
         {
             Contract.Requires(writer != null);
@@ -584,7 +584,7 @@ namespace BuildXL.Engine
                     foreach (var kvp in mountsImpactingBuild)
                     {
                         writer.Write(kvp.Key);
-                        writer.Write(kvp.Value.Path.ToString(pathTable));
+                        writer.Write(kvp.Value == null ? null : kvp.Value.Path.ToString(pathTable));
                     }
                 }
             }
@@ -919,7 +919,7 @@ namespace BuildXL.Engine
                 {
                     // The previously used mount is not known
                     result.MissType = GraphCacheMissReason.MountChanged;
-                    result.FirstMissIdentifier = string.Format(CultureInfo.InvariantCulture, Strings.InputTracker_MountRemoved, mountName);
+                    result.FirstMissIdentifier = string.Format(CultureInfo.InvariantCulture, Strings.InputTracker_MountRemoved, mountName, previousPath);
                     Logger.Log.InputTrackerDetectedMountChanged(loggingContext, mountName, previousPath, string.Empty);
                     return result;
                 }

--- a/Public/Src/Engine/Dll/InputTracker.cs
+++ b/Public/Src/Engine/Dll/InputTracker.cs
@@ -584,7 +584,8 @@ namespace BuildXL.Engine
                     foreach (var kvp in mountsImpactingBuild)
                     {
                         writer.Write(kvp.Key);
-                        writer.Write(kvp.Value == null ? null : kvp.Value.Path.ToString(pathTable));
+                        // You can't have an unnamed mount, but you can have an empty path value
+                        writer.Write(kvp.Value == null ? string.Empty : kvp.Value.Path.ToString(pathTable));
                     }
                 }
             }

--- a/Public/Src/Engine/Dll/InputTracker.cs
+++ b/Public/Src/Engine/Dll/InputTracker.cs
@@ -530,7 +530,9 @@ namespace BuildXL.Engine
         /// </summary>
         public void WriteToFile(
             BinaryWriter writer,
+            PathTable pathTable,
             IReadOnlyDictionary<string, string> buildParametersImpactingBuild,
+            IReadOnlyDictionary<string, IMount> mountsImpactingBuild,
             string changeTrackingStatePath)
         {
             Contract.Requires(writer != null);
@@ -566,6 +568,23 @@ namespace BuildXL.Engine
                     {
                         writer.Write(kvp.Key);
                         writer.Write(NormalizeEnvironmentVariableValue(kvp.Value));
+                    }
+                }
+            }
+
+            // Write the mounts that impact the build
+            if (mountsImpactingBuild == null)
+            {
+                writer.Write(0);
+            }
+            else
+            {
+                writer.Write(mountsImpactingBuild.Count);
+                {
+                    foreach (var kvp in mountsImpactingBuild)
+                    {
+                        writer.Write(kvp.Key);
+                        writer.Write(kvp.Value.Path.ToString(pathTable));
                     }
                 }
             }
@@ -613,7 +632,7 @@ namespace BuildXL.Engine
         /// Deserializes input tracker and writes it as text.
         /// </summary>
         /// <remarks>
-        /// We never create an input tracker from its serialized form. In <see cref="MatchesReader(LoggingContext, BinaryReader, FileContentTable, JournalState, TimeSpan?, string, IBuildParameters, Engine.GraphFingerprint, int, IConfiguration, bool)"/>
+        /// We never create an input tracker from its serialized form. In <see cref="MatchesReader(LoggingContext, BinaryReader, FileContentTable, JournalState, TimeSpan?, string, IBuildParameters, MountsTable, Engine.GraphFingerprint, int, IConfiguration, bool)"/>
         /// we do both serialization and input matching simultaneously. This method is only intended for analyzer to read and print the content of input tracker.
         /// </remarks>
         public static void ReadAndWriteText(BinaryReader reader, TextWriter writer)
@@ -636,6 +655,24 @@ namespace BuildXL.Engine
                 }
 
                 foreach (var envVar in envVarList.OrderBy(tuple => tuple.Item1, StringComparer.OrdinalIgnoreCase))
+                {
+                    writer.WriteLine(I($"\t - ({envVar.Item1}, {envVar.Item2})"));
+                }
+            }
+
+            int mountsImpactingBuildCount = reader.ReadInt32();
+
+            if (mountsImpactingBuildCount > 0)
+            {
+                var mountList = new List<(string, string)>();
+                writer.WriteLine("Mounts: ");
+
+                for (int i = 0; i < mountsImpactingBuildCount; ++i)
+                {
+                    mountList.Add((reader.ReadString(), reader.ReadString()));
+                }
+
+                foreach (var envVar in mountList.OrderBy(tuple => tuple.Item1, StringComparer.OrdinalIgnoreCase))
                 {
                     writer.WriteLine(I($"\t - ({envVar.Item1}, {envVar.Item2})"));
                 }
@@ -703,6 +740,7 @@ namespace BuildXL.Engine
             EngineSerializer serializer,
             FileContentTable fileContentTable,
             IBuildParameters availableEnvironmentVariables,
+            MountsTable availableMounts,
             GraphFingerprint graphFingerprint,
             int maxDegreeOfParallelism,
             IConfiguration configuration,
@@ -736,6 +774,7 @@ namespace BuildXL.Engine
                                     timeLimitForJournalScanning,
                                     changeTrackingStatePath,
                                     availableEnvironmentVariables,
+                                    availableMounts,
                                     graphFingerprint,
                                     maxDegreeOfParallelism,
                                     configuration,
@@ -767,6 +806,7 @@ namespace BuildXL.Engine
             TimeSpan? timeLimitForJournalScanning,
             string changeTrackingStatePath,
             IBuildParameters availableEnvironmentVariables,
+            MountsTable availableMounts,
             GraphFingerprint graphFingerprint,
             int maxDegreeOfParallelism,
             IConfiguration configuration,
@@ -851,7 +891,41 @@ namespace BuildXL.Engine
                 }
             }
 
-            // Step 4: Check if input files in the input tracker match the actual ones using journal scan and, if needed, checking content hashes.
+            // Step 4: Check if all mounts in the previous input tracker match with the current ones.
+            var availableMountsByName = availableMounts.MountsByName;
+            int mountCount = reader.ReadInt32();
+            for (int i = 0; i < mountCount; i++)
+            {
+                string mountName = reader.ReadString();
+                string previousPath = reader.ReadString();
+
+                if (availableMountsByName.ContainsKey(mountName))
+                {
+                    string currentPath = availableMountsByName[mountName].Path.ToString(availableMounts.MountPathExpander.PathTable);
+                    if (!previousPath.Equals(currentPath, StringComparison.OrdinalIgnoreCase))
+                    {
+                        result.MissType = GraphCacheMissReason.MountChanged;
+                        result.FirstMissIdentifier = string.Format(
+                            CultureInfo.InvariantCulture,
+                            Strings.InputTracker_MountChanged,
+                            mountName,
+                            previousPath,
+                            currentPath);
+                        Logger.Log.InputTrackerDetectedMountChanged(loggingContext, mountName, previousPath, currentPath);
+                        return result;
+                    }
+                }
+                else
+                {
+                    // The previously used mount is not known
+                    result.MissType = GraphCacheMissReason.MountChanged;
+                    result.FirstMissIdentifier = string.Format(CultureInfo.InvariantCulture, Strings.InputTracker_MountRemoved, mountName);
+                    Logger.Log.InputTrackerDetectedMountChanged(loggingContext, mountName, previousPath, string.Empty);
+                    return result;
+                }
+            }
+
+            // Step 5: Check if input files in the input tracker match the actual ones using journal scan and, if needed, checking content hashes.
 
             // The previous run may have had journal-based change tracking enabled. If so, we can try to establish the absence
             // of changes without checking individual files.

--- a/Public/Src/Engine/Dll/Strings.resx
+++ b/Public/Src/Engine/Dll/Strings.resx
@@ -216,4 +216,10 @@
   <data name="Layout_DefaultJunctionNameTotLogFolder" xml:space="preserve">
     <value>BuildXLCurrentLog</value>
   </data>
+  <data name="InputTracker_MountChanged" xml:space="preserve">
+    <value>Mount {0} was:'{1}' now:'{2}'</value>
+  </data>
+  <data name="InputTracker_MountRemoved" xml:space="preserve">
+    <value>{0} was previously defined as a mount but is now undefined</value>
+  </data>
 </root>

--- a/Public/Src/Engine/Dll/Strings.resx
+++ b/Public/Src/Engine/Dll/Strings.resx
@@ -220,6 +220,6 @@
     <value>Mount {0} was:'{1}' now:'{2}'</value>
   </data>
   <data name="InputTracker_MountRemoved" xml:space="preserve">
-    <value>{0} was previously defined as a mount but is now undefined</value>
+    <value>Mount '{0}' has been removed, it was previously defined as '{1}'</value>
   </data>
 </root>

--- a/Public/Src/Engine/Dll/Tracing/Log.cs
+++ b/Public/Src/Engine/Dll/Tracing/Log.cs
@@ -143,6 +143,16 @@ namespace BuildXL.Engine.Tracing
         public abstract void InputTrackerDetectedEnvironmentVariableChanged(LoggingContext context, string variableName, string recordedValue, string currentValue);
 
         [GeneratedEvent(
+           (ushort)LogEventId.InputTrackerDetectedMountChanged,
+           EventGenerators = EventGenerators.LocalOnly,
+           EventLevel = Level.Verbose,
+           EventTask = (ushort)Events.Tasks.Engine,
+           EventOpcode = (byte)EventOpcode.Start,
+           Keywords = (int)(Events.Keywords.UserMessage),
+           Message = "Input tracker detected first changed mount: Mount name: {mountName} | Recorded path: {recordedPath} | Current path: {currentPath}")]
+        public abstract void InputTrackerDetectedMountChanged(LoggingContext context, string mountName, string recordedPath, string currentPath);
+
+        [GeneratedEvent(
             (ushort)LogEventId.InputTrackerUnableToDetectChangedInputFileByCheckingContentHash,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,
@@ -2871,6 +2881,11 @@ If you can't update and need this feature after July 2018 please reach out to th
         /// One or more environment variables changed
         /// </summary>
         EnvironmentVariableChanged,
+
+        /// <summary>
+        /// One or more mounts or mount paths changed
+        /// </summary>
+        MountChanged,
 
         /// <summary>
         /// One or more spec files changed

--- a/Public/Src/Engine/Dll/Tracing/LogEventId.cs
+++ b/Public/Src/Engine/Dll/Tracing/LogEventId.cs
@@ -131,6 +131,8 @@ namespace BuildXL.Engine.Tracing
         FailureLaunchingBuildExplorerFileNotFound = 2895,
         FailureLaunchingBuildExplorerException = 2896,
 
+        InputTrackerDetectedMountChanged = 2987,
+
         // RESERVED TO [2800, 2899] (BuildXL.Engine.dll)
 
         // Distribution [7000, 7050]

--- a/Public/Src/Engine/UnitTests/Engine/MiniBuild.cs
+++ b/Public/Src/Engine/UnitTests/Engine/MiniBuild.cs
@@ -650,7 +650,6 @@ namespace Test.BuildXL.EngineTests
             // Revert environment variable.
             Configuration.Startup.Properties[EnvVarName] = "Env1";
 
-            System.Diagnostics.Debugger.Launch();
             RunEngine("Third build");
 
             AssertInformationalEventLogged(FrontEndEventId.FrontEndStartEvaluateValues, count: 0);

--- a/Public/Src/Engine/UnitTests/Engine/MiniBuild.cs
+++ b/Public/Src/Engine/UnitTests/Engine/MiniBuild.cs
@@ -650,6 +650,7 @@ namespace Test.BuildXL.EngineTests
             // Revert environment variable.
             Configuration.Startup.Properties[EnvVarName] = "Env1";
 
+            System.Diagnostics.Debugger.Launch();
             RunEngine("Third build");
 
             AssertInformationalEventLogged(FrontEndEventId.FrontEndStartEvaluateValues, count: 0);

--- a/Public/Src/FrontEnd/UnitTests/Script.Ast/Test.BuildXL.FrontEnd.Script.dsc
+++ b/Public/Src/FrontEnd/UnitTests/Script.Ast/Test.BuildXL.FrontEnd.Script.dsc
@@ -15,6 +15,7 @@ namespace Script {
 
     @@public
     export const dll = BuildXLSdk.test({
+        testFramework: importFrom("Sdk.Managed.Testing.XUnit").framework,
         assemblyName: "Test.BuildXL.FrontEnd.Script",
         sources: globR(d`.`, "*.cs"),
         runTestArgs: {


### PR DESCRIPTION
When checking whether the build graph can be re-used, InputTracker should take into account any changes to build mount paths and automatically return a graph cache miss if there are any changes. 

Otherwise, a graph might be re-used with the wrong mount paths causing incorrect tracking and possibly Disallowed File Accesses for the new mount paths. For example, when different users share the same EngineCache and have different user profile mount paths.