### PR TITLE
Downgrade detours heap size logging to diagnostic

### DIFF
--- a/Public/Src/Engine/Processes/Tracing/Log.cs
+++ b/Public/Src/Engine/Processes/Tracing/Log.cs
@@ -413,7 +413,7 @@ namespace BuildXL.Processes.Tracing
             (int)EventId.LogDetoursMaxHeapSize,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,
-            Keywords = (int)Events.Keywords.UserMessage,
+            Keywords = (int)(Events.Keywords.UserMessage | Events.Keywords.Diagnostics),
             EventTask = (int)Events.Tasks.PipExecutor,
             Message = Events.PipPrefix + "Maximum detours heap size for process in the pip is {maxDetoursHeapSizeInBytes} bytes. The processName '{processName}'. The processId is: {processId}. The manifestSize in bytes is: {manifestSizeInBytes}. The finalDetoursHeapSize in bytes is: {finalDetoursHeapSizeInBytes}. The allocatedPoolEntries is: {allocatedPoolEntries}. The maxHandleMapEntries is: {maxHandleMapEntries}. The handleMapEntries is: {handleMapEntries}.")]
         public abstract void LogDetoursMaxHeapSize(


### PR DESCRIPTION
This log message was added over a year ago to debug a detours bug. The bug's long been fixed and the message is pretty chatty. Downgrade to to a diagnostic event.