### PR TITLE
Make AllowSameContentDoubleWrites the default for MSBuild resolver

### DIFF
--- a/Public/Sdk/Public/Prelude/Prelude.Configuration.Resolvers.dsc
+++ b/Public/Sdk/Public/Prelude/Prelude.Configuration.Resolvers.dsc
@@ -3,6 +3,7 @@
 
 /// <reference path="Prelude.Core.dsc"/>
 /// <reference path="Prelude.IO.dsc"/>
+/// <reference path="Prelude.Configuration.dsc"/>
 
 /**
  * Source resolver that uses specified source paths for module resolution.
@@ -212,6 +213,11 @@ interface MsBuildResolver extends ResolverBase, UntrackingSettings {
      * Defaults to false.
      */
     useLegacyProjectIsolation?: boolean;
+
+    /**
+     * Policy to apply when a double write occurs. By default double writes are only allowed if the produced content is the same.
+     */
+    doubleWritePolicy?: DoubleWritePolicy;
 }
 
 

--- a/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
+++ b/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
@@ -438,9 +438,8 @@ namespace BuildXL.FrontEnd.MsBuild
                 processBuilder.ContainerIsolationLevel = ContainerIsolationLevel.IsolateAllOutputs;
             }
 
-            // Until we can deal with double writes in a better way, this unsafe option allows the build to progress and
-            // prints warnings 
-            processBuilder.DoubleWritePolicy |= DoubleWritePolicy.UnsafeFirstDoubleWriteWins;
+            // By default the double write policy is to allow same content double writes.
+            processBuilder.DoubleWritePolicy |= m_resolverSettings.DoubleWritePolicy ?? DoubleWritePolicy.AllowSameContentDoubleWrites;
 
             SetUntrackedFilesAndDirectories(processBuilder);
 

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/SchedulingTests/MsBuildProcessBuilderTests.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/SchedulingTests/MsBuildProcessBuilderTests.cs
@@ -67,8 +67,8 @@ namespace Test.BuildXL.FrontEnd.MsBuild
 
             // Undeclared sources are allowed as long as they are true sources
             Assert.True(testProj.AllowUndeclaredSourceReads);
-            // Double writes are allowed as warnings
-            Assert.True(testProj.DoubleWritePolicy == DoubleWritePolicy.UnsafeFirstDoubleWriteWins);
+            // Double writes are allowed as long as the written content is the same
+            Assert.True(testProj.DoubleWritePolicy == DoubleWritePolicy.AllowSameContentDoubleWrites);
             // Working directory is the project directory
             Assert.True(testProj.WorkingDirectory == project.FullPath.GetParent(PathTable));
             // Log file is configured

--- a/Public/Src/Utilities/Configuration/Resolvers/IMsBuildResolverSettings.cs
+++ b/Public/Src/Utilities/Configuration/Resolvers/IMsBuildResolverSettings.cs
@@ -128,5 +128,13 @@ namespace BuildXL.Utilities.Configuration
         /// Defaults to false.
         /// </remarks>
         bool?  UseLegacyProjectIsolation { get; }
+
+        /// <summary>
+        /// Policy to apply when a double write occurs.
+        /// </summary>
+        /// <remarks>
+        /// By default double writes are only allowed if the produced content is the same.
+        /// </remarks>
+        DoubleWritePolicy? DoubleWritePolicy { get; set; }
     }
 }

--- a/Public/Src/Utilities/Configuration/Resolvers/Mutable/MsBuildResolverSettings.cs
+++ b/Public/Src/Utilities/Configuration/Resolvers/Mutable/MsBuildResolverSettings.cs
@@ -43,6 +43,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             KeepProjectGraphFile = resolverSettings.KeepProjectGraphFile;
             EnableTransitiveProjectReferences = resolverSettings.EnableTransitiveProjectReferences;
             UseLegacyProjectIsolation = resolverSettings.UseLegacyProjectIsolation;
+            DoubleWritePolicy = resolverSettings.DoubleWritePolicy;
         }
 
         /// <inheritdoc/>
@@ -101,5 +102,8 @@ namespace BuildXL.Utilities.Configuration.Mutable
 
         /// <inheritdoc/>
         public bool? UseLegacyProjectIsolation { get; set; }
+
+        /// <inheritdoc/>
+        public DoubleWritePolicy? DoubleWritePolicy { get; set; }
     }
 }


### PR DESCRIPTION
A same-content double write is a common enough pattern for MSBuild repos. Make this the default policy for the MSBuild resolver and allow the user to configure it.