### PR TITLE
Include cache file existence check when materializing file

### DIFF
--- a/Public/Src/Utilities/Storage/Tracing/Log.cs
+++ b/Public/Src/Utilities/Storage/Tracing/Log.cs
@@ -474,6 +474,15 @@ namespace BuildXL.Storage.Tracing
         public abstract void StorageCacheContentPinned(LoggingContext loggingContext, string casEntry, string cacheId);
 
         [GeneratedEvent(
+            (int)EventId.FileMaterializationMismatchFileExistenceResult,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Verbose,
+            Keywords = (int)Events.Keywords.UserMessage,
+            EventTask = (ushort)Events.Tasks.PipExecutor,
+            Message = "File existence check on '{0}' results in '{1}', but cache decided it as '{2}'")]
+        public abstract void FileMaterializationMismatchFileExistenceResult(LoggingContext loggingContext, string path, string message, string cacheExistence);
+
+        [GeneratedEvent(
             (int)EventId.StorageKnownUsnHit,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,

--- a/Public/Src/Utilities/Storage/Tracing/Log.cs
+++ b/Public/Src/Utilities/Storage/Tracing/Log.cs
@@ -479,7 +479,7 @@ namespace BuildXL.Storage.Tracing
             EventLevel = Level.Verbose,
             Keywords = (int)Events.Keywords.UserMessage,
             EventTask = (ushort)Events.Tasks.PipExecutor,
-            Message = "File existence check on '{0}' results in '{1}', but cache decided it as '{2}'")]
+            Message = "File existence check on '{path}' results in '{message}', but cache decided it as '{cacheExistence}'")]
         public abstract void FileMaterializationMismatchFileExistenceResult(LoggingContext loggingContext, string path, string message, string cacheExistence);
 
         [GeneratedEvent(

--- a/Public/Src/Utilities/Utilities/Tracing/EventId.cs
+++ b/Public/Src/Utilities/Utilities/Tracing/EventId.cs
@@ -495,7 +495,7 @@ namespace BuildXL.Utilities.Tracing
         MaterializeFilePipProducerNotFound = 739,
 
         StoreSymlinkWarning = 740,
-        // was StoreWarnDueToUnableToDetermineReparsePoint = 741,
+        FileMaterializationMismatchFileExistenceResult = 741,
 
         SerializingToPipFingerprintEntryResultInCorruptedData = 742,
         DeserializingCorruptedPipFingerprintEntry = 743,


### PR DESCRIPTION
We have an issue when file materialization failed because file exists at the destination, although we delete the file before file placing from cache occurs. We suspect that our file existence check failed, but then cache's file existence check determines that the file exists.

[AB#1410450](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1410450)