### PR TITLE
Improve performance for worker's reconciliation

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/CheckpointManager.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/CheckpointManager.cs
@@ -341,16 +341,15 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             return true;
         }
 
-        private Task<BoolResult> RestoreFileAsync(OperationContext context, AbsolutePath checkpointTargetDirectory, string relativePath, string storageId, bool forceUseExistingFiles = false)
+        private Task<BoolResult> RestoreFileAsync(OperationContext context, AbsolutePath checkpointTargetDirectory, string relativePath, string storageId)
         {
             return context.PerformOperationAsync(
                 _tracer,
                 async () =>
                 {
                     var incrementalCheckpointFile = _incrementalCheckpointDirectory / relativePath;
-                    if ((forceUseExistingFiles || (
-                            _incrementalCheckpointInfo.TryGetValue(relativePath, out var fileStorageId)
-                            && storageId == fileStorageId))
+                    if ((_incrementalCheckpointInfo.TryGetValue(relativePath, out var fileStorageId)
+                            && storageId == fileStorageId)
                         && _database.IsImmutable(incrementalCheckpointFile)
                         && _fileSystem.FileExists(incrementalCheckpointFile))
                     {

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/CheckpointManager.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/CheckpointManager.cs
@@ -7,9 +7,9 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Threading.Tasks;
-using BuildXL.Cache.ContentStore.Interfaces.Utils;
 using BuildXL.Cache.ContentStore.Distributed.NuCache.EventStreaming;
 using BuildXL.Cache.ContentStore.Distributed.Redis;
+using BuildXL.Cache.ContentStore.Extensions;
 using BuildXL.Cache.ContentStore.FileSystem;
 using BuildXL.Cache.ContentStore.Tracing;
 using BuildXL.Cache.ContentStore.Tracing.Internal;
@@ -45,7 +45,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
 
         private CounterCollection<ContentLocationStoreCounters> Counters { get; }
 
-        private CheckpointConfiguration _configuration;
+        private readonly CheckpointConfiguration _configuration;
 
         /// <summary>
         /// Maps file name to storage id for the currently downloaded checkpoint
@@ -67,6 +67,8 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             _fileSystem = new PassThroughFileSystem();
             _checkpointStagingDirectory = configuration.WorkingDirectory / "staging";
             _incrementalCheckpointDirectory = configuration.WorkingDirectory / "incremental";
+            _fileSystem.CreateDirectory(_incrementalCheckpointDirectory);
+
             _incrementalCheckpointInfoFile = _incrementalCheckpointDirectory / "checkpointInfo.txt";
             Counters = counters;
         }
@@ -316,7 +318,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
 
         private static void RestoreFullCheckpointAsync(AbsolutePath checkpointFile, AbsolutePath extractedCheckpointDirectory)
         {
-            // Extracting the checkpoint archieve
+            // Extracting the checkpoint archive
             ZipFile.ExtractToDirectory(checkpointFile.ToString(), extractedCheckpointDirectory.ToString());
         }
 
@@ -327,38 +329,48 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             // Parse the checkpoint info for the checkpoint being restored
             var newCheckpointInfo = ParseCheckpointInfo(checkpointFile);
 
-            foreach (var entry in newCheckpointInfo)
+
+            foreach (var (key, value) in newCheckpointInfo)
             {
-                var relativePath = entry.Key;
-                var storageId = entry.Value;
-
-                var incrementalCheckpointFile = _incrementalCheckpointDirectory / relativePath;
-
-                if (_incrementalCheckpointInfo.TryGetValue(relativePath, out var fileStorageId)
-                    && storageId == fileStorageId
-                    && _database.IsImmutable(incrementalCheckpointFile)
-                    && _fileSystem.FileExists(incrementalCheckpointFile))
-                {
-                    // File is already present in the incremental checkpoint directory, no need to download it
-                    await _storage.TouchBlobAsync(context, incrementalCheckpointFile, storageId, isUploader: false).ThrowIfFailure();
-                    Counters[ContentLocationStoreCounters.IncrementalCheckpointFilesDownloadSkipped].Increment();
-                }
-                else
-                {
-                    // File is missing, different, or mutable so download it and update it in the incremental checkpoint
-                    _fileSystem.DeleteFile(incrementalCheckpointFile);
-                    await _storage.TryGetFileAsync(context, storageId, incrementalCheckpointFile).ThrowIfFailure();
-                    Counters[ContentLocationStoreCounters.IncrementalCheckpointFilesDownloaded].Increment();
-                }
-
-                // Move the file from the incremental checkpoint into the extraction directory for loading by the database
-                await HardlinkWithFallBackAsync(context, incrementalCheckpointFile, checkpointTargetDirectory / relativePath);
+                await RestoreFileAsync(context, checkpointTargetDirectory, key, value).ThrowIfFailure();
             }
-
+            
             // Finalize by adding the incremental checkpoint info file to the local incremental checkpoint directory
             await HardlinkWithFallBackAsync(context, checkpointFile, _incrementalCheckpointInfoFile);
             UpdateIncrementalCheckpointInfo(newCheckpointInfo);
             return true;
+        }
+
+        private Task<BoolResult> RestoreFileAsync(OperationContext context, AbsolutePath checkpointTargetDirectory, string relativePath, string storageId, bool forceUseExistingFiles = false)
+        {
+            return context.PerformOperationAsync(
+                _tracer,
+                async () =>
+                {
+                    var incrementalCheckpointFile = _incrementalCheckpointDirectory / relativePath;
+                    if ((forceUseExistingFiles || (
+                            _incrementalCheckpointInfo.TryGetValue(relativePath, out var fileStorageId)
+                            && storageId == fileStorageId))
+                        && _database.IsImmutable(incrementalCheckpointFile)
+                        && _fileSystem.FileExists(incrementalCheckpointFile))
+                    {
+                        // File is already present in the incremental checkpoint directory, no need to download it
+                        await _storage.TouchBlobAsync(context, incrementalCheckpointFile, storageId, isUploader: false).ThrowIfFailure();
+                        Counters[ContentLocationStoreCounters.IncrementalCheckpointFilesDownloadSkipped].Increment();
+                    }
+                    else
+                    {
+                        // File is missing, different, or mutable so download it and update it in the incremental checkpoint
+                        _fileSystem.DeleteFile(incrementalCheckpointFile);
+                        await _storage.TryGetFileAsync(context, storageId, incrementalCheckpointFile).ThrowIfFailure();
+                        Counters[ContentLocationStoreCounters.IncrementalCheckpointFilesDownloaded].Increment();
+                    }
+
+                    // Move the file from the incremental checkpoint into the extraction directory for loading by the database
+                    await HardlinkWithFallBackAsync(context, incrementalCheckpointFile, checkpointTargetDirectory / relativePath);
+                    return BoolResult.Success;
+                }, extraStartMessage: relativePath
+            );
         }
     }
 }

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabaseExtensions.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabaseExtensions.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using BuildXL.Cache.ContentStore.Tracing.Internal;
+
+namespace BuildXL.Cache.ContentStore.Distributed.NuCache
+{
+    /// <summary>
+    /// Set of extension methods for <see cref="BuildXL.Cache.ContentStore.Distributed.NuCache.ContentLocationDatabase"/>
+    /// </summary>
+    public static class ContentLocationDatabaseExtensions
+    {
+        /// <summary>
+        /// Enumerates all the hashes with <see cref="ContentLocationEntry"/> from a <paramref name="database"/> for a given <paramref name="currentMachineId"/>.
+        /// </summary>
+        public static IEnumerable<(ShortHash hash, ContentLocationEntry entry)> EnumerateSortedDatabaseEntriesForMachineId(
+            this ContentLocationDatabase database,
+            OperationContext context,
+            MachineId currentMachineId)
+        {
+            foreach (var (key, entry) in database.EnumerateEntriesWithSortedKeys(
+                context.Token,
+                rawValue => database.HasMachineId(rawValue, currentMachineId.Index)))
+            {
+                yield return (key, entry);
+            }
+        }
+
+        /// <summary>
+        /// Enumerates all the hashes with <see cref="ContentLocationEntry"/> from a <paramref name="database"/> for a given <paramref name="currentMachineId"/>.
+        /// </summary>
+        public static IEnumerable<(ShortHash hash, long size)> EnumerateSortedHashesWithContentSizeForMachineId(
+            this ContentLocationDatabase database,
+            OperationContext context,
+            MachineId currentMachineId)
+        {
+            foreach (var (hash, entry) in EnumerateSortedDatabaseEntriesForMachineId(database, context, currentMachineId))
+            {
+                yield return (hash, entry.ContentSize);
+            }
+        }
+    }
+}

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/EventStreaming/StreamBinaryReader.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/EventStreaming/StreamBinaryReader.cs
@@ -15,7 +15,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
     /// <remarks>
     /// The instance of this type is not thread-safe.
     /// </remarks>
-    internal sealed class StreamBinaryReader 
+    public sealed class StreamBinaryReader 
     {
         private readonly MemoryStream _eventReadBuffer;
         private readonly BuildXLReader _eventBufferReader;
@@ -35,6 +35,16 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             _eventReadBuffer.Position = 0;
 
             return deserializeFunc(_eventBufferReader);
+        }
+
+        /// <nodoc />
+        public TResult Deserialize<TResult, TState>(ArraySegment<byte> data, TState state, Func<TState, BuildXLReader, TResult> deserializeFunc)
+        {
+            _eventReadBuffer.Position = 0;
+            _eventReadBuffer.Write(data.Array, data.Offset, data.Count);
+            _eventReadBuffer.Position = 0;
+
+            return deserializeFunc(state, _eventBufferReader);
         }
 
         /// <nodoc />

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/InMemory/MemoryContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/InMemory/MemoryContentLocationDatabase.cs
@@ -61,6 +61,20 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache.InMemory
         }
 
         /// <inheritdoc />
+        public override IEnumerable<(ShortHash key, ContentLocationEntry entry)> EnumerateEntriesWithSortedKeys(
+            CancellationToken token,
+            EnumerationFilter filter = null)
+        {
+            foreach (var kvp in _map)
+            {
+                if (filter == null || filter(Serialize(kvp.Value)))
+                {
+                    yield return (kvp.Key, kvp.Value);
+                }
+            }
+        }
+
+        /// <inheritdoc />
         protected override BoolResult SaveCheckpointCore(OperationContext context, AbsolutePath checkpointDirectory)
         {
             return BoolResult.Success;

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStoreConfiguration.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStoreConfiguration.cs
@@ -195,7 +195,7 @@ namespace BuildXL.Cache.ContentStore.Distributed
         /// <summary>
         /// The maximum number of gigabytes to retain in CAS
         /// </summary>
-        public int MaxRetentionGb { get; set; } = 1;
+        public int MaxRetentionGb { get; set; } = 20;
 
         /// <summary>
         /// Defines the target maximum number of simulataneous copies
@@ -306,6 +306,11 @@ namespace BuildXL.Cache.ContentStore.Distributed
         /// The interval by which the checkpoint manager applies checkpoints to the local database.
         /// </summary>
         public TimeSpan RestoreCheckpointInterval { get; set; } = TimeSpan.FromMinutes(10);
+
+        /// <summary>
+        /// Number of files downloaded in parallel during restroring process.
+        /// </summary>
+        public int RestoreCheckpointDegreeOfParallelism { get; set; } = 24;
 
         /// <inheritdoc />
         public CheckpointConfiguration(AbsolutePath workingDirectory) => WorkingDirectory = workingDirectory;

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStoreConfiguration.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStoreConfiguration.cs
@@ -307,11 +307,6 @@ namespace BuildXL.Cache.ContentStore.Distributed
         /// </summary>
         public TimeSpan RestoreCheckpointInterval { get; set; } = TimeSpan.FromMinutes(10);
 
-        /// <summary>
-        /// Number of files downloaded in parallel during restroring process.
-        /// </summary>
-        public int RestoreCheckpointDegreeOfParallelism { get; set; } = 24;
-
         /// <inheritdoc />
         public CheckpointConfiguration(AbsolutePath workingDirectory) => WorkingDirectory = workingDirectory;
     }

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/MachineIdSets/ArrayMachineIdSet.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/MachineIdSets/ArrayMachineIdSet.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BuildXL.Cache.ContentStore.Distributed.NuCache
+{
+    /// <summary>
+    /// Represents a set of machine ids that contains a content based on a flat list of machine ids.
+    /// </summary>
+    public class ArrayMachineIdSet : ArrayMachineIdSetBase
+    {
+        /// <summary>
+        /// The indices of the machine ids represented by this set.
+        /// </summary>
+        private readonly ushort[] _machineIds;
+
+        /// <inheritdoc />
+        public override bool IsEmpty => Count == 0;
+
+        /// <nodoc />
+        public ArrayMachineIdSet(ushort[] machineIds)
+        {
+            _machineIds = machineIds;
+        }
+
+        /// <inheritdoc />
+        public override bool this[int index] => _machineIds.Contains((ushort)index);
+
+        /// <inheritdoc />
+        public override int Count => _machineIds.Length;
+
+        /// <inheritdoc />
+        protected override IEnumerable<ushort> EnumerateRawMachineIds()
+        {
+            foreach (var id in _machineIds)
+            {
+                yield return id;
+            }
+        }
+    }
+}

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/MachineIdSets/BitMachineIdSet.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/MachineIdSets/BitMachineIdSet.cs
@@ -117,6 +117,15 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             return new BitMachineIdSet(data, 0);
         }
 
+        internal static bool HasMachineIdCore(BuildXLReader reader, int index)
+        {
+            var count = reader.ReadInt32Compact();
+
+            var data = reader.ReadBytes(count);
+
+            return GetValue(data, 0, index);
+        }
+
         /// <summary>
         /// Enumerates the bits in the machine id set
         /// </summary>
@@ -146,7 +155,14 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             return $"Count: {Count}";
         }
 
-        private static bool GetValue(byte[] data, int offset, int index)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="data"></param>
+        /// <param name="offset"></param>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        public static bool GetValue(byte[] data, int offset, int index)
         {
             int dataIndex = offset + index / 8;
 

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/MachineIdSets/HashSetMachineIdSet.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/MachineIdSets/HashSetMachineIdSet.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace BuildXL.Cache.ContentStore.Distributed.NuCache
+{
+    /// <summary>
+    /// Represents a set of machine ids that contains a content based on a hash set.
+    /// </summary>
+    public sealed class HashSetMachineIdSet : ArrayMachineIdSetBase
+    {
+        /// <summary>
+        /// The indices of the machine ids represented by this set
+        /// </summary>
+        private readonly HashSet<ushort> _machineIds;
+
+        /// <inheritdoc />
+        public override bool IsEmpty => Count == 0;
+
+        /// <nodoc />
+        public HashSetMachineIdSet(ushort[] machineIds)
+        {
+            _machineIds = new HashSet<ushort>(machineIds);
+        }
+
+        /// <nodoc />
+        internal HashSetMachineIdSet(HashSet<ushort> machineIds)
+        {
+            _machineIds = machineIds;
+        }
+
+        /// <inheritdoc />
+        public override bool this[int index] => _machineIds.Contains((ushort)index);
+
+        /// <inheritdoc />
+        public override int Count => _machineIds.Count;
+
+        /// <inheritdoc />
+        protected override IEnumerable<ushort> EnumerateRawMachineIds()
+        {
+            foreach (var machineId in _machineIds)
+            {
+                yield return machineId;
+            }
+        }
+    }
+}

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/MachineIdSets/MachineIdSet.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/MachineIdSets/MachineIdSet.cs
@@ -91,6 +91,23 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         /// <nodoc />
         protected abstract void SerializeCore(BuildXLWriter writer);
 
+        /// <summary>
+        /// Returns true if deserialized instance would have a machine id with a given index.
+        /// </summary>
+        public static bool HasMachineId(BuildXLReader reader, int index)
+        {
+            var format = (SetFormat)reader.ReadByte();
+
+            if (format == SetFormat.Bits)
+            {
+                return BitMachineIdSet.HasMachineIdCore(reader, index);
+            }
+            else
+            {
+                return ArrayMachineIdSet.HasMachineIdCore(reader, index);
+            }
+        }
+
         /// <nodoc />
         public static MachineIdSet Deserialize(BuildXLReader reader)
         {

--- a/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/LocalLocationStoreDistributedContentTests.cs
+++ b/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/LocalLocationStoreDistributedContentTests.cs
@@ -127,7 +127,7 @@ namespace ContentStoreTest.Distributed.Sessions
                 configuration.RedisGlobalStoreSecondaryConnectionString = _secondaryGlobalStoreDatabase.ConnectionString;
             }
 
-            configuration.DistributedCentralStore = null;//new DistributedCentralStoreConfiguration(rootPath);
+            configuration.DistributedCentralStore = new DistributedCentralStoreConfiguration(rootPath);
 
             _configurations[index] = configuration;
             var testPathTransformer = new TestPathTransformer();

--- a/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/LocalLocationStoreDistributedContentTests.cs
+++ b/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/LocalLocationStoreDistributedContentTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -29,6 +30,7 @@ using BuildXL.Cache.ContentStore.InterfacesTest.Results;
 using BuildXL.Cache.ContentStore.Stores;
 using BuildXL.Cache.ContentStore.Tracing.Internal;
 using BuildXL.Cache.ContentStore.UtilitiesCore;
+using BuildXL.Utilities;
 using BuildXL.Utilities.Collections;
 using BuildXL.Utilities.Tracing;
 using ContentStoreTest.Distributed.ContentLocation;
@@ -37,6 +39,7 @@ using ContentStoreTest.Test;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
+using AbsolutePath = BuildXL.Cache.ContentStore.Interfaces.FileSystem.AbsolutePath;
 
 namespace ContentStoreTest.Distributed.Sessions
 {
@@ -124,7 +127,7 @@ namespace ContentStoreTest.Distributed.Sessions
                 configuration.RedisGlobalStoreSecondaryConnectionString = _secondaryGlobalStoreDatabase.ConnectionString;
             }
 
-            configuration.DistributedCentralStore = new DistributedCentralStoreConfiguration(rootPath);
+            configuration.DistributedCentralStore = null;//new DistributedCentralStoreConfiguration(rootPath);
 
             _configurations[index] = configuration;
             var testPathTransformer = new TestPathTransformer();
@@ -1361,42 +1364,6 @@ namespace ContentStoreTest.Distributed.Sessions
                 });
         }
 
-        [Fact(Skip = "Diagnostic purposes only")]
-        public async Task TestCollectContentLocationDatabaseStats()
-        {
-            string databasePath = @"Put Path Here";
-            var db = new RocksDbContentLocationDatabase(TestClock, new RocksDbContentLocationDatabaseConfiguration(new AbsolutePath(databasePath))
-            {
-                CleanOnInitialize = false
-            }, () => CollectionUtilities.EmptyArray<MachineId>());
-
-            var context = new OperationContext(new Context(Logger));
-            await db.StartupAsync(context).ThrowIfFailure();
-
-            var entries = db.EnumerateSortedKeys(Token).AsParallel().Select(k => db.TryGetEntry(context, k, out var entry) ? entry : ContentLocationEntry.Missing).OrderBy(e => e.ContentSize).ToList();
-            StringBuilder builder = new StringBuilder();
-
-            long lastPercentage = -1;
-            long i = 0;
-            long accumulatedSize = 0;
-            foreach (var locationEntry in entries)
-            {
-                long percentage = (i * 100) / entries.Count;
-                if (percentage != lastPercentage)
-                {
-                    lastPercentage = percentage;
-                    builder.AppendLine($"{i}, {percentage}, {locationEntry.ContentSize}, {accumulatedSize}");
-                    Logger.Debug($"{i}, {percentage}, {locationEntry.ContentSize}, {accumulatedSize}");
-                }
-
-                i++;
-                if (locationEntry.ContentSize > 0)
-                {
-                    accumulatedSize += locationEntry.ContentSize;
-                }
-            }
-        }
-
         [Fact]
         public async Task DualRedundancyGlobalRedisTest()
         {
@@ -1911,9 +1878,9 @@ namespace ContentStoreTest.Distributed.Sessions
             }
         }
 
-        private void ConfigureWithOneMaster()
+        protected void ConfigureWithOneMaster(CentralStoreConfiguration centralStoreConfiguration = null)
         {
-            var centralStoreConfiguration = new LocalDiskCentralStoreConfiguration(TestRootDirectoryPath / "centralstore", Guid.NewGuid().ToString());
+            centralStoreConfiguration = centralStoreConfiguration ?? new LocalDiskCentralStoreConfiguration(TestRootDirectoryPath / "centralstore", Guid.NewGuid().ToString());
 
             // Extremely hacky way to make the first redis instance to be a master and the rest to be workers.
             ConfigureRocksDbContentLocationBasedTest(
@@ -1935,7 +1902,7 @@ namespace ContentStoreTest.Distributed.Sessions
         private static readonly TimeSpan LocalDatabaseEntryTimeToLive = TimeSpan.FromMinutes(3);
         private const int SafeToLazilyUpdateMachineCountThreshold = 3;
         private const int ReplicaCreditInMinutes = 3;
-        private bool _enableReconciliation;
+        protected bool _enableReconciliation;
         private ContentLocationMode _readMode = ContentLocationMode.LocalLocationStore;
         private ContentLocationMode _writeMode = ContentLocationMode.LocalLocationStore;
         private bool _enableSecondaryRedis = false;

--- a/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/ReconciliationPerformanceTests.cs
+++ b/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/ReconciliationPerformanceTests.cs
@@ -1,0 +1,192 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using BuildXL.Cache.ContentStore.Distributed;
+using BuildXL.Cache.ContentStore.Distributed.NuCache;
+using BuildXL.Cache.ContentStore.Distributed.NuCache.EventStreaming;
+using BuildXL.Cache.ContentStore.Distributed.Redis;
+using BuildXL.Cache.ContentStore.Interfaces.Results;
+using BuildXL.Cache.ContentStore.Interfaces.Tracing;
+using BuildXL.Cache.ContentStore.InterfacesTest.Results;
+using BuildXL.Cache.ContentStore.Tracing.Internal;
+using BuildXL.Utilities.Collections;
+using ContentStoreTest.Distributed.Redis;
+using Xunit;
+using Xunit.Abstractions;
+using AbsolutePath = BuildXL.Cache.ContentStore.Interfaces.FileSystem.AbsolutePath;
+
+namespace ContentStoreTest.Distributed.Sessions
+{
+    [Trait("Category", "Integration")]
+    [Trait("Category", "LongRunningTest")]
+    [Collection("Redis-based tests")]
+    public class ReconciliationPerformanceTests : LocalLocationStoreDistributedContentTests
+    {
+        /// <nodoc />
+        public ReconciliationPerformanceTests(LocalRedisFixture redis, ITestOutputHelper output)
+            : base(redis, output)
+        {
+        }
+
+        [Fact(Skip = "For manual testing only")]
+        public async Task MimicReconciliationWithFullDatabaseEnumerationByKeys()
+        {
+            // This is an original and slower version of reconciliation.
+            string databasePath = @"C:\Users\seteplia\AppData\Local\Temp\CloudStore\DatabaseTest\";
+            var db = new RocksDbContentLocationDatabase(TestClock, new RocksDbContentLocationDatabaseConfiguration(new AbsolutePath(databasePath))
+            {
+                CleanOnInitialize = false
+            }, () => CollectionUtilities.EmptyArray<MachineId>());
+            
+
+            var context = new OperationContext(new Context(Logger));
+            await db.StartupAsync(context).ThrowIfFailure();
+
+            var sw = Stopwatch.StartNew();
+            var reconcile = MimicOldReconcile(context, machineId: 42, db);
+            sw.Stop();
+
+            Output.WriteLine($"Reconcile by {sw.ElapsedMilliseconds}ms. Added: {reconcile.addedContent.Count}, removed: {reconcile.removedContent.Count}");
+        }
+
+        [Fact(Skip = "For manual testing only")]
+        public async Task MimicReconcileWithMachineIdFilteringWithNoDeserialization()
+        {
+            string databasePath = @"C:\Users\seteplia\AppData\Local\Temp\CloudStore\DatabaseTest\";
+            var db = new RocksDbContentLocationDatabase(TestClock, new RocksDbContentLocationDatabaseConfiguration(new AbsolutePath(databasePath))
+            {
+                CleanOnInitialize = false
+            }, () => CollectionUtilities.EmptyArray<MachineId>());
+
+            var context = new OperationContext(new Context(Logger));
+            await db.StartupAsync(context).ThrowIfFailure();
+
+            var sw = Stopwatch.StartNew();
+            var reconcile = MimicFastReconcileLogic(context, machineId: 42, db);
+            sw.Stop();
+
+            Output.WriteLine($"Reconcile by {sw.ElapsedMilliseconds}ms. Added: {reconcile.addedContent.Count}, removed: {reconcile.removedContent.Count}");
+        }
+
+        [Fact(Skip = "For manual testing only")]
+        public async Task ReconciliationOverRealStorage()
+        {
+            _enableReconciliation = true;
+            var checkpointsKey = Guid.NewGuid().ToString();
+            // Copy and paste a real connection string here.
+            var storageConnectionString = string.Empty;
+            // Consider updating this directory if you want to keep data between invocations.
+            var workingDirectory = TestRootDirectoryPath;
+            var configuration = new LocalDiskCentralStoreConfiguration(
+                workingDirectory,
+                checkpointsKey);
+            var blobStoreConfiguration = new BlobCentralStoreConfiguration(
+                connectionString: storageConnectionString,
+                containerName: "checkpoints",
+                checkpointsKey: checkpointsKey);
+
+            ConfigureWithOneMaster(blobStoreConfiguration);
+
+            await RunTestAsync(
+                new Context(Logger),
+                2,
+                async context =>
+                {
+                    var master = context.GetMaster();
+                    var worker = context.GetFirstWorker();
+                    var workerId = worker.LocalLocationStore.LocalMachineId;
+
+                    var workerSession = context.Sessions[context.GetFirstWorkerIndex()];
+
+                    var checkpointState = new CheckpointState(
+                        Role.Worker,
+                        EventSequencePoint.Parse("24382354"),
+                        "MD5:8C4856EA13F6AD59B65D8F6781D2A2F9||DCS||incrementalCheckpoints/24382354.10a0ca0f-d63f-4992-a088-f67bd00abd8a.checkpointInfo.txt|Incremental",
+                        DateTime.Now);
+                    // Next heartbeat workers to restore checkpoint
+                    await worker.LocalLocationStore.RestoreCheckpointAsync(new OperationContext(context), checkpointState, inline: true, forceRestore: true).ShouldBeSuccess();
+                    var reconcileResult = await worker.LocalLocationStore.ReconcileAsync(context).ShouldBeSuccess();
+                    Output.WriteLine($"Reconcile result: {reconcileResult}");
+                });
+        }
+
+        private static IEnumerable<(ShortHash hash, long size)> GetSortedDatabaseEntriesWithLocalLocationOld(OperationContext context, RocksDbContentLocationDatabase db, int index)
+        {
+            foreach (var hash in db.EnumerateSortedKeys(context.Token))
+            {
+                if (db.TryGetEntry(context, hash, out var entry))
+                {
+                    if (entry.Locations[index])
+                    {
+                        // Entry is present on the local machine
+                        yield return (hash, entry.ContentSize);
+                    }
+                }
+            }
+        }
+
+        private static (List<ShortHash> removedContent, List<ShortHashWithSize> addedContent) MimicOldReconcile(OperationContext context, int machineId, RocksDbContentLocationDatabase db)
+        {
+            var dbContent = GetSortedDatabaseEntriesWithLocalLocationOld(context, db, machineId);
+
+            // Diff the two views of the local machines content (left = local store, right = content location db)
+            // Then send changes as events
+            (ShortHash hash, long size)[] allLocalStoreContent = new (ShortHash hash, long size)[0];
+            var diffedContent = NuCacheCollectionUtilities.DistinctDiffSorted(leftItems: allLocalStoreContent, rightItems: dbContent, t => t.hash);
+
+            var addedContent = new List<ShortHashWithSize>();
+            var removedContent = new List<ShortHash>();
+
+            foreach (var diffItem in diffedContent)
+            {
+                if (diffItem.mode == MergeMode.LeftOnly)
+                {
+                    // Content is not in DB but is in the local store need to send add event
+                    addedContent.Add(new ShortHashWithSize(diffItem.item.hash, diffItem.item.size));
+                }
+                else
+                {
+                    // Content is in DB but is not local store need to send remove event
+                    removedContent.Add(diffItem.item.hash);
+                }
+            }
+
+            return (removedContent, addedContent);
+        }
+
+
+        private static (List<ShortHash> removedContent, List<ShortHashWithSize> addedContent) MimicFastReconcileLogic(OperationContext context, int machineId, RocksDbContentLocationDatabase db)
+        {
+            var dbContent = db.EnumerateSortedHashesWithContentSizeForMachineId(context, new MachineId(machineId));
+
+            // Diff the two views of the local machines content (left = local store, right = content location db)
+            // Then send changes as events
+            (ShortHash hash, long size)[] allLocalStoreContent = new (ShortHash hash, long size)[0];
+            var diffedContent = NuCacheCollectionUtilities.DistinctDiffSorted(leftItems: allLocalStoreContent, rightItems: dbContent, t => t.hash);
+
+            var addedContent = new List<ShortHashWithSize>();
+            var removedContent = new List<ShortHash>();
+
+            foreach (var diffItem in diffedContent)
+            {
+                if (diffItem.mode == MergeMode.LeftOnly)
+                {
+                    // Content is not in DB but is in the local store need to send add event
+                    addedContent.Add(new ShortHashWithSize(diffItem.item.hash, diffItem.item.size));
+                }
+                else
+                {
+                    // Content is in DB but is not local store need to send remove event
+                    removedContent.Add(diffItem.item.hash);
+                }
+            }
+
+            return (removedContent, addedContent);
+        }
+    }
+}

--- a/Public/Src/Cache/ContentStore/Test/Test/TestBase.cs
+++ b/Public/Src/Cache/ContentStore/Test/Test/TestBase.cs
@@ -28,7 +28,7 @@ namespace ContentStoreTest.Test
         // The file system may be null.
         protected IAbsFileSystem FileSystem => _fileSystem.Value;
 
-        protected AbsolutePath TestRootDirectoryPath => _testRootDirectory.Value.Path;
+        protected virtual AbsolutePath TestRootDirectoryPath => _testRootDirectory.Value.Path;
 
         protected readonly ILogger Logger;
 

--- a/Public/Src/Utilities/KeyValueStore/IBuildXLKeyValueStore.cs
+++ b/Public/Src/Utilities/KeyValueStore/IBuildXLKeyValueStore.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using BuildXL.Engine.Cache.KeyValueStores;
+using RocksDbSharp;
 
 namespace BuildXL.Engine.Cache
 {
@@ -26,6 +27,24 @@ namespace BuildXL.Engine.Cache
         /// <param name="startValue">The start value for iterating keys to garbage collect (optional)</param>
         GarbageCollectResult GarbageCollect(
             Func<byte[], bool> canCollect, 
+            string primaryColumnFamilyName = null, 
+            IEnumerable<string> additionalColumnFamilyNames = null, 
+            CancellationToken cancellationToken = default, 
+            byte[] startValue = null);
+        
+        /// <summary>
+        /// Iterates through all the keys in a column family and garbage collects.
+        /// </summary>
+        /// <param name="canCollect">Whether the key's entry can be garbage collected.</param>
+        /// <param name="primaryColumnFamilyName">The column family to use. If null, the store's default column is used.</param>
+        /// <param name="additionalColumnFamilyNames">
+        /// If provided, any keys determined to be garbage collectable will also be removed across the column families specified by this parameter.
+        /// The key removal will happen atomically across the primary and additional column families passed into this function.
+        /// </param>
+        /// <param name="cancellationToken">Cancellation token for terminating garbage collection (optional)</param>
+        /// <param name="startValue">The start value for iterating keys to garbage collect (optional)</param>
+        GarbageCollectResult GarbageCollectByKeyValue(
+            Func<Iterator, bool> canCollect, 
             string primaryColumnFamilyName = null, 
             IEnumerable<string> additionalColumnFamilyNames = null, 
             CancellationToken cancellationToken = default, 


### PR DESCRIPTION

TLDR; This pr speeds up reconciliation process that was causing builds to fail in MW_PS03 stamp 6 times.

Today some of the Windows builds are failing with materialization errors because reconciliation process takes too long.

Here is an example:

* Machine A starts the build
* During startup Machine A detects that reconciliation is required because local database is out of sync with the content directory.
* Machine A stops sending all events to the master and starts reconciliation process
* Content B is put to Machine A during the build:
** Content B is added to global redis but the master is not notified because reconciliation is still running
* The build takes longer than redis retention period (like 3 hours) but reconciliation is still not done.
* Machine C tries to pin the content B but it fails because content B is gone from redis but was still not added to LLS.

This change improves local database enumeration process and speeds up the reconciliation up to 6 times.

Here are some stats for a database with 15 million entries:

Before: 
Reconcile by 86492ms. Added: 0, removed: 39714
After
Reconcile by 12337ms. Added: 0, removed: 39714

The time went down 6 times and memory went down for about the same rate.

Some screenshots from a profiler:

## Before
![Reconsile_Before](https://user-images.githubusercontent.com/726448/56231370-23b25880-6033-11e9-8860-8a0ca1fa60e3.png)

## After
![Reconcile_After](https://user-images.githubusercontent.com/726448/56231379-290fa300-6033-11e9-96b2-b016aac31c94.png)
