### PR TITLE
Temporarily disable FingerprintStoreTest failing on Mac

### DIFF
--- a/Public/Src/Engine/UnitTests/FingerprintStore/FingerprintStoreTests.cs
+++ b/Public/Src/Engine/UnitTests/FingerprintStore/FingerprintStoreTests.cs
@@ -255,7 +255,7 @@ namespace Test.BuildXL.FingerprintStore
         /// 2. A cache hit will still refresh the age of an entry. With incremental scheduling disabled, 
         /// a pip must be completely removed from the build to be garbage collected.
         /// </summary>
-        [Fact]
+        [Fact(Skip = "Bug 1513463")]
         public void VerifyGarbageCollectWorks()
         {
             var testHooks = new SchedulerTestHooks()


### PR DESCRIPTION
This test is failing non-deterministically in Mac PR validation but not failing locally on Windows. Investigation in progress, but in the meanwhile just disable the test so PRs don't get blocked.

Bug [AB#1513463](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1513463) to fix and re-enable test.