### PR TITLE
Make Helium infrastructure aware of WCI tombstone files

### DIFF
--- a/Public/Src/Engine/Processes/SandboxedProcessPipExecutionResult.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessPipExecutionResult.cs
@@ -308,11 +308,5 @@ namespace BuildXL.Processes
         /// Duration of process start time in milliseconds
         /// </summary>
         public long ProcessStartTimeMs { get; set; }
-
-        /// <summary>
-        /// Dictionary of directories where the process wrote outputs, to the original directories the process
-        /// specified. This is only populated in the case the process ran inside a container, otherwise it is empty.
-        /// </summary>
-        public IReadOnlyDictionary<AbsolutePath, AbsolutePath> RemappedOutputDirectories { get; }
     }
 }

--- a/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
@@ -2997,14 +2997,14 @@ namespace BuildXL.Processes
                     // If outputs were redirected, they are not in their expected location but it their redirected one
                     if (fileOutputsAreRedirected)
                     {
-                        expectedOutputPath = m_processInContainerManager.GetRedirectedOutput(expectedOutput.Path, m_containerConfiguration).ToString(m_pathTable);
+                        expectedOutputPath = m_processInContainerManager.GetRedirectedDeclaredOutputFile(expectedOutput.Path, m_containerConfiguration).ToString(m_pathTable);
                     }
                     else
                     {
                         expectedOutputPath = expectedOutput.Path.ToString(m_pathTable);
                     }
 
-                    if (!FileExistsNoFollow(expectedOutputPath) &&
+                    if (!FileExistsNoFollow(expectedOutputPath, fileOutputsAreRedirected) &&
                         expectedOutput != m_pip.StandardOutput &&
                         expectedOutput != m_pip.StandardError)
                     {
@@ -3039,10 +3039,14 @@ namespace BuildXL.Processes
             return allOutputsPresent;
         }
 
-        private bool FileExistsNoFollow(string path)
+        private bool FileExistsNoFollow(string path, bool fileOutputsAreRedirected)
         {
             var maybeResult = FileUtilities.TryProbePathExistence(path, followSymlink: false);
-            return maybeResult.Succeeded && maybeResult.Result == PathExistence.ExistsAsFile;
+            var existsAsFile = maybeResult.Succeeded && maybeResult.Result == PathExistence.ExistsAsFile;
+
+            // If file outputs are not redirected, this is simply file existence. Otherwise, we have 
+            // to check that the file is not a WCI tombstone, since this means the file is not really there.
+            return existsAsFile && !(fileOutputsAreRedirected && FileUtilities.IsWciTombstoneFile(path));
         }
 
         // (lubol): TODO: Add handling of the translate paths strings. Add code here to address VSO Task# 989041.

--- a/Public/Src/Utilities/Native/IO/FileUtilities.cs
+++ b/Public/Src/Utilities/Native/IO/FileUtilities.cs
@@ -684,10 +684,22 @@ namespace BuildXL.Native.IO
             }
         }
 
+        /// <see cref="IFileSystem.IsWciReparseArtifact(string)"/>
+        public static bool IsWciReparseArtifact(string path)
+        {
+            return s_fileSystem.IsWciReparseArtifact(path);
+        }
+
         /// <see cref="IFileSystem.IsWciReparsePoint(string)"/>
         public static bool IsWciReparsePoint(string path)
         {
             return s_fileSystem.IsWciReparsePoint(path);
+        }
+
+        /// <see cref="IFileSystem.IsWciTombstoneFile(string)"/>
+        public static bool IsWciTombstoneFile(string path)
+        {
+            return s_fileSystem.IsWciTombstoneFile(path);
         }
 
         /// <see cref="IFileSystem.GetChainOfReparsePoints(SafeFileHandle, string, IList{string})"/>

--- a/Public/Src/Utilities/Native/IO/IFileSystem.cs
+++ b/Public/Src/Utilities/Native/IO/IFileSystem.cs
@@ -319,12 +319,31 @@ namespace BuildXL.Native.IO
 
 
         /// <summary>
+        /// Whether <paramref name="path"/> is a WCI reparse point or tombstone file
+        /// </summary>
+        /// <remarks>
+        /// Equivalent to <see cref="IsWciReparsePoint(string)"/> OR <see cref="IsWciTombstoneFile(string)"/>, but
+        /// if in need to see if any of the two conditions hold, calling this function is more efficient since
+        /// it implies opening the file stream once.
+        /// </remarks>
+        bool IsWciReparseArtifact(string path);
+
+        /// <summary>
+        /// Whether <paramref name="path"/> is a WCI tombstone file
+        /// </summary>
+        /// <remarks>
+        /// A WCI tombstone file is used to 'hide' deleted files for processes running in a container
+        /// </remarks>
+        bool IsWciTombstoneFile(string path);
+
+        /// <summary>
         /// Whether <paramref name="path"/> is a WCI reparse point
         /// </summary>
         /// <remarks>
         /// The case of WCI reparse points is handled by this specific function (as opposed to
         /// including this functionality in <see cref="TryGetReparsePointType(string)"/>) since
         /// there is a slightly increased perf cost compared to the regular file attribute check
+        /// A WCI reparse point is used to represent processes accessing virtualized files in a read-only way
         /// </remarks>
         bool IsWciReparsePoint(string path);
 

--- a/Public/Src/Utilities/Native/IO/Unix/FileSystem.Unix.cs
+++ b/Public/Src/Utilities/Native/IO/Unix/FileSystem.Unix.cs
@@ -953,7 +953,19 @@ namespace BuildXL.Native.IO.Unix
         }
 
         /// <inheritdoc/>
+        public bool IsWciReparseArtifact(string path)
+        {
+            return false;
+        }
+
+        /// <inheritdoc/>
         public bool IsWciReparsePoint(string path)
+        {
+            return false;
+        }
+
+        /// <inheritdoc/>
+        public bool IsWciTombstoneFile(string path)
         {
             return false;
         }

--- a/Public/Src/Utilities/Native/IO/Windows/FileSystem.Win.cs
+++ b/Public/Src/Utilities/Native/IO/Windows/FileSystem.Win.cs
@@ -859,7 +859,10 @@ namespace BuildXL.Native.IO.Windows
             IO_REPARSE_TAG_SYMLINK = 0xA000000C, // Used for symbolic link support. See section 2.1.2.4.
             [SuppressMessage("Microsoft.Naming", "CA1700:DoNotNameEnumValuesReserved")]
             [SuppressMessage("Microsoft.Naming", "CA1707:RemoveUnderscoresFromMemberName")]
-            IO_REPARSE_TAG_WCIFS = 0x80000018 // The tag for a WCI reparse point
+            IO_REPARSE_TAG_WCIFS = 0x80000018, // The tag for a WCI reparse point
+            [SuppressMessage("Microsoft.Naming", "CA1700:DoNotNameEnumValuesReserved")]
+            [SuppressMessage("Microsoft.Naming", "CA1707:RemoveUnderscoresFromMemberName")]
+            IO_REPARSE_TAG_WCIFS_TOMBSTONE = 0xA000001F // The tag for a WCI tombstone file
         }
 
         [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
@@ -3370,7 +3373,27 @@ namespace BuildXL.Native.IO.Windows
         }
 
         /// <inheritdoc/>
+        public bool IsWciReparseArtifact(string path)
+        {
+            return IsWCIReparsePointWithTag(path, DwReserved0Flag.IO_REPARSE_TAG_WCIFS, DwReserved0Flag.IO_REPARSE_TAG_WCIFS_TOMBSTONE);
+        }
+
+        /// <inheritdoc/>
         public bool IsWciReparsePoint(string path)
+        {
+            return IsWCIReparsePointWithTag(path, DwReserved0Flag.IO_REPARSE_TAG_WCIFS);
+        }
+
+        /// <inheritdoc/>
+        public bool IsWciTombstoneFile(string path)
+        {
+            return IsWCIReparsePointWithTag(path, DwReserved0Flag.IO_REPARSE_TAG_WCIFS_TOMBSTONE);
+        }
+
+        /// <summary>
+        /// Whether the given path contains any of the given tags
+        /// </summary>
+        private bool IsWCIReparsePointWithTag(string path, DwReserved0Flag tag1, DwReserved0Flag tag2 = DwReserved0Flag.IO_REPARSE_TAG_RESERVED_ZERO)
         {
             Contract.Requires(!string.IsNullOrEmpty(path));
 
@@ -3382,12 +3405,14 @@ namespace BuildXL.Native.IO.Windows
                 {
                     return
                         (findResult.DwFileAttributes & FileAttributes.ReparsePoint) != 0 &&
-                        findResult.DwReserved0 == (uint) DwReserved0Flag.IO_REPARSE_TAG_WCIFS;
+                        (findResult.DwReserved0 == (uint)tag1 || (tag2 == DwReserved0Flag.IO_REPARSE_TAG_RESERVED_ZERO || findResult.DwReserved0 == (uint)tag2));
                 }
 
                 return false;
             }
         }
+
+
 
         [DllImport("ntdll.dll", ExactSpelling = true)]
         internal static extern NtStatus NtSetInformationFile(

--- a/Public/Src/Utilities/Native/IO/Windows/FileSystem.Win.cs
+++ b/Public/Src/Utilities/Native/IO/Windows/FileSystem.Win.cs
@@ -862,7 +862,7 @@ namespace BuildXL.Native.IO.Windows
             IO_REPARSE_TAG_WCIFS = 0x80000018, // The tag for a WCI reparse point
             [SuppressMessage("Microsoft.Naming", "CA1700:DoNotNameEnumValuesReserved")]
             [SuppressMessage("Microsoft.Naming", "CA1707:RemoveUnderscoresFromMemberName")]
-            IO_REPARSE_TAG_WCIFS_TOMBSTONE = 0xA000001F // The tag for a WCI tombstone file
+            IO_REPARSE_TAG_WCIFS_TOMBSTONE = 0xA000001F, // The tag for a WCI tombstone file
         }
 
         [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
@@ -3411,8 +3411,6 @@ namespace BuildXL.Native.IO.Windows
                 return false;
             }
         }
-
-
 
         [DllImport("ntdll.dll", ExactSpelling = true)]
         internal static extern NtStatus NtSetInformationFile(

--- a/Public/Src/Utilities/UnitTests/Executables/TestProcess/Operation.cs
+++ b/Public/Src/Utilities/UnitTests/Executables/TestProcess/Operation.cs
@@ -80,6 +80,11 @@ namespace Test.BuildXL.Executables.TestProcess
             WriteFile,
 
             /// <summary>
+            /// Type for moving a file
+            /// </summary>
+            MoveFile,
+
+            /// <summary>
             /// Write a file conditionally based on an input file
             /// </summary>
             WriteFileIfInputEqual,
@@ -353,6 +358,9 @@ namespace Test.BuildXL.Executables.TestProcess
                     case Type.LaunchDebugger:
                         Debugger.Launch();
                         return;
+                    case Type.MoveFile:
+                        DoMoveFile();
+                        return;
                 }
             }
             catch (Exception e)
@@ -402,6 +410,14 @@ namespace Test.BuildXL.Executables.TestProcess
             return content == Environment.NewLine
                 ? new Operation(Type.AppendNewLine, path, doNotInfer: doNotInfer)
                 : new Operation(Type.WriteFile, path, content, doNotInfer: doNotInfer);
+        }
+
+        /// <summary>
+        /// Moves source to destination
+        /// </summary>
+        public static Operation MoveFile(FileArtifact source, FileArtifact destination, bool doNotInfer = false)
+        {
+            return new Operation(Type.MoveFile, source, content: null, linkPath: destination, doNotInfer: doNotInfer);
         }
 
         /// <summary>
@@ -725,6 +741,11 @@ namespace Test.BuildXL.Executables.TestProcess
             }
 
             Directory.Move(FileOrDirectoryToString(Path), FileOrDirectoryToString(LinkPath));
+        }
+
+        private void DoMoveFile()
+        {
+            File.Move(FileOrDirectoryToString(Path), FileOrDirectoryToString(LinkPath));
         }
 
         private void DoProbe()


### PR DESCRIPTION
Certain file operations happening under Helium containers (in particular moves) leave tombstone files as  leftover artifacts after the container is torn down. This PR makes the container manager and related components aware of them