### PR TITLE
Use historic cpu usage info as weight

### DIFF
--- a/Public/Src/App/Bxl/Args.cs
+++ b/Public/Src/App/Bxl/Args.cs
@@ -1026,6 +1026,9 @@ namespace BuildXL
                             "useHardlinks",
                             sign => engineConfiguration.UseHardlinks = sign),
                         OptionHandlerFactory.CreateBoolOption(
+                            "useHistoricalCpuUsageInfo",
+                            sign => schedulingConfiguration.UseHistoricalCpuUsageInfo = sign),
+                        OptionHandlerFactory.CreateBoolOption(
                             "useHistoricalRamUsageInfo",
                             sign => schedulingConfiguration.UseHistoricalRamUsageInfo = sign),
                         OptionHandlerFactory.CreateOption(

--- a/Public/Src/Engine/Scheduler/Distribution/Worker.cs
+++ b/Public/Src/Engine/Scheduler/Distribution/Worker.cs
@@ -425,7 +425,7 @@ namespace BuildXL.Scheduler.Distribution
             var processRunnablePip = runnablePip as ProcessRunnablePip;
             // If a process has a weight higher than the total number of process slots, still allow it to run as long as there are no other
             // processes running (the number of acquired slots is 0)
-            if (AcquiredProcessSlots != 0 && AcquiredProcessSlots + processRunnablePip.Process.Weight > (EffectiveTotalProcessSlots * loadFactor))
+            if (AcquiredProcessSlots != 0 && AcquiredProcessSlots + processRunnablePip.Weight > (EffectiveTotalProcessSlots * loadFactor))
             {
                 limitingResource = WorkerResource.AvailableProcessSlots;
                 return false;
@@ -434,7 +434,7 @@ namespace BuildXL.Scheduler.Distribution
             StringId limitingResourceName = StringId.Invalid;
             if (processRunnablePip.TryAcquireResources(m_workerSemaphores, GetAdditionalResourceInfo(processRunnablePip), out limitingResourceName))
             {
-                Interlocked.Add(ref m_acquiredProcessSlots, processRunnablePip.Process.Weight);
+                Interlocked.Add(ref m_acquiredProcessSlots, processRunnablePip.Weight);
                 OnWorkerResourcesChanged(WorkerResource.AvailableProcessSlots, increased: false);
                 runnablePip.AcquiredResourceWorker = this;
                 limitingResource = null;
@@ -512,7 +512,7 @@ namespace BuildXL.Scheduler.Distribution
             {
                 Contract.Assert(processRunnablePip.Resources.HasValue);
 
-                Interlocked.Add(ref m_acquiredProcessSlots, -processRunnablePip.Process.Weight);
+                Interlocked.Add(ref m_acquiredProcessSlots, -processRunnablePip.Weight);
 
                 var resources = processRunnablePip.Resources.Value;
                 m_workerSemaphores.ReleaseResources(resources);

--- a/Public/Src/Engine/Scheduler/ProcessRunnablePip.cs
+++ b/Public/Src/Engine/Scheduler/ProcessRunnablePip.cs
@@ -21,6 +21,16 @@ namespace BuildXL.Scheduler
         /// <nodoc/>
         public Process Process => (Process)Pip;
 
+       
+        /// <summary>
+        /// Process weight
+        /// </summary>
+        /// <remarks>
+        /// If process weight is defined as greater than 1 in the specs, use it. 
+        /// Otherwise, use the weight based on historic cpu usage.
+        /// </remarks>
+        public int Weight => Process.Weight > 1 ? Process.Weight : m_weightBasedOnHistoricCpuUsage;
+
         /// <nodoc/>
         public RunnableFromCacheResult CacheResult { get; private set; }
 
@@ -47,15 +57,27 @@ namespace BuildXL.Scheduler
         /// </summary>
         public CacheableProcess CacheableProcess { get; private set; }
 
+        private readonly int m_weightBasedOnHistoricCpuUsage;
+
         internal ProcessRunnablePip(
             LoggingContext phaseLoggingContext,
             PipId pipId,
             int priority,
             Func<RunnablePip, Task> executionFunc,
             IPipExecutionEnvironment environment,
+            ushort cpuUsageInPercents = 0,
             Pip pip = null)
             : base(phaseLoggingContext, pipId, PipType.Process, priority, executionFunc, environment, pip)
         {
+            if (cpuUsageInPercents > 100)
+            {
+                m_weightBasedOnHistoricCpuUsage = (int)Math.Ceiling(cpuUsageInPercents / 100.0);
+            }
+            else
+            {
+                // If cpu usage is less than 100%, just use the lowest possible weight.
+                m_weightBasedOnHistoricCpuUsage = 1;
+            }
         }
 
         /// <nodoc/>

--- a/Public/Src/Engine/Scheduler/ProcessRunnablePip.cs
+++ b/Public/Src/Engine/Scheduler/ProcessRunnablePip.cs
@@ -26,10 +26,10 @@ namespace BuildXL.Scheduler
         /// Process weight
         /// </summary>
         /// <remarks>
-        /// If process weight is defined as greater than 1 in the specs, use it. 
+        /// If process weight is defined as greater than the minimum weight in the specs, use it. 
         /// Otherwise, use the weight based on historic cpu usage.
         /// </remarks>
-        public int Weight => Process.Weight > 1 ? Process.Weight : m_weightBasedOnHistoricCpuUsage;
+        public int Weight => Process.Weight > Process.MinWeight ? Process.Weight : m_weightBasedOnHistoricCpuUsage;
 
         /// <nodoc/>
         public RunnableFromCacheResult CacheResult { get; private set; }
@@ -76,7 +76,7 @@ namespace BuildXL.Scheduler
             else
             {
                 // If cpu usage is less than 100%, just use the lowest possible weight.
-                m_weightBasedOnHistoricCpuUsage = 1;
+                m_weightBasedOnHistoricCpuUsage = Process.MinWeight;
             }
         }
 

--- a/Public/Src/Engine/Scheduler/RunnablePip.cs
+++ b/Public/Src/Engine/Scheduler/RunnablePip.cs
@@ -410,12 +410,13 @@ namespace BuildXL.Scheduler
             PipId pipId,
             PipType type,
             int priority,
-            Func<RunnablePip, Task> executionFunc)
+            Func<RunnablePip, Task> executionFunc,
+            ushort cpuUsageInPercent)
         {
             switch (type)
             {
                 case PipType.Process:
-                    return new ProcessRunnablePip(loggingContext, pipId, priority, executionFunc, environment);
+                    return new ProcessRunnablePip(loggingContext, pipId, priority, executionFunc, environment, cpuUsageInPercent);
                 default:
                     return new RunnablePip(loggingContext, pipId, type, priority, executionFunc, environment);
             }
@@ -434,7 +435,7 @@ namespace BuildXL.Scheduler
             switch (pip.PipType)
             {
                 case PipType.Process:
-                    return new ProcessRunnablePip(loggingContext, pip.PipId, priority, executionFunc, environment, pip);
+                    return new ProcessRunnablePip(loggingContext, pip.PipId, priority, executionFunc, environment, pip: pip);
                 default:
                     return new RunnablePip(loggingContext, pip.PipId, pip.PipType, priority, executionFunc, environment, pip);
             }

--- a/Public/Src/Engine/UnitTests/Scheduler/PipQueueTest.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/PipQueueTest.cs
@@ -141,7 +141,7 @@ namespace Test.BuildXL.Scheduler
                             var contentHash = ContentHashingUtilities.HashString(contents.ToString(pathTable));
                             executionEnvironment.AddExpectedWrite(writeFile, destinationArtifact, contentHash);
 
-                            var runnable = RunnablePip.Create(loggingContext, executionEnvironment, pipId, pipTable.GetPipType(pipId), 0, taskFactory);
+                            var runnable = RunnablePip.Create(loggingContext, executionEnvironment, pipId, pipTable.GetPipType(pipId), 0, taskFactory, 0);
                             runnable.Start(new OperationTracker(loggingContext), loggingContext);
                             runnable.SetDispatcherKind(DispatcherKind.IO);
                             phase1PipQueue.Enqueue(runnable);
@@ -252,7 +252,7 @@ namespace Test.BuildXL.Scheduler
                                                     callback(pipId, task);
                                                 };
 
-                                            var runnable = RunnablePip.Create(loggingContext, executionEnvironment, pipId, pipTable.GetPipType(pipId), 0, taskFactoryWithCallback);
+                                            var runnable = RunnablePip.Create(loggingContext, executionEnvironment, pipId, pipTable.GetPipType(pipId), 0, taskFactoryWithCallback, 0);
                                             runnable.Start(new OperationTracker(loggingContext), loggingContext);
                                             runnable.SetDispatcherKind(queueKind);
                                             phase2PipQueue.Enqueue(runnable);

--- a/Public/Src/Pips/Dll/Operations/Process.cs
+++ b/Public/Src/Pips/Dll/Operations/Process.cs
@@ -17,6 +17,11 @@ namespace BuildXL.Pips.Operations
     public sealed partial class Process : Pip
     {
         /// <summary>
+        /// Minimum process weight
+        /// </summary>
+        public const int MinWeight = 1;
+
+        /// <summary>
         /// Maximum allowed timeout
         /// </summary>
         public static readonly TimeSpan MaxTimeout = int.MaxValue.MillisecondsToTimeSpan();
@@ -439,7 +444,7 @@ namespace BuildXL.Pips.Operations
             ProcessAbsentPathProbeInUndeclaredOpaquesMode = absentPathProbeMode;
             DoubleWritePolicy = doubleWritePolicy;
             ContainerIsolationLevel = containerIsolationLevel;
-            Weight = weight.HasValue && weight.Value > 0 ? weight.Value : 1;
+            Weight = weight.HasValue && weight.Value > 0 ? weight.Value : MinWeight;
         }
 
         /// <summary>

--- a/Public/Src/Utilities/Configuration/IScheduleConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/IScheduleConfiguration.cs
@@ -303,6 +303,7 @@ namespace BuildXL.Utilities.Configuration
         /// </remarks>
         bool UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing { get; }
 
+        /// <summary>
         /// Indicates whether historic cpu information should be used to decide the weight of process pips.
         /// </summary>
         bool UseHistoricalCpuUsageInfo { get; }

--- a/Public/Src/Utilities/Configuration/IScheduleConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/IScheduleConfiguration.cs
@@ -302,5 +302,9 @@ namespace BuildXL.Utilities.Configuration
         /// TODO: Remove this when https://gitlab.kitware.com/cmake/cmake/issues/19162 has reached mainstream versions
         /// </remarks>
         bool UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing { get; }
+
+        /// Indicates whether historic cpu information should be used to decide the weight of process pips.
+        /// </summary>
+        bool UseHistoricalCpuUsageInfo { get; }
     }
 }

--- a/Public/Src/Utilities/Configuration/Mutable/ScheduleConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/ScheduleConfiguration.cs
@@ -312,5 +312,8 @@ namespace BuildXL.Utilities.Configuration.Mutable
 
         /// <inheritdoc />
         public bool UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing { get; set; }
+
+        /// <inheritdoc />
+        public bool UseHistoricalCpuUsageInfo { get; set; }
     }
 }


### PR DESCRIPTION
In the historic running timetable, we do record the cpu usage per pip. That is calculated as 100*(usertime+kerneltime)/wallclocktime. That information can be used as weight. This is mainly for WDG builds. 