### PR TITLE
Add proper qualifier support to MSBuildResolver

### DIFF
--- a/Public/Src/Engine/Scheduler/BuildXL.Scheduler.dsc
+++ b/Public/Src/Engine/Scheduler/BuildXL.Scheduler.dsc
@@ -45,6 +45,7 @@ namespace Scheduler {
             "BuildXL.Engine",
             "Test.BuildXL.FingerprintStore",
             "Test.BuildXL.Scheduler",
+            "Test.BuildXL.FrontEnd.MsBuild",
             "Test.Tool.Analyzers",
             "IntegrationTest.BuildXL.Scheduler",
         ],

--- a/Public/Src/FrontEnd/CMake/CMakeWorkspaceResolver.cs
+++ b/Public/Src/FrontEnd/CMake/CMakeWorkspaceResolver.cs
@@ -50,6 +50,7 @@ namespace BuildXL.FrontEnd.CMake
 
         private AbsolutePath ProjectRoot => m_resolverSettings.ProjectRoot;
         private AbsolutePath m_buildDirectory;
+        private QualifierId[] m_requestedQualifiers;
         private const string DefaultBuildTarget = "all";
 
         // AsyncLazy graph
@@ -168,7 +169,8 @@ namespace BuildXL.FrontEnd.CMake
                 FrontEndHost,
                 Context,
                 Configuration,
-                m_embeddedResolverSettings.Value));
+                m_embeddedResolverSettings.Value,
+                m_requestedQualifiers));
         }
 
         private async Task<Possible<Unit>> GenerateBuildDirectoryAsync()
@@ -359,12 +361,14 @@ namespace BuildXL.FrontEnd.CMake
         }
 
         /// <inheritdoc cref="IDScriptWorkspaceModuleResolver" />
-        public bool TryInitialize([NotNull] FrontEndHost host, [NotNull] FrontEndContext context, [NotNull] IConfiguration configuration, [NotNull] IResolverSettings resolverSettings)
+        public bool TryInitialize([NotNull] FrontEndHost host, [NotNull] FrontEndContext context, [NotNull] IConfiguration configuration, [NotNull] IResolverSettings resolverSettings, [NotNull] QualifierId[] requestedQualifiers)
         {
             InitializeInterpreter(host, context, configuration);
             m_resolverSettings = resolverSettings as ICMakeResolverSettings;
             Contract.Assert(m_resolverSettings != null);
             m_buildDirectory = Configuration.Layout.OutputDirectory.Combine(Context.PathTable, m_resolverSettings.BuildDirectory);
+            m_requestedQualifiers = requestedQualifiers;
+
             return true;
         }
 

--- a/Public/Src/FrontEnd/Core/FrontEndHostController.Workspace.cs
+++ b/Public/Src/FrontEnd/Core/FrontEndHostController.Workspace.cs
@@ -91,9 +91,9 @@ namespace BuildXL.FrontEnd.Core
         /// Builds and filters the worksapce.
         /// </summary>
         [System.Diagnostics.ContractsLight.Pure]
-        internal Workspace DoPhaseBuildWorkspace(IConfiguration configuration, FrontEndEngineAbstraction engineAbstraction, EvaluationFilter evaluationFilter)
+        internal Workspace DoPhaseBuildWorkspace(IConfiguration configuration, FrontEndEngineAbstraction engineAbstraction, EvaluationFilter evaluationFilter, QualifierId[] requestedQualifiers)
         {
-            if (!TryGetWorkspaceProvider(configuration, out var workspaceProvider, out var failures))
+            if (!TryGetWorkspaceProvider(configuration, requestedQualifiers, out var workspaceProvider, out var failures))
             {
                 var workspaceConfiguration = GetWorkspaceConfiguration(configuration);
 

--- a/Public/Src/FrontEnd/Core/FrontEndHostController.cs
+++ b/Public/Src/FrontEnd/Core/FrontEndHostController.cs
@@ -345,6 +345,11 @@ namespace BuildXL.FrontEnd.Core
                 CycleDetector = null;
             }
 
+            if (!TryGetQualifiers(configuration, startupConfiguration.QualifierIdentifiers, out QualifierId[] qualifiersToEvaluate))
+            {
+                return false;
+            }
+
             // Frontend and resolver initialization happens before any other phase. Frontend initialization should happen before any 
             // access to the workspace resolver factory: a frontend may trigger a workspace resolver creation with a particular setting.
             // TODO: during workspace construction the workspace resolver factory is accessed directly, which is wrong from an architecture
@@ -357,7 +362,7 @@ namespace BuildXL.FrontEnd.Core
                 delegate(LoggingContext nestedLoggingContext, ref InitializeResolversStatistics statistics)
                 {
                     // TODO: Use nestedLoggingContext for resolver errors
-                    var success = TryInitializeFrontEndsAndResolvers(configuration);
+                    var success = TryInitializeFrontEndsAndResolvers(configuration, qualifiersToEvaluate);
 
                     statistics.ResolverCount = success ? m_resolvers.Length : 0;
 
@@ -375,7 +380,7 @@ namespace BuildXL.FrontEnd.Core
                 m_logger.FrontEndBuildWorkspacePhaseComplete,
                 delegate(LoggingContext nestedLoggingContext, ref WorkspaceStatistics statistics)
                 {
-                    Workspace = DoPhaseBuildWorkspace(configuration, engineAbstraction, evaluationFilter);
+                    Workspace = DoPhaseBuildWorkspace(configuration, engineAbstraction, evaluationFilter, qualifiersToEvaluate);
 
                     statistics.ProjectCount = Workspace.SpecCount;
                     statistics.ModuleCount = Workspace.ModuleCount;
@@ -435,11 +440,6 @@ namespace BuildXL.FrontEnd.Core
 
                     return result.Succeeded;
                 }))
-            {
-                return false;
-            }
-
-            if (!TryGetQualifiers(configuration, startupConfiguration.QualifierIdentifiers, out QualifierId[] qualifiersToEvaluate))
             {
                 return false;
             }
@@ -1073,7 +1073,7 @@ namespace BuildXL.FrontEnd.Core
         /// <summary>
         /// Initializes front-ends.
         /// </summary>
-        public bool TryInitializeFrontEndsAndResolvers(IConfiguration configuration)
+        public bool TryInitializeFrontEndsAndResolvers(IConfiguration configuration, QualifierId[] requestedQualifiers)
         {
             Contract.Requires(configuration != null);
             Contract.Requires(HostState == State.ConfigInterpreted);
@@ -1089,7 +1089,7 @@ namespace BuildXL.FrontEnd.Core
             // The factory context may be not set if the controller is not using the workspace, so we set that here
             if (!m_workspaceResolverFactory.IsInitialized)
             {
-                m_workspaceResolverFactory.Initialize(FrontEndContext, this, configuration);
+                m_workspaceResolverFactory.Initialize(FrontEndContext, this, configuration, requestedQualifiers);
             }
 
             foreach (IFrontEnd frontEnd in m_frontEndFactory.RegisteredFrontEnds)
@@ -1135,7 +1135,7 @@ namespace BuildXL.FrontEnd.Core
         }
 
         /// <summary>
-        /// An alternative to <see cref="TryInitializeFrontEndsAndResolvers(IConfiguration)"/> used for testing.  Instead
+        /// An alternative to <see cref="TryInitializeFrontEndsAndResolvers(IConfiguration, QualifierId[])"/> used for testing.  Instead
         /// of taking and parsing a config object, this method directly takes a list of resolvers.
         /// </summary>
         internal void InitializeResolvers(IEnumerable<IResolver> resolvers)
@@ -1147,14 +1147,14 @@ namespace BuildXL.FrontEnd.Core
         /// <summary>
         /// Returns a <see cref="IWorkspaceProvider"/> responsible for <see cref="Workspace"/> computation.
         /// </summary>
-        internal bool TryGetWorkspaceProvider(IConfiguration configuration, out IWorkspaceProvider workspaceProvider, out IEnumerable<Failure> failures)
+        internal bool TryGetWorkspaceProvider(IConfiguration configuration, QualifierId[] requestedQualifiers, out IWorkspaceProvider workspaceProvider, out IEnumerable<Failure> failures)
         {
             var workspaceConfiguration = GetWorkspaceConfiguration(configuration);
 
             // This is the point where we have all the objects we need to complete setting up the workspace factory
             if (!m_workspaceResolverFactory.IsInitialized)
             {
-                m_workspaceResolverFactory.Initialize(FrontEndContext, this, configuration);
+                m_workspaceResolverFactory.Initialize(FrontEndContext, this, configuration, requestedQualifiers);
             }
 
             return TryGetWorkspaceProvider(workspaceConfiguration, out workspaceProvider, out failures);
@@ -1324,7 +1324,7 @@ namespace BuildXL.FrontEnd.Core
             // Register the meta pips for the modules and the specs with the graph
             RegisterModuleAndSpecPips(Workspace);
 
-            // Workspace has been converted and is not needed any more
+            // Workspace has been converted and is not needed anymore
             CleanWorkspaceMemory();
 
             // Evaluate with progress reporting

--- a/Public/Src/FrontEnd/Download/DownloadWorkspaceResolver.cs
+++ b/Public/Src/FrontEnd/Download/DownloadWorkspaceResolver.cs
@@ -61,12 +61,13 @@ namespace BuildXL.FrontEnd.Download
         }
 
         /// <inheritdoc />
-        public bool TryInitialize([NotNull] FrontEndHost host, [NotNull] FrontEndContext context, [NotNull] IConfiguration configuration, [NotNull] IResolverSettings resolverSettings)
+        public bool TryInitialize([NotNull] FrontEndHost host, [NotNull] FrontEndContext context, [NotNull] IConfiguration configuration, [NotNull] IResolverSettings resolverSettings, [NotNull] QualifierId[] requestedQualifiers)
         {
             Contract.Requires(context != null);
             Contract.Requires(host != null);
             Contract.Requires(configuration != null);
             Contract.Requires(resolverSettings != null);
+            Contract.Requires(requestedQualifiers?.Length > 0);
 
             var settings = resolverSettings as IDownloadResolverSettings;
             Contract.Assert(settings != null);

--- a/Public/Src/FrontEnd/MsBuild.Serialization/GlobalProperties.cs
+++ b/Public/Src/FrontEnd/MsBuild.Serialization/GlobalProperties.cs
@@ -23,5 +23,11 @@ namespace BuildXL.FrontEnd.MsBuild.Serialization
         /// <nodoc/>
         public GlobalProperties(IEnumerable<KeyValuePair<string, string>> dictionary): base(dictionary.ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.OrdinalIgnoreCase))
         { }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return $"[{string.Join(";", Keys.Select(key => $"{key.ToUpperInvariant()}={this[key]}"))}]";
+        }
     }
 }

--- a/Public/Src/FrontEnd/MsBuild.Serialization/GlobalPropertiesDeserializer.cs
+++ b/Public/Src/FrontEnd/MsBuild.Serialization/GlobalPropertiesDeserializer.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace BuildXL.FrontEnd.MsBuild.Serialization
+{
+    /// <summary>
+    /// Allows global properties to be deserialized
+    /// </summary>
+    /// <remarks>
+    /// Newtonsoft does not support deserializing read-only collections where references may be preserved
+    /// </remarks>
+    public sealed class GlobalPropertiesDeserializer : JsonConverter
+    {
+        /// <nodoc/>
+        public GlobalPropertiesDeserializer()
+        {
+        }
+
+        /// <inheritdoc/>
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType.IsAssignableFrom(typeof(GlobalProperties));
+        }
+
+        /// <inheritdoc/>
+        public override bool CanWrite => false;
+
+        /// <inheritdoc/>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var dictionary = serializer.Deserialize<Dictionary<string, string>>(reader);
+            return dictionary == null ? null : new GlobalProperties(dictionary);
+        }
+
+        /// <inheritdoc/>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Public/Src/FrontEnd/MsBuild.Serialization/GraphSerializationSettings.cs
+++ b/Public/Src/FrontEnd/MsBuild.Serialization/GraphSerializationSettings.cs
@@ -19,6 +19,7 @@ namespace BuildXL.FrontEnd.MsBuild.Serialization
             PreserveReferencesHandling = PreserveReferencesHandling.Objects,
             Formatting = Formatting.Indented,
             NullValueHandling = NullValueHandling.Include,
+            Converters = new [] { new GlobalPropertiesDeserializer() }
         };
     }
 }

--- a/Public/Src/FrontEnd/MsBuild.Serialization/MSBuildGraphBuilderArguments.cs
+++ b/Public/Src/FrontEnd/MsBuild.Serialization/MSBuildGraphBuilderArguments.cs
@@ -33,11 +33,14 @@ namespace BuildXL.FrontEnd.MsBuild.Serialization
         /// <summary>
         /// Global MSBuild properties to use for all projects
         /// </summary>
-        /// <remarks>
-        /// Can be null
-        /// </remarks>
         [JsonProperty(IsReference = false)]
-        public IReadOnlyDictionary<string, string> GlobalProperties { get; }
+        public GlobalProperties GlobalProperties { get; }
+
+        /// <summary>
+        /// All requested qualifiers for this build, represented as global properties
+        /// </summary>
+        [JsonProperty(IsReference = false)]
+        public IReadOnlyCollection<GlobalProperties> RequestedQualifiers { get; }
 
         /// <summary>
         /// Collection of paths to search for the MSBuild toolset (assemblies), and MSBuild.exe itself
@@ -58,15 +61,18 @@ namespace BuildXL.FrontEnd.MsBuild.Serialization
             string enlistmentRoot,
             IReadOnlyCollection<string> projectsToParse, 
             string outputPath, 
-            IReadOnlyDictionary<string, string> globalProperties, 
+            GlobalProperties globalProperties,
             IReadOnlyCollection<string> mSBuildSearchLocations, 
-            IReadOnlyCollection<string> entryPointTargets)
+            IReadOnlyCollection<string> entryPointTargets,
+            IReadOnlyCollection<GlobalProperties> requestedQualifiers)
         {
             Contract.Requires(!string.IsNullOrEmpty(enlistmentRoot));
             Contract.Requires(projectsToParse?.Count > 0);
             Contract.Requires(!string.IsNullOrEmpty(outputPath));
+            Contract.Requires(globalProperties != null);
             Contract.Requires(mSBuildSearchLocations != null);
             Contract.Requires(entryPointTargets != null);
+            Contract.Requires(requestedQualifiers?.Count > 0);
 
             EnlistmentRoot = enlistmentRoot;
             ProjectsToParse = projectsToParse;
@@ -74,6 +80,7 @@ namespace BuildXL.FrontEnd.MsBuild.Serialization
             GlobalProperties = globalProperties;
             MSBuildSearchLocations = mSBuildSearchLocations;
             EntryPointTargets = entryPointTargets;
+            RequestedQualifiers = requestedQualifiers;
         }
 
         /// <inheritdoc/>
@@ -83,8 +90,9 @@ namespace BuildXL.FrontEnd.MsBuild.Serialization
 $@"Enlistment root: {EnlistmentRoot}
 Project entry points: [{string.Join(", ", ProjectsToParse)}]
 Serialized graph path: {OutputPath}
-Global properties: {(GlobalProperties == null ? "null" : string.Join(" ", GlobalProperties.Select(kvp => $"[{kvp.Key}]={kvp.Value}")))}
-Search locations: {string.Join(" ", MSBuildSearchLocations)}";
+Global properties: {string.Join(" ", GlobalProperties.Select(kvp => $"[{kvp.Key}]={kvp.Value}"))}
+Search locations: {string.Join(" ", MSBuildSearchLocations)}
+Requested qualifiers: {string.Join(" ", RequestedQualifiers.Select(qualifier => string.Join(";", qualifier.Select(kvp => $"[{kvp.Key}]={kvp.Value}"))))}";
         }
     }
 }

--- a/Public/Src/FrontEnd/MsBuild/MsBuildResolverUtils.cs
+++ b/Public/Src/FrontEnd/MsBuild/MsBuildResolverUtils.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using BuildXL.FrontEnd.MsBuild.Serialization;
+using BuildXL.FrontEnd.Sdk;
+using BuildXL.Utilities;
+
+namespace BuildXL.FrontEnd.MsBuild
+{
+    /// <nodoc/>
+    public class MsBuildResolverUtils
+    {
+        /// <summary>
+        /// Encodes a qualifier as MSBuild global properties
+        /// </summary>
+        public static GlobalProperties CreateQualifierAsGlobalProperties(QualifierId qualifierId, FrontEndContext context)
+        {
+            var stringTable = context.StringTable;
+            var qualifier = context.QualifierTable.GetQualifier(qualifierId);
+            return new GlobalProperties(
+                qualifier.Keys.ToDictionary(
+                    key => key.ToString(stringTable),
+                    key =>
+                    {
+                        qualifier.TryGetValue(stringTable, key, out StringId value);
+                        return value.ToString(stringTable);
+                    }));
+        }
+    }
+}

--- a/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
+++ b/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
@@ -480,7 +480,7 @@ namespace BuildXL.FrontEnd.MsBuild
                                                     
             processBuilder.SetResponseFileSpecification(rspFileSpec);
 
-            if (!TryAddMsBuildArguments(project, qualifier, processBuilder.ArgumentsBuilder, logDirectory, outputResultCacheFile, out failureDetail))
+            if (!TryAddMsBuildArguments(project, processBuilder.ArgumentsBuilder, logDirectory, outputResultCacheFile, out failureDetail))
             {
                 return false;
             }
@@ -516,7 +516,7 @@ namespace BuildXL.FrontEnd.MsBuild
             return true;
         }
 
-        private bool TryAddMsBuildArguments(ProjectWithPredictions<AbsolutePath> project, Qualifier qualifier, PipDataBuilder pipDataBuilder, AbsolutePath logDirectory, AbsolutePath outputResultCacheFile, out string failureDetail)
+        private bool TryAddMsBuildArguments(ProjectWithPredictions<AbsolutePath> project, PipDataBuilder pipDataBuilder, AbsolutePath logDirectory, AbsolutePath outputResultCacheFile, out string failureDetail)
         {
             // Common arguments to all MsBuildExe invocations
             pipDataBuilder.AddRange(s_commonArgumentsToMsBuildExe.Select(argument => PipDataAtom.FromString(argument)));
@@ -537,21 +537,6 @@ namespace BuildXL.FrontEnd.MsBuild
             foreach(var kvp in project.GlobalProperties)
             {
                 AddMsBuildProperty(pipDataBuilder, kvp.Key, kvp.Value);
-            }
-
-            // The specified qualifier, unless overridden by a global property, is turned into a property as well
-            // This means that:
-            // 1) if the project is not being referenced with a specific property that matters to the qualifier, the requested qualifier is used
-            // 2) if a particular property (e.g. platform) is set when referencing the project, that is honored
-            foreach (StringId key in qualifier.Keys)
-            {
-                string keyAsString = key.ToString(m_context.StringTable);
-                if (!project.GlobalProperties.ContainsKey(keyAsString))
-                {
-                    var success = qualifier.TryGetValue(m_context.StringTable, keyAsString, out string value);
-                    Contract.Assert(success);
-                    AddMsBuildProperty(pipDataBuilder, keyAsString, value);
-                }
             }
 
             // Configure binary logger if specified

--- a/Public/Src/FrontEnd/MsBuild/Tracing/Log.cs
+++ b/Public/Src/FrontEnd/MsBuild/Tracing/Log.cs
@@ -105,9 +105,9 @@ namespace BuildXL.FrontEnd.MsBuild.Tracing
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Error,
             EventTask = (ushort)Events.Tasks.Parser,
-            Message = Events.LabeledProvenancePrefix + "Too many parsing entry point candidates were found under '{rootTraversal}'. Please configure 'FileNameEntryPoint' in the configuration settings to pick one from the following list: {candidates}",
+            Message = Events.LabeledProvenancePrefix + "Too many parsing entry point candidates were found under '{rootTraversal}'. Please configure 'fileNameEntryPoints' in the configuration settings to define the desired list of projects.",
             Keywords = (int)(Events.Keywords.UserMessage | Events.Keywords.Diagnostics))]
-        public abstract void TooManyParsingEntryPointCandidates(LoggingContext context, Location location, string rootTraversal, string candidates);
+        public abstract void TooManyParsingEntryPointCandidates(LoggingContext context, Location location, string rootTraversal);
 
         [GeneratedEvent(
             (ushort)LogEventId.GraphConstructionInternalError,

--- a/Public/Src/FrontEnd/Ninja/NinjaWorkspaceResolver.cs
+++ b/Public/Src/FrontEnd/Ninja/NinjaWorkspaceResolver.cs
@@ -215,7 +215,7 @@ namespace BuildXL.FrontEnd.Ninja
         }
 
         /// <inheritdoc cref="IDScriptWorkspaceModuleResolver" />
-        public bool TryInitialize([NotNull] FrontEndHost host, [NotNull] FrontEndContext context, [NotNull] IConfiguration configuration, [NotNull] IResolverSettings resolverSettings)
+        public bool TryInitialize([NotNull] FrontEndHost host, [NotNull] FrontEndContext context, [NotNull] IConfiguration configuration, [NotNull] IResolverSettings resolverSettings, [NotNull] QualifierId[] requestedQualifiers)
         {
             InitializeInterpreter(host, context, configuration);
             m_resolverSettings = resolverSettings as INinjaResolverSettings;

--- a/Public/Src/FrontEnd/Nuget/WorkspaceNugetModuleResolver.cs
+++ b/Public/Src/FrontEnd/Nuget/WorkspaceNugetModuleResolver.cs
@@ -64,7 +64,7 @@ namespace BuildXL.FrontEnd.Nuget
 
         // These are set during Initialize
         private INugetResolverSettings m_resolverSettings;
-
+        private QualifierId[] m_requestedQualifiers;
         private PackageRegistry m_packageRegistry;
         private IReadOnlyDictionary<string, string> m_repositories;
         private FrontEndContext m_context;
@@ -310,18 +310,20 @@ namespace BuildXL.FrontEnd.Nuget
         }
 
         /// <inheritdoc/>
-        public bool TryInitialize(FrontEndHost host, FrontEndContext context, IConfiguration configuration, IResolverSettings resolverSettings)
+        public bool TryInitialize(FrontEndHost host, FrontEndContext context, IConfiguration configuration, IResolverSettings resolverSettings, QualifierId[] requestedQualifiers)
         {
             Contract.Requires(context != null);
             Contract.Requires(host != null);
             Contract.Requires(configuration != null);
             Contract.Requires(resolverSettings != null);
+            Contract.Requires(requestedQualifiers?.Length > 0);
 
             var nugetResolverSettings = resolverSettings as INugetResolverSettings;
             Contract.Assert(nugetResolverSettings != null);
 
             m_context = context;
             m_resolverSettings = nugetResolverSettings;
+            m_requestedQualifiers = requestedQualifiers;
 
             m_repositories = ComputeRepositories(nugetResolverSettings.Repositories);
             var possibleRegistry = PackageRegistry.Create(context, m_resolverSettings.Packages);
@@ -349,7 +351,7 @@ namespace BuildXL.FrontEnd.Nuget
         public void SetDownloadedPackagesForTesting(IDictionary<string, NugetAnalyzedPackage> downloadedPackages)
         {
             var possiblePackages = GenerateSpecsForDownloadedPackages(downloadedPackages);
-            var result = m_embeddedSpecsResolver.TryInitialize(m_host, m_context, m_configuration, CreateSettingsForEmbeddedResolver(downloadedPackages.Values));
+            var result = m_embeddedSpecsResolver.TryInitialize(m_host, m_context, m_configuration, CreateSettingsForEmbeddedResolver(downloadedPackages.Values), m_requestedQualifiers);
             Contract.Assert(result);
 
             Analysis.IgnoreResult(
@@ -514,7 +516,7 @@ namespace BuildXL.FrontEnd.Nuget
                 var possiblePackages = GenerateSpecsForDownloadedPackages(restoredPackagesById);
 
                 // At this point we know which are all the packages that contain embedded specs, so we can initialize the embedded resolver properly
-                if (!m_embeddedSpecsResolver.TryInitialize(m_host, m_context, m_configuration, CreateSettingsForEmbeddedResolver(restoredPackagesById.Values)))
+                if (!m_embeddedSpecsResolver.TryInitialize(m_host, m_context, m_configuration, CreateSettingsForEmbeddedResolver(restoredPackagesById.Values), m_requestedQualifiers))
                 {
                     var failure = new WorkspaceModuleResolverGenericInitializationFailure(Kind);
                     Logger.Log.NugetFailedDownloadPackagesAndGenerateSpecs(m_context.LoggingContext, failure.DescribeIncludingInnerFailures());

--- a/Public/Src/FrontEnd/Script/WorkspaceResolvers/WorkspaceDefaultSourceModuleResolver.cs
+++ b/Public/Src/FrontEnd/Script/WorkspaceResolvers/WorkspaceDefaultSourceModuleResolver.cs
@@ -60,14 +60,15 @@ namespace BuildXL.FrontEnd.Script
         }
 
         /// <inheritdoc/>
-        public override bool TryInitialize(FrontEndHost host, FrontEndContext context, IConfiguration configuration, IResolverSettings resolverSettings)
+        public override bool TryInitialize(FrontEndHost host, FrontEndContext context, IConfiguration configuration, IResolverSettings resolverSettings, QualifierId[] requestedQualifiers)
         {
             Contract.Requires(context != null);
             Contract.Requires(host != null);
             Contract.Requires(configuration != null);
             Contract.Requires(resolverSettings != null);
+            Contract.Requires(requestedQualifiers?.Length > 0);
 
-            if (!base.TryInitialize(host, context, configuration, resolverSettings))
+            if (!base.TryInitialize(host, context, configuration, resolverSettings, requestedQualifiers))
             {
                 return false;
             }

--- a/Public/Src/FrontEnd/Script/WorkspaceResolvers/WorkspaceSourceModuleResolver.cs
+++ b/Public/Src/FrontEnd/Script/WorkspaceResolvers/WorkspaceSourceModuleResolver.cs
@@ -139,12 +139,13 @@ namespace BuildXL.FrontEnd.Script
         }
 
         /// <nodoc/>
-        public virtual bool TryInitialize(FrontEndHost host, FrontEndContext context, IConfiguration configuration, IResolverSettings resolverSettings)
+        public virtual bool TryInitialize(FrontEndHost host, FrontEndContext context, IConfiguration configuration, IResolverSettings resolverSettings, QualifierId[] requestedQualifiers)
         {
             Contract.Requires(context != null);
             Contract.Requires(host != null);
             Contract.Requires(configuration != null);
             Contract.Requires(resolverSettings != null);
+            Contract.Requires(requestedQualifiers?.Length > 0);
 
             var sourceResolverSettings = resolverSettings as IDScriptResolverSettings;
             Contract.Assert(sourceResolverSettings != null);

--- a/Public/Src/FrontEnd/Sdk/Workspaces/Core/DScriptWorkspaceResolverFactory.cs
+++ b/Public/Src/FrontEnd/Sdk/Workspaces/Core/DScriptWorkspaceResolverFactory.cs
@@ -20,7 +20,7 @@ namespace BuildXL.FrontEnd.Workspaces.Core
         private FrontEndContext m_frontEndContext;
         private FrontEndHost m_frontEndHost;
         private IConfiguration m_configuration;
-
+        private QualifierId[] m_requestedQualifiers;
         private readonly Dictionary<string, Func<IDScriptWorkspaceModuleResolver>> m_registeredKinds;
         private readonly Dictionary<IResolverSettings, IDScriptWorkspaceModuleResolver> m_instantiatedResolvers;
 
@@ -60,10 +60,11 @@ namespace BuildXL.FrontEnd.Workspaces.Core
         /// <remarks>
         /// This is exposed as a separate methods since the set context is usually available after resolvers are registered.
         /// </remarks>
-        public void Initialize(FrontEndContext context, FrontEndHost host, IConfiguration configuration)
+        public void Initialize(FrontEndContext context, FrontEndHost host, IConfiguration configuration, QualifierId[] requestedQualifiers)
         {
             Contract.Requires(context != null);
             Contract.Requires(host != null);
+            Contract.Requires(requestedQualifiers?.Length > 0);
             Contract.Requires(!IsInitialized);
             Contract.Ensures(IsInitialized);
 
@@ -71,6 +72,7 @@ namespace BuildXL.FrontEnd.Workspaces.Core
             m_frontEndContext = context;
             m_frontEndHost = host;
             m_configuration = configuration;
+            m_requestedQualifiers = requestedQualifiers;
         }
 
         /// <summary>
@@ -94,7 +96,7 @@ namespace BuildXL.FrontEnd.Workspaces.Core
 
             // There is not, so we need to create and instantiate one.
             resolver = m_registeredKinds[resolverSettings.Kind]();
-            if (!resolver.TryInitialize(m_frontEndHost, m_frontEndContext, m_configuration, resolverSettings))
+            if (!resolver.TryInitialize(m_frontEndHost, m_frontEndContext, m_configuration, resolverSettings, m_requestedQualifiers))
             {
                 return new WorkspaceModuleResolverGenericInitializationFailure(resolverSettings.Kind);
             }

--- a/Public/Src/FrontEnd/Sdk/Workspaces/IDScriptWorkspaceModuleResolver.cs
+++ b/Public/Src/FrontEnd/Sdk/Workspaces/IDScriptWorkspaceModuleResolver.cs
@@ -3,6 +3,7 @@
 
 using JetBrains.Annotations;
 using BuildXL.Utilities.Configuration;
+using BuildXL.Utilities;
 
 namespace BuildXL.FrontEnd.Sdk.Workspaces
 {
@@ -16,6 +17,11 @@ namespace BuildXL.FrontEnd.Sdk.Workspaces
         /// <summary>
         /// Initializes the workspace resolver
         /// </summary>
-        bool TryInitialize([NotNull]FrontEndHost host, [NotNull]FrontEndContext context, [NotNull]IConfiguration configuration, [NotNull]IResolverSettings resolverSettings);
+        bool TryInitialize(
+            [NotNull]FrontEndHost host, 
+            [NotNull]FrontEndContext context, 
+            [NotNull]IConfiguration configuration, 
+            [NotNull]IResolverSettings resolverSettings,
+            [NotNull]QualifierId[] requestedQualifiers);
     }
 }

--- a/Public/Src/FrontEnd/UnitTests/Core/DsTest.cs
+++ b/Public/Src/FrontEnd/UnitTests/Core/DsTest.cs
@@ -1011,7 +1011,8 @@ namespace Test.BuildXL.FrontEnd.Core
             DScriptWorkspaceResolverFactory workspaceFactory,
             AbsolutePath fileToProcess,
             out IConfiguration finalConfig,
-            out Workspace workspace)
+            out Workspace workspace,
+            QualifierId[] requestedQualifiers = null)
         {
             Contract.Requires(config != null);
 
@@ -1032,9 +1033,12 @@ namespace Test.BuildXL.FrontEnd.Core
             controller.SetState(frontEndEngineAbstraction, GetPipGraph(), config);
 
             var evaluationFilter = fileToProcess.IsValid ? EvaluationFilter.FromSingleSpecPath(FrontEndContext.SymbolTable, FrontEndContext.PathTable, fileToProcess) : EvaluationFilter.Empty;
-            workspace = BuildAndAnalyzeWorkspace(controller, engine.Configuration, frontEndEngineAbstraction, evaluationFilter);
 
-            bool initFrontEnds = controller.TryInitializeFrontEndsAndResolvers(engine.Configuration);
+            var requestedQualifiersOrDefault = requestedQualifiers ?? new QualifierId[] { engine.Context.QualifierTable.EmptyQualifierId };
+
+            workspace = BuildAndAnalyzeWorkspace(controller, engine.Configuration, frontEndEngineAbstraction, evaluationFilter, requestedQualifiersOrDefault);
+
+            bool initFrontEnds = controller.TryInitializeFrontEndsAndResolvers(engine.Configuration, requestedQualifiers: requestedQualifiersOrDefault);
             if (!initFrontEnds)
             {
                 return null;
@@ -1046,10 +1050,10 @@ namespace Test.BuildXL.FrontEnd.Core
 
         protected virtual bool FilterWorkspaceForConversion => false;
 
-        private Workspace BuildAndAnalyzeWorkspace(FrontEndHostController controller, IConfiguration configuration, BasicFrontEndEngineAbstraction frontEndEngineAbstraction, EvaluationFilter evaluationFilter)
+        private Workspace BuildAndAnalyzeWorkspace(FrontEndHostController controller, IConfiguration configuration, BasicFrontEndEngineAbstraction frontEndEngineAbstraction, EvaluationFilter evaluationFilter, QualifierId[] requestedQualifiers)
         {
             BeforeBuildWorkspaceHook();
-            var workspace = controller.DoPhaseBuildWorkspace(configuration, frontEndEngineAbstraction, evaluationFilter);
+            var workspace = controller.DoPhaseBuildWorkspace(configuration, frontEndEngineAbstraction, evaluationFilter, requestedQualifiers: requestedQualifiers);
 
             if (workspace.Succeeded)
             {
@@ -1239,7 +1243,7 @@ namespace Test.BuildXL.FrontEnd.Core
                 resolverSettings = sourceResolverSettings;
             }
 
-            workspaceFactory.Initialize(context, frontEndHost, frontEndHost.Configuration);
+            workspaceFactory.Initialize(context, frontEndHost, frontEndHost.Configuration, requestedQualifiers: new QualifierId[] { context.QualifierTable.EmptyQualifierId });
             var workspaceResolver = workspaceFactory.TryGetResolver(resolverSettings).Result;
 
             var resolver = frontEnd.CreateResolver(resolverSettings.Kind);

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/ExecutionTests/MSBuildQualifierTests.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/ExecutionTests/MSBuildQualifierTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using BuildXL.Pips.Operations;
+using BuildXL.Utilities.Configuration;
+using TypeScript.Net.Extensions;
+using Xunit;
+using Xunit.Abstractions;
+using BuildXL.Utilities.Configuration.Mutable;
+using BuildXL.Engine;
+using BuildXL.Scheduler.Graph;
+
+namespace Test.BuildXL.FrontEnd.MsBuild
+{
+    public sealed class MsBuildQualifierTests : MsBuildPipExecutionTestBase
+    {
+        public MsBuildQualifierTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        /// <summary>
+        /// We just need the engine to schedule pips
+        /// </summary>
+        protected override EnginePhases Phase => EnginePhases.Schedule;
+
+        [Fact]
+        public void EachRequestedQualifierIsHonored()
+        {
+            var config = Build()
+                .AddSpec(R("A.proj"), CreateHelloWorldProject())
+                .PersistSpecsAndGetConfiguration();
+
+            var result = RunEngineWithConfigAndRequestedQualifiers(config, new List<string> { "configuration=debug", "configuration=release" });
+
+            // We should find two scheduled processes, one for debug the other one for release
+            var processes = result.EngineState.PipGraph.RetrievePipsOfType(PipType.Process);
+            Assert.Equal(2, processes.Count());
+
+            Assert.Equal(1, processes.Where(process => ProcessContainsArguments((Process)process, "/p:configuration=\"debug\"")).Count());
+            Assert.Equal(1, processes.Where(process => ProcessContainsArguments((Process)process, "/p:configuration=\"release\"")).Count());
+        }
+
+        [Fact]
+        public void DependenciesHonorRequestedQualifiers()
+        {
+            var config = Build("fileNameEntryPoints: [r`B.proj`]")
+                .AddSpec(R("A.proj"), CreateHelloWorldProject())
+                .AddSpec(R("B.proj"), CreateWriteFileTestProject("out.txt", "A.proj"))
+                .PersistSpecsAndGetConfiguration();
+
+            var result = RunEngineWithConfigAndRequestedQualifiers(config, new List<string> { "configuration=debug", "configuration=release" });
+
+            // We should find four scheduled processes: A and B with debug and release versions
+            var processes = result.EngineState.PipGraph.RetrievePipsOfType(PipType.Process);
+            Assert.Equal(4, processes.Count());
+
+            var pathToProjA = config.Layout.SourceDirectory.Combine(PathTable, "A.proj").ToString(PathTable);
+            var pathToProjB = config.Layout.SourceDirectory.Combine(PathTable, "B.proj").ToString(PathTable);
+
+            var projADebug = processes.Single(process => ProcessContainsArguments((Process)process, "/p:configuration=\"debug\"", pathToProjA));
+            var projARelease = processes.Single(process => ProcessContainsArguments((Process)process, "/p:configuration=\"release\"", pathToProjA));
+            var projBDebug = processes.Single(process => ProcessContainsArguments((Process)process, "/p:configuration=\"debug\"", pathToProjB));
+            var projBRelease = processes.Single(process => ProcessContainsArguments((Process)process, "/p:configuration=\"release\"", pathToProjB));
+
+            // The B -> A relationship should be reflected on each version of the qualifier, such that BDebug -> ADebug and BRelease -> ARelease
+            Assert.True(result.EngineState.PipGraph.IsReachableFrom(projADebug.PipId.ToNodeId(), projBDebug.PipId.ToNodeId()));
+            Assert.True(result.EngineState.PipGraph.IsReachableFrom(projARelease.PipId.ToNodeId(), projBRelease.PipId.ToNodeId()));
+        }
+
+        #region Helper
+
+        private BuildXLEngineResult RunEngineWithConfigAndRequestedQualifiers(ICommandLineConfiguration config, List<string> requestedQualifiers)
+        {
+            ((StartupConfiguration)config.Startup).QualifierIdentifiers = requestedQualifiers;
+            return RunEngineWithConfig(config);
+        }
+
+        private bool ProcessContainsArguments(Process process, params string[] arguments)
+        {
+            var processArguments = RetrieveProcessArguments(process);
+            return arguments.All(contained => processArguments.Contains(contained));
+        }
+
+        #endregion
+
+    }
+}

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/ExecutionTests/MsBuildGraphConstructionTests.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/ExecutionTests/MsBuildGraphConstructionTests.cs
@@ -176,6 +176,19 @@ namespace Test.BuildXL.FrontEnd.MsBuild
             AssertVerboseEventLogged(LogEventId.ProjectWithEmptyTargetsIsNotScheduled);
         }
 
+        [Fact]
+        public void GlobalPropertyKeysAreCaseInsensitive()
+        {
+            var config = Build("globalProperties: Map.empty<string, string>().add('Blah', 'a').add('BLAH', 'b')")
+                .AddSpec(R("A.proj"), CreateHelloWorldProject())
+                .PersistSpecsAndGetConfiguration();
+
+            var result = RunEngineWithConfig(config);
+            Assert.False(result.IsSuccess);
+
+            AssertErrorEventLogged(LogEventId.InvalidResolverSettings);
+        }
+
         #region helpers
 
         private Process CreateDummyProjectWithEnvironment(Dictionary<string, string> environment)

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/ExecutionTests/MsBuildIntegrationTests.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/ExecutionTests/MsBuildIntegrationTests.cs
@@ -112,7 +112,7 @@ namespace Test.BuildXL.FrontEnd.MsBuild
         }
 
         [Fact]
-        public void ProjectThatRemovesAFileDuringEvalutionIsProperlyHandled()
+        public void ProjectThatRemovesAFileDuringEvaluationIsProperlyHandled()
         {
             // This project writes and deletes a file during evaluation
             var mainProject =

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/Infrastructure/MsBuildPipSchedulingTestBase.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/Infrastructure/MsBuildPipSchedulingTestBase.cs
@@ -64,7 +64,7 @@ namespace Test.BuildXL.FrontEnd.MsBuild.Infrastructure
         /// Starts the addition of projects
         /// </summary>
         /// <returns></returns>
-        public MsBuildProjectBuilder Start(MsBuildResolverSettings resolverSettings = null, QualifierId qualifierId = default)
+        public MsBuildProjectBuilder Start(MsBuildResolverSettings resolverSettings = null, QualifierId currentQualifier = default, QualifierId[] requestedQualifiers = default)
         {
             var settings = resolverSettings ?? new MsBuildResolverSettings();
             // Make sure the Root is set
@@ -73,12 +73,17 @@ namespace Test.BuildXL.FrontEnd.MsBuild.Infrastructure
                 settings.Root = AbsolutePath.Create(PathTable, TestRoot);
             }
 
-            if (qualifierId == default)
+            if (currentQualifier == default)
             {
-                qualifierId = FrontEndContext.QualifierTable.CreateQualifier(CollectionUtilities.EmptyDictionary<string, string>());
+                currentQualifier = FrontEndContext.QualifierTable.EmptyQualifierId;
             }
 
-            return new MsBuildProjectBuilder(this, settings, qualifierId);
+            if (requestedQualifiers == default)
+            {
+                requestedQualifiers = new QualifierId[] { FrontEndContext.QualifierTable .EmptyQualifierId };
+            }
+
+            return new MsBuildProjectBuilder(this, settings, currentQualifier, requestedQualifiers);
         }
 
         /// <summary>
@@ -108,7 +113,7 @@ namespace Test.BuildXL.FrontEnd.MsBuild.Infrastructure
 
         /// <summary>
         /// Uses <see cref="MsBuildPipConstructor"/> to schedule the specified projects and retrieves the result
-        internal MsBuildSchedulingResult ScheduleAll(MsBuildResolverSettings resolverSettings, IEnumerable<ProjectWithPredictions> projectsWithPredictions, QualifierId qualifierId)
+        internal MsBuildSchedulingResult ScheduleAll(MsBuildResolverSettings resolverSettings, IEnumerable<ProjectWithPredictions> projectsWithPredictions, QualifierId currentQualifier, QualifierId[] requestedQualifiers)
         {
             var sharedModuleRegistry = new ModuleRegistry();
             var constants = new GlobalConstants(FrontEndContext.SymbolTable);
@@ -116,7 +121,7 @@ namespace Test.BuildXL.FrontEnd.MsBuild.Infrastructure
             var workspaceFactory = CreateWorkspaceFactoryForTesting(constants, sharedModuleRegistry, ParseAndEvaluateLogger);
             var frontEndFactory = CreateFrontEndFactoryForEvaluation(constants, sharedModuleRegistry, workspaceFactory, ParseAndEvaluateLogger);
 
-            using (var controller = CreateFrontEndHost(GetDefaultCommandLine(), frontEndFactory, workspaceFactory, AbsolutePath.Invalid, out _, out _))
+            using (var controller = CreateFrontEndHost(GetDefaultCommandLine(), frontEndFactory, workspaceFactory, AbsolutePath.Invalid, out _, out _, requestedQualifiers))
             {
                 var pipConstructor = new PipConstructor(
                     FrontEndContext,
@@ -130,7 +135,7 @@ namespace Test.BuildXL.FrontEnd.MsBuild.Infrastructure
 
                 foreach (var projectWithPredictions in projectsWithPredictions)
                 {
-                    var result = pipConstructor.TrySchedulePipForFile(projectWithPredictions, qualifierId, out string failureDetail, out Process process);
+                    var result = pipConstructor.TrySchedulePipForFile(projectWithPredictions, currentQualifier, out string failureDetail, out Process process);
                     schedulingResults[projectWithPredictions] = (result, failureDetail, process);
                 }
 

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/Infrastructure/MsBuildProjectBuilder.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/Infrastructure/MsBuildProjectBuilder.cs
@@ -18,18 +18,21 @@ namespace Test.BuildXL.FrontEnd.MsBuild.Infrastructure
         private readonly MsBuildPipSchedulingTestBase m_testBase;
         private readonly MsBuildResolverSettings m_resolverSettings;
         private readonly QualifierId m_qualifierId;
+        private readonly QualifierId[] m_requestedQualifiers;
 
         /// <nodoc/>
-        public MsBuildProjectBuilder(MsBuildPipSchedulingTestBase testBase, MsBuildResolverSettings resolverSettings, QualifierId qualifierId)
+        public MsBuildProjectBuilder(MsBuildPipSchedulingTestBase testBase, MsBuildResolverSettings resolverSettings, QualifierId currentQualifier, QualifierId[] requestedQualifiers)
         {
             Contract.Requires(testBase != null);
             Contract.Requires(resolverSettings != null);
-            Contract.Requires(qualifierId != QualifierId.Invalid);
+            Contract.Requires(currentQualifier != QualifierId.Invalid);
+            Contract.Requires(requestedQualifiers?.Length > 0);
 
             m_projects = new HashSet<ProjectWithPredictions>();
             m_testBase = testBase;
             m_resolverSettings = resolverSettings;
-            m_qualifierId = qualifierId;
+            m_qualifierId = currentQualifier;
+            m_requestedQualifiers = requestedQualifiers;
         }
 
         /// <summary>
@@ -45,7 +48,7 @@ namespace Test.BuildXL.FrontEnd.MsBuild.Infrastructure
         /// <nodoc/>
         internal MsBuildSchedulingResult ScheduleAll()
         {
-            return m_testBase.ScheduleAll(m_resolverSettings, m_projects, m_qualifierId);
+            return m_testBase.ScheduleAll(m_resolverSettings, m_projects, m_qualifierId, m_requestedQualifiers);
         }
     }
 }

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/SchedulingTests/MsBuildProcessBuilderTests.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/SchedulingTests/MsBuildProcessBuilderTests.cs
@@ -127,7 +127,7 @@ namespace Test.BuildXL.FrontEnd.MsBuild
                 new Tuple<StringId, StringId>(StringId.Create(StringTable, "key1"), StringId.Create(StringTable, "value1")),
                 new Tuple<StringId, StringId>(StringId.Create(StringTable, "key2"), StringId.Create(StringTable, "value2")));
 
-            var key1Key2Project = Start(qualifierId: key1Key2Qualifier)
+            var key1Key2Project = Start(currentQualifier: key1Key2Qualifier)
                 .Add(project)
                 .ScheduleAll()
                 .AssertSuccess()
@@ -137,7 +137,7 @@ namespace Test.BuildXL.FrontEnd.MsBuild
                 new Tuple<StringId, StringId>(StringId.Create(StringTable, "key2"), StringId.Create(StringTable, "value2")),
                 new Tuple<StringId, StringId>(StringId.Create(StringTable, "key1"), StringId.Create(StringTable, "value1")));
 
-            var key2Key1Project = Start(qualifierId: key2Key1Qualifier)
+            var key2Key1Project = Start(currentQualifier: key2Key1Qualifier)
                 .Add(project)
                 .ScheduleAll()
                 .AssertSuccess()

--- a/Public/Src/FrontEnd/UnitTests/Nuget/NugetResolverUnitTests.cs
+++ b/Public/Src/FrontEnd/UnitTests/Nuget/NugetResolverUnitTests.cs
@@ -253,7 +253,7 @@ $@"module({{
             var host = CreateFrontEndHostControllerForTesting();
 
             var nugetResolver = new WorkspaceNugetModuleResolver(m_constants, new ModuleRegistry(), new FrontEndStatistics());
-            nugetResolver.TryInitialize(host, m_testContext, new ConfigurationImpl(), new NugetResolverSettings());
+            nugetResolver.TryInitialize(host, m_testContext, new ConfigurationImpl(), new NugetResolverSettings(), new QualifierId[] { m_testContext.QualifierTable.EmptyQualifierId });
 
             return nugetResolver;
         }

--- a/Public/Src/Tools/Tool.MsBuildGraphBuilder/Program.cs
+++ b/Public/Src/Tools/Tool.MsBuildGraphBuilder/Program.cs
@@ -58,7 +58,7 @@ namespace MsBuildGraphBuilderTool
         private static MSBuildGraphBuilderArguments DeserializeArguments(string argumentFile)
         {
             var serializer = JsonSerializer.Create(ProjectGraphSerializationSettings.Settings);
-
+ 
             MSBuildGraphBuilderArguments arguments;
             using (StreamReader sr = new StreamReader(argumentFile))
             using (JsonReader reader = new JsonTextReader(sr))

--- a/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphDecorationTests.cs
+++ b/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphDecorationTests.cs
@@ -81,9 +81,10 @@ namespace Test.ProjectGraphBuilder
                     TemporaryDirectory,
                     new[] { entryPoint },
                     outputFile,
-                    globalProperties: null,
+                    globalProperties: GlobalProperties.Empty,
                     mSBuildSearchLocations: new string[] {TestDeploymentDir},
-                    entryPointTargets: new string[0]);
+                    entryPointTargets: new string[0],
+                    requestedQualifiers: new GlobalProperties[] { GlobalProperties.Empty});
 
                 MsBuildGraphBuilder.BuildGraphAndSerializeForTesting(assemblyLoader, reporter, arguments);
             }

--- a/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphProgressTests.cs
+++ b/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphProgressTests.cs
@@ -73,9 +73,10 @@ namespace Test.ProjectGraphBuilder
                 TestOutputDirectory,
                 new[] { m_entryPoint },
                 outputFile,
-                globalProperties: null,
+                globalProperties: GlobalProperties.Empty,
                 mSBuildSearchLocations: new[] {TestDeploymentDir},
-                entryPointTargets: new string[0]);
+                entryPointTargets: new string[0],
+                requestedQualifiers: new GlobalProperties[] { GlobalProperties.Empty });
 
             MsBuildGraphBuilder.BuildGraphAndSerializeForTesting(MsBuildAssemblyLoader.Instance, reporter, arguments);
             var result = SimpleDeserializer.Instance.DeserializeGraph(outputFile);

--- a/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphStaticPredictionTests.cs
+++ b/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphStaticPredictionTests.cs
@@ -48,9 +48,10 @@ namespace Test.ProjectGraphBuilder
                     TestOutputDirectory,
                     new[] { entryPoint },
                     outputFile,
-                    globalProperties: null,
-                    mSBuildSearchLocations: new[] {TestDeploymentDir},
-                    entryPointTargets: new string[0]));
+                    globalProperties: GlobalProperties.Empty,
+                    mSBuildSearchLocations: new[] { TestDeploymentDir },
+                    entryPointTargets: new string[0],
+                    requestedQualifiers: new GlobalProperties[] { GlobalProperties.Empty }));
 
             var result = SimpleDeserializer.Instance.DeserializeGraph(outputFile);
 
@@ -75,9 +76,10 @@ namespace Test.ProjectGraphBuilder
                     TestOutputDirectory,
                     new[] { entryPoint },
                     outputFile,
-                    globalProperties: null,
-                    mSBuildSearchLocations: new[] {TestDeploymentDir},
-                    entryPointTargets: new string[0]);
+                    globalProperties: GlobalProperties.Empty,
+                    mSBuildSearchLocations: new[] { TestDeploymentDir },
+                    entryPointTargets: new string[0],
+                    requestedQualifiers: new GlobalProperties[] { GlobalProperties.Empty });
 
                 MsBuildGraphBuilder.BuildGraphAndSerializeForTesting(
                     MsBuildAssemblyLoader.Instance, 


### PR DESCRIPTION
This PR allows the MSBuild resolver to consider all requested qualifiers when building the MSBuild graph and filter pips based on the current qualifier at execution time.
This implies a minor extension on the IResolver interfaces, so resolvers know what are the requested qualifiers at parsing time. In the context of specs where the qualifier space is not self-contained in the spec themselves, this extension may also benefit other potential resolvers.