### PR TITLE
Make StoreOutputToCache- compatible with rewritten targets of copy and write file

### DIFF
--- a/Public/Src/Engine/Scheduler/Artifacts/FileContentManager.cs
+++ b/Public/Src/Engine/Scheduler/Artifacts/FileContentManager.cs
@@ -2302,7 +2302,7 @@ namespace BuildXL.Scheduler.Artifacts
                                             materializingOutputs,
                                             fileArtifact,
                                             contentHash,
-                                            fileArtifact.Path);
+                                            fileArtifact);
 
                                     // Try to be conservative here due to distributed builds (e.g., the files may not exist on other machines).
                                     isAvailable = possiblyStored.Succeeded;
@@ -2360,7 +2360,7 @@ namespace BuildXL.Scheduler.Artifacts
                                                 materializingOutputs,
                                                 otherFile,
                                                 contentHash,
-                                                fileArtifact.Path);
+                                                fileArtifact);
 
                                         isAvailable = possiblyStored.Succeeded;
                                     }
@@ -2492,16 +2492,16 @@ namespace BuildXL.Scheduler.Artifacts
             bool materializingOutputs,
             FileArtifact fileArtifact,
             ContentHash hash,
-            AbsolutePath targetPath)
+            FileArtifact targetFile)
         {
-            if (!Configuration.Schedule.StoreOutputsToCache)
+            if (!Configuration.Schedule.StoreOutputsToCache && !m_host.IsFileRewritten(targetFile))
             {
                 return new Failure<string>("Storing content to cache is not allowed");
             }
 
             using (operationContext.StartOperation(OperationCounter.FileContentManagerRestoreContentInCache))
             {
-                FileRealizationMode fileRealizationMode = GetFileRealizationModeForCacheRestore(pip, materializingOutputs, fileArtifact, targetPath);
+                FileRealizationMode fileRealizationMode = GetFileRealizationModeForCacheRestore(pip, materializingOutputs, fileArtifact, targetFile.Path);
                 bool shouldReTrack = fileRealizationMode != FileRealizationMode.Copy;
 
                 var possiblyStored = await LocalDiskContentStore.TryStoreAsync(

--- a/Public/Src/Engine/Scheduler/Artifacts/IFileContentManagerHost.cs
+++ b/Public/Src/Engine/Scheduler/Artifacts/IFileContentManagerHost.cs
@@ -134,5 +134,10 @@ namespace BuildXL.Scheduler.Artifacts
         /// </summary>
         /// <returns>True if the file was materialize by the host. Failure if host supports materializing the file and failed during materialization.</returns>
         Task<Possible<ContentMaterializationOrigin>> TryMaterializeFileAsync(FileArtifact artifact, OperationContext operationContext);
+
+        /// <summary>
+        /// Checks if a file is ever rewritten.
+        /// </summary>
+        bool IsFileRewritten(in FileArtifact fileArtifact);
     }
 }

--- a/Public/Src/Engine/Scheduler/PipExecutor.cs
+++ b/Public/Src/Engine/Scheduler/PipExecutor.cs
@@ -136,7 +136,7 @@ namespace BuildXL.Scheduler
             var pipInfo = new PipInfo(pip, context);
             var pipDescription = pipInfo.Description;
 
-            bool shouldStoreOutputToCache = environment.Configuration.Schedule.StoreOutputsToCache;
+            
 
             string destination = pip.Destination.Path.ToString(pathTable);
             string source = pip.Source.Path.ToString(pathTable);
@@ -199,6 +199,8 @@ namespace BuildXL.Scheduler
                     {
                         Contract.Assume(sourceContentInfo.Hash != WellKnownContentHashes.UntrackedFile);
                     }
+
+                    bool shouldStoreOutputToCache = environment.Configuration.Schedule.StoreOutputsToCache || IsRewriteOutputFile(environment, pip.Destination);
 
                     // If the file is symlink and the chain is valid, the final target is a source file
                     // (otherwise, we would not have passed symlink chain validation).
@@ -766,7 +768,9 @@ namespace BuildXL.Scheduler
                             fileWritten,
                             "WriteAllBytes only returns false when the predicate parameter (not supplied) fails. Otherwise it should throw a BuildXLException and be handled below.");
 
-                        var possiblyStored = environment.Configuration.Schedule.StoreOutputsToCache
+                        bool shouldStoreOutputsToCache = environment.Configuration.Schedule.StoreOutputsToCache || IsRewriteOutputFile(environment, destinationFile);
+
+                        var possiblyStored = shouldStoreOutputsToCache
                             ? await environment.LocalDiskContentStore.TryStoreAsync(
                                 environment.Cache.ArtifactContentCache,
                                 GetFileRealizationMode(environment),

--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -5307,6 +5307,14 @@ namespace BuildXL.Scheduler
         }
 
         [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes")]
+        bool IFileContentManagerHost.IsFileRewritten(in FileArtifact artifact)
+        {
+            Contract.Requires(artifact.IsValid);
+
+            return IsFileRewritten(artifact);
+        }
+
+        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes")]
         void IFileContentManagerHost.ReportContent(FileArtifact artifact, in FileMaterializationInfo trackedFileContentInfo, PipOutputOrigin origin)
         {
             // NOTE: Artifacts may be materialized as absent path so we need to check here

--- a/Public/Src/Engine/UnitTests/Scheduler/PipQueueTest.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/PipQueueTest.cs
@@ -441,6 +441,12 @@ namespace Test.BuildXL.Scheduler
                 return false;
             }
 
+            /// <inheritdoc />
+            public bool IsFileRewritten(in FileArtifact fileArtifact)
+            {
+                return false;
+            }
+
             public void ReportContent(FileArtifact artifact, in FileMaterializationInfo trackedFileContentInfo, PipOutputOrigin origin)
             {
                 if (!artifact.IsOutputFile)

--- a/Public/Src/Engine/UnitTests/Scheduler/Utils/DummyPipExecutionEnvironment.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/Utils/DummyPipExecutionEnvironment.cs
@@ -440,6 +440,12 @@ namespace Test.BuildXL.Scheduler.Utils
         }
 
         /// <inheritdoc />
+        public bool IsFileRewritten(in FileArtifact fileArtifact)
+        {
+            return false;
+        }
+
+        /// <inheritdoc />
         public void ReportContent(FileArtifact artifact, in FileMaterializationInfo hash, PipOutputOrigin origin)
         {
             if (!artifact.IsOutputFile)


### PR DESCRIPTION
If the targets of the copy/write file pips are rewritten, then we need to store them to cache, although /storeoutputtocache- is used.

[AB#1511558](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1511558)