### PR TITLE
Add lazy directory materialization for IPC pips

### DIFF
--- a/Public/Sdk/Public/Transformers/Transformer.Ipc.dsc
+++ b/Public/Sdk/Public/Transformers/Transformer.Ipc.dsc
@@ -42,7 +42,7 @@ namespace Transformer {
          * moniker) just before the files are needed.  This makes sense for pips that expect that often
          * times they will not have to access the actual files on disk.  
          */
-        lazilyMaterializedDependencies?: Input[];        
+        lazilyMaterializedDependencies?: Input[];
 
         /**
          * Whether this pip must execute on the master node in a distributed build.  Defaults to false.

--- a/Public/Sdk/Public/Transformers/Transformer.Ipc.dsc
+++ b/Public/Sdk/Public/Transformers/Transformer.Ipc.dsc
@@ -35,12 +35,16 @@ namespace Transformer {
         connectRetryDelayMillis?: number;
 
         /** 
-         * Files not to materialize eagerly.  
+         * Artifact not to materialize eagerly.  
          * 
-         * IPC pips may want to use this option when they will explicitly request file materialization
+         * IPC pips may want to use this option when they will explicitly request artifact materialization
          * from BuildXL (via a BuildXL service identified by the Transformer.getIpcServerMoniker()
-         * moniker) just before the files are needed.  This makes sense for pips that expect that often
-         * times they will not have to access the actual files on disk.  
+         * moniker) just before the artifacts are needed. This makes sense for pips that expect that often
+         * times they will not have to access the actual files on disk.
+         * 
+         * Another example where it might be needed is when an ipc pip depends on a directory but actually
+         * needs only a subset of files from that directory. By marking this directory for lazy materialization,
+         * an ipc pip can only bring the required files from cache.
          */
         lazilyMaterializedDependencies?: Input[];
 

--- a/Public/Sdk/Public/Transformers/Transformer.Ipc.dsc
+++ b/Public/Sdk/Public/Transformers/Transformer.Ipc.dsc
@@ -42,7 +42,7 @@ namespace Transformer {
          * moniker) just before the files are needed.  This makes sense for pips that expect that often
          * times they will not have to access the actual files on disk.  
          */
-        lazilyMaterializedDependencies?: File[];
+        lazilyMaterializedDependencies?: Input[];        
 
         /**
          * Whether this pip must execute on the master node in a distributed build.  Defaults to false.

--- a/Public/Sdk/UnitTests/Transformers/Test.ipcSend.dsc
+++ b/Public/Sdk/UnitTests/Transformers/Test.ipcSend.dsc
@@ -37,12 +37,14 @@ namespace Sdk.Tests {
             serviceFinalizationCmds: [ finalizationCmd ]
         });
 
+        const staticDirectory = Transformer.sealDirectory({root: d`src/dir`, files: [f`src/dir/file.txt`]});
+
         Transformer.ipcSend({
             moniker: moniker,
             connectRetryDelayMillis: 1000,
             maxConnectRetries: 2,
             fileDependencies: [ f`src/ipc-src.txt` ],
-            lazilyMaterializedDependencies: [ f`src/ipc-src.txt` ],
+            lazilyMaterializedDependencies: [ f`src/ipc-src.txt`, staticDirectory ],
             messageBody: [],
             outputFile: p`out/stdout1.txt`,
             targetService: servicePip.serviceId,

--- a/Public/Sdk/UnitTests/Transformers/Test.ipcSend/fullIpcSend.lkg
+++ b/Public/Sdk/UnitTests/Transformers/Test.ipcSend/fullIpcSend.lkg
@@ -37,11 +37,12 @@ Transformer.createService({
     implicitOutputs: [f`./Out/service-stdout.txt`],
     consoleOutput: p`./Out/service-stdout.txt`,
 });
+Transformer.sealDirectory({root: d`./src/dir`, files: [f`./src/dir/file.txt`]});
 Transformer.ipcSend({
     connectRetryDelayMillis: 1000,
     maxConnectRetries: 2,
     fileDependencies: [f`./src/ipc-src.txt`],
-    lazilyMaterializedDependencies: [f`./src/ipc-src.txt`],
+    lazilyMaterializedDependencies: [f`./src/ipc-src.txt`, d`./src/dir`],
     messageBody: {
         escaping: "CRuntimeArgumentRules",
         separator: " ",

--- a/Public/Src/Engine/Scheduler/CacheablePipInfo.cs
+++ b/Public/Src/Engine/Scheduler/CacheablePipInfo.cs
@@ -88,17 +88,26 @@ namespace BuildXL.Scheduler
         /// </summary>
         public static CacheablePipInfo GetIpcCacheInfo(IpcPip pip, PipExecutionContext context, bool omitLazilyMaterializedDependencies)
         {
-            var dependencies = omitLazilyMaterializedDependencies && pip.LazilyMaterializedDependencies.Any()
-                ? ReadOnlyArray<FileArtifact>.From(pip.FileDependencies.Except(pip.LazilyMaterializedDependencies))
+            var fileDependencies = omitLazilyMaterializedDependencies && pip.LazilyMaterializedDependencies.Any(a => a.IsFile)
+                ? ReadOnlyArray<FileArtifact>.From(
+                    pip.FileDependencies.Except(
+                        pip.LazilyMaterializedDependencies.Where(a => a.IsFile).Select(a => a.FileArtifact)))
                 : pip.FileDependencies;
+            
+            var directoryDependencies = omitLazilyMaterializedDependencies && pip.LazilyMaterializedDependencies.Any(a => a.IsDirectory)
+                ? ReadOnlyArray<DirectoryArtifact>.From(
+                    pip.DirectoryDependencies.Except(
+                        pip.LazilyMaterializedDependencies.Where(a => a.IsDirectory).Select(a => a.DirectoryArtifact)))
+                : pip.DirectoryDependencies;
+
             return new CacheablePipInfo(
                 pip: pip,
                 context: context,
                 allowPreserveOutputs: false,
                 outputs: ReadOnlyArray<FileArtifactWithAttributes>.FromWithoutCopy(pip.OutputFile.WithAttributes()),
-                dependencies: dependencies,
+                dependencies: fileDependencies,
                 directoryOutputs: ReadOnlyArray<DirectoryArtifact>.Empty,
-                directoryDependencies: ReadOnlyArray<DirectoryArtifact>.Empty);
+                directoryDependencies: directoryDependencies);
         }
     }
 }

--- a/Public/Src/FrontEnd/Script/Ambients/Transformers/AmbientTransformer.Ipc.cs
+++ b/Public/Src/FrontEnd/Script/Ambients/Transformers/AmbientTransformer.Ipc.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Diagnostics.ContractsLight;
 using System.Globalization;
 using BuildXL.FrontEnd.Script.Evaluator;
 using BuildXL.FrontEnd.Script.Types;
@@ -172,7 +173,8 @@ namespace BuildXL.FrontEnd.Script.Ambients.Transformers
                         out var staticDirectory,
                         context: new ConversionContext(pos: i, objectCtx: skipMaterializationLiteral));
 
-                    // either fileArtifact or staticDirectory is valid at this point (otherwise, ExpectFileOrStaticDirectory would have thrown an exception) 
+                    Contract.Assert(fileArtifact.IsValid ^ staticDirectory != null);
+
                     skipMaterializationArtifacts[i] = fileArtifact.IsValid
                         ? FileOrDirectoryArtifact.Create(fileArtifact)
                         : FileOrDirectoryArtifact.Create(staticDirectory.Root);

--- a/Public/Src/FrontEnd/SdkTesting/Helper/TestPipPrinter.cs
+++ b/Public/Src/FrontEnd/SdkTesting/Helper/TestPipPrinter.cs
@@ -539,6 +539,11 @@ namespace BuildXL.FrontEnd.Script.Testing.Helper
             return Generate(directory.Path, "d");
         }
 
+        private IExpression Generate(FileOrDirectoryArtifact artifact)
+        {
+            return Generate(artifact.Path, artifact.IsFile ? "f" : "d");
+        }
+
         private IExpression Generate(AbsolutePath path)
         {
             return Generate(path, "p");

--- a/Public/Src/Pips/Dll/Artifacts/PipArtifacts.cs
+++ b/Public/Src/Pips/Dll/Artifacts/PipArtifacts.cs
@@ -178,7 +178,7 @@ namespace BuildXL.Pips.Artifacts
                         overrideLazyInputAction = overrideLazyInputAction ?? inputAction;
                         foreach (var input in ipcPip.LazilyMaterializedDependencies)
                         {
-                            if (!overrideLazyInputAction(FileOrDirectoryArtifact.Create(input)))
+                            if (!overrideLazyInputAction(input))
                             {
                                 return false;
                             }

--- a/Public/Src/Pips/Dll/Operations/IpcPip.cs
+++ b/Public/Src/Pips/Dll/Operations/IpcPip.cs
@@ -21,7 +21,7 @@ namespace BuildXL.Pips.Operations
             ReadOnlyArray<PipId> servicePipDependencies,
             ReadOnlyArray<FileArtifact> fileDependencies,
             ReadOnlyArray<DirectoryArtifact> directoryDependencies,
-            ReadOnlyArray<FileArtifact> skipMaterializationFor,
+            ReadOnlyArray<FileOrDirectoryArtifact> skipMaterializationFor,
             ReadOnlyArray<StringId> tags,
             bool isServiceFinalization,
             bool mustRunOnMaster,
@@ -81,15 +81,15 @@ namespace BuildXL.Pips.Operations
         public ReadOnlyArray<DirectoryArtifact> DirectoryDependencies { get; }
 
         /// <summary>
-        /// Files not to materialize eagerly.
+        /// Artifacts (files and/or directories) not to materialize eagerly.
         /// </summary>
         /// <remarks>
-        /// IPC pips may want to use this option when they will explicitly request file materialization
+        /// IPC pips may want to use this option when they will explicitly request file/directory materialization
         /// from BuildXL, via a BuildXL service identified by the Transformer.getIpcServerMoniker()
-        /// moniker, just before the files are needed.This makes sense for pips that expect that often
+        /// moniker, just before the files are needed. This makes sense for pips that expect that often
         /// times they will not have to access the actual files on disk.
         /// </remarks>
-        public ReadOnlyArray<FileArtifact> LazilyMaterializedDependencies { get; }
+        public ReadOnlyArray<FileOrDirectoryArtifact> LazilyMaterializedDependencies { get; }
 
         /// <summary>
         /// Output file where the response from the server will be written.
@@ -118,7 +118,7 @@ namespace BuildXL.Pips.Operations
             ReadOnlyArray<PipId>? servicePipDependencies = null,
             ReadOnlyArray<FileArtifact>? fileDependencies = null,
             ReadOnlyArray<DirectoryArtifact>? directoryDependencies = null,
-            ReadOnlyArray<FileArtifact>? lazilyMaterializedDependencies = null,
+            ReadOnlyArray<FileOrDirectoryArtifact>? lazilyMaterializedDependencies = null,
             ReadOnlyArray<StringId>? tags = null,
             bool? isServiceFinalization = null,
             bool? mustRunOnMaster = null,
@@ -170,7 +170,7 @@ namespace BuildXL.Pips.Operations
                 servicePipDependencies: ToReadOnlyArray(servicePipDependencies),
                 fileDependencies: ToReadOnlyArray(fileDependencies),
                 directoryDependencies: ToReadOnlyArray(directoryDependencies),
-                skipMaterializationFor: ReadOnlyArray<FileArtifact>.Empty,
+                skipMaterializationFor: ReadOnlyArray<FileOrDirectoryArtifact>.Empty,
                 tags: ToReadOnlyArray(tags),
                 isServiceFinalization: isServiceFinalization,
                 mustRunOnMaster: mustRunOnMaster,
@@ -185,7 +185,7 @@ namespace BuildXL.Pips.Operations
         }
 
         internal static IpcPip InternalDeserialize(PipReader reader)
-        {
+        {            
             bool hasProvenance = reader.ReadBoolean();
             return new IpcPip(
                 ipcInfo: IpcClientInfo.Deserialize(reader),
@@ -194,7 +194,7 @@ namespace BuildXL.Pips.Operations
                 servicePipDependencies: reader.ReadReadOnlyArray(reader1 => ((PipReader)reader1).ReadPipId()),
                 fileDependencies: reader.ReadReadOnlyArray(reader1 => reader1.ReadFileArtifact()),
                 directoryDependencies: reader.ReadReadOnlyArray(reader1 => reader1.ReadDirectoryArtifact()),
-                skipMaterializationFor: reader.ReadReadOnlyArray(reader1 => reader1.ReadFileArtifact()),
+                skipMaterializationFor: reader.ReadReadOnlyArray(reader1 => reader1.ReadFileOrDirectoryArtifact()),
                 tags: reader.ReadReadOnlyArray(reader1 => reader1.ReadStringId()),
                 isServiceFinalization: reader.ReadBoolean(),
                 mustRunOnMaster: reader.ReadBoolean(),

--- a/Public/Src/Pips/Dll/Operations/IpcPip.cs
+++ b/Public/Src/Pips/Dll/Operations/IpcPip.cs
@@ -185,7 +185,7 @@ namespace BuildXL.Pips.Operations
         }
 
         internal static IpcPip InternalDeserialize(PipReader reader)
-        {            
+        {
             bool hasProvenance = reader.ReadBoolean();
             return new IpcPip(
                 ipcInfo: IpcClientInfo.Deserialize(reader),

--- a/Public/Src/Pips/Dll/PipConstructionHelper.cs
+++ b/Public/Src/Pips/Dll/PipConstructionHelper.cs
@@ -371,7 +371,7 @@ namespace BuildXL.Pips
             ReadOnlyArray<PipId> servicePipDependencies,
             ReadOnlyArray<FileArtifact> fileDependencies,
             ReadOnlyArray<DirectoryArtifact> directoryDependencies,
-            ReadOnlyArray<FileArtifact> skipMaterializationFor,
+            ReadOnlyArray<FileOrDirectoryArtifact> skipMaterializationFor,
             bool isServiceFinalization,
             bool mustRunOnMaster,
             string[] tags,

--- a/Public/Src/Tools/DropDaemon/Tool.DropDaemonRunner.dsc
+++ b/Public/Src/Tools/DropDaemon/Tool.DropDaemonRunner.dsc
@@ -278,7 +278,10 @@ export namespace DropDaemonRunner {
                     ...directoryMessageBody,
                     
                 ],
-                lazilyMaterializedDependencies: fileInfos.map(fi => fi.file),
+                lazilyMaterializedDependencies: [
+                    ...fileInfos.map(fi => fi.file),
+                    ...directoryInfos.map(di => di.directory)
+                ],
             })
         );
     }

--- a/Public/Src/Tools/DropDaemon/Tool.DropDaemonRunner.dsc
+++ b/Public/Src/Tools/DropDaemon/Tool.DropDaemonRunner.dsc
@@ -276,7 +276,6 @@ export namespace DropDaemonRunner {
                 messageBody: [
                     ...fileMessageBody,
                     ...directoryMessageBody,
-                    
                 ],
                 lazilyMaterializedDependencies: [
                     ...fileInfos.map(fi => fi.file),

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/DumpPipAnalyzer.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/DumpPipAnalyzer.cs
@@ -537,7 +537,9 @@ namespace BuildXL.Execution.Analyzer
                 m_html.CreateRow("OutputFile", pip.OutputFile),
                 m_html.CreateRow("ServicePip Dependencies", pip.ServicePipDependencies),
                 m_html.CreateRow("File Dependencies", pip.FileDependencies),
-                m_html.CreateRow("LazilyMaterialized Dependencies", pip.LazilyMaterializedDependencies),
+                m_html.CreateRow("Directory Dependencies", pip.DirectoryDependencies),
+                m_html.CreateRow("LazilyMaterialized File Dependencies", pip.LazilyMaterializedDependencies.Where(a => a.IsFile).Select(a => a.FileArtifact)),
+                m_html.CreateRow("LazilyMaterialized Directory Dependencies", pip.LazilyMaterializedDependencies.Where(a => a.IsDirectory).Select(a => a.DirectoryArtifact)),
                 m_html.CreateRow("IsServiceFinalization", pip.IsServiceFinalization),
                 m_html.CreateRow("MustRunOnMaster", pip.MustRunOnMaster));
         }

--- a/Public/Src/Utilities/Utilities/BuildXLReader.cs
+++ b/Public/Src/Utilities/Utilities/BuildXLReader.cs
@@ -336,6 +336,20 @@ namespace BuildXL.Utilities
         }
 
         /// <summary>
+        /// Reads FileOrDirectoryArtifact
+        /// </summary>        
+        public FileOrDirectoryArtifact ReadFileOrDirectoryArtifact()
+        {
+            Start<FileOrDirectoryArtifact>();
+            var isFileArtifact = ReadBoolean();
+            var value = isFileArtifact
+                ? FileOrDirectoryArtifact.Create(ReadFileArtifact())
+                : FileOrDirectoryArtifact.Create(ReadDirectoryArtifact());
+            End();
+            return value;
+        }
+
+        /// <summary>
         /// Reads a ReadOnlyArray
         /// </summary>
         public ReadOnlyArray<T> ReadReadOnlyArray<T>(Func<BuildXLReader, T> reader)

--- a/Public/Src/Utilities/Utilities/BuildXLWriter.cs
+++ b/Public/Src/Utilities/Utilities/BuildXLWriter.cs
@@ -289,6 +289,24 @@ namespace BuildXL.Utilities
         }
 
         /// <summary>
+        /// Writes a FileOrDirectoryArtifact
+        /// </summary>
+        public void Write(FileOrDirectoryArtifact value)
+        {
+            Start<FileOrDirectoryArtifact>();
+            Write(value.IsFile);
+            if (value.IsFile)
+            {
+                Write(value.FileArtifact);
+            }
+            else
+            {
+                Write(value.DirectoryArtifact);
+            }
+            End();
+        }
+
+        /// <summary>
         /// Writes a ReadOnlyArray
         /// </summary>
         public void Write<T>(ReadOnlyArray<T> value, Action<BuildXLWriter, T> writer)


### PR DESCRIPTION
The change is mainly needed so drop pips would not materialize all the files from inside drop artifacts. For example, if customers want to upload only small subset of files from a directory, in the past we would materialize all the files (even though we did not need them) and then upload only those files that match a filter. With this change, we would not materialize directory artifacts at all; instead, dropdaemon will only materialize  those files that match the filter.

[AB#1487719](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1487719)