### PR TITLE
[MacOS] Add default source seal directories lazily

### DIFF
--- a/Public/Src/Engine/Dll/DisallowedGraph.cs
+++ b/Public/Src/Engine/Dll/DisallowedGraph.cs
@@ -157,8 +157,9 @@ namespace BuildXL.Engine
         }
 
         /// <inheritdoc />
-        public void ApplyCurrentOsDefaults(ProcessBuilder processBuilder)
+        public bool ApplyCurrentOsDefaults(ProcessBuilder processBuilder)
         {
+            return false;
         }
     }
 }

--- a/Public/Src/Engine/Scheduler/Graph/PatchablePipGraph.cs
+++ b/Public/Src/Engine/Scheduler/Graph/PatchablePipGraph.cs
@@ -492,9 +492,9 @@ namespace BuildXL.Scheduler.Graph
         }
 
         /// <inheritdoc />
-        public void ApplyCurrentOsDefaults(ProcessBuilder processBuilder)
+        public bool ApplyCurrentOsDefaults(ProcessBuilder processBuilder)
         {
-            m_builder.ApplyCurrentOsDefaults(processBuilder);
+            return m_builder.ApplyCurrentOsDefaults(processBuilder);
         }
     }
 }

--- a/Public/Src/Engine/Scheduler/Graph/PipGraph.Builder.cs
+++ b/Public/Src/Engine/Scheduler/Graph/PipGraph.Builder.cs
@@ -294,7 +294,7 @@ namespace BuildXL.Scheduler.Graph
             }
 
             /// <inheritdoc />
-            public void ApplyCurrentOsDefaults(ProcessBuilder processBuilder)
+            public bool ApplyCurrentOsDefaults(ProcessBuilder processBuilder)
             {
                 if (OperatingSystemHelper.IsUnixOS)
                 {
@@ -309,7 +309,7 @@ namespace BuildXL.Scheduler.Graph
                         }
                     }
 
-                    m_macOsDefaults.ProcessDefaults(processBuilder);
+                    return m_macOsDefaults.ProcessDefaults(processBuilder);
                 }
                 else
                 {
@@ -324,7 +324,7 @@ namespace BuildXL.Scheduler.Graph
                         }
                     }
 
-                    m_windowsOsDefaults.ProcessDefaults(processBuilder);
+                    return m_windowsOsDefaults.ProcessDefaults(processBuilder);
                 }
             }
 

--- a/Public/Src/Engine/Scheduler/Graph/PipGraph.MacOsDefaults.cs
+++ b/Public/Src/Engine/Scheduler/Graph/PipGraph.MacOsDefaults.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Linq;
 using BuildXL.Pips.Builders;
 using BuildXL.Pips.Operations;
 using BuildXL.Utilities;
@@ -17,8 +19,20 @@ namespace BuildXL.Scheduler.Graph
             private static readonly SortedReadOnlyArray<FileArtifact, OrdinalFileArtifactComparer> s_emptySealContents
                 = CollectionUtilities.EmptySortedReadOnlyArray<FileArtifact, OrdinalFileArtifactComparer>(OrdinalFileArtifactComparer.Instance);
 
+            private class DefaultSourceSealDirectories
+            {
+                public readonly bool IsValid;
+                public readonly DirectoryArtifact[] Directories;
+
+                public DefaultSourceSealDirectories(DirectoryArtifact[] dirs)
+                {
+                    IsValid     = dirs.All(d => d.IsValid);
+                    Directories = dirs;
+                }
+            }
+
             private readonly PipProvenance m_provenance;
-            private readonly DirectoryArtifact[] m_inputDirectories;
+            private readonly Lazy<DefaultSourceSealDirectories> m_lazySourceSealDirectories;
             private readonly FileArtifact[] m_untrackedFiles;
             private readonly DirectoryArtifact[] m_untrackedDirectories;
 
@@ -35,8 +49,9 @@ namespace BuildXL.Scheduler.Graph
                     PipData.Invalid);
 
                 // Sealed Source inputs
-                m_inputDirectories =
-                    new[]
+                // (using Lazy so that these directories are sealed and added to the graph only if explicitly requested by a process)
+                m_lazySourceSealDirectories = Lazy.Create(() =>
+                    new DefaultSourceSealDirectories(new[]
                     {
                         GetSourceSeal(pathTable, pipGraph, MacPaths.Applications),
                         GetSourceSeal(pathTable, pipGraph, MacPaths.Library),
@@ -44,7 +59,7 @@ namespace BuildXL.Scheduler.Graph
                         GetSourceSeal(pathTable, pipGraph, MacPaths.UsrBin),
                         GetSourceSeal(pathTable, pipGraph, MacPaths.UsrInclude),
                         GetSourceSeal(pathTable, pipGraph, MacPaths.UsrLib),
-                    };
+                    }));
 
                 m_untrackedFiles =
                     new[]
@@ -79,11 +94,17 @@ namespace BuildXL.Scheduler.Graph
             /// <summary>
             /// Augments the processBuilder with the OS dependencies
             /// </summary>
-            public void ProcessDefaults(ProcessBuilder processBuilder)
+            public bool ProcessDefaults(ProcessBuilder processBuilder)
             {
                 if ((processBuilder.Options & Process.Options.DependsOnCurrentOs) != 0)
                 {
-                    foreach (var inputDirectory in m_inputDirectories)
+                    var defaultSourceSealDirs = m_lazySourceSealDirectories.Value;
+                    if (!defaultSourceSealDirs.IsValid)
+                    {
+                        return false;
+                    }
+
+                    foreach (var inputDirectory in defaultSourceSealDirs.Directories)
                     {
                         processBuilder.AddInputDirectory(inputDirectory);
                     }
@@ -98,6 +119,8 @@ namespace BuildXL.Scheduler.Graph
                         processBuilder.AddUntrackedDirectoryScope(untrackedDirectory);
                     }
                 }
+
+                return true;
             }
 
             private DirectoryArtifact GetSourceSeal(PathTable pathTable, PipGraph.Builder pipGraph, string path)

--- a/Public/Src/Engine/Scheduler/Graph/PipGraph.WindowsDefaults.cs
+++ b/Public/Src/Engine/Scheduler/Graph/PipGraph.WindowsDefaults.cs
@@ -44,7 +44,7 @@ namespace BuildXL.Scheduler.Graph
             /// <summary>
             /// Augments the processBuilder with the OS dependencies
             /// </summary>
-            public void ProcessDefaults(ProcessBuilder processBuilder)
+            public bool ProcessDefaults(ProcessBuilder processBuilder)
             {
                 if ((processBuilder.Options & Process.Options.DependsOnCurrentOs) != 0)
                 {
@@ -64,6 +64,8 @@ namespace BuildXL.Scheduler.Graph
                 {
                     processBuilder.AddUntrackedDirectoryScope(m_commonApplicationDataPath);
                 }
+
+                return true;
             }
 
             private static DirectoryArtifact GetSpecialFolder(PathTable pathTable, Environment.SpecialFolder specialFolder, params string[] subFolders)

--- a/Public/Src/Engine/UnitTests/EngineTestUtilities/TestEnv.cs
+++ b/Public/Src/Engine/UnitTests/EngineTestUtilities/TestEnv.cs
@@ -388,8 +388,9 @@ namespace Test.BuildXL.TestUtilities
             }
 
             /// <inheritdoc />
-            public void ApplyCurrentOsDefaults(ProcessBuilder processBuilder)
+            public bool ApplyCurrentOsDefaults(ProcessBuilder processBuilder)
             {
+                return true;
             }
         }
 

--- a/Public/Src/Pips/Dll/IPipGraph.cs
+++ b/Public/Src/Pips/Dll/IPipGraph.cs
@@ -138,7 +138,6 @@ namespace BuildXL.Pips
         /// <summary>
         /// Allows the graph to set defaults for the current process;
         /// </summary>
-        /// <param name="processBuilder"></param>
-        void ApplyCurrentOsDefaults(ProcessBuilder processBuilder);
+        bool ApplyCurrentOsDefaults(ProcessBuilder processBuilder);
     }
 }

--- a/Public/Src/Pips/Dll/PipConstructionHelper.cs
+++ b/Public/Src/Pips/Dll/PipConstructionHelper.cs
@@ -346,6 +346,9 @@ namespace BuildXL.Pips
         /// <nodoc />
         public bool TryAddProcess(ProcessBuilder processBuilder, out ProcessOutputs processOutputs, out Process pip)
         {
+            // Applying defaults can fail if, for example, a source sealed directory cannot be 
+            // created because it is not under a mount.  That error must be propagated, because
+            // otherwise an error will be logged but the evaluation will succeed.
             if (PipGraph?.ApplyCurrentOsDefaults(processBuilder) == false)
             {
                 pip = null;

--- a/Public/Src/Pips/Dll/PipConstructionHelper.cs
+++ b/Public/Src/Pips/Dll/PipConstructionHelper.cs
@@ -346,7 +346,12 @@ namespace BuildXL.Pips
         /// <nodoc />
         public bool TryAddProcess(ProcessBuilder processBuilder, out ProcessOutputs processOutputs, out Process pip)
         {
-            PipGraph?.ApplyCurrentOsDefaults(processBuilder);
+            if (PipGraph?.ApplyCurrentOsDefaults(processBuilder) == false)
+            {
+                pip = null;
+                processOutputs = null;
+                return false;
+            }
 
             if (!processBuilder.TryFinish(this, out pip, out processOutputs))
             {


### PR DESCRIPTION
1. Make sure default source seal directories are added to the pip graph only if explicitly requested (by virtue of setting `DependsOnCurrentOs`)

2. Propagate errors if creating default source seal directories fails.

[AB#1517833](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1517833)