### PR TITLE
Add factory for GRPC P2P cache

### DIFF
--- a/Public/Src/Cache/ContentStore/Interfaces/FileSystem/AbsolutePath.cs
+++ b/Public/Src/Cache/ContentStore/Interfaces/FileSystem/AbsolutePath.cs
@@ -37,6 +37,26 @@ namespace BuildXL.Cache.ContentStore.Interfaces.FileSystem
         public static int MinimumPathLength = OperatingSystemHelper.IsWindowsOS ? 2 : 1;
 
         /// <summary>
+        /// Create an AbsolutePath for the root of a drive.
+        /// </summary>
+        public static AbsolutePath RootPath(char driveLetter = default(char))
+        {
+            if (OperatingSystemHelper.IsWindowsOS)
+            {
+                if (driveLetter == default(char))
+                {
+                    throw new ArgumentException(nameof(driveLetter));
+                }
+
+                return new AbsolutePath($"{driveLetter}:{System.IO.Path.DirectorySeparatorChar}{System.IO.Path.DirectorySeparatorChar}");
+            }
+            else
+            {
+                return new AbsolutePath(System.IO.Path.DirectorySeparatorChar.ToString());
+            }
+        }
+
+        /// <summary>
         ///     Initializes a new instance of the <see cref="AbsolutePath" /> class.
         /// </summary>
         public AbsolutePath(string path)

--- a/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
@@ -31,11 +31,12 @@ namespace BuildXL.Cache.Host.Configuration
             };
         }
 
-        public static DistributedContentSettings CreateEnabled(IDictionary<string, string> connectionSecretNameMap)
+        public static DistributedContentSettings CreateEnabled(IDictionary<string, string> connectionSecretNameMap, bool isGrpcCopierEnabled = false)
         {
             return new DistributedContentSettings(connectionSecretNameMap)
             {
-                IsDistributedContentEnabled = true
+                IsDistributedContentEnabled = true,
+                IsGrpcCopierEnabled = isGrpcCopierEnabled
             };
         }
 

--- a/Public/Src/Cache/DistributedCache.Host/Service/Internal/DualServerClientContentStore.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Service/Internal/DualServerClientContentStore.cs
@@ -1,0 +1,172 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.ContractsLight;
+using System.Threading;
+using System.Threading.Tasks;
+using BuildXL.Cache.ContentStore.Distributed.Redis.Credentials;
+using BuildXL.Cache.ContentStore.Interfaces.Distributed;
+using BuildXL.Cache.ContentStore.Interfaces.FileSystem;
+using BuildXL.Cache.ContentStore.Interfaces.Logging;
+using BuildXL.Cache.ContentStore.Interfaces.Results;
+using BuildXL.Cache.ContentStore.Interfaces.Sessions;
+using BuildXL.Cache.ContentStore.Interfaces.Stores;
+using BuildXL.Cache.ContentStore.Interfaces.Tracing;
+using BuildXL.Cache.ContentStore.Service;
+using BuildXL.Cache.ContentStore.Sessions;
+using BuildXL.Cache.ContentStore.Stores;
+using BuildXL.Cache.Host.Configuration;
+
+namespace BuildXL.Cache.Host.Service.Internal
+{
+    /// <summary>
+    /// Content store containing both a distributed <see cref="LocalContentStore"/> and <see cref="ServiceClientContentStore"/>.
+    /// </summary>
+    public class DualServerClientContentStore : IContentStore
+    {
+        private LocalContentServer _localContentServer;
+        private ServiceClientContentStore _serviceClientContentStore;
+
+        /// <inheritdoc />
+        public bool StartupCompleted => (_localContentServer?.StartupCompleted ?? false) && (_serviceClientContentStore?.StartupCompleted ?? false);
+
+        /// <inheritdoc />
+        public bool StartupStarted => (_localContentServer?.StartupStarted ?? false) && (_serviceClientContentStore?.StartupStarted ?? false);
+
+        /// <inheritdoc />
+        public bool ShutdownCompleted => (_localContentServer?.ShutdownCompleted ?? false) && (_serviceClientContentStore?.ShutdownCompleted ?? false);
+
+        /// <inheritdoc />
+        public bool ShutdownStarted => (_localContentServer?.ShutdownStarted ?? false) && (_serviceClientContentStore?.ShutdownStarted ?? false);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="fileSystem">File system object used by the client.</param>
+        /// <param name="logger">Logger.</param>
+        /// <param name="copier">File copier used by the content server.</param>
+        /// <param name="pathTransformer">File path transformer used by the content server.</param>
+        /// <param name="maxQuotaMB">Maximum size (in MB) of the cache.</param>
+        /// <param name="cacheName">Name of the cache.</param>
+        /// <param name="grpcPort">GRPC port which the server listens to and the client transmits to.</param>
+        /// <param name="stampId">Redis stamp identifier.</param>
+        /// <param name="ringId">Redis ring identifier.</param>
+        /// <param name="scenarioName">Unique name for the CAS. Allows multiple CAS services to coexist.</param>
+        /// <param name="dataRootPath">Path to the root of CAS content.</param>
+        public DualServerClientContentStore(
+            IAbsFileSystem fileSystem,
+            ILogger logger,
+            IAbsolutePathFileCopier copier,
+            IAbsolutePathTransformer pathTransformer,
+            int maxQuotaMB,
+            string cacheName,
+            int grpcPort,
+            string stampId,
+            string ringId,
+            string scenarioName,
+            AbsolutePath dataRootPath)
+        {
+            Contract.Assert(grpcPort >= 0);
+            Contract.Assert(maxQuotaMB >= 0);
+            Contract.Assert(!string.IsNullOrWhiteSpace(cacheName));
+            Contract.Assert(!string.IsNullOrWhiteSpace(ringId));
+            Contract.Assert(!string.IsNullOrWhiteSpace(stampId));
+
+            var redisConnectionString = Environment.GetEnvironmentVariable(EnvironmentConnectionStringProvider.RedisConnectionStringEnvironmentVariable);
+
+            var localCasSettings = LocalCasSettings.Default(maxQuotaMB, dataRootPath.Path, cacheName, (uint)grpcPort);
+            localCasSettings.ServiceSettings.ScenarioName = scenarioName;
+
+            if (dataRootPath.IsLocal)
+            {
+                localCasSettings.DrivePreferenceOrder.Add(AbsolutePath.RootPath(dataRootPath.DriveLetter).Path);
+            }
+
+            var contentServerFactory = new ContentServerFactory(new DistributedCacheServiceArguments(
+                logger,
+                copier,
+                pathTransformer,
+                new TestDistributedCacheServiceHost(),
+                new HostInfo(stampId, ringId, new List<string>()),
+                default(CancellationToken),
+                dataRootPath.Path,
+                new DistributedCacheServiceConfiguration(
+                    localCasSettings,
+                    DistributedContentSettings.CreateEnabled(new Dictionary<string, string>() { { stampId, redisConnectionString } }, true)),
+                string.Empty));
+            _localContentServer = contentServerFactory.Create();
+
+            _serviceClientContentStore = new ServiceClientContentStore(
+                logger,
+                fileSystem,
+                new ServiceClientContentStoreConfiguration(cacheName, new ServiceClientRpcConfiguration(grpcPort), scenarioName));
+        }
+
+        /// <inheritdoc />
+        public CreateSessionResult<IReadOnlyContentSession> CreateReadOnlySession(Context context, string name, ImplicitPin implicitPin)
+        {
+            return _serviceClientContentStore.CreateReadOnlySession(context, name, implicitPin);
+        }
+
+        /// <inheritdoc />
+        public CreateSessionResult<IContentSession> CreateSession(Context context, string name, ImplicitPin implicitPin)
+        {
+            return _serviceClientContentStore.CreateSession(context, name, implicitPin);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            _serviceClientContentStore?.Dispose();
+            _localContentServer?.Dispose();
+        }
+
+        /// <inheritdoc />
+        public Task<GetStatsResult> GetStatsAsync(Context context)
+        {
+            return _serviceClientContentStore.GetStatsAsync(context);
+        }
+
+        /// <inheritdoc />
+        public async Task<BoolResult> ShutdownAsync(Context context)
+        {
+            await _serviceClientContentStore.ShutdownAsync(context).ThrowIfFailure();
+            return await _localContentServer.ShutdownAsync(context).ThrowIfFailure();
+        }
+
+        /// <inheritdoc />
+        public async Task<BoolResult> StartupAsync(Context context)
+        {
+            await _localContentServer.StartupAsync(context).ThrowIfFailure();
+            return await _serviceClientContentStore.StartupAsync(context).ThrowIfFailure();
+        }
+
+        private sealed class TestDistributedCacheServiceHost : IDistributedCacheServiceHost
+        {
+            public string GetSecretStoreValue(string key)
+            {
+                return key;
+            }
+
+            public void OnStartedService()
+            {
+            }
+
+            public Task OnStartingServiceAsync()
+            {
+                return Task.Run(() => { });
+            }
+
+            public void OnTeardownCompleted()
+            {
+            }
+
+            public Task<Dictionary<string, string>> RetrieveKeyVaultSecretsAsync(List<string> secrets, CancellationToken token)
+            {
+                return Task.FromResult(new Dictionary<string, string>());
+            }
+        }
+    }
+}

--- a/Public/Src/Cache/DistributedCache.Host/Service/Internal/LocalCasSettingsExtensions.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Service/Internal/LocalCasSettingsExtensions.cs
@@ -44,9 +44,9 @@ namespace BuildXL.Cache.Host.Service.Internal
                 // check that the stamp has the capabilities required by the named cache.
                 if (kvp.Value.RequiredCapabilities != null && kvp.Value.RequiredCapabilities.Count > 0)
                 {
-                    string missingCaps = String.Join(",", kvp.Value.RequiredCapabilities
+                    string missingCaps = string.Join(",", kvp.Value.RequiredCapabilities
                         .Where(cap => !hostCapabilities.Contains(cap, StringComparer.OrdinalIgnoreCase)));
-                    if (!String.IsNullOrEmpty(missingCaps))
+                    if (!string.IsNullOrEmpty(missingCaps))
                     {
                         logger.Debug(
                             "Named cache '{0}' was discarded since environment lacks required capabilities: {1}.",

--- a/Public/Src/Cache/MemoizationStore/Library/BuildXL.Cache.MemoizationStore.Library.dsc
+++ b/Public/Src/Cache/MemoizationStore/Library/BuildXL.Cache.MemoizationStore.Library.dsc
@@ -16,12 +16,15 @@ namespace Library {
                 importFrom("Microsoft.Diagnostics.Tracing.EventSource.Redist").pkg,
                 NetFx.System.Data.dll,
             ]),
+            ContentStore.Distributed.dll,
             ContentStore.UtilitiesCore.dll,
             ContentStore.Grpc.dll,
             ContentStore.Hashing.dll,
             ContentStore.Interfaces.dll,
             ContentStore.Library.dll,
             Interfaces.dll,
+
+            importFrom("BuildXL.Cache.DistributedCache.Host").Service.dll,
 
             importFrom("BuildXL.Utilities").dll,
 


### PR DESCRIPTION
New factory for GRPC peer-to-peer cache. Here's a rough sketch of the types:

MemoizationStoreCacheFactory : ICacheFactory
    - MemoizationStoreAdapterCache : ICache
        - LocalCache : OneLevelCache
            - DualServerClientContentStore : IContentStore
                - LocalContentServer
                    - DistributedContentStore : IContentStore
                        - FileSystemContentStore : IContentStore
                - ServiceClientContentStore : IContentStore
            - SqlLiteMemoizationStore
