### PR TITLE
Bump fingerprint version

### DIFF
--- a/Public/Src/Engine/Scheduler/Fingerprints/PipFingerprintingVersion.cs
+++ b/Public/Src/Engine/Scheduler/Fingerprints/PipFingerprintingVersion.cs
@@ -32,7 +32,8 @@ namespace BuildXL.Scheduler.Fingerprints
         /// 56: Added NeedsToRunInContainer, ContainerIsolationLevel and DoubleWritePolicy
         /// 57: Fixed enumeration in StoreContentForProcessAndCreateCacheEntryAsync
         /// 58: Added RequiresAdmin field into the process pip.
+        /// 59: Bumping version due to corrupted data in the cache.
         /// </remarks>
-        TwoPhaseV2 = 58,
+        TwoPhaseV2 = 59,
     }
 }


### PR DESCRIPTION
Some cache entries contain corrupted data. Instead of tracking it down and deleting those entries - let's bump the FP version.