### PR TITLE
Fix find handles to deleted file test for Windows 10 1903

### DIFF
--- a/Public/Src/Utilities/UnitTests/Storage.Untracked/FileUtilitiesTests.Unsafe.cs
+++ b/Public/Src/Utilities/UnitTests/Storage.Untracked/FileUtilitiesTests.Unsafe.cs
@@ -330,7 +330,7 @@ namespace Test.BuildXL.Storage
                 builder.AppendLine(FileUtilitiesMessages.NoProcessesUsingHandle);
                 builder.AppendLine(FileUtilitiesMessages.PathMayBePendingDeletion);
                 // Befores Windows 10 Version 1903, attempting to create a file handle to a file pending deletion would throw an access exception, including calling File.Exists
-                // With Windows 10 Version 1903 and later, creating handles to filese on the pending deletion queue does not throw exceptions and pending deletion files are considered deleted by File.Exists
+                // With Windows 10 Version 1903 and later, creating handles to files on the pending deletion queue does not throw exceptions and pending deletion files are considered deleted by File.Exists
                 // This change in behavior is NOT true for directories, see testing below for the directory behavior
                 XAssert.IsTrue(openHandles.Contains(builder.ToString()) || /* Check for Windows 10 Version 1903 and later */ !File.Exists(file));
                 XAssert.IsFalse(openHandles.Contains(FileUtilitiesMessages.ActiveHandleUsage + file));

--- a/Public/Src/Utilities/UnitTests/Storage.Untracked/FileUtilitiesTests.Unsafe.cs
+++ b/Public/Src/Utilities/UnitTests/Storage.Untracked/FileUtilitiesTests.Unsafe.cs
@@ -334,7 +334,10 @@ namespace Test.BuildXL.Storage
                 builder.AppendLine(file);
                 builder.AppendLine(FileUtilitiesMessages.NoProcessesUsingHandle);
                 builder.AppendLine(FileUtilitiesMessages.PathMayBePendingDeletion);
-                XAssert.IsTrue(openHandles.Contains(builder.ToString()));
+                // Befores Windows 10 Version 1903, attempting to create a file handle to a file pending deletion would throw an access exception, including calling File.Exists
+                // With Windows 10 Version 1903 and later, creating handles to filese on the pending deletion queue does not throw exceptions and pending deletion files are considered deleted by File.Exists
+                // This change in behavior is NOT true for directories, see testing below for the directory behavior
+                XAssert.IsTrue(openHandles.Contains(builder.ToString()) || /* Check for Windows 10 Version 1903 and later */ !File.Exists(file));
                 XAssert.IsFalse(openHandles.Contains(FileUtilitiesMessages.ActiveHandleUsage + file));
             }
 

--- a/Public/Src/Utilities/UnitTests/Storage.Untracked/FileUtilitiesTests.Unsafe.cs
+++ b/Public/Src/Utilities/UnitTests/Storage.Untracked/FileUtilitiesTests.Unsafe.cs
@@ -292,11 +292,6 @@ namespace Test.BuildXL.Storage
         /// If a file or directory is on the Windows pending deletion queue,
         /// no process will report having an open handle
         /// </summary>
-        /// <remarks>
-        /// This test is failing on an RS6 preview. The failure is not related to Helium
-        /// but probably to some behavior change in the APIs this test uses. Requiring the Helium
-        /// drivers to NOT be available is just a very cheap way of detecting an RS6 preview.
-        /// </remarks>
         [FactIfSupported(requiresHeliumDriversNotAvailable: true)]
         public void FailToFindAllOpenHandlesPendingDeletion()
         {


### PR DESCRIPTION
When BuildXL fails to delete a file due to access denied issues or similar, it attempts to find all open handles to the file for logging. 

Previously, if the file was in the Windows "pending deletion" state (file deleted, but there is an open handle with FileShare.Delete permissions to it somewhere), Windows would thrown an access exception if any attempt to create a new file handle to the file was created. BuildXL's attempts to find open handles would also fail to detect any existing file handles open.

The test FileUtilitiesUnsafeTests.FailToFindAllOpenHandlesPendingDeletion pins this behavior.

With Windows 10, Version 1903, Windows no longer throws an access exception in the above scenario and the File is considered deleted by C# File.Exists as long as all existing handles have FileShare.Delete permissions. but BuildXL is still unable to detect any existing file handles open. 

This adds an or condition to fix the assumptions of the test to handle Version 1903.

Fixes [AB#1496544](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1496544)