### PR TITLE
Avoid scrubbing non-scrubbable mountpoints

### DIFF
--- a/Public/Src/App/Bxl/Args.cs
+++ b/Public/Src/App/Bxl/Args.cs
@@ -991,7 +991,10 @@ namespace BuildXL
                             CommandLineUtilities.ParseBoolEnumOption(opt, sign, PreserveOutputsMode.Enabled, PreserveOutputsMode.Disabled),
                             isUnsafe: true,
                             isEnabled: (() => sandboxConfiguration.UnsafeSandboxConfiguration.PreserveOutputs != PreserveOutputsMode.Disabled)),
-
+                        OptionHandlerFactory.CreateBoolOption(
+                            "unsafe_DisableSharedOpaqueEmptyDirectoryScrubbing",
+                            sign => schedulingConfiguration.UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing = sign,
+                            isUnsafe: true),
                         // TODO: Remove this!
                         OptionHandlerFactory.CreateBoolOption(
                             "unsafe_SourceFileCanBeInsideOutputDirectory",

--- a/Public/Src/App/Bxl/Args.cs
+++ b/Public/Src/App/Bxl/Args.cs
@@ -889,6 +889,10 @@ namespace BuildXL
                             sign => schedulingConfiguration.UnsafeDisableGraphPostValidation = sign,
                             isUnsafe: true),
                         OptionHandlerFactory.CreateBoolOption(
+                            "unsafe_DisableSharedOpaqueEmptyDirectoryScrubbing",
+                            sign => schedulingConfiguration.UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing = sign,
+                            isUnsafe: true),
+                        OptionHandlerFactory.CreateBoolOption(
                             "unsafe_ExistingDirectoryProbesAsEnumerations",
                             sign => sandboxConfiguration.UnsafeSandboxConfigurationMutable.ExistingDirectoryProbesAsEnumerations = sign,
                             isUnsafe: true),
@@ -991,10 +995,6 @@ namespace BuildXL
                             CommandLineUtilities.ParseBoolEnumOption(opt, sign, PreserveOutputsMode.Enabled, PreserveOutputsMode.Disabled),
                             isUnsafe: true,
                             isEnabled: (() => sandboxConfiguration.UnsafeSandboxConfiguration.PreserveOutputs != PreserveOutputsMode.Disabled)),
-                        OptionHandlerFactory.CreateBoolOption(
-                            "unsafe_DisableSharedOpaqueEmptyDirectoryScrubbing",
-                            sign => schedulingConfiguration.UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing = sign,
-                            isUnsafe: true),
                         // TODO: Remove this!
                         OptionHandlerFactory.CreateBoolOption(
                             "unsafe_SourceFileCanBeInsideOutputDirectory",

--- a/Public/Src/Engine/Dll/DirectoryScrubber.cs
+++ b/Public/Src/Engine/Dll/DirectoryScrubber.cs
@@ -360,6 +360,7 @@ namespace BuildXL.Engine
                         {
                             try
                             {
+                                Tracing.Logger.Log.ScrubbingDirectory(pm.LoggingContext, directory);
                                 FileUtilities.DeleteDirectoryContents(directory, deleteRootDirectory: true, tempDirectoryCleaner: m_tempDirectoryCleaner);
                                 Interlocked.Increment(ref directoriesRemovedRecursively);
                             }

--- a/Public/Src/Engine/Dll/DirectoryScrubber.cs
+++ b/Public/Src/Engine/Dll/DirectoryScrubber.cs
@@ -360,7 +360,6 @@ namespace BuildXL.Engine
                         {
                             try
                             {
-                                Tracing.Logger.Log.ScrubbingDirectory(pm.LoggingContext, directory);
                                 FileUtilities.DeleteDirectoryContents(directory, deleteRootDirectory: true, tempDirectoryCleaner: m_tempDirectoryCleaner);
                                 Interlocked.Increment(ref directoriesRemovedRecursively);
                             }

--- a/Public/Src/Engine/Dll/Engine.cs
+++ b/Public/Src/Engine/Dll/Engine.cs
@@ -2173,7 +2173,8 @@ namespace BuildXL.Engine
                 { "unsafe_LazySymlinkCreation", Logger.Log.ConfigUnsafeLazySymlinkCreation },
                 { "unsafe_MonitorFileAccesses", Logger.Log.ConfigUnsafeDisabledFileAccessMonitoring },
                 { "unsafe_PreserveOutputs", Logger.Log.ConfigPreserveOutputs },
-                { "unsafe_SourceFileCanBeInsideOutputDirectory", loggingContext => { } },
+                { "unsafe_DisableSharedOpaqueEmptyDirectoryScrubbing", Logger.Log.ConfigUnsafeDisableSharedOpaqueEmptyDirectoryScrubbing },
+                { "unsafe_SourceFileCanBeInsideOutputDirectory", loggingContext => { } /* Special case: unsafe option we do not want logged */ },
                 { "unsafe_UnexpectedFileAccessesAreErrors", Logger.Log.ConfigUnsafeUnexpectedFileAccessesAsWarnings },
             };
         }

--- a/Public/Src/Engine/Dll/Engine.cs
+++ b/Public/Src/Engine/Dll/Engine.cs
@@ -2157,6 +2157,7 @@ namespace BuildXL.Engine
                 { "unsafe_DisableCycleDetection", Logger.Log.ConfigUnsafeDisableCycleDetection },
                 { "unsafe_DisableDetours", Logger.Log.ConfigDisableDetours },
                 { "unsafe_DisableGraphPostValidation", loggingContext => { } /* Special case: unsafe option we do not want logged */ },
+                { "unsafe_DisableSharedOpaqueEmptyDirectoryScrubbing", Logger.Log.ConfigUnsafeDisableSharedOpaqueEmptyDirectoryScrubbing },
                 { "unsafe_ExistingDirectoryProbesAsEnumerations", Logger.Log.ConfigUnsafeExistingDirectoryProbesAsEnumerations },
                 { "unsafe_ForceSkipDeps", Logger.Log.ForceSkipDependenciesEnabled },
                 { "unsafe_IgnoreGetFinalPathNameByHandle", Logger.Log.ConfigIgnoreGetFinalPathNameByHandle },
@@ -2173,7 +2174,6 @@ namespace BuildXL.Engine
                 { "unsafe_LazySymlinkCreation", Logger.Log.ConfigUnsafeLazySymlinkCreation },
                 { "unsafe_MonitorFileAccesses", Logger.Log.ConfigUnsafeDisabledFileAccessMonitoring },
                 { "unsafe_PreserveOutputs", Logger.Log.ConfigPreserveOutputs },
-                { "unsafe_DisableSharedOpaqueEmptyDirectoryScrubbing", Logger.Log.ConfigUnsafeDisableSharedOpaqueEmptyDirectoryScrubbing },
                 { "unsafe_SourceFileCanBeInsideOutputDirectory", loggingContext => { } /* Special case: unsafe option we do not want logged */ },
                 { "unsafe_UnexpectedFileAccessesAreErrors", Logger.Log.ConfigUnsafeUnexpectedFileAccessesAsWarnings },
             };

--- a/Public/Src/Engine/Dll/EngineSchedule.cs
+++ b/Public/Src/Engine/Dll/EngineSchedule.cs
@@ -810,7 +810,9 @@ namespace BuildXL.Engine
                     // Everything that is not an output under a shared opaque is considered part of the build. 
                     isPathInBuild: path =>
                         // Scheduler.PipGraph.IsPathInBuild is used for extra safety.
-                        scheduler.PipGraph.IsPathInBuild(AbsolutePath.Create(scheduler.Context.PathTable, path)) || !SharedOpaqueOutputHelper.IsSharedOpaqueOutput(path) || (configuration.Schedule.UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing && Directory.Exists(path) && !Directory.EnumerateFileSystemEntries(path).Any()), 
+                        scheduler.PipGraph.IsPathInBuild(AbsolutePath.Create(scheduler.Context.PathTable, path)) ||
+                        !SharedOpaqueOutputHelper.IsSharedOpaqueOutput(path) ||
+                        ShouldRemoveEmptyDirectories(configuration, path),
                     pathsToScrub: sharedOpaqueDirectories.Select(directory => directory.Path.ToString(scheduler.Context.PathTable)),
                     blockedPaths: nonScrubbablePaths,
                     nonDeletableRootDirectories: outputDirectories,
@@ -822,6 +824,11 @@ namespace BuildXL.Engine
                 Logger.Log.ScrubbingSharedOpaquesStarted(loggingContext);
                 scrubber.RemoveExtraneousFilesAndDirectories(scheduler.Context.CancellationToken);
             }
+        }
+
+        private static bool ShouldRemoveEmptyDirectories(IConfiguration configuration, string path)
+        {
+            return configuration.Schedule.UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing && Directory.Exists(path) && !Directory.EnumerateFileSystemEntries(path).Any();
         }
 
         internal static IReadOnlyList<string> GetNonScrubbablePaths(

--- a/Public/Src/Engine/Dll/EngineSchedule.cs
+++ b/Public/Src/Engine/Dll/EngineSchedule.cs
@@ -810,8 +810,7 @@ namespace BuildXL.Engine
                     // Everything that is not an output under a shared opaque is considered part of the build. 
                     isPathInBuild: path =>
                         // Scheduler.PipGraph.IsPathInBuild is used for extra safety.
-                        scheduler.PipGraph.IsPathInBuild(AbsolutePath.Create(scheduler.Context.PathTable, path)) ||
-                        !SharedOpaqueOutputHelper.IsSharedOpaqueOutput(path), 
+                        scheduler.PipGraph.IsPathInBuild(AbsolutePath.Create(scheduler.Context.PathTable, path)) || !SharedOpaqueOutputHelper.IsSharedOpaqueOutput(path) || (configuration.Schedule.UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing && Directory.Exists(path) && !Directory.EnumerateFileSystemEntries(path).Any()), 
                     pathsToScrub: sharedOpaqueDirectories.Select(directory => directory.Path.ToString(scheduler.Context.PathTable)),
                     blockedPaths: nonScrubbablePaths,
                     nonDeletableRootDirectories: outputDirectories,

--- a/Public/Src/Engine/Dll/EngineSchedule.cs
+++ b/Public/Src/Engine/Dll/EngineSchedule.cs
@@ -828,6 +828,7 @@ namespace BuildXL.Engine
 
         private static bool ShouldRemoveEmptyDirectories(IConfiguration configuration, string path)
         {
+            // EnumerateFileSystemEntries is known to be slow, but is used anyways because of the expected use-case.
             return configuration.Schedule.UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing && Directory.Exists(path) && !Directory.EnumerateFileSystemEntries(path).Any();
         }
 

--- a/Public/Src/Engine/Dll/Tracing/Log.cs
+++ b/Public/Src/Engine/Dll/Tracing/Log.cs
@@ -1815,6 +1815,15 @@ If you can't update and need this feature after July 2018 please reach out to th
         private const string ScrubbingStatusPrefix = "Scrubbing files extraneous to this build.";
 
         [GeneratedEvent(
+            (ushort)EventId.ConfigUnsafeSharedOpaqueEmptyDirectoryScrubbingDisabled,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Warning,
+            Keywords = (int)Events.Keywords.UserMessage,
+            EventTask = (int)Events.Tasks.Engine,
+            Message = "/unsafe_DisableSharedOpaqueEmptyDirectoryScrubbing: removal of empty directories within shared opaques has been disabled. This is an unsafe configuration since it may work in detriment of build correctness.")]
+        public abstract void ConfigUnsafeDisableSharedOpaqueEmptyDirectoryScrubbing(LoggingContext context);
+
+        [GeneratedEvent(
             (int)EventId.ScrubbingStarted,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Informational,

--- a/Public/Src/Engine/UnitTests/Engine/SharedOpaqueEngineTests.cs
+++ b/Public/Src/Engine/UnitTests/Engine/SharedOpaqueEngineTests.cs
@@ -82,8 +82,10 @@ namespace Test.BuildXL.Engine
             Assert.True(File.Exists(Path.Combine(objDir, outOfBuildFile)));
         }
 
-        [Fact]
-        public void UnsafeEmptyDirectoriesUnderSharedOpaqueAreNotScrubbedWhenDisabled()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void UnsafeEmptyDirectoriesUnderSharedOpaqueAreNotScrubbedWhenDisabled(bool disableEmptyDirectoryScrubbing)
         {
             // The unsafe option should be off by default
             Assert.False(Configuration.Schedule.UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing);
@@ -96,18 +98,14 @@ namespace Test.BuildXL.Engine
             var spec0 = ProduceFileUnderSharedOpaque(file);
             AddModule("Module0", ("spec0.dsc", spec0), placeInRoot: true);
 
-            // When the option is disabled, the untracked directory should be removed
             Assert.False(Directory.Exists(untrackedDirectoryPath));
             Directory.CreateDirectory(untrackedDirectoryPath);
-            Configuration.Schedule.UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing = false;
+            Configuration.Schedule.UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing = disableEmptyDirectoryScrubbing;
             RunEngine(expectSuccess: true);
-            Assert.False(Directory.Exists(untrackedDirectoryPath));
 
-            // When the option is enabled, it should not.
-            Directory.CreateDirectory(untrackedDirectoryPath);
-            Configuration.Schedule.UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing = true;
-            RunEngine(expectSuccess: true);
-            Assert.True(Directory.Exists(untrackedDirectoryPath));
+            // When the option is disabled, the untracked directory should be removed.
+            Assert.Equal(Directory.Exists(untrackedDirectoryPath), disableEmptyDirectoryScrubbing);
+
             Configuration.Schedule.UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing = false;
         }
 

--- a/Public/Src/Utilities/Configuration/IScheduleConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/IScheduleConfiguration.cs
@@ -286,5 +286,13 @@ namespace BuildXL.Utilities.Configuration
         /// Skip hash source file pips during graph creation.
         /// </summary>
         bool SkipHashSourceFile { get; }
+
+        /// <summary>
+        /// Unsafe configuration that stops the shared opaque scrubber from deleting empty directories
+        /// </summary>
+        /// <remarks>
+        /// TODO: Remove this when https://gitlab.kitware.com/cmake/cmake/issues/19162 has reached mainstream versions
+        /// </remarks>
+        bool UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing { get; }
     }
 }

--- a/Public/Src/Utilities/Configuration/IScheduleConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/IScheduleConfiguration.cs
@@ -291,6 +291,14 @@ namespace BuildXL.Utilities.Configuration
         /// Unsafe configuration that stops the shared opaque scrubber from deleting empty directories
         /// </summary>
         /// <remarks>
+        /// The reason this flag is unsafe is because not deleting empty directories may introduce 
+        /// nondeterminism to a build; shared opaques should be wiped-clean of non-build files before 
+        /// engine execution.
+        /// 
+        /// For example, if ./a is a shared opaque, ./a/b is an undeclared empty directory, and some.exe 
+        /// fails if ./a/b does not exist, then this flag will allow some.exe to execute successfully 
+        /// even though it normally would not.
+        /// 
         /// TODO: Remove this when https://gitlab.kitware.com/cmake/cmake/issues/19162 has reached mainstream versions
         /// </remarks>
         bool UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing { get; }

--- a/Public/Src/Utilities/Configuration/Mutable/ScheduleConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/ScheduleConfiguration.cs
@@ -70,6 +70,8 @@ namespace BuildXL.Utilities.Configuration.Mutable
             TelemetryTagPrefix = null;
 
             SkipHashSourceFile = false;
+
+            UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing = false;
         }
 
         /// <nodoc />
@@ -131,6 +133,8 @@ namespace BuildXL.Utilities.Configuration.Mutable
             MasterCpuMultiplier = template.MasterCpuMultiplier;
             MasterCacheLookupMultiplier = template.MasterCacheLookupMultiplier;
             SkipHashSourceFile = template.SkipHashSourceFile;
+
+            UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing = template.UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing;
         }
 
         /// <inheritdoc />
@@ -305,5 +309,8 @@ namespace BuildXL.Utilities.Configuration.Mutable
 
         /// <inheritdoc />
         public bool SkipHashSourceFile { get; set; }
+
+        /// <inheritdoc />
+        public bool UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing { get; set; }
     }
 }

--- a/Public/Src/Utilities/Utilities/Tracing/EventId.cs
+++ b/Public/Src/Utilities/Utilities/Tracing/EventId.cs
@@ -531,6 +531,7 @@ namespace BuildXL.Utilities.Tracing
         CleaningDirectoryFailed = 864,
 
         ScrubbingFailedToEnumerateMissingDirectory = 865,
+        ConfigUnsafeSharedOpaqueEmptyDirectoryScrubbingDisabled = 866,
 
         // Config
         ConfigUnsafeDisabledFileAccessMonitoring = 900,


### PR DESCRIPTION
When working on the VcPkg integration, a few packages would fail to build due to BXL scrubbing internal CMake directories that were pre-made and empty by build-time (these were located inside a shared opaque).

The agreed-upon solution is to introduce an unsafe flag to instruct the shared opaque scrubber to specifically not remove these empty directories.