### PR TITLE
Build orchestrator polling adjustments

### DIFF
--- a/Public/Src/Tools/Orchestrator/Constants.cs
+++ b/Public/Src/Tools/Orchestrator/Constants.cs
@@ -101,11 +101,11 @@ namespace BuildXL.Orchestrator
         /// <summary>
         /// The maximum time an agent waits for the other agents to get ready before failing
         /// </summary>
-        public const int MaxWaitingPeriodBeforeFailingInSeconds = 200;
+        public const int MaxWaitingPeriodBeforeFailingInSeconds = 600;
 
         /// <summary>
         /// The time the agent waits before re-checking if the other agents are ready
         /// </summary>
-        public const int PollRetryPeriodInSeconds = 10;
+        public const int PollRetryPeriodInSeconds = 20;
     }
 }


### PR DESCRIPTION
Relax the polling conditions for distributed build orchestration as workers can be slow at times and the the initial timeout would fail the orchestration process to early.