### PR TITLE
Add JsonTree.Serialize to give FingerprintStore analyzers JSON output

### DIFF
--- a/Public/Src/Engine/Scheduler/Tracing/FingerprintStoreReader.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/FingerprintStoreReader.cs
@@ -174,7 +174,7 @@ namespace BuildXL.Scheduler.Tracing
             /// </summary>
             public JsonNode GetWeakFingerprintTree()
             {
-                return JsonTree.BuildTree(m_entry.WeakFingerprintToInputs.Value);
+                return JsonTree.Deserialize(m_entry.WeakFingerprintToInputs.Value);
             }
 
             /// <summary>
@@ -183,8 +183,8 @@ namespace BuildXL.Scheduler.Tracing
             public JsonNode GetStrongFingerprintTree()
             {
                 var strongEntry = m_entry.StrongFingerprintEntry;
-                var strongFingerprintTree = JsonTree.BuildTree(strongEntry.StrongFingerprintToInputs.Value);
-                var pathSetTree = JsonTree.BuildTree(strongEntry.PathSetHashToInputs.Value);
+                var strongFingerprintTree = JsonTree.Deserialize(strongEntry.StrongFingerprintToInputs.Value);
+                var pathSetTree = JsonTree.Deserialize(strongEntry.PathSetHashToInputs.Value);
 
                 return MergeStrongFingerprintAndPathSetTrees(strongFingerprintTree, pathSetTree);
             }
@@ -371,7 +371,7 @@ namespace BuildXL.Scheduler.Tracing
                 {
                     WriteToPipFile(PrettyFormatJsonField(new KeyValuePair<string, string>(directoryFingerprint, inputs)).ToString());
 
-                    var directoryMembershipTree = JsonTree.BuildTree(inputs);
+                    var directoryMembershipTree = JsonTree.Deserialize(inputs);
                     for (var it = directoryMembershipTree.Children.First; it != null; it = it.Next)
                     {
                         JsonTree.ReparentBranch(it.Value, pathSetNode);

--- a/Public/Src/Engine/UnitTests/Cache/JsonTreeTests.cs
+++ b/Public/Src/Engine/UnitTests/Cache/JsonTreeTests.cs
@@ -19,8 +19,8 @@ namespace Test.BuildXL.Engine.Cache
             string jsonA = "{\"Dependencies\":[{\"a\":\"valueA\"},{\"b\":\"valueB\"}]}";
             string jsonB = "{\"Dependencies\":[{\"b\":\"valueB\"},{\"a\":\"valueA\"}]}";
 
-            var treeA = JsonTree.BuildTree(jsonA);
-            var treeB = JsonTree.BuildTree(jsonB);
+            var treeA = JsonTree.Deserialize(jsonA);
+            var treeB = JsonTree.Deserialize(jsonB);
 
             var changeList = JsonTree.DiffTrees(treeA, treeB);
             // The change list must detect either "a" or "b" as having moved positions
@@ -39,8 +39,8 @@ namespace Test.BuildXL.Engine.Cache
             string jsonA = "{\"Object\":[{\"WeakFingerprint\":\"097ED1ED5703816B8F286410076E658260D029BC\"},{\"StrongFingerprint\":\"C926945B5824E1CC7C512D66FB3B8FE869B71936\"}]}";
             string jsonB = "{\"Object\":[{\"WeakFingerprint\":\"097ED1ED5703816B8F286410076E658260D029BC\"},{\"StrongFingerprint\":\"DefinitelyNotTheSameFingerprint\"}]}";
 
-            var treeA = JsonTree.BuildTree(jsonA);
-            var treeB = JsonTree.BuildTree(jsonB);
+            var treeA = JsonTree.Deserialize(jsonA);
+            var treeB = JsonTree.Deserialize(jsonB);
 
             var changeList = JsonTree.DiffTrees(treeA, treeB);
             AssertUnchanged("WeakFingerprint", changeList);
@@ -55,8 +55,8 @@ namespace Test.BuildXL.Engine.Cache
             string jsonB = "{\"Object\":[{\"PathSet\":\"VSO0:890000000000000000000000000000000000000000000000000000000000000000\"}," +
                 "{\"ObservedInputs\":[{\"P\":\"\"},{\"P\":\"\"},{\"P\":\"CHANGEDVALUE\"},{\"P\":\"\"},{\"P\":\"\"},{\"P\":\"\"},{\"E\":\"VSO0:4D939FB1E1CE7586909F84F4FEFB0F385B31DD586FF97FC14874BCDB4B2A801400\"}]}]}";
 
-            var treeA = JsonTree.BuildTree(jsonA);
-            var treeB = JsonTree.BuildTree(jsonB);
+            var treeA = JsonTree.Deserialize(jsonA);
+            var treeB = JsonTree.Deserialize(jsonB);
 
             var changeList = JsonTree.DiffTrees(treeA, treeB);
             AssertChanged("P", changeList);
@@ -96,8 +96,8 @@ namespace Test.BuildXL.Engine.Cache
                 "{\"Environment\":[]},{\"WarningTimeout\":\"-1\"},{\"AddedTimeout\":\"-1\"},{\"WarningRegex.Pattern\":\"^\\\\s*((((((\\\\d+>)?[a-zA-Z]?:[^:]*)|([^:]*))):)|())(()|([^:]*? ))warning( \\\\s*([^: ]*))?\\\\s*:.*$\"},{\"WarningRegex.Options\":\"1\"}," +
                 "{\"ErrorRegex.Pattern\":\".*\"},{\"ErrorRegex.Options\":\"1\"},{\"SuccessExitCodes\":[]}]}";
 
-            var treeA = JsonTree.BuildTree(jsonA);
-            var treeB = JsonTree.BuildTree(jsonB);
+            var treeA = JsonTree.Deserialize(jsonA);
+            var treeB = JsonTree.Deserialize(jsonB);
 
             var changeList = JsonTree.DiffTrees(treeA, treeB);
             AssertUnchanged("Outputs", changeList);

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/PipFingerprintAnalyzer.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/PipFingerprintAnalyzer.cs
@@ -119,10 +119,10 @@ namespace BuildXL.Execution.Analyzer
             using (var pipSession = m_storeReader.StartPipRecordingSession(PipFormattedSemistableHash))
             {
                 m_writer.WriteLine("WEAKFINGERPRINT:");
-                m_writer.WriteLine(JsonTree.PrintTree(pipSession.GetWeakFingerprintTree()));
+                m_writer.WriteLine(JsonTree.Serialize(pipSession.GetWeakFingerprintTree()));
                 m_writer.WriteLine();
                 m_writer.WriteLine("STRONGFINGERPRINT:");
-                m_writer.WriteLine(JsonTree.PrintTree(pipSession.GetStrongFingerprintTree()));
+                m_writer.WriteLine(JsonTree.Serialize(pipSession.GetStrongFingerprintTree()));
             }
 
             m_writer.Flush();


### PR DESCRIPTION
The FingerprintStore uses JSON to store the pip fingerprints, and during analysis, that JSON is turned into an object tree that can be manipulated to add better semantic meaning to pathset and strong fingerprint inputs for the sake of higher quality analysis. 

Previously, there was no way to serialize the object tree back to JSON, so the analyzers output custom formats.

This makes the analyzer output less flexible/parseable and also prohibits us from using a JSON diffing tool for cache miss analysis.

Changes
- Add "JsonTree.Serialize" to make the deserialization two-way
- Rename "JsonTree.BuildTree" to "JsonTree.Deserialize"
- Make PipFingerprintAnalyzer output in JSON instead of custom format