### PR TITLE
Add missing double write policy on DScript side

### DIFF
--- a/Public/Sdk/Public/Prelude/Prelude.Configuration.dsc
+++ b/Public/Sdk/Public/Prelude/Prelude.Configuration.dsc
@@ -306,6 +306,8 @@ interface UnsafeSandboxConfiguration {
 type DoubleWritePolicy =  
         // double writes are blocked
         "doubleWritesAreErrors" | 
+        // double writes are allowed as long as the file content is the same
+        "allowSameContentDoubleWrites" |
         // double writes are allowed, and the first process writing the output will (non-deterministically)
         // win the race. Consider this will result in a non-deterministic deployment for a given build, and is therefore unsafe.
         "unsafeFirstDoubleWriteWins";


### PR DESCRIPTION
The policy to allow same content double writes was missing on DScript side. Added it to the prelude.