### PR TITLE
Let cloudbuild selfhost build pick up Qtest binary from BuildXL sdk

### DIFF
--- a/Public/Sdk/SelfHost/BuildXL/Testing/QTest/qtestFramework.dsc
+++ b/Public/Sdk/SelfHost/BuildXL/Testing/QTest/qtestFramework.dsc
@@ -12,7 +12,7 @@ const qTestContents = importFrom("CB.QTest").Contents.all;
 @@public
 export const qTestTool: Transformer.ToolDefinition = {
     exe: qTestContents.getFile(r`tools/DBS.QTest.exe`),
-    description: "CloudBuild QTest",
+    description: "SelfHost Dev Build QTest",
     runtimeDirectoryDependencies: [
         qTestContents
     ],
@@ -141,7 +141,7 @@ function runTest(args : TestRunArguments) : File[] {
         qTestTimeoutSec: 540,
         useVsTest150:true,
         vstestSettingsFile: f`test.runsettings`,
-        qTestTool: qTestTool,
+        qTestTool: Environment.hasVariable("[Sdk.BuildXL]qtestDeploymentPath") ? undefined : qTestTool,
         qTestLogs: logDir,
         tags: args.tags,
     });

--- a/Public/Sdk/SelfHost/BuildXL/Tools/QTest/Tool.QTestRunner.dsc
+++ b/Public/Sdk/SelfHost/BuildXL/Tools/QTest/Tool.QTestRunner.dsc
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import {Artifact, Cmd, Transformer, Tool} from "Sdk.Transformers";
-const root = d`.`;
+const root = Environment.hasVariable("[Sdk.BuildXL]qtestDeploymentPath") ? d`${Environment.getFileValue("[Sdk.BuildXL]qtestDeploymentPath")}` : d`.`;
 
 @@public
 export const qTestTool: Transformer.ToolDefinition = {
@@ -17,6 +17,7 @@ export const qTestTool: Transformer.ToolDefinition = {
         d`${Context.getMount("LocalAppData").path}`
     ]),
     dependsOnWindowsDirectories: true,
+    dependsOnAppDataDirectory: true,
     prepareTempDirectory: true,
 };
 const defaultArgs: QTestArguments = {


### PR DESCRIPTION
Will change GBR to pass [Sdk.BuildXL]qtestDeploymentPath.

With these changes, selfhost build will pick up Qtest as below strategy:
Dev build: SDK from BuildXL enlistment, Qtest binary (DBS.QTest.exe and its dependencies) from BuildXL enlistment. Nothing actually change for Dev build.
Cloud build: SDK from BuildXL enlistment, Qtest binary (DBS.QTest.exe and its dependencies) from qbit deployment

Office build will not be impacted.