### PR TITLE
Attempt to fix BuildXL that appeared to hang in temporary cleaner's disposal

### DIFF
--- a/Public/Src/Engine/Scheduler/Tracing/Log.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/Log.cs
@@ -2178,8 +2178,8 @@ namespace BuildXL.Scheduler.Tracing
             EventGenerators = EventGenerators.LocalOnly,
             Keywords = (int)Events.Keywords.UserMessage,
             EventTask = (int)Events.Tasks.PipExecutor,
-            Message = "Temp cleaner thread exited with {0} cleaned, {1} remaining and {2} failed temp directories, {3} cleaned, {4} remaining and {5} failed temp files.")]
-        public abstract void PipTempCleanerSummary(LoggingContext context, long cleanedDirs, long remainingDirs, long failedDirs, long cleanedFiles, long remainingFiles, long failedFiles);
+            Message = "Temp cleaner thread exited with {0} cleaned, {1} remaining and {2} failed temp directories, {3} cleaned, {4} remaining and {5} failed temp files. (timed out: {6})")]
+        public abstract void PipTempCleanerSummary(LoggingContext context, long cleanedDirs, long remainingDirs, long failedDirs, long cleanedFiles, long remainingFiles, long failedFiles, bool timedout);
 
         [GeneratedEvent(
             (int)EventId.RunningTimeAdded,

--- a/Public/Src/Utilities/Native/IO/FileUtilities.cs
+++ b/Public/Src/Utilities/Native/IO/FileUtilities.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.ContractsLight;
 using System.IO;
 using System.Security.AccessControl;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using BuildXL.Native.IO.Windows;
 using BuildXL.Utilities;
@@ -137,9 +138,14 @@ namespace BuildXL.Native.IO
             return s_fileSystem.TryRemoveDirectory(path, out hr);
         }
 
-        /// <see cref="IFileUtilities.DeleteDirectoryContents(string, bool, Func{string, bool}, ITempDirectoryCleaner)"/>
-        public static void DeleteDirectoryContents(string path, bool deleteRootDirectory = false, Func<string, bool> shouldDelete = null, ITempDirectoryCleaner tempDirectoryCleaner = null) =>
-            s_fileUtilities.DeleteDirectoryContents(path, deleteRootDirectory, shouldDelete, tempDirectoryCleaner);
+        /// <see cref="IFileUtilities.DeleteDirectoryContents(string, bool, Func{string, bool}, ITempDirectoryCleaner, CancellationToken?)"/>
+        public static void DeleteDirectoryContents(
+            string path, 
+            bool deleteRootDirectory = false, 
+            Func<string, bool> shouldDelete = null, 
+            ITempDirectoryCleaner tempDirectoryCleaner = null,
+            CancellationToken? cancellationToken = default) =>
+            s_fileUtilities.DeleteDirectoryContents(path, deleteRootDirectory, shouldDelete, tempDirectoryCleaner, cancellationToken);
 
         /// <see cref="IFileSystem.EnumerateDirectoryEntries(string, bool, Action{string, string, FileAttributes}, bool)"/>
         public static EnumerateDirectoryResult EnumerateDirectoryEntries(

--- a/Public/Src/Utilities/Native/IO/IFileUtilities.cs
+++ b/Public/Src/Utilities/Native/IO/IFileUtilities.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Security.AccessControl;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using BuildXL.Native.Streams;
 using BuildXL.Utilities;
@@ -68,7 +69,13 @@ namespace BuildXL.Native.IO
         /// <param name="deleteRootDirectory">whether to also delete the root directory</param>
         /// <param name="shouldDelete">a function which returns true if file should be deleted and false otherwise.</param>
         /// <param name="tempDirectoryCleaner">provides and cleans a temp directory for move-deleting files</param>
-        void DeleteDirectoryContents(string path, bool deleteRootDirectory, Func<string, bool> shouldDelete, ITempDirectoryCleaner tempDirectoryCleaner = null);
+        /// <param name="cancellationToken">provides cancelation capability.</param>
+        void DeleteDirectoryContents(
+            string path, 
+            bool deleteRootDirectory, 
+            Func<string, bool> shouldDelete, 
+            ITempDirectoryCleaner tempDirectoryCleaner = null, 
+            CancellationToken? cancellationToken = default);
 
         /// <summary>
         /// Recursively enumerates the contents of a directory along with any open handles.

--- a/Public/Src/Utilities/Native/IO/Unix/FileUtilities.Unix.cs
+++ b/Public/Src/Utilities/Native/IO/Unix/FileUtilities.Unix.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Security.AccessControl;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using BuildXL.Utilities;
 using BuildXL.Utilities.Tasks;
@@ -44,16 +45,18 @@ namespace BuildXL.Native.IO.Unix
             string path,
             bool deleteRootDirectory = false,
             Func<string, bool> shouldDelete = null,
-            ITempDirectoryCleaner tempDirectoryCleaner = null)
+            ITempDirectoryCleaner tempDirectoryCleaner = null,
+            CancellationToken? cancellationToken = default)
         {
-            DeleteDirectoryContentsInternal(path, deleteRootDirectory, shouldDelete, tempDirectoryCleaner);
+            DeleteDirectoryContentsInternal(path, deleteRootDirectory, shouldDelete, tempDirectoryCleaner, cancellationToken);
         }
 
         private int DeleteDirectoryContentsInternal(
             string path,
             bool deleteRootDirectory,
             Func<string, bool> shouldDelete,
-            ITempDirectoryCleaner tempDirectoryCleaner)
+            ITempDirectoryCleaner tempDirectoryCleaner,
+            CancellationToken? cancellationToken)
         {
             int remainingChildCount = 0;
 
@@ -68,6 +71,8 @@ namespace BuildXL.Native.IO.Unix
                 path,
                 (name, attributes) =>
                 {
+                    cancellationToken?.ThrowIfCancellationRequested();
+
                     var isDirectory = FileUtilities.IsDirectoryNoFollow(attributes);
                     string childPath = Path.Combine(path, name);
 
@@ -77,7 +82,8 @@ namespace BuildXL.Native.IO.Unix
                             childPath,
                             deleteRootDirectory: true,
                             shouldDelete: shouldDelete,
-                            tempDirectoryCleaner: tempDirectoryCleaner);
+                            tempDirectoryCleaner: tempDirectoryCleaner,
+                            cancellationToken: cancellationToken);
 
                         if (subDirectoryCount > 0)
                         {

--- a/Public/Src/Utilities/Native/IO/Windows/FileUtilities.Win.cs
+++ b/Public/Src/Utilities/Native/IO/Windows/FileUtilities.Win.cs
@@ -12,6 +12,7 @@ using System.Runtime.InteropServices;
 using System.Security.AccessControl;
 using System.Security.Principal;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using BuildXL.Native.Streams.Windows;
 using BuildXL.Native.Tracing;
@@ -114,7 +115,8 @@ namespace BuildXL.Native.IO.Windows
             string path,
             bool deleteRootDirectory = false,
             Func<string, bool> shouldDelete = null,
-            ITempDirectoryCleaner tempDirectoryCleaner = null)
+            ITempDirectoryCleaner tempDirectoryCleaner = null,
+            CancellationToken? cancellationToken = default)
         {
             var maybeExistence = s_fileSystem.TryProbePathExistence(path, followSymlink: true);
 
@@ -127,7 +129,8 @@ namespace BuildXL.Native.IO.Windows
                 NormalizeDirectoryPath(path),
                 deleteRootDirectory: deleteRootDirectory,
                 shouldDelete: shouldDelete,
-                tempDirectoryCleaner: tempDirectoryCleaner);
+                tempDirectoryCleaner: tempDirectoryCleaner,
+                cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -144,6 +147,7 @@ namespace BuildXL.Native.IO.Windows
         /// <param name="deleteRootDirectory">If false, only the contents of the root directory will be deleted</param>
         /// <param name="shouldDelete">a function which returns true if file should be deleted and false otherwise.</param>
         /// <param name="tempDirectoryCleaner">provides and cleans a temp directory for move-deletes</param>
+        /// <param name="cancellationToken">provides cancellation capability</param>
         /// <returns>
         /// How many entries remain in the directory, the count is not recursive. This function could be successful with a count greater than one because of <paramref name="shouldDelete"/>
         /// </returns>
@@ -152,7 +156,8 @@ namespace BuildXL.Native.IO.Windows
             string directoryPath,
             bool deleteRootDirectory,
             Func<string, bool> shouldDelete = null,
-            ITempDirectoryCleaner tempDirectoryCleaner = null)
+            ITempDirectoryCleaner tempDirectoryCleaner = null,
+            CancellationToken? cancellationToken = default)
         {
             var defaultDeleteCheck = new Func<string, bool>(p => true);
             shouldDelete = shouldDelete ?? defaultDeleteCheck;
@@ -168,6 +173,8 @@ namespace BuildXL.Native.IO.Windows
                     directoryPath,
                     (name, attr) =>
                     {
+                        cancellationToken?.ThrowIfCancellationRequested();
+
                         string childPath = Path.Combine(directoryPath, name);
                         if ((attr & FileAttributes.Directory) != 0)
                         {
@@ -175,7 +182,8 @@ namespace BuildXL.Native.IO.Windows
                                 childPath,
                                 deleteRootDirectory: true,
                                 shouldDelete: shouldDelete,
-                                tempDirectoryCleaner: tempDirectoryCleaner);
+                                tempDirectoryCleaner: tempDirectoryCleaner,
+                                cancellationToken: cancellationToken);
                             if (subDirectoryEntryCount > 0)
                             {
                                 remainingChildCount++;

--- a/Public/Src/Utilities/UnitTests/TestUtilities/TestMoveDeleteCleaner.cs
+++ b/Public/Src/Utilities/UnitTests/TestUtilities/TestMoveDeleteCleaner.cs
@@ -2,13 +2,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;
+using System.Threading;
 using BuildXL.Native.IO;
 
 namespace Test.BuildXL.TestUtilities
 {
     /// <summary>
     /// This is minimal implementation of <see cref="ITempDirectoryCleaner"/> for unit tests or test bases
-    /// This can be passed into <see cref="FileUtilities.DeleteDirectoryContents(string, bool, System.Func{string, bool}, ITempDirectoryCleaner)"/>
+    /// This can be passed into <see cref="FileUtilities.DeleteDirectoryContents(string, bool, System.Func{string, bool}, ITempDirectoryCleaner, CancellationToken?)"/>
     /// and <see cref="FileUtilities.DeleteFile(string, bool, ITempDirectoryCleaner)"/> to enable move-deletes,
     /// which are more reliable and less prone to unexected exceptions than Windows delete.
     /// </summary>


### PR DESCRIPTION
BuildXL appeared to hanged upon disposing temp cleaner. The dump file only shows that the dispose method was stuck on Thread.Join. 

These changes attempt at fixing this issue by doing two things:

- Add cancellation token during directory deletion.
- Add timeout to Thread.Join (temp cleaner is best effort)

[AB#1518235](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1518235)