### PR TITLE
Empty file optimizations

### DIFF
--- a/Public/Src/Cache/ContentStore/Library/FileSystem/PassThroughFileSystem.cs
+++ b/Public/Src/Cache/ContentStore/Library/FileSystem/PassThroughFileSystem.cs
@@ -350,7 +350,7 @@ namespace BuildXL.Cache.ContentStore.FileSystem
 
             using (await ConcurrentAccess.WaitToken())
             {
-                return await OpenInsideSemaphoreAsync(path, fileAccess, fileMode, share, options, bufferSize);
+                return OpenInternal(path, fileAccess, fileMode, share, options, bufferSize);
             }
         }
 
@@ -416,9 +416,9 @@ namespace BuildXL.Cache.ContentStore.FileSystem
 
         private async Task CopyFileInsideSemaphoreAsync(AbsolutePath sourcePath, AbsolutePath destinationPath, bool replaceExisting)
         {
-            // It is very important to call OpenInsideSemaphoreAsync and not to call OpenAsync method that will re-acquire the semaphore once again.
+            // It is very important to call OpenInternal and not to call OpenAsync method that will re-acquire the semaphore once again.
             // Violating this rule may cause a deadlock.
-            using (var readStream = await OpenInsideSemaphoreAsync(
+            using (var readStream = OpenInternal(
                 sourcePath, FileAccess.Read, FileMode.Open, FileShare.Read | FileShare.Delete, FileOptions.None, AbsFileSystemExtension.DefaultFileStreamBufferSize))
             {
                 if (readStream == null)
@@ -431,8 +431,8 @@ namespace BuildXL.Cache.ContentStore.FileSystem
 
                 var mode = replaceExisting ? FileMode.OpenOrCreate : FileMode.CreateNew;
 
-                using (var writeStream = await OpenInsideSemaphoreAsync(
-                    destinationPath, FileAccess.Write, mode, FileShare.Delete, FileOptions.None, AbsFileSystemExtension.DefaultFileStreamBufferSize).ConfigureAwait(false))
+                using (var writeStream = OpenInternal(
+                    destinationPath, FileAccess.Write, mode, FileShare.Delete, FileOptions.None, AbsFileSystemExtension.DefaultFileStreamBufferSize))
                 {
                     if (writeStream == null)
                     {
@@ -445,10 +445,8 @@ namespace BuildXL.Cache.ContentStore.FileSystem
             }
         }
 
-        private Task<Stream> OpenInsideSemaphoreAsync(AbsolutePath path, FileAccess accessMode, FileMode mode, FileShare share, FileOptions options, int bufferSize)
+        private Stream OpenInternal(AbsolutePath path, FileAccess accessMode, FileMode mode, FileShare share, FileOptions options, int bufferSize)
         {
-            return Task.Run(() =>
-            {
                 if (OperatingSystemHelper.IsUnixOS)
                 {
                     if (DirectoryExists(path))
@@ -528,7 +526,6 @@ namespace BuildXL.Cache.ContentStore.FileSystem
                         handle.Dispose();
                     }
                 }
-            });
         }
 
         private FileOptions GetOptions(AbsolutePath path, FileOptions options)

--- a/Public/Src/Cache/ContentStore/Library/Stores/FileSystemContentStoreInternal.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/FileSystemContentStoreInternal.cs
@@ -918,6 +918,14 @@ namespace BuildXL.Cache.ContentStore.Stores
                     }
                 }
 
+                // If we are given the empty file, the put is a no-op.
+                // We have dedicated logic for pinning and returning without having
+                // the empty file in the cache directory.
+                if (_settings.UseEmptyFileHashShortcut && content.Hash.IsEmptyHash())
+                {
+                    return new PutResult(content.Hash, 0L);
+                }
+
                 using (LockSet<ContentHash>.LockHandle contentHashHandle = await _lockSet.AcquireAsync(content.Hash))
                 {
                     CheckPinned(content.Hash, pinRequest);
@@ -2202,17 +2210,16 @@ namespace BuildXL.Cache.ContentStore.Stores
                     return new PlaceFileResult(PlaceFileResult.ResultCode.NotPlacedAlreadyExists);
                 }
 
-                // If this is the empty hash, then put the empty file into the cache
-                if (_settings.UseEmptyFileHashShortcut && contentHashWithPath.Hash.IsEmptyHash() && !await ContainsAsync(context, contentHashWithPath.Hash, pinRequest))
+                // If this is the empty hash, then directly create an empty file.
+                // This avoids hash-level lock, all I/O in the cache directory, and even
+                // operations in the in-memory representation of the cache.
+                if (_settings.UseEmptyFileHashShortcut && contentHashWithPath.Hash.IsEmptyHash())
                 {
-                    // Put the empty file
-                    var putResult = await PutStreamAsync(context, _emptyFileStream, contentHash, pinRequest);
-                    if (!putResult.Succeeded)
-                    {
-                        // Because this is an optimization for the empty file, we shouldn't fail here.
-                        // Instead, let the normal path have a try.
-                        context.Debug($"Failed to place empty file by putting the empty stream: {putResult}");
-                    }
+                    // TODO: Respect I/O semaphore, set file permissions
+                    FileSystem.CreateDirectory(contentHashWithPath.Path.Parent);
+                    using (File.Create(contentHashWithPath.Path.Path)) { }
+
+                    return new PlaceFileResult(PlaceFileResult.ResultCode.PlacedWithCopy);
                 }
 
                 // Lookup hash in content directory
@@ -2802,6 +2809,8 @@ namespace BuildXL.Cache.ContentStore.Stores
                 // The batching needs to go further down.
                 foreach (var contentHash in contentHashes)
                 {
+                    // Pinning the empty file always succeeds; no I/O or other operations required,
+                    // because we have dedicated logic to place it when required.
                     if (_settings.UseEmptyFileHashShortcut && contentHash.IsEmptyHash())
                     {
                         results.Add(new PinResult(contentSize: 0, lastAccessTime: Clock.UtcNow, code: PinResult.ResultCode.Success));
@@ -2950,13 +2959,16 @@ namespace BuildXL.Cache.ContentStore.Stores
         {
             return OpenStreamCall<ContentStoreInternalTracer>.RunAsync(_tracer, OperationContext(context), contentHash, async () =>
             {
+
+                // Short-circut requests for the empty stream
+                // No lock is required since no file is involved.
+                if (_settings.UseEmptyFileHashShortcut && contentHash.IsEmptyHash())
+                {
+                    return new OpenStreamResult(_emptyFileStream);
+                }
+
                 using (await _lockSet.AcquireAsync(contentHash))
                 {
-                    if (_settings.UseEmptyFileHashShortcut && contentHash.IsEmptyHash())
-                    {
-                        return new OpenStreamResult(_emptyFileStream);
-                    }
-
                     var stream = await OpenStreamInternalWithLockAsync(context, contentHash, pinRequest, FileShare.Read | FileShare.Delete);
                     return new OpenStreamResult(stream);
                 }

--- a/Public/Src/Cache/ContentStore/Library/Stores/FileSystemContentStoreInternal.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/FileSystemContentStoreInternal.cs
@@ -2215,9 +2215,8 @@ namespace BuildXL.Cache.ContentStore.Stores
                 // operations in the in-memory representation of the cache.
                 if (_settings.UseEmptyFileHashShortcut && contentHashWithPath.Hash.IsEmptyHash())
                 {
-                    // TODO: Respect I/O semaphore, set file permissions
                     FileSystem.CreateDirectory(contentHashWithPath.Path.Parent);
-                    using (File.Create(contentHashWithPath.Path.Path)) { }
+                    using (await FileSystem.OpenAsync(contentHashWithPath.Path, FileAccess.Write, FileMode.Create, FileShare.None, FileOptions.None, 1).ConfigureAwait(false)) { }
 
                     return new PlaceFileResult(PlaceFileResult.ResultCode.PlacedWithCopy);
                 }


### PR DESCRIPTION
Change empty file optimization to no have empty files in cache directory at all. This should address situation with 1000s of empty file placements are slow due to (1) replica logic for hard-links to file in cache and (2) per-hash lock.