### PR TITLE
Add explanatory comments to Kusto query for SuggestedBugName

### DIFF
--- a/Shared/Scripts/kusto/functions/AnnotatedSessions.csl
+++ b/Shared/Scripts/kusto/functions/AnnotatedSessions.csl
@@ -2,13 +2,27 @@
 // AnnotatedSessions(ago(7d), now())
 .create-or-alter function with (folder = "common", docstring = "AnnotatedSessions", skipvalidation = "true") AnnotatedSessions(startDate:datetime, endDate:datetime)
 {
+// ************** Exception regexes **************
+// The goal of the following regexes is parse enough information out of the crash exception and stack trace that a single line can be created that uniquely identifies the crash, this can be used as a "SuggestedBugName".
+// The SuggestedBugName should be unique enough to differentiate conceptually different crashes, but generic enough that slight variations in the exception or crash stack still results in the same SuggestedBugName.
+// The logic is to combine the innermost exception in the first line of the crash, which should be the most relevant exception if there are aggregated exceptions,
+// and the innermost BuildXL function name of the stack trace, which should be the most specific but still relevant source of the crash.
+//
+// A regex to find the innermost exception on the first line
 let exceptionRegex = @"(?:.*\s?)\.(\S*Exception:[^\n\r]*)";
+// A regex to find the innermost BuildXL function name in the crash stack to uniquely identify
+// The "[^NU]" segement excludes any function name that starts with BuildXL.N or BuildXL.U, the intention is to exclude the very common classes BuildXL.Native and BuildXL.Utilities
 let buildXlFuncNameRegex = @"at\s[^\\/].*?((Domino|BuildXL)\.[^NU][\w.]*[\w<]+>?)";
+// A fall back regex to match generic function name patterns if a BuildXL one could not be found
 let anyFuncNameRegex = @"at\s.*?([A-Z][\w]*\.[\w.]*[\w<]+>?)";
+// A regex to match file paths, so they can be replaced with a generic
 let matchPathsRegex = @"[\S\\/]*\S[\\/][\S\\/]*";
-let matchNumsRegex = @"\d+";
 let pathsReplacement = "[path]";
+// A regex to match numbers, so they can be replaced with a generic
+let matchNumsRegex = @"\d+";
 let numsReplacement = "[#]";
+// ******************************************************
+//
 // 1. Query the dominoinvocation table to collect all of the builds of domino to look at.
 //      Apply time filter
 //      Extract some details out of the Environemtn to categorize the build


### PR DESCRIPTION
Add some explanation about the logic for parsing crash exceptions into unique bug names that can be used to file bugs.