### PR TITLE
Remove unused argument from drop deamon api.

### DIFF
--- a/Public/Src/Tools/DropDaemon/Tool.DropDaemonInterfaces.dsc
+++ b/Public/Src/Tools/DropDaemon/Tool.DropDaemonInterfaces.dsc
@@ -220,13 +220,13 @@ export interface DropRunner {
      * Preferred method is to use addArtifactsToDrop.
      * If used, directoryContentFilter must specify a .Net-style case-insensitive regex.
      */
-    addDirectoriesToDrop: (createResult: DropCreateResult, args: DropOperationArguments, directories: DirectoryInfo[], directoryContentFilter? : string) => Result;
+    addDirectoriesToDrop: (createResult: DropCreateResult, args: DropOperationArguments, directories: DirectoryInfo[]) => Result;
 
     /** 
      * Adds artifacts to drop.
      * If used, directoryContentFilter must specify a .Net-style case-insensitive regex.
      */
-    addArtifactsToDrop: (createResult: DropCreateResult, args: DropOperationArguments, artifacts: DropArtifactInfo[], directoryContentFilter? : string) => Result;
+    addArtifactsToDrop: (createResult: DropCreateResult, args: DropOperationArguments, artifacts: DropArtifactInfo[]) => Result;
 
     // ------------------------------- for legacy type conversion --------------------------
 


### PR DESCRIPTION
directoryContentFilter was migrated into DirectoryInfo/DropDirectoryInfo, but we forgot to clean the interface definition.