### PR TITLE
Use different BundleIDs for debug and release kexts

### DIFF
--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/NonDeterminismProbeTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/NonDeterminismProbeTests.cs
@@ -22,7 +22,8 @@ namespace IntegrationTest.BuildXL.Scheduler
         }
 
         [Feature(Features.OpaqueDirectory)]
-        [Theory]
+        // TODO 1519677: Fix this bug on Mojave macOS
+	    [TheoryIfSupported(requiresWindowsBasedOperatingSystem: true)]
         [InlineData(false)]
         [InlineData(true)]
         public void NonDeterminismOpaqueDirectoryOutput(bool fileListedAsNormalOutput)
@@ -77,7 +78,8 @@ namespace IntegrationTest.BuildXL.Scheduler
         }
 
         [Feature(Features.OpaqueDirectory)]
-        [Fact]
+        // TODO 1519677: Fix this bug on Mojave macOS
+	    [FactIfSupported(requiresWindowsBasedOperatingSystem: true)]
         public void NonDeterminismOpaqueDirectoryOutputDifferentFiles()
         {
             string untracked = Path.Combine(ObjectRoot, "untracked.txt");

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/NonDeterminismProbeTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/NonDeterminismProbeTests.cs
@@ -21,8 +21,8 @@ namespace IntegrationTest.BuildXL.Scheduler
         {
         }
 
-        [Feature(Features.OpaqueDirectory)]
         // TODO 1519677: Fix this bug on Mojave macOS
+        [Feature(Features.OpaqueDirectory)]
 	    [TheoryIfSupported(requiresWindowsBasedOperatingSystem: true)]
         [InlineData(false)]
         [InlineData(true)]
@@ -77,8 +77,8 @@ namespace IntegrationTest.BuildXL.Scheduler
             AssertInformationalEventLogged(EventId.DeterminismProbeEncounteredNondeterministicDirectoryOutput, 1);
         }
 
-        [Feature(Features.OpaqueDirectory)]
         // TODO 1519677: Fix this bug on Mojave macOS
+        [Feature(Features.OpaqueDirectory)]
 	    [FactIfSupported(requiresWindowsBasedOperatingSystem: true)]
         public void NonDeterminismOpaqueDirectoryOutputDifferentFiles()
         {

--- a/Public/Src/Sandbox/MacOs/BundleInfoDebug.xcconfig
+++ b/Public/Src/Sandbox/MacOs/BundleInfoDebug.xcconfig
@@ -1,0 +1,2 @@
+BUILDXL_BUNDLE_IDENTIFIER = com.microsoft.buildxl.debug.sandbox
+BUILDXL_CLASS_PREFIX = com_microsoft_buildxl_debug_

--- a/Public/Src/Sandbox/MacOs/BundleInfoTest.xcconfig
+++ b/Public/Src/Sandbox/MacOs/BundleInfoTest.xcconfig
@@ -1,2 +1,0 @@
-BUILDXL_BUNDLE_IDENTIFIER = com.microsoft.buildxl.test.sandbox
-BUILDXL_CLASS_PREFIX = com_microsoft_buildxl_test_

--- a/Public/Src/Sandbox/MacOs/projects.dsc
+++ b/Public/Src/Sandbox/MacOs/projects.dsc
@@ -55,8 +55,9 @@ namespace Sandbox {
         };
     }
 
-    const bundleInfoMainFile = f`BundleInfo.xcconfig`;
-    const bundleInfoTestFile = f`BundleInfoTest.xcconfig`;
+    const bundleInfoXCConfig = qualifier.configuration === "debug"
+        ? f`BundleInfoDebug.xcconfig`
+        : f`BundleInfo.xcconfig`;
 
     const isMacOs = Context.getCurrentHost().os === "macOS";
     const interopXcodeproj = Transformer.sealDirectory({
@@ -97,17 +98,14 @@ namespace Sandbox {
             project: interopXcodeproj,
             scheme: "InteropLibrary",
             outFiles: [ a`libBuildXLInterop.dylib` ],
-            xcconfig: bundleInfo || bundleInfoMainFile
+            xcconfig: bundleInfo || bundleInfoXCConfig
         }).outFiles[0];
     }
 
     const testConfigurationName = "debugTest";
 
     @@public
-    export const libInterop = isMacOs && buildLibInterop();
-
-    @@public
-    export const libInteropTest = isMacOs && buildLibInterop(bundleInfoTestFile);
+    export const libInterop = isMacOs && buildLibInterop(bundleInfoXCConfig);
 
     @@public
     export const coreDumpTester = isMacOs && build({
@@ -132,11 +130,11 @@ namespace Sandbox {
         dSYMDwarf: DerivedFile
     }
 
-    function buildKext(bundleInfo?: File): KextFiles {
+    function buildKext(bundleInfo: File): KextFiles {
         const result = build({
             project: sandboxXcodeproj,
             scheme: "BuildXLSandbox",
-            xcconfig: bundleInfo || bundleInfoMainFile,
+            xcconfig: bundleInfo || bundleInfoXCConfig,
             outFiles: [
                 r`BuildXLSandbox.kext/Contents/Info.plist`,
                 r`BuildXLSandbox.kext/Contents/MacOS/BuildXLSandbox`,
@@ -159,8 +157,5 @@ namespace Sandbox {
     }
 
     @@public
-    export const kext = isMacOs && buildKext();
-
-    @@public
-    export const kextTest = isMacOs && buildKext(bundleInfoTestFile);
+    export const kext = isMacOs && buildKext(bundleInfoXCConfig);
 }

--- a/Public/Src/Sandbox/MacOs/scripts/sandbox-load.sh.1
+++ b/Public/Src/Sandbox/MacOs/scripts/sandbox-load.sh.1
@@ -8,7 +8,6 @@ sandbox-load \- Load BuildXLSandbox kernel extension for macOS
 [--enable-counters]
 [--verbose-logging]
 [--kext] \fIsrc-dir\fR
-[--kext-bundle-id] \fIbundle-id\fR
 .SH DESCRIPTION
 Loads a 'BuildXLSandbox' kernel extension from a given location.
 
@@ -28,9 +27,6 @@ Requires root privileges to execute 'kextload'.
 .BI --kext "src-dir"
 Required.  Directory containing a compiled BuildXLSandbox kernel extension binaries.
 The name of this directory must end in ".kext".
-.TP
-.BI --kext-bundle-id "bundle-id"
-Optional.  The bundle id of the BuildXL sandbox kernel extension.  Defaults to "com.microsoft.buildxl.sandbox".
 .TP
 .BI --deploy-dir "deploy-dir"
 Optional.  Destination to which to copy the extension from \fIsrc-dir\fR prior to loading it.


### PR DESCRIPTION
This change improves the typical dev loop by allowing 2 kexts to be loaded at the same time:
  1. one that came with the LKG (which one is compiled as `release`), and
  2. one compiled as `debug` from the current sources

The first one is typically used to compile current sources, and the second one is then typically used for running tests.