### PR TITLE
Fix bug in ReadOnlyEmptyContentStore used when remote content is disabled

### DIFF
--- a/Public/Src/Cache/ContentStore/Library/Stores/ReadOnlyEmptyContentStore.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/ReadOnlyEmptyContentStore.cs
@@ -58,11 +58,11 @@ namespace BuildXL.Cache.ContentStore.Stores
 
         /// <inheritdoc />
         protected override Task<PinResult> PinCoreAsync(OperationContext operationContext, ContentHash contentHash, UrgencyHint urgencyHint, Counter retryCounter)
-            => Task.FromResult(new PinResult(PinResult.ResultCode.ContentNotFound));
+            => Task.FromResult(PinResult.ContentNotFound);
 
         /// <inheritdoc />
         protected override Task<IEnumerable<Task<Indexed<PinResult>>>> PinCoreAsync(OperationContext operationContext, IReadOnlyList<ContentHash> contentHashes, UrgencyHint urgencyHint, Counter retryCounter, Counter fileCounter)
-            => Task.FromResult(contentHashes.Select((hash, i) => Task.FromResult(new PinResult(PinResult.ContentNotFound).WithIndex(i))));
+            => Task.FromResult(contentHashes.Select((hash, i) => Task.FromResult(PinResult.ContentNotFound.WithIndex(i))));
 
         /// <inheritdoc />
         protected override Task<PlaceFileResult> PlaceFileCoreAsync(OperationContext operationContext, ContentHash contentHash, AbsolutePath path, FileAccessMode accessMode, FileReplacementMode replacementMode, FileRealizationMode realizationMode, UrgencyHint urgencyHint, Counter retryCounter)


### PR DESCRIPTION
Don't construct PinResult from another PinResult as this causes PinResult to get created as an Error with the origin result code as a the error string. BuildXL relies on the result code being ContentNotFound (not Error) for pin failures due to missing content.