### PR TITLE
[macOS] Untrack /usr/lib by default instead of sealing it

### DIFF
--- a/Public/Src/Engine/Scheduler/Graph/PipGraph.MacOsDefaults.cs
+++ b/Public/Src/Engine/Scheduler/Graph/PipGraph.MacOsDefaults.cs
@@ -53,42 +53,53 @@ namespace BuildXL.Scheduler.Graph
                 m_lazySourceSealDirectories = Lazy.Create(() =>
                     new DefaultSourceSealDirectories(new[]
                     {
-                        GetSourceSeal(pathTable, pipGraph, MacPaths.Applications),
-                        GetSourceSeal(pathTable, pipGraph, MacPaths.Library),
-                        GetSourceSeal(pathTable, pipGraph, MacPaths.UserProvisioning),
-                        GetSourceSeal(pathTable, pipGraph, MacPaths.UsrBin),
-                        GetSourceSeal(pathTable, pipGraph, MacPaths.UsrInclude),
-                        GetSourceSeal(pathTable, pipGraph, MacPaths.UsrLib),
-                    }));
+                        MacPaths.Applications,
+                        MacPaths.Library,
+                        MacPaths.UserProvisioning,
+                        // consider untracking /usr/bin and /usr/include because they are not writable by default
+                        MacPaths.UsrBin,
+                        MacPaths.UsrInclude,
+                    }
+                    .Select(p => GetSourceSeal(pathTable, pipGraph, p))
+                    .ToArray()));
 
                 m_untrackedFiles =
                     new[]
                     {
                         // login.keychain is created by the OS the first time any process invokes an OS API that references the keychain.
                         // Untracked because build state will not be stored there and code signing will fail if required certs are in the keychain
-                        FileArtifact.CreateSourceFile(AbsolutePath.Create(pathTable, MacPaths.Etc)),
-                        FileArtifact.CreateSourceFile(AbsolutePath.Create(pathTable, MacPaths.UserKeyChainsDb)),
-                        FileArtifact.CreateSourceFile(AbsolutePath.Create(pathTable, MacPaths.UserKeyChains)),
-                        FileArtifact.CreateSourceFile(AbsolutePath.Create(pathTable, MacPaths.UserCFTextEncoding)),
-                        FileArtifact.CreateSourceFile(AbsolutePath.Create(pathTable, MacPaths.TmpDir)),
-                        
-                    };
+                        MacPaths.Etc,
+                        MacPaths.UserKeyChainsDb,
+                        MacPaths.UserKeyChains,
+                        MacPaths.UserCFTextEncoding,
+                        MacPaths.TmpDir
+                    }
+                    .Select(p => FileArtifact.CreateSourceFile(AbsolutePath.Create(pathTable, p)))
+                    .ToArray();
 
                 m_untrackedDirectories =
                     new[]
                     {
-                        DirectoryArtifact.CreateWithZeroPartialSealId(pathTable, MacPaths.Bin),
-                        DirectoryArtifact.CreateWithZeroPartialSealId(pathTable, MacPaths.Dev),
-                        DirectoryArtifact.CreateWithZeroPartialSealId(pathTable, MacPaths.Private),
-                        DirectoryArtifact.CreateWithZeroPartialSealId(pathTable, MacPaths.Sbin),
-                        DirectoryArtifact.CreateWithZeroPartialSealId(pathTable, MacPaths.SystemLibrary),
-                        DirectoryArtifact.CreateWithZeroPartialSealId(pathTable, MacPaths.UsrLibexec),
-                        DirectoryArtifact.CreateWithZeroPartialSealId(pathTable, MacPaths.UsrShare),
-                        DirectoryArtifact.CreateWithZeroPartialSealId(pathTable, MacPaths.UsrStandalone),
-                        DirectoryArtifact.CreateWithZeroPartialSealId(pathTable, MacPaths.UsrSbin),
-                        DirectoryArtifact.CreateWithZeroPartialSealId(pathTable, MacPaths.Var),
-                        DirectoryArtifact.CreateWithZeroPartialSealId(pathTable, MacPaths.UserPreferences),
-                    };
+                        MacPaths.Bin,
+                        MacPaths.Dev,
+                        MacPaths.Private,
+                        MacPaths.Sbin,
+                        MacPaths.SystemLibrary,
+                        MacPaths.UsrLibexec,
+                        MacPaths.UsrShare,
+                        MacPaths.UsrStandalone,
+                        MacPaths.UsrSbin,
+                        MacPaths.Var,
+                        MacPaths.UserPreferences,
+                        // it's important to untrack /usr/lib instead of creating a sealed source directory
+                        //   - the set of dynamically loaded libraries during an execution of a process is 
+                        //     not necessarily deterministic, i.e., when the same process---which itself is
+                        //     deterministic---is executed multiple times on same inputs, the set of 
+                        //     dynamically loaded libraries is not necessarily going to stay the same.
+                        MacPaths.UsrLib
+                    }
+                    .Select(p => DirectoryArtifact.CreateWithZeroPartialSealId(pathTable, p))
+                    .ToArray();
             }
 
             /// <summary>

--- a/Public/Src/Engine/UnitTests/FingerprintStore/FingerprintStoreTests.cs
+++ b/Public/Src/Engine/UnitTests/FingerprintStore/FingerprintStoreTests.cs
@@ -108,8 +108,7 @@ namespace Test.BuildXL.FingerprintStore
         /// Content addressable entries like content hashes don't need to be replaced if an entry with the
         /// same key already exists.
         /// </summary>
-        // TODO 1519677: Fix this bug on Mojave macOS
-        [FactIfSupported(requiresWindowsBasedOperatingSystem: true)]
+        [Fact]
         public void DontOverwriteExistingContentAddressableEntries()
         {
             // Use a test hook to capture fingerprint store counters
@@ -256,7 +255,7 @@ namespace Test.BuildXL.FingerprintStore
         /// 2. A cache hit will still refresh the age of an entry. With incremental scheduling disabled,
         /// a pip must be completely removed from the build to be garbage collected.
         /// </summary>
-        [Fact(Skip = "Bug 1513463")]
+        [Fact]
         public void VerifyGarbageCollectWorks()
         {
             var testHooks = new SchedulerTestHooks()

--- a/Public/Src/Engine/UnitTests/FingerprintStore/FingerprintStoreTests.cs
+++ b/Public/Src/Engine/UnitTests/FingerprintStore/FingerprintStoreTests.cs
@@ -4,6 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BuildXL.Engine.Cache.KeyValueStores;
 using BuildXL.Engine.Cache.Serialization;
 using BuildXL.Native.IO;
 using BuildXL.Pips;
@@ -12,6 +16,7 @@ using BuildXL.Scheduler;
 using BuildXL.Scheduler.Fingerprints;
 using BuildXL.Scheduler.Tracing;
 using BuildXL.Utilities;
+using BuildXL.Utilities.Configuration;
 using BuildXL.Utilities.Tracing;
 using Test.BuildXL.Executables.TestProcess;
 using Test.BuildXL.Scheduler;
@@ -19,13 +24,9 @@ using Test.BuildXL.TestUtilities.Xunit;
 using Xunit;
 using Xunit.Abstractions;
 using static BuildXL.Scheduler.Tracing.FingerprintStore;
+
 using FingerprintStoreClass = BuildXL.Scheduler.Tracing.FingerprintStore;
 using BuildXLConfiguration = BuildXL.Utilities.Configuration;
-using System.Threading.Tasks;
-using System.Linq;
-using System.Threading;
-using BuildXL.Engine.Cache.KeyValueStores;
-using BuildXL.Utilities.Configuration;
 
 namespace Test.BuildXL.FingerprintStore
 {

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/NonDeterminismProbeTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/NonDeterminismProbeTests.cs
@@ -21,9 +21,8 @@ namespace IntegrationTest.BuildXL.Scheduler
         {
         }
 
-        // TODO 1519677: Fix this bug on Mojave macOS
         [Feature(Features.OpaqueDirectory)]
-	    [TheoryIfSupported(requiresWindowsBasedOperatingSystem: true)]
+	    [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public void NonDeterminismOpaqueDirectoryOutput(bool fileListedAsNormalOutput)
@@ -77,9 +76,8 @@ namespace IntegrationTest.BuildXL.Scheduler
             AssertInformationalEventLogged(EventId.DeterminismProbeEncounteredNondeterministicDirectoryOutput, 1);
         }
 
-        // TODO 1519677: Fix this bug on Mojave macOS
         [Feature(Features.OpaqueDirectory)]
-	    [FactIfSupported(requiresWindowsBasedOperatingSystem: true)]
+	    [Fact]
         public void NonDeterminismOpaqueDirectoryOutputDifferentFiles()
         {
             string untracked = Path.Combine(ObjectRoot, "untracked.txt");
@@ -90,9 +88,9 @@ namespace IntegrationTest.BuildXL.Scheduler
             // depending on the content of the untracked file.
             var builderA = CreatePipBuilder(new Operation[]
             {
-                Operation.WriteFileIfInputEqual(CreateOutputFileArtifact(opaqueDirPath), untracked, "1", "deterministic-content"),
-                Operation.WriteFile(CreateOutputFileArtifact(opaqueDirPath), "deterministic-content", doNotInfer: true),
-                Operation.WriteFileIfInputEqual(CreateOutputFileArtifact(opaqueDirPath), untracked, "2", "deterministic-content"),
+                Operation.WriteFileIfInputEqual(CreateOutputFileArtifact(opaqueDirPath, prefix: "write-if-1"), untracked, "1", "deterministic-content"),
+                Operation.WriteFile(CreateOutputFileArtifact(opaqueDirPath, prefix: "write-always"), "deterministic-content", doNotInfer: true),
+                Operation.WriteFileIfInputEqual(CreateOutputFileArtifact(opaqueDirPath, prefix: "write-if-2"), untracked, "2", "deterministic-content"),
             });
 
             builderA.AddOutputDirectory(opaqueDirPath);


### PR DESCRIPTION
It's important to untrack `/usr/lib` instead of making it a source sealed directory because the set of dynamically loaded libraries (from `/usr/lib`) during an execution of a process is not necessarily deterministic.  For example, when the same process---which itself is deterministic---is executed multiple times on the same inputs, the set of dynamically loaded libraries can vary from time to time.

Re-enabled tests:
  - `IntegrationTest.BuildXL.Scheduler.NonDeterminismProbeTests`
      - NonDeterminismOpaqueDirectoryOutputDifferentFiles
      - NonDeterminismOpaqueDirectoryOutput
  - `Test.BuildXL.FingerprintStore.FingerprintStoreTests`
      - VerifyGarbageCollectWorks
      - DontOverwriteExistingContentAddressableEntries

[AB#1519677](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1519677)
[AB#1513463](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1513463)
[AB#1520150](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1520150)