### PR TITLE
Use exponential back off with key vault.

### DIFF
--- a/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
@@ -262,8 +262,21 @@ namespace BuildXL.Cache.Host.Configuration
         [DataMember]
         public int? ContentLocationDatabaseEntryTimeToLiveMinutes { get; set; }
 
+        // Key Vault Settings
         [DataMember]
         public string KeyVaultSettingsString { get; set; }
+
+        [DataMember]
+        public int KeyVaultRetryCount { get; set; } = 5;
+
+        [DataMember]
+        public int KeyVaultMinBackoffSeconds { get; set; } = 10;
+
+        [DataMember]
+        public int KeyVaultMaxBackoffSeconds { get; set; } = 60;
+
+        [DataMember]
+        public int KeyVaultDeltaBackoffSeconds { get; set; } = 10;
 
         [DataMember]
         public string EventHubSecretName { get; set; }


### PR DESCRIPTION
Instead of accessing a key vault instance once, the code starts using exponential backoff with some random seed to prevent key vault from being overwhelmed too quickly.