### PR TITLE
Do not create checkpoint if no events were received.

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
@@ -541,7 +541,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         {
             // Need to obtain the sequence point first to avoid race between the sequence point and the database's state.
             EventSequencePoint currentSequencePoint = EventStore.GetLastProcessedSequencePoint();
-            if (currentSequencePoint == null)
+            if (currentSequencePoint == null || currentSequencePoint.SequenceNumber == null)
             {
                 Tracer.Debug(context.TracingContext, "Could not create a checkpoint because the sequence point is missing. Apparently, no events were processed at this time.");
                 return BoolResult.Success;


### PR DESCRIPTION
Master service should not create checkpoints if no events were received.

The current logic was checking the result of `EventStore.GetLastProcessedSequencePoint` to `null` to check this case. But the sequence point can be non-null, but still contain no sequence numbers.

Fix for #AB1510624