### PR TITLE
Avoid OutOfMemory Exception during runtime cache miss

### DIFF
--- a/Public/Src/Engine/Scheduler/Tracing/Log.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/Log.cs
@@ -4150,7 +4150,7 @@ namespace BuildXL.Scheduler.Tracing
             EventLevel = Level.Verbose,
             Keywords = (int)Events.Keywords.UserMessage,
             EventTask = (ushort)Events.Tasks.Storage,
-            Message = "Cache miss analysis failed for {pipDescription} with exception: {exception}\r\nOld entry:\r\n{oldEntry}\r\nNew entry:\r\n{newEntry}")]
+            Message = "Cache miss analysis failed for {pipDescription} with exception: {exception}\r\nOld entry keys:\r\n{oldEntry}\r\nNew entry keys:\r\n{newEntry}")]
         public abstract void CacheMissAnalysisException(LoggingContext loggingContext, string pipDescription, string exception, string oldEntry, string newEntry);
 
         [GeneratedEvent(

--- a/Public/Src/Engine/Scheduler/Tracing/RuntimeCacheMissAnalyzer.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/RuntimeCacheMissAnalyzer.cs
@@ -212,7 +212,7 @@ namespace BuildXL.Scheduler.Tracing
             catch (Exception ex)
             {
                 // Cache miss analysis shouldn't fail the build
-                Logger.Log.CacheMissAnalysisException(m_loggingContext, pipDescription, ex.ToString(), oldEntry?.ToString(), newEntry?.ToString());
+                Logger.Log.CacheMissAnalysisException(m_loggingContext, pipDescription, ex.ToString(), oldEntry?.PipToFingerprintKeys.ToString(), newEntry?.PipToFingerprintKeys.ToString());
             }
         }
 


### PR DESCRIPTION
Don't print full FingerprintStoreEntry when logging information about a Runtime cache miss analysis exception. The FingerprintStoreEntry.ToString() method will cause OutOfMemory if the pip's fingerprint is huge. FingerprintStore.ToString() is convenient for debugging, and is never called anywhere else so it is being left as-is.

During post-build cache miss, FingerprintStoreEntry.Print() is used to write incrementally, directly to a file and don't have to deal with the CLR memory limitations like runtime cache miss.

Cache miss analysis itself is done in pieces (weak & strong) and never has to assemble the entire FingerprintStoreEntry into one string.

Fixes [AB#1503656](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1503656)