### PR TITLE
Expose weight through to QTest SDK

### DIFF
--- a/Public/Sdk/Public/Managed/testing.dsc
+++ b/Public/Sdk/Public/Managed/testing.dsc
@@ -11,7 +11,7 @@ import * as Xml from "Sdk.Xml";
  * uses the test frameworks runtest function to execute the test.
  */
 @@public
-export function test(args: TestArguments) : TestResult {
+export function test(args: TestArguments) : TestResult {   
     let testFramework = args.testFramework;
     if (!testFramework)
     {
@@ -266,6 +266,9 @@ export interface TestRunArguments {
      * Allows test runs to be tagged.
      */
     tags?: string[];
+
+    /** Optionally override to increase the weight of test pips that require more machine resources */
+    weight?: number;
 }
 
 @@public

--- a/Public/Sdk/Public/Managed/testing.dsc
+++ b/Public/Sdk/Public/Managed/testing.dsc
@@ -11,7 +11,7 @@ import * as Xml from "Sdk.Xml";
  * uses the test frameworks runtest function to execute the test.
  */
 @@public
-export function test(args: TestArguments) : TestResult {   
+export function test(args: TestArguments) : TestResult {
     let testFramework = args.testFramework;
     if (!testFramework)
     {

--- a/Public/Sdk/SelfHost/BuildXL/Testing/QTest/qtestFramework.dsc
+++ b/Public/Sdk/SelfHost/BuildXL/Testing/QTest/qtestFramework.dsc
@@ -144,6 +144,7 @@ function runTest(args : TestRunArguments) : File[] {
         qTestTool: qTestTool,
         qTestLogs: logDir,
         tags: args.tags,
+        weight: args.weight,
     });
 
     return [

--- a/Public/Sdk/SelfHost/BuildXL/Tools/QTest/Tool.QTestRunner.dsc
+++ b/Public/Sdk/SelfHost/BuildXL/Tools/QTest/Tool.QTestRunner.dsc
@@ -164,7 +164,7 @@ export function runQTest(args: QTestArguments): Result {
         consoleOutput: consolePath,
         workingDirectory: sandboxDir,
         tempDirectory: tempDirectory,
-        weight : args.weight,
+        weight: args.weight,
         disableCacheLookup: Environment.getFlag("[Sdk.BuildXL]qTestForceTest"),
         additionalTempDirectories : [sandboxDir],
         dependencies: [

--- a/Public/Sdk/SelfHost/BuildXL/Tools/QTest/Tool.QTestRunner.dsc
+++ b/Public/Sdk/SelfHost/BuildXL/Tools/QTest/Tool.QTestRunner.dsc
@@ -164,7 +164,7 @@ export function runQTest(args: QTestArguments): Result {
         consoleOutput: consolePath,
         workingDirectory: sandboxDir,
         tempDirectory: tempDirectory,
-        // TODO - hook this up for Heisenbug queues (runs tests a bunch under qtest process)
+        weight : args.weight,
         disableCacheLookup: Environment.getFlag("[Sdk.BuildXL]qTestForceTest"),
         additionalTempDirectories : [sandboxDir],
         dependencies: [
@@ -258,6 +258,8 @@ export interface QTestArguments extends Transformer.RunnerArguments {
     qTestAdditionalOptions?: string;
     /** Path to runsettings file that will be passed on to vstest.console.exe. */
     vstestSettingsFile?: File;
+    /** Optionally override to increase the weight of test pips that require more machine resources */
+    weight?: number;
 }
 /**
  * Test results from a vstest.console.exe run

--- a/Public/Src/Cache/VerticalStore/UnitTests/BasicFilesystem/Test.BuildXL.Cache.BasicFilesystem.dsc
+++ b/Public/Src/Cache/VerticalStore/UnitTests/BasicFilesystem/Test.BuildXL.Cache.BasicFilesystem.dsc
@@ -19,5 +19,7 @@ namespace BasicFilesystem{
             importFrom("BuildXL.Cache.ContentStore").UtilitiesCore.dll,
             importFrom("BuildXL.Utilities").dll,
         ],
+        // Increase the weight of these tests since they do more I/O
+        runTestArgs: { weight: 2},
     });
 }


### PR DESCRIPTION
Exposing the process weight configuration through the QTest SDK and also through to the Managed SDK. Only enabled for QTest pips.