### PR TITLE
Add double write policy to allow same content double writes

### DIFF
--- a/Public/Src/Engine/Processes/Containers/ProcessInContainerManager.cs
+++ b/Public/Src/Engine/Processes/Containers/ProcessInContainerManager.cs
@@ -375,7 +375,7 @@ namespace BuildXL.Processes.Containers
                     return true;
                 }
 
-                if (process.DoubleWritePolicy == DoubleWritePolicy.DoubleWritesAreErrors)
+                if (!process.DoubleWritePolicy.ImpliesDoubleWriteCanHappen())
                 {
                     // Error logged by the caller
                     isDisallowed = true;

--- a/Public/Src/Engine/Processes/Containers/ProcessInContainerManager.cs
+++ b/Public/Src/Engine/Processes/Containers/ProcessInContainerManager.cs
@@ -383,9 +383,6 @@ namespace BuildXL.Processes.Containers
                     return false;
                 }
 
-                // DoubleWritePolicy.UnsafeFirstDoubleWriteWins case
-                Contract.Assert(process.DoubleWritePolicy == DoubleWritePolicy.UnsafeFirstDoubleWriteWins);
-
                 // Just log a verbose message for tracking purposes
                 Tracing.Logger.Log.DoubleWriteAllowedDueToPolicy(m_loggingContext, process.SemiStableHash, process.GetDescription(pipExecutionContext), destPath);
 

--- a/Public/Src/Engine/Processes/Containers/ProcessInContainerManager.cs
+++ b/Public/Src/Engine/Processes/Containers/ProcessInContainerManager.cs
@@ -375,7 +375,7 @@ namespace BuildXL.Processes.Containers
                     return true;
                 }
 
-                if (!process.DoubleWritePolicy.ImpliesDoubleWriteCanHappen())
+                if (!process.DoubleWritePolicy.ImpliesDoubleWriteAllowed())
                 {
                     // Error logged by the caller
                     isDisallowed = true;

--- a/Public/Src/Engine/Scheduler/FileMonitoringViolationAnalyzer.cs
+++ b/Public/Src/Engine/Scheduler/FileMonitoringViolationAnalyzer.cs
@@ -466,7 +466,7 @@ namespace BuildXL.Scheduler
 
             if (exclusiveOpaqueDirectories?.Count > 0)
             {
-                ReportExclusiveOpaqueViolations(pip, exclusiveOpaqueDirectories, dynamicViolations, outputArtifactInfo, allowedDoubleWriteViolations);
+                ReportExclusiveOpaqueViolations(pip, exclusiveOpaqueDirectories, dynamicViolations, outputArtifactInfo);
             }
 
             if (allowedUndeclaredReads?.Count > 0)
@@ -785,8 +785,7 @@ namespace BuildXL.Scheduler
             Process pip,
             IReadOnlyCollection<(DirectoryArtifact, ReadOnlyArray<FileArtifact>)> exclusiveOpaqueContent,
             List<ReportedViolation> reportedViolations,
-            IReadOnlyDictionary<FileArtifact, FileMaterializationInfo> outputArtifactsInfo,
-            [CanBeNull] Dictionary<FileArtifact, (FileMaterializationInfo, ReportedViolation)> allowedSameContentDoubleWriteViolations)
+            IReadOnlyDictionary<FileArtifact, FileMaterializationInfo> outputArtifactsInfo)
         {
             // Static outputs under exclusive opaques are blocked by construction
             // Same for sealed source directories under exclusive opaques (not allowed at graph construction time)
@@ -797,11 +796,7 @@ namespace BuildXL.Scheduler
                 foreach (FileArtifact fileArtifact in directoryContent)
                 {
                     var outputArtifactInfo = GetOutputMaterializationInfo(pip, outputArtifactsInfo, fileArtifact);
-                    RegisterWriteInPathAndUpdateViolations(pip, fileArtifact.Path, reportedViolations, outputArtifactInfo, out ReportedViolation? allowedSameContentDoubleWriteViolation);
-                    if (allowedSameContentDoubleWriteViolations != null && allowedSameContentDoubleWriteViolation.HasValue)
-                    {
-                        allowedSameContentDoubleWriteViolations[fileArtifact] = (outputArtifactInfo, allowedSameContentDoubleWriteViolation.Value);
-                    }
+                    RegisterWriteInPathAndUpdateViolations(pip, fileArtifact.Path, reportedViolations, outputArtifactInfo, out _);
                 }
             }
         }

--- a/Public/Src/Engine/Scheduler/FileMonitoringViolationAnalyzer.cs
+++ b/Public/Src/Engine/Scheduler/FileMonitoringViolationAnalyzer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.ContractsLight;
 using System.Linq;
@@ -10,6 +11,7 @@ using BuildXL.Pips;
 using BuildXL.Pips.Operations;
 using BuildXL.Processes;
 using BuildXL.Scheduler.Tracing;
+using BuildXL.Storage;
 using BuildXL.Utilities;
 using BuildXL.Utilities.Collections;
 using BuildXL.Utilities.Configuration;
@@ -17,8 +19,6 @@ using BuildXL.Utilities.Instrumentation.Common;
 using BuildXL.Utilities.Tracing;
 using JetBrains.Annotations;
 using static BuildXL.Utilities.FormattableStringEx;
-using BuildXL.Storage;
-using System.Collections.ObjectModel;
 
 #pragma warning disable 1591 // disabling warning about missing API documentation; TODO: Remove this line and write documentation!
 

--- a/Public/Src/Engine/Scheduler/IFileMonitoringViolationAnalyzer.cs
+++ b/Public/Src/Engine/Scheduler/IFileMonitoringViolationAnalyzer.cs
@@ -29,7 +29,7 @@ namespace BuildXL.Scheduler
         /// <returns>true if there were no violations marked as error</returns>
         /// <remarks>
         /// If double writes involving same-content files are detected but allowed, a collection of those non-reported violations 
-        /// are returned. This is usefule for the case of cache convergence, where outputs may change after the main violation analysis
+        /// are returned. This is useful for the case of cache convergence, where outputs may change after the main violation analysis
         /// is done.
         /// </remarks>
         AnalyzePipViolationsResult AnalyzePipViolations(

--- a/Public/Src/Engine/Scheduler/IFileMonitoringViolationAnalyzer.cs
+++ b/Public/Src/Engine/Scheduler/IFileMonitoringViolationAnalyzer.cs
@@ -4,10 +4,12 @@
 using System.Collections.Generic;
 using BuildXL.Pips.Operations;
 using BuildXL.Processes;
+using BuildXL.Storage;
 using BuildXL.Utilities;
 using BuildXL.Utilities.Collections;
 using BuildXL.Utilities.Tracing;
 using JetBrains.Annotations;
+using static BuildXL.Scheduler.FileMonitoringViolationAnalyzer;
 
 namespace BuildXL.Scheduler
 {
@@ -25,6 +27,11 @@ namespace BuildXL.Scheduler
         /// Analyzes an unordered sequence of violations for a single pip. This may be called only once per pip.
         /// </summary>
         /// <returns>true if there were no violations marked as error</returns>
+        /// <remarks>
+        /// If double writes involving same-content files are detected but allowed, a collection of those non-reported violations 
+        /// are returned. This is usefule for the case of cache convergence, where outputs may change after the main violation analysis
+        /// is done.
+        /// </remarks>
         AnalyzePipViolationsResult AnalyzePipViolations(
             Process pip,
             [CanBeNull] IReadOnlyCollection<ReportedFileAccess> violations,
@@ -32,7 +39,9 @@ namespace BuildXL.Scheduler
             [CanBeNull] IReadOnlyCollection<(DirectoryArtifact, ReadOnlyArray<FileArtifact>)> exclusiveOpaqueDirectoryContent,
             [CanBeNull] IReadOnlyDictionary<AbsolutePath, IReadOnlyCollection<AbsolutePath>> sharedOpaqueDirectoryWriteAccesses,
             [CanBeNull] IReadOnlySet<AbsolutePath> allowedUndeclaredReads,
-            [CanBeNull] IReadOnlySet<AbsolutePath> absentPathProbesUnderOutputDirectories);
+            [CanBeNull] IReadOnlySet<AbsolutePath> absentPathProbesUnderOutputDirectories,
+            ReadOnlyArray<(FileArtifact fileArtifact, FileMaterializationInfo fileInfo, PipOutputOrigin pipOutputOrigin)> outputsContent,
+            out IReadOnlyDictionary<FileArtifact, (FileMaterializationInfo, ReportedViolation)> allowedSameContentDoubleWriteViolations);
 
         /// <summary>
         /// Analyzes all dynamic violations. This is useful when replaying a pip from the cache, since otherwise some violations may not be seen.
@@ -42,7 +51,19 @@ namespace BuildXL.Scheduler
             [CanBeNull] IReadOnlyCollection<(DirectoryArtifact, ReadOnlyArray<FileArtifact>)> exclusiveOpaqueDirectoryContent,
             [CanBeNull] IReadOnlyDictionary<AbsolutePath, IReadOnlyCollection<AbsolutePath>> sharedOpaqueDirectoryWriteAccesses,
             [CanBeNull] IReadOnlySet<AbsolutePath> allowedUndeclaredReads,
-            [CanBeNull] IReadOnlySet<AbsolutePath> absentPathProbesUnderOutputDirectories);
+            [CanBeNull] IReadOnlySet<AbsolutePath> absentPathProbesUnderOutputDirectories,
+            ReadOnlyArray<(FileArtifact fileArtifact, FileMaterializationInfo fileInfo, PipOutputOrigin pipOutputOrigin)> outputsContent);
+
+        /// <summary>
+        /// Analyzes double writes after a cache convergence event. This may introduce new violations that were not flagged before convergence
+        /// </summary>
+        /// <remarks>
+        /// The analysis is based on same-content double write violations that were allowed on the first place, before cache convergence happened
+        /// </remarks>
+        AnalyzePipViolationsResult AnalyzeDoubleWritesOnCacheConvergence(
+            Process pip,
+            ReadOnlyArray<(FileArtifact fileArtifact, FileMaterializationInfo fileInfo, PipOutputOrigin pipOutputOrigin)> convergedContent,
+            IReadOnlyDictionary<FileArtifact, (FileMaterializationInfo fileMaterializationInfo, ReportedViolation reportedViolation)> allowedDoubleWriteViolations);
     }
 
     /// <summary>

--- a/Public/Src/Engine/Scheduler/PipExecutor.cs
+++ b/Public/Src/Engine/Scheduler/PipExecutor.cs
@@ -995,8 +995,7 @@ namespace BuildXL.Scheduler
             {
                 var analyzePipViolationsResult = AnalyzePipViolationsResult.NoViolations;
 
-                // Regardless of if we will fail the pip or not, maybe analyze them for higher-level dependency violations.
-                if (processExecutionResult.SharedDynamicDirectoryWriteAccesses != null)
+                if (allowedSameContentDoubleWriteViolations.Count > 0)
                 {
                     analyzePipViolationsResult = environment.FileMonitoringViolationAnalyzer.AnalyzeDoubleWritesOnCacheConvergence(
                         process,

--- a/Public/Src/Engine/Scheduler/Tracing/Log.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/Log.cs
@@ -1879,6 +1879,23 @@ namespace BuildXL.Scheduler.Tracing
             string producingPipDescription);
 
         [GeneratedEvent(
+             (int)LogEventId.AllowedSameContentDoubleWrite,
+             EventGenerators = EventGenerators.LocalOnly,
+             EventLevel = Level.Verbose,
+             Keywords = (int)Events.Keywords.UserMessage | (int)Events.Keywords.DependencyAnalysis,
+             EventTask = (int)Events.Tasks.Scheduler,
+             Message =
+                 PipDependencyAnalysisPrefix +
+                 "Allowed double write: This pip wrote to the path '{2}', which could have been produced earlier by the pip [{3}]. " +
+                 "However, the content produced was the same for both and the configured double write policy allows for it.")]
+        public abstract void AllowedSameContentDoubleWrite(
+            LoggingContext context,
+            long pipSemiStableHash,
+            string pipDescription,
+            string path,
+            string producingPipDescription);
+
+        [GeneratedEvent(
             (int)LogEventId.DependencyViolationReadRace,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,
@@ -3161,6 +3178,20 @@ namespace BuildXL.Scheduler.Tracing
             long producingPipSemiStableHash,
             string producingPipDescription,
             string producingPipValueId);
+
+        [GeneratedEvent(
+            (int)EventId.AllowSameContentPolicyNotAvailableForStaticallyDeclaredOutputs,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Warning,
+            Keywords = (int)(Events.Keywords.UserMessage | Events.Keywords.UserError),
+            EventTask = (int)Events.Tasks.Scheduler,
+            Message =
+                "Pip '{pipDescription}' is participating in a double write to the path '{outputFile}'. The double write policy for this pip is set to allow double writes as long as the content of the produced file is the same. " +
+                "However, this policy is only supported for output files under opaque directories, not for statically specified output files. The double write will be flagged as an error regardless of the produced content.")]
+        public abstract void AllowSameContentPolicyNotAvailableForStaticallyDeclaredOutputs(
+            LoggingContext context,
+            string pipDescription,
+            string outputFile);
 
         [GeneratedEvent(
             (int)EventId.RewritingPreservedOutput,

--- a/Public/Src/Engine/Scheduler/Tracing/LogEventId.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/LogEventId.cs
@@ -130,6 +130,8 @@ namespace BuildXL.Scheduler.Tracing
         FailedToDeleteCorruptFile = 5042,
         AbsentPathProbeInsideUndeclaredOpaqueDirectory = 5043,
 
+        AllowedSameContentDoubleWrite = 5044,
+
         // was DependencyViolationGenericWithRelatedPip_AsError = 25000,
         // was DependencyViolationGeneric_AsError = 25001,
         // was DependencyViolationDoubleWrite_AsError = 25002,

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SharedOpaqueDirectoryTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SharedOpaqueDirectoryTests.cs
@@ -5,13 +5,16 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using BuildXL.Native.IO;
+using BuildXL.Pips;
 using BuildXL.Pips.Builders;
 using BuildXL.Pips.Operations;
 using BuildXL.Processes;
+using BuildXL.Scheduler;
+using BuildXL.Scheduler.Filter;
 using BuildXL.Utilities;
-using BuildXL.Utilities.Tracing;
 using BuildXL.Utilities.Configuration;
 using BuildXL.Utilities.Configuration.Mutable;
+using BuildXL.Utilities.Tracing;
 using Test.BuildXL.Executables.TestProcess;
 using Test.BuildXL.Scheduler;
 using Test.BuildXL.TestUtilities;
@@ -19,10 +22,6 @@ using Test.BuildXL.TestUtilities.Xunit;
 using Xunit;
 using Xunit.Abstractions;
 using LogEventId = BuildXL.Scheduler.Tracing.LogEventId;
-using BuildXL.Processes;
-using BuildXL.Pips;
-using BuildXL.Scheduler;
-using BuildXL.Scheduler.Filter;
 
 namespace IntegrationTest.BuildXL.Scheduler
 {

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SharedOpaqueDirectoryTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SharedOpaqueDirectoryTests.cs
@@ -19,6 +19,10 @@ using Test.BuildXL.TestUtilities.Xunit;
 using Xunit;
 using Xunit.Abstractions;
 using LogEventId = BuildXL.Scheduler.Tracing.LogEventId;
+using BuildXL.Processes;
+using BuildXL.Pips;
+using BuildXL.Scheduler;
+using BuildXL.Scheduler.Filter;
 
 namespace IntegrationTest.BuildXL.Scheduler
 {
@@ -904,6 +908,74 @@ namespace IntegrationTest.BuildXL.Scheduler
                 doubleWriteProducerPipCacheHitExpected: false);
         }
 
+        [Fact]
+        public void CacheConvergenceCanTriggerAdditionalOutputContentAwareViolations()
+        {
+            // Make cache look-ups always result in cache misses. This allows us to store outputs in the cache but get cache misses for the same pip next time. 
+            // This enables us to recreate cache convergence
+            Configuration.Cache.ArtificialCacheMissOptions = new ArtificialCacheMissConfig()
+            {
+                Rate = ushort.MaxValue,
+                Seed = 0,
+                IsInverted = false
+            };
+
+            // We need to simulate cache convergence, and for that we will make a pip produce outputs based on undeclared inputs, so
+            // we need to turn off DFAs as errors
+            Configuration.Sandbox.UnsafeSandboxConfigurationMutable.UnexpectedFileAccessesAreErrors = false;
+
+            // Shared opaque to produce outputs
+            string sharedOpaqueDir = Path.Combine(ObjectRoot, "sharedopaquedir");
+            AbsolutePath sharedOpaqueDirPath = AbsolutePath.Create(Context.PathTable, sharedOpaqueDir);
+
+            // We will generate a double write over these files
+            var output = CreateOutputFileArtifact(sharedOpaqueDirPath);
+            var outputAsSource = FileArtifact.CreateSourceFile(output.Path);
+
+            Directory.CreateDirectory(sharedOpaqueDir);
+            File.WriteAllText(outputAsSource.Path.ToString(Context.PathTable), "content");
+
+            // This pip reads output and rewrites it.
+            var builderA = CreatePipBuilder(new Operation[] {
+                Operation.ReadAndWriteFile(FileArtifact.CreateSourceFile(output.Path), output, doNotInfer: true),
+                Operation.WriteFile(CreateOutputFileArtifact(ObjectRoot))});
+            builderA.AddOutputDirectory(sharedOpaqueDirPath, SealDirectoryKind.SharedOpaque);
+            builderA.DoubleWritePolicy = DoubleWritePolicy.AllowSameContentDoubleWrites;
+            var processA = SchedulePipBuilder(builderA);
+
+            // And the same for this one. The previous one has a static dummy output so just they don't collide in weak fingerprint
+            var builderB = CreatePipBuilder(new Operation[] { Operation.ReadAndWriteFile(outputAsSource, output, doNotInfer: true) });
+            builderB.AddOutputDirectory(sharedOpaqueDirPath, SealDirectoryKind.SharedOpaque);
+            builderB.DoubleWritePolicy = DoubleWritePolicy.AllowSameContentDoubleWrites;
+            var processB = SchedulePipBuilder(builderB);
+
+            // We only want to run processB, but we need to add both pips in the graph so we can get cache hits the second time
+            RunScheduler(filter: new RootFilter(new PipIdFilter(processB.Process.SemiStableHash))).AssertSuccess();
+
+            ResetPipGraphBuilder();
+
+            // Change the content of the source file. This will make both pips change the output they generate (without changing their fingerprints)
+            File.WriteAllText(outputAsSource.Path.ToString(Context.PathTable), "modified content");
+
+            // This will write 'modified content'
+            processA = SchedulePipBuilder(builderA);
+            // This will writes 'modified content' as well, and therefore this will be a same-content double write
+            // But then the pip will converge into the cached outputs on the first run (i.e. 'content')
+            processB = SchedulePipBuilder(builderB);
+
+            // Run both pips now making sure they run in order. Check convergence actually happened for process B
+            var result = RunScheduler(constraintExecutionOrder: new (Pip, Pip)[] { (processA.Process, processB.Process) });
+            result.AssertPipExecutorStatCounted(PipExecutorCounter.ProcessPipTwoPhaseCacheEntriesConverged, 1);
+
+            // The pre-convergence analysis will find an allowed same-content double write
+            AssertVerboseEventLogged(LogEventId.AllowedSameContentDoubleWrite);
+
+            // The post-convergence analysis should find the double write
+            // Since we are running with DFAs as warnings, it won't be logger as an error
+            AssertWarningEventLogged(EventId.FileMonitoringWarning);
+            AssertVerboseEventLogged(LogEventId.DependencyViolationDoubleWrite);
+        }
+
         private void FirstDoubleWriteWinsMakesPipUnCacheableRunner(
             IEnumerable<Operation> writeOperation, 
             AbsolutePath sharedOpaqueDirPath, 
@@ -913,6 +985,7 @@ namespace IntegrationTest.BuildXL.Scheduler
             // originalProducerPip writes an artifact in a shared opaque directory
             ProcessBuilder originalProducerPipBuilder = CreatePipBuilder(writeOperation);
             originalProducerPipBuilder.AddOutputDirectory(sharedOpaqueDirPath, SealDirectoryKind.SharedOpaque);
+            originalProducerPipBuilder.DoubleWritePolicy |= DoubleWritePolicy.UnsafeFirstDoubleWriteWins;
             ProcessWithOutputs originalProducerPipResult = SchedulePipBuilder(originalProducerPipBuilder);
 
             // doubleWriteProducerPip writes the same artifact in a shared opaque directory

--- a/Public/Src/Engine/UnitTests/Scheduler/FileMonitoringViolationAnalyzerTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/FileMonitoringViolationAnalyzerTests.cs
@@ -61,7 +61,7 @@ namespace Test.BuildXL.Scheduler
                 allowedUndeclaredReads: null,
                 absentPathProbesUnderOutputDirectories: null,
                 ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
-                out var _);
+                out _);
 
             analyzer.AssertContainsViolation(
                 new DependencyViolation(
@@ -98,7 +98,7 @@ namespace Test.BuildXL.Scheduler
                 allowedUndeclaredReads: null,
                 absentPathProbesUnderOutputDirectories: null,
                 ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
-                out var _);
+                out _);
 
             analyzer.AssertContainsViolation(
                 new DependencyViolation(
@@ -134,7 +134,7 @@ namespace Test.BuildXL.Scheduler
                 allowedUndeclaredReads: null,
                 absentPathProbesUnderOutputDirectories: null,
                 ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
-                out var _);
+                out _);
 
             AssertVerboseEventLogged(LogEventId.DependencyViolationDoubleWrite);
             AssertErrorEventLogged(EventId.FileMonitoringError);
@@ -170,7 +170,7 @@ namespace Test.BuildXL.Scheduler
                 allowedUndeclaredReads: null,
                 absentPathProbesUnderOutputDirectories: null,
                 ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
-                out var _);
+                out _);
 
             AssertVerboseEventLogged(LogEventId.DependencyViolationDoubleWrite);
 
@@ -205,7 +205,7 @@ namespace Test.BuildXL.Scheduler
                 allowedUndeclaredReads: null,
                 absentPathProbesUnderOutputDirectories: null,
                 ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
-                out var _);
+                out _);
 
             analyzer.AssertContainsViolation(
                 new DependencyViolation(
@@ -242,7 +242,7 @@ namespace Test.BuildXL.Scheduler
                 allowedUndeclaredReads: null,
                 absentPathProbesUnderOutputDirectories: null,
                 ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
-                out var _);
+                out _);
 
             analyzer.AssertContainsViolation(
                 new DependencyViolation(
@@ -280,7 +280,7 @@ namespace Test.BuildXL.Scheduler
                 allowedUndeclaredReads: null,
                 absentPathProbesUnderOutputDirectories: null,
                 ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
-                out var _);
+                out _);
 
             analyzer.AssertContainsViolation(
                 new DependencyViolation(
@@ -317,7 +317,7 @@ namespace Test.BuildXL.Scheduler
                 allowedUndeclaredReads: null,
                 absentPathProbesUnderOutputDirectories: null,
                 ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
-                out var _);
+                out _);
             AssertVerboseEventLogged(LogEventId.DependencyViolationReadRace);
             AssertErrorEventLogged(EventId.FileMonitoringError);
         }
@@ -346,7 +346,7 @@ namespace Test.BuildXL.Scheduler
                     allowedUndeclaredReads: null,
                     absentPathProbesUnderOutputDirectories: null,
                     ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
-                    out var _); 
+                    out _); 
 
             AssertTrue(!analyzePipViolationsResult.IsViolationClean);
             AssertErrorEventLogged(EventId.FileMonitoringError);
@@ -375,7 +375,7 @@ namespace Test.BuildXL.Scheduler
                 allowedUndeclaredReads: null,
                 absentPathProbesUnderOutputDirectories: null,
                 ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
-                out var _);
+                out _);
 
             AssertVerboseEventLogged(LogEventId.DependencyViolationUndeclaredOrderedRead);
             AssertErrorEventLogged(EventId.FileMonitoringError);
@@ -413,7 +413,7 @@ namespace Test.BuildXL.Scheduler
                 allowedUndeclaredReads: null,
                 absentPathProbesUnderOutputDirectories: null,
                 ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
-                out var _);
+                out _);
 
             analyzer.AssertContainsViolation(
                 new DependencyViolation(
@@ -469,7 +469,7 @@ namespace Test.BuildXL.Scheduler
                 allowedUndeclaredReads: null,
                 absentPathProbesUnderOutputDirectories: null,
                 ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
-                out var _);
+                out _);
 
             analyzer.AssertContainsViolation(
                 new DependencyViolation(
@@ -510,7 +510,7 @@ namespace Test.BuildXL.Scheduler
                 allowedUndeclaredReads: null,
                 absentPathProbesUnderOutputDirectories: null,
                 ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
-                out var _);
+                out _);
 
             analyzer.AnalyzePipViolations(
                 producerViolator,
@@ -524,7 +524,7 @@ namespace Test.BuildXL.Scheduler
                 allowedUndeclaredReads: null,
                 absentPathProbesUnderOutputDirectories: null,
                 ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
-                out var _);
+                out _);
 
             analyzer.AnalyzePipViolations(
                 consumerViolator2,
@@ -538,7 +538,7 @@ namespace Test.BuildXL.Scheduler
                 allowedUndeclaredReads: null,
                 absentPathProbesUnderOutputDirectories: null,
                 ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
-                out var _);
+                out _);
 
             analyzer.AssertContainsViolation(
                 new DependencyViolation(
@@ -620,7 +620,7 @@ namespace Test.BuildXL.Scheduler
                 allowedUndeclaredReads: null,
                 absentPathProbesUnderOutputDirectories: null,
                 ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
-                out var _);
+                out _);
 
             AssertErrorEventLogged(EventId.FileMonitoringError);
 
@@ -669,7 +669,7 @@ namespace Test.BuildXL.Scheduler
                 allowedUndeclaredReads: null,
                 absentPathProbesUnderOutputDirectories: null,
                 ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
-                out var _);
+                out _);
 
             analyzer.AssertContainsViolation(
                 new DependencyViolation(
@@ -735,7 +735,7 @@ namespace Test.BuildXL.Scheduler
                 allowedUndeclaredReads: null,
                 absentPathProbesUnderOutputDirectories: null,
                 outputsContent,
-                out var _);
+                out _);
 
             analyzer.AnalyzePipViolations(
                 violator,
@@ -746,7 +746,7 @@ namespace Test.BuildXL.Scheduler
                 allowedUndeclaredReads: null,
                 absentPathProbesUnderOutputDirectories: null,
                 outputsContent,
-                out var _);
+                out _);
 
             // Based on the double write policy, the violation is an error or it is not raised
             if (doubleWritePolicy == DoubleWritePolicy.DoubleWritesAreErrors)
@@ -788,7 +788,7 @@ namespace Test.BuildXL.Scheduler
                 allowedUndeclaredReads: null,
                 absentPathProbesUnderOutputDirectories: null,
                 ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
-                out var _);
+                out _);
             
             XAssert.IsTrue(result.IsViolationClean);
         }

--- a/Public/Src/Engine/UnitTests/Scheduler/FileMonitoringViolationAnalyzerTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/FileMonitoringViolationAnalyzerTests.cs
@@ -17,6 +17,9 @@ using Test.BuildXL.TestUtilities.Xunit;
 using Xunit;
 using Xunit.Abstractions;
 using static BuildXL.Utilities.FormattableStringEx;
+using BuildXL.Storage;
+using BuildXL.Utilities.Collections;
+using BuildXL.Cache.ContentStore.Hashing;
 
 namespace Test.BuildXL.Scheduler
 {
@@ -56,7 +59,9 @@ namespace Test.BuildXL.Scheduler
                 exclusiveOpaqueDirectoryContent: null,
                 sharedOpaqueDirectoryWriteAccesses: null,
                 allowedUndeclaredReads: null,
-                absentPathProbesUnderOutputDirectories: null);
+                absentPathProbesUnderOutputDirectories: null,
+                ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
+                out var _);
 
             analyzer.AssertContainsViolation(
                 new DependencyViolation(
@@ -91,7 +96,9 @@ namespace Test.BuildXL.Scheduler
                 exclusiveOpaqueDirectoryContent: null,
                 sharedOpaqueDirectoryWriteAccesses: null,
                 allowedUndeclaredReads: null,
-                absentPathProbesUnderOutputDirectories: null);
+                absentPathProbesUnderOutputDirectories: null,
+                ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
+                out var _);
 
             analyzer.AssertContainsViolation(
                 new DependencyViolation(
@@ -125,7 +132,9 @@ namespace Test.BuildXL.Scheduler
                 exclusiveOpaqueDirectoryContent: null,
                 sharedOpaqueDirectoryWriteAccesses: null,
                 allowedUndeclaredReads: null,
-                absentPathProbesUnderOutputDirectories: null);
+                absentPathProbesUnderOutputDirectories: null,
+                ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
+                out var _);
 
             AssertVerboseEventLogged(LogEventId.DependencyViolationDoubleWrite);
             AssertErrorEventLogged(EventId.FileMonitoringError);
@@ -159,7 +168,9 @@ namespace Test.BuildXL.Scheduler
                 exclusiveOpaqueDirectoryContent: null,
                 sharedOpaqueDirectoryWriteAccesses: null,
                 allowedUndeclaredReads: null,
-                absentPathProbesUnderOutputDirectories: null);
+                absentPathProbesUnderOutputDirectories: null,
+                ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
+                out var _);
 
             AssertVerboseEventLogged(LogEventId.DependencyViolationDoubleWrite);
 
@@ -192,7 +203,9 @@ namespace Test.BuildXL.Scheduler
                 exclusiveOpaqueDirectoryContent: null,
                 sharedOpaqueDirectoryWriteAccesses: null,
                 allowedUndeclaredReads: null,
-                absentPathProbesUnderOutputDirectories: null);
+                absentPathProbesUnderOutputDirectories: null,
+                ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
+                out var _);
 
             analyzer.AssertContainsViolation(
                 new DependencyViolation(
@@ -227,7 +240,9 @@ namespace Test.BuildXL.Scheduler
                 exclusiveOpaqueDirectoryContent: null,
                 sharedOpaqueDirectoryWriteAccesses: null,
                 allowedUndeclaredReads: null,
-                absentPathProbesUnderOutputDirectories: null);
+                absentPathProbesUnderOutputDirectories: null,
+                ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
+                out var _);
 
             analyzer.AssertContainsViolation(
                 new DependencyViolation(
@@ -263,7 +278,9 @@ namespace Test.BuildXL.Scheduler
                 exclusiveOpaqueDirectoryContent: null,
                 sharedOpaqueDirectoryWriteAccesses: null,
                 allowedUndeclaredReads: null,
-                absentPathProbesUnderOutputDirectories: null);
+                absentPathProbesUnderOutputDirectories: null,
+                ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
+                out var _);
 
             analyzer.AssertContainsViolation(
                 new DependencyViolation(
@@ -298,7 +315,9 @@ namespace Test.BuildXL.Scheduler
                 exclusiveOpaqueDirectoryContent: null,
                 sharedOpaqueDirectoryWriteAccesses: null,
                 allowedUndeclaredReads: null,
-                absentPathProbesUnderOutputDirectories: null);
+                absentPathProbesUnderOutputDirectories: null,
+                ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
+                out var _);
             AssertVerboseEventLogged(LogEventId.DependencyViolationReadRace);
             AssertErrorEventLogged(EventId.FileMonitoringError);
         }
@@ -325,7 +344,9 @@ namespace Test.BuildXL.Scheduler
                     exclusiveOpaqueDirectoryContent: null,
                     sharedOpaqueDirectoryWriteAccesses: null,
                     allowedUndeclaredReads: null,
-                    absentPathProbesUnderOutputDirectories: null); 
+                    absentPathProbesUnderOutputDirectories: null,
+                    ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
+                    out var _); 
 
             AssertTrue(!analyzePipViolationsResult.IsViolationClean);
             AssertErrorEventLogged(EventId.FileMonitoringError);
@@ -352,7 +373,9 @@ namespace Test.BuildXL.Scheduler
                 exclusiveOpaqueDirectoryContent: null,
                 sharedOpaqueDirectoryWriteAccesses: null,
                 allowedUndeclaredReads: null,
-                absentPathProbesUnderOutputDirectories: null);
+                absentPathProbesUnderOutputDirectories: null,
+                ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
+                out var _);
 
             AssertVerboseEventLogged(LogEventId.DependencyViolationUndeclaredOrderedRead);
             AssertErrorEventLogged(EventId.FileMonitoringError);
@@ -388,7 +411,9 @@ namespace Test.BuildXL.Scheduler
                 exclusiveOpaqueDirectoryContent: null,
                 sharedOpaqueDirectoryWriteAccesses: null,
                 allowedUndeclaredReads: null,
-                absentPathProbesUnderOutputDirectories: null);
+                absentPathProbesUnderOutputDirectories: null,
+                ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
+                out var _);
 
             analyzer.AssertContainsViolation(
                 new DependencyViolation(
@@ -442,7 +467,9 @@ namespace Test.BuildXL.Scheduler
                 exclusiveOpaqueDirectoryContent: null,
                 sharedOpaqueDirectoryWriteAccesses: null,
                 allowedUndeclaredReads: null,
-                absentPathProbesUnderOutputDirectories: null);
+                absentPathProbesUnderOutputDirectories: null,
+                ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
+                out var _);
 
             analyzer.AssertContainsViolation(
                 new DependencyViolation(
@@ -481,7 +508,9 @@ namespace Test.BuildXL.Scheduler
                 exclusiveOpaqueDirectoryContent: null,
                 sharedOpaqueDirectoryWriteAccesses: null,
                 allowedUndeclaredReads: null,
-                absentPathProbesUnderOutputDirectories: null);
+                absentPathProbesUnderOutputDirectories: null,
+                ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
+                out var _);
 
             analyzer.AnalyzePipViolations(
                 producerViolator,
@@ -493,7 +522,9 @@ namespace Test.BuildXL.Scheduler
                 exclusiveOpaqueDirectoryContent: null,
                 sharedOpaqueDirectoryWriteAccesses: null,
                 allowedUndeclaredReads: null,
-                absentPathProbesUnderOutputDirectories: null);
+                absentPathProbesUnderOutputDirectories: null,
+                ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
+                out var _);
 
             analyzer.AnalyzePipViolations(
                 consumerViolator2,
@@ -505,7 +536,9 @@ namespace Test.BuildXL.Scheduler
                 exclusiveOpaqueDirectoryContent: null,
                 sharedOpaqueDirectoryWriteAccesses: null,
                 allowedUndeclaredReads: null,
-                absentPathProbesUnderOutputDirectories: null);
+                absentPathProbesUnderOutputDirectories: null,
+                ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
+                out var _);
 
             analyzer.AssertContainsViolation(
                 new DependencyViolation(
@@ -585,8 +618,9 @@ namespace Test.BuildXL.Scheduler
                 exclusiveOpaqueDirectoryContent: null,
                 sharedOpaqueDirectoryWriteAccesses: null,
                 allowedUndeclaredReads: null,
-                absentPathProbesUnderOutputDirectories: null
-            );
+                absentPathProbesUnderOutputDirectories: null,
+                ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
+                out var _);
 
             AssertErrorEventLogged(EventId.FileMonitoringError);
 
@@ -623,7 +657,7 @@ namespace Test.BuildXL.Scheduler
             AbsolutePath violatorOutput = CreateAbsolutePath(context, JunkPath);
             AbsolutePath producerOutput = CreateAbsolutePath(context, DoubleWritePath);
 
-            Process producer = graph.AddProcess(producerOutput);
+            Process producer = graph.AddProcess(producerOutput, doubleWritePolicy);
             Process violator = graph.AddProcess(violatorOutput, doubleWritePolicy);
 
             analyzer.AnalyzePipViolations(
@@ -633,7 +667,9 @@ namespace Test.BuildXL.Scheduler
                 exclusiveOpaqueDirectoryContent: null,
                 sharedOpaqueDirectoryWriteAccesses: null,
                 allowedUndeclaredReads: null,
-                absentPathProbesUnderOutputDirectories: null);
+                absentPathProbesUnderOutputDirectories: null,
+                ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
+                out var _);
 
             analyzer.AssertContainsViolation(
                 new DependencyViolation(
@@ -655,6 +691,74 @@ namespace Test.BuildXL.Scheduler
             else
             {
                 AssertWarningEventLogged(EventId.FileMonitoringWarning);
+            }
+        }
+
+        [Theory]
+        [InlineData(DoubleWritePolicy.DoubleWritesAreErrors)]
+        [InlineData(DoubleWritePolicy.AllowSameContentDoubleWrites)]
+        public void DoubleWritePolicyIsContentAware(DoubleWritePolicy doubleWritePolicy)
+        {
+            BuildXLContext context = BuildXLContext.CreateInstanceForTesting();
+            var graph = new QueryablePipDependencyGraph(context);
+            var analyzer = new TestFileMonitoringViolationAnalyzer(
+                LoggingContext,
+                context,
+                graph,
+                // Set this to test the logic of base.HandleDependencyViolation(...) instead of the overriding fake
+                doLogging: true,
+                collectNonErrorViolations: true);
+
+            // Create the path where the double write will occur, and a random file content that will be used for both producers
+            AbsolutePath doubleWriteOutput = CreateAbsolutePath(context, JunkPath);
+            ContentHash contentHash = ContentHashingUtilities.CreateRandom();
+            var fileContentInfo = new FileContentInfo(contentHash, contentHash.Length);
+            var outputsContent = new (FileArtifact, FileMaterializationInfo, PipOutputOrigin)[]
+                {
+                    (FileArtifact.CreateOutputFile(doubleWriteOutput), new FileMaterializationInfo(fileContentInfo, doubleWriteOutput.GetName(context.PathTable)), PipOutputOrigin.NotMaterialized)
+                }.ToReadOnlyArray();
+            var sharedOpaqueRoot = doubleWriteOutput.GetParent(context.PathTable);
+            var sharedOpaqueDirectoryWriteAccesses = new Dictionary<AbsolutePath, IReadOnlyCollection<AbsolutePath>> { [sharedOpaqueRoot] = new AbsolutePath[] { doubleWriteOutput } };
+
+            // Create two processes that claim to produce some arbitrary static output files. We are not really use those outputs but tell
+            // the analyzer that these processes wrote into shared opaques
+            Process producer = graph.AddProcess(CreateAbsolutePath(context, X("/X/out/static1")), doubleWritePolicy);
+            Process violator = graph.AddProcess(CreateAbsolutePath(context, X("/X/out/static2")), doubleWritePolicy);
+
+            // Run the analysis for both pips
+            analyzer.AnalyzePipViolations(
+                producer,
+                new ReportedFileAccess[0],
+                new ReportedFileAccess[0],
+                exclusiveOpaqueDirectoryContent: null,
+                sharedOpaqueDirectoryWriteAccesses: sharedOpaqueDirectoryWriteAccesses,
+                allowedUndeclaredReads: null,
+                absentPathProbesUnderOutputDirectories: null,
+                outputsContent,
+                out var _);
+
+            analyzer.AnalyzePipViolations(
+                violator,
+                new ReportedFileAccess[0],
+                new ReportedFileAccess[0],
+                exclusiveOpaqueDirectoryContent: null,
+                sharedOpaqueDirectoryWriteAccesses: sharedOpaqueDirectoryWriteAccesses,
+                allowedUndeclaredReads: null,
+                absentPathProbesUnderOutputDirectories: null,
+                outputsContent,
+                out var _);
+
+            // Based on the double write policy, the violation is an error or it is not raised
+            if (doubleWritePolicy == DoubleWritePolicy.DoubleWritesAreErrors)
+            {
+                AssertErrorEventLogged(EventId.FileMonitoringError);
+                AssertVerboseEventLogged(LogEventId.DependencyViolationDoubleWrite);
+            }
+            else
+            {
+                // AllowSameContentDoubleWrites case
+                AssertVerboseEventLogged(LogEventId.AllowedSameContentDoubleWrite);
+                analyzer.AssertNoExtraViolationsCollected();
             }
         }
 
@@ -682,8 +786,9 @@ namespace Test.BuildXL.Scheduler
                 exclusiveOpaqueDirectoryContent: null,
                 sharedOpaqueDirectoryWriteAccesses: null,
                 allowedUndeclaredReads: null,
-                absentPathProbesUnderOutputDirectories: null
-            );
+                absentPathProbesUnderOutputDirectories: null,
+                ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
+                out var _);
             
             XAssert.IsTrue(result.IsViolationClean);
         }

--- a/Public/Src/Engine/UnitTests/Scheduler/PipQueueTest.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/PipQueueTest.cs
@@ -651,8 +651,8 @@ namespace Test.BuildXL.Scheduler
                                 pipScope,
                                 executionResult,
                                 cacheableProcess.Process,
-                                out var _,
-                                out var _);
+                                out _,
+                                out _);
 
                             executionResult = await PipExecutor.PostProcessExecution(operationContext, environment, pipScope, cacheableProcess, executionResult);
                             PipExecutor.ReportExecutionResultOutputContent(operationContext, environment, cacheableProcess.Description, executionResult);

--- a/Public/Src/Engine/UnitTests/Scheduler/PipQueueTest.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/PipQueueTest.cs
@@ -651,6 +651,7 @@ namespace Test.BuildXL.Scheduler
                                 pipScope,
                                 executionResult,
                                 cacheableProcess.Process,
+                                out var _,
                                 out var _);
 
                             executionResult = await PipExecutor.PostProcessExecution(operationContext, environment, pipScope, cacheableProcess, executionResult);

--- a/Public/Src/Engine/UnitTests/Scheduler/PipTestBase.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/PipTestBase.cs
@@ -1066,7 +1066,10 @@ namespace Test.BuildXL.Scheduler
                             case Operation.Type.WriteFileWithRetries:
                                 dao.Outputs.Add(op.Path.FileArtifact);
                                 break;
-
+                            case Operation.Type.ReadAndWriteFile:
+                                dao.Outputs.Add(op.LinkPath.FileArtifact);
+                                dao.Dependencies.Add(op.Path.FileArtifact);
+                                break;
                             case Operation.Type.CreateHardlink:
                                 dao.Dependencies.Add(op.LinkPath.FileArtifact);
                                 dao.Outputs.Add(op.Path.FileArtifact);

--- a/Public/Src/Engine/UnitTests/Scheduler/QueryablePipDependencyGraph.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/QueryablePipDependencyGraph.cs
@@ -172,7 +172,7 @@ namespace Test.BuildXL.Scheduler
 
         public DirectoryArtifact TryGetSealSourceAncestor(AbsolutePath path)
         {
-            throw new NotImplementedException();
+            return DirectoryArtifact.Invalid;
         }
 
         public Pip GetSealedDirectoryPip(DirectoryArtifact directoryArtifact, PipQueryContext queryContext)
@@ -182,7 +182,9 @@ namespace Test.BuildXL.Scheduler
 
         public bool TryGetTempDirectoryAncestor(AbsolutePath path, out Pip pip, out AbsolutePath temPath)
         {
-            throw new NotImplementedException();
+            temPath = AbsolutePath.Invalid;
+            pip = null;
+            return false;
         }
         
         #endregion

--- a/Public/Src/Engine/UnitTests/Scheduler/TestPipQueue.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/TestPipQueue.cs
@@ -200,7 +200,7 @@ namespace Test.BuildXL.Scheduler
             m_pendingConstraintCount[after] = refcount + 1;
         }
 
-        public void Unpause()
+        public TestPipQueue Unpause()
         {
             Contract.Requires(Paused);
             Contract.Ensures(!Paused);
@@ -218,6 +218,8 @@ namespace Test.BuildXL.Scheduler
             {
                 pausedQueueActions.Dequeue()();
             }
+
+            return this;
         }
 
         /// <inheritdoc/>

--- a/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
+++ b/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
@@ -440,7 +440,7 @@ namespace BuildXL.FrontEnd.MsBuild
 
             // Until we can deal with double writes in a better way, this unsafe option allows the build to progress and
             // prints warnings 
-            processBuilder.DoubleWritePolicy |= DoubleWritePolicy.AllowSameContentDoubleWrites;
+            processBuilder.DoubleWritePolicy |= DoubleWritePolicy.UnsafeFirstDoubleWriteWins;
 
             SetUntrackedFilesAndDirectories(processBuilder);
 

--- a/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
+++ b/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
@@ -440,7 +440,7 @@ namespace BuildXL.FrontEnd.MsBuild
 
             // Until we can deal with double writes in a better way, this unsafe option allows the build to progress and
             // prints warnings 
-            processBuilder.DoubleWritePolicy |= DoubleWritePolicy.UnsafeFirstDoubleWriteWins;
+            processBuilder.DoubleWritePolicy |= DoubleWritePolicy.AllowSameContentDoubleWrites;
 
             SetUntrackedFilesAndDirectories(processBuilder);
 

--- a/Public/Src/FrontEnd/Script/Ambients/Transformers/AmbientTransformer.Process.cs
+++ b/Public/Src/FrontEnd/Script/Ambients/Transformers/AmbientTransformer.Process.cs
@@ -48,6 +48,7 @@ namespace BuildXL.FrontEnd.Script.Ambients.Transformers
         private static readonly Dictionary<string, DoubleWritePolicy> s_doubleWritePolicyMap = new Dictionary<string, DoubleWritePolicy>(StringComparer.Ordinal)
         {
             ["doubleWritesAreErrors"] = DoubleWritePolicy.DoubleWritesAreErrors,
+            ["allowSameContentDoubleWrites"] = DoubleWritePolicy.AllowSameContentDoubleWrites,
             ["unsafeFirstDoubleWriteWins"] = DoubleWritePolicy.UnsafeFirstDoubleWriteWins,
         };
 

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/WhitelistAnalyzer.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/WhitelistAnalyzer.cs
@@ -14,6 +14,7 @@ using BuildXL.Processes;
 using BuildXL.Scheduler;
 using BuildXL.Scheduler.Graph;
 using BuildXL.Scheduler.Tracing;
+using BuildXL.Storage;
 using BuildXL.ToolSupport;
 using BuildXL.Utilities;
 using BuildXL.Utilities.Collections;
@@ -215,7 +216,9 @@ namespace BuildXL.Execution.Analyzer
                             exclusiveOpaqueDirectoryContent: ReadOnlyArray<(DirectoryArtifact, ReadOnlyArray<FileArtifact>)>.Empty,
                             sharedOpaqueDirectoryWriteAccesses: null,
                             allowedUndeclaredReads: null,
-                            absentPathProbesUnderOutputDirectories: null);
+                            absentPathProbesUnderOutputDirectories: null,
+                            ReadOnlyArray<(FileArtifact, FileMaterializationInfo, PipOutputOrigin)>.Empty,
+                            out _);
                         ;
                     }
                 }

--- a/Public/Src/Utilities/Configuration/DoubleWritePolicy.cs
+++ b/Public/Src/Utilities/Configuration/DoubleWritePolicy.cs
@@ -53,7 +53,7 @@ namespace BuildXL.Utilities.Configuration
         /// <summary>
         /// Whether the double-write policy implies that double writes are possible without implying a build break
         /// </summary>
-        public static bool ImpliesDoubleWriteCanHappen(this DoubleWritePolicy policy)
+        public static bool ImpliesDoubleWriteAllowed(this DoubleWritePolicy policy)
         {
             switch (policy)
             {

--- a/Public/Src/Utilities/Configuration/DoubleWritePolicy.cs
+++ b/Public/Src/Utilities/Configuration/DoubleWritePolicy.cs
@@ -15,8 +15,10 @@ namespace BuildXL.Utilities.Configuration
         /// </summary>
         DoubleWritesAreErrors,
 
-        // Double writes are allowed as long as the file content is the same
-        // AllowSameContentDoubleWrites // TODO: to be implemented
+        /// <summary>
+        /// Double writes are allowed as long as the file content is the same
+        /// </summary>
+        AllowSameContentDoubleWrites,
 
         /// <summary>
         /// Double writes are allowed and the first output will (non-deterministically) represent the final
@@ -32,16 +34,34 @@ namespace BuildXL.Utilities.Configuration
     public static class DoubleWritePolicyExtensions
     {
         /// <summary>
-        /// Whether the double-write policy implies that double writes should be flagged as errors
+        /// Whether the double-write policy implies that double writes should be flagged as a warning (as opposed to an error)
         /// </summary>
-        public static bool ImpliesDoubleWriteIsError(this DoubleWritePolicy policy)
+        public static bool ImpliesDoubleWriteIsWarning(this DoubleWritePolicy policy)
         {
             switch (policy)
             {
                 case DoubleWritePolicy.DoubleWritesAreErrors:
-                    return true;
-                case DoubleWritePolicy.UnsafeFirstDoubleWriteWins:
+                case DoubleWritePolicy.AllowSameContentDoubleWrites:
                     return false;
+                case DoubleWritePolicy.UnsafeFirstDoubleWriteWins:
+                    return true;
+                default:
+                    throw new InvalidOperationException("Unexpected double write policy " + policy.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Whether the double-write policy implies that double writes are possible without implying a build break
+        /// </summary>
+        public static bool ImpliesDoubleWriteCanHappen(this DoubleWritePolicy policy)
+        {
+            switch (policy)
+            {
+                case DoubleWritePolicy.DoubleWritesAreErrors:
+                    return false;
+                case DoubleWritePolicy.AllowSameContentDoubleWrites:
+                case DoubleWritePolicy.UnsafeFirstDoubleWriteWins:
+                    return true;
                 default:
                     throw new InvalidOperationException("Unexpected double write policy " + policy.ToString());
             }

--- a/Public/Src/Utilities/Utilities/Tracing/EventId.cs
+++ b/Public/Src/Utilities/Utilities/Tracing/EventId.cs
@@ -1049,6 +1049,7 @@ namespace BuildXL.Utilities.Tracing
         FailedToCreateHardlinkOnMerge = 12209,
         DoubleWriteAllowedDueToPolicy = 12210,
         DisallowedDoubleWriteOnMerge = 12211,
+        AllowSameContentPolicyNotAvailableForStaticallyDeclaredOutputs = 12212,
 
         // Status logging
         Status = 12400,


### PR DESCRIPTION
Add a double write policy that allows for double writes as long as the written content is the same.