### PR TITLE
ReadOnlyEmptyContentSession implements ContentSessionBase for logs

### DIFF
--- a/Public/Src/Cache/ContentStore/Library/Stores/ReadOnlyEmptyContentStore.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/ReadOnlyEmptyContentStore.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using BuildXL.Cache.ContentStore.Hashing;
 using BuildXL.Cache.ContentStore.Interfaces.FileSystem;
@@ -9,8 +8,11 @@ using BuildXL.Cache.ContentStore.Interfaces.Results;
 using BuildXL.Cache.ContentStore.Interfaces.Sessions;
 using BuildXL.Cache.ContentStore.Interfaces.Stores;
 using BuildXL.Cache.ContentStore.Interfaces.Tracing;
+using BuildXL.Cache.ContentStore.Sessions;
 using BuildXL.Cache.ContentStore.Tracing;
+using BuildXL.Cache.ContentStore.Tracing.Internal;
 using BuildXL.Cache.ContentStore.Utils;
+using BuildXL.Utilities.Tracing;
 
 namespace BuildXL.Cache.ContentStore.Stores
 {
@@ -37,12 +39,12 @@ namespace BuildXL.Cache.ContentStore.Stores
     /// <summary>
     /// ContentSession is empty and does not accept content. Useful when we want to disable content; specifically, to bypass talking to VSTS/CASaaS when unnecessary.
     /// </summary>
-    public class ReadOnlyEmptyContentSession : StartupShutdownBase, IContentSession
+    public class ReadOnlyEmptyContentSession : ContentSessionBase
     {
         /// <nodoc />
         public ReadOnlyEmptyContentSession(string name)
+            : base(name)
         {
-            Name = name;
         }
 
         private const string ErrorMessage = "Unsupported operation.";
@@ -51,42 +53,39 @@ namespace BuildXL.Cache.ContentStore.Stores
         protected override Tracer Tracer { get; } = new Tracer(nameof(ReadOnlyEmptyContentSession));
 
         /// <inheritdoc />
-        public string Name { get; private set; }
-
-        /// <inheritdoc />
-        public Task<OpenStreamResult> OpenStreamAsync(Context context, ContentHash contentHash, CancellationToken cts, UrgencyHint urgencyHint = UrgencyHint.Nominal)
+        protected override Task<OpenStreamResult> OpenStreamCoreAsync(OperationContext operationContext, ContentHash contentHash, UrgencyHint urgencyHint, Counter retryCounter)
             => Task.FromResult(new OpenStreamResult(null)); // Null stream signals failue.
 
         /// <inheritdoc />
-        public Task<PinResult> PinAsync(Context context, ContentHash contentHash, CancellationToken cts, UrgencyHint urgencyHint = UrgencyHint.Nominal)
+        protected override Task<PinResult> PinCoreAsync(OperationContext operationContext, ContentHash contentHash, UrgencyHint urgencyHint, Counter retryCounter)
             => Task.FromResult(new PinResult(PinResult.ResultCode.ContentNotFound));
 
         /// <inheritdoc />
-        public Task<IEnumerable<Task<Indexed<PinResult>>>> PinAsync(Context context, IReadOnlyList<ContentHash> contentHashes, CancellationToken cts, UrgencyHint urgencyHint = UrgencyHint.Nominal)
+        protected override Task<IEnumerable<Task<Indexed<PinResult>>>> PinCoreAsync(OperationContext operationContext, IReadOnlyList<ContentHash> contentHashes, UrgencyHint urgencyHint, Counter retryCounter, Counter fileCounter)
             => Task.FromResult(contentHashes.Select((hash, i) => Task.FromResult(new PinResult(PinResult.ContentNotFound).WithIndex(i))));
 
         /// <inheritdoc />
-        public Task<PlaceFileResult> PlaceFileAsync(Context context, ContentHash contentHash, AbsolutePath path, FileAccessMode accessMode, FileReplacementMode replacementMode, FileRealizationMode realizationMode, CancellationToken cts, UrgencyHint urgencyHint = UrgencyHint.Nominal)
+        protected override Task<PlaceFileResult> PlaceFileCoreAsync(OperationContext operationContext, ContentHash contentHash, AbsolutePath path, FileAccessMode accessMode, FileReplacementMode replacementMode, FileRealizationMode realizationMode, UrgencyHint urgencyHint, Counter retryCounter)
             => Task.FromResult(new PlaceFileResult(PlaceFileResult.ResultCode.NotPlacedContentNotFound));
 
         /// <inheritdoc />
-        public Task<IEnumerable<Task<Indexed<PlaceFileResult>>>> PlaceFileAsync(Context context, IReadOnlyList<ContentHashWithPath> hashesWithPaths, FileAccessMode accessMode, FileReplacementMode replacementMode, FileRealizationMode realizationMode, CancellationToken cts, UrgencyHint urgencyHint = UrgencyHint.Nominal)
+        protected override Task<IEnumerable<Task<Indexed<PlaceFileResult>>>> PlaceFileCoreAsync(OperationContext operationContext, IReadOnlyList<ContentHashWithPath> hashesWithPaths, FileAccessMode accessMode, FileReplacementMode replacementMode, FileRealizationMode realizationMode, UrgencyHint urgencyHint, Counter retryCounter)
             => Task.FromResult(hashesWithPaths.Select((hash, i) => Task.FromResult(new PlaceFileResult(PlaceFileResult.ResultCode.NotPlacedContentNotFound).WithIndex(i))));
 
         /// <inheritdoc />
-        public Task<PutResult> PutFileAsync(Context context, HashType hashType, AbsolutePath path, FileRealizationMode realizationMode, CancellationToken cts, UrgencyHint urgencyHint = UrgencyHint.Nominal)
+        protected override Task<PutResult> PutFileCoreAsync(OperationContext operationContext, HashType hashType, AbsolutePath path, FileRealizationMode realizationMode, UrgencyHint urgencyHint, Counter retryCounter)
             => Task.FromResult(new PutResult(new BoolResult(ErrorMessage)));
 
         /// <inheritdoc />
-        public Task<PutResult> PutFileAsync(Context context, ContentHash contentHash, AbsolutePath path, FileRealizationMode realizationMode, CancellationToken cts, UrgencyHint urgencyHint = UrgencyHint.Nominal)
+        protected override Task<PutResult> PutFileCoreAsync(OperationContext operationContext, ContentHash contentHash, AbsolutePath path, FileRealizationMode realizationMode, UrgencyHint urgencyHint, Counter retryCounter)
             => Task.FromResult(new PutResult(contentHash, ErrorMessage));
 
         /// <inheritdoc />
-        public Task<PutResult> PutStreamAsync(Context context, HashType hashType, Stream stream, CancellationToken cts, UrgencyHint urgencyHint = UrgencyHint.Nominal)
+        protected override Task<PutResult> PutStreamCoreAsync(OperationContext operationContext, HashType hashType, Stream stream, UrgencyHint urgencyHint, Counter retryCounter)
             => Task.FromResult(new PutResult(new BoolResult(ErrorMessage)));
 
         /// <inheritdoc />
-        public Task<PutResult> PutStreamAsync(Context context, ContentHash contentHash, Stream stream, CancellationToken cts, UrgencyHint urgencyHint = UrgencyHint.Nominal)
+        protected override Task<PutResult> PutStreamCoreAsync(OperationContext operationContext, ContentHash contentHash, Stream stream, UrgencyHint urgencyHint, Counter retryCounter)
             => Task.FromResult(new PutResult(contentHash, ErrorMessage));
     }
 }


### PR DESCRIPTION
Strange bahavior has been seen on tests, and lack of logging has made it more difficult to debug.

Implementing ContentSessionBase automatically gives us logging for all operations.