### PR TITLE
Test querying the journal on getting the journal accessor, even in elevated mode

### DIFF
--- a/Public/Src/Engine/Dll/Engine.cs
+++ b/Public/Src/Engine/Dll/Engine.cs
@@ -1456,7 +1456,12 @@ namespace BuildXL.Engine
                     loggingContext,
                     volumeMap,
                     m_initialCommandLineConfiguration.Startup.ConfigFile.ToString(Context.PathTable))
-                : default(Optional<IChangeJournalAccessor>);
+                : default;
+
+            if (!journal.IsValid)
+            {
+                Logger.Log.FailedToGetJournalAccessor(loggingContext);
+            }
 
             return journal.IsValid ? JournalState.CreateEnabledJournal(volumeMap, journal.Value) : JournalState.DisabledJournal;
         }

--- a/Public/Src/Engine/Dll/Tracing/Log.cs
+++ b/Public/Src/Engine/Dll/Tracing/Log.cs
@@ -2658,10 +2658,10 @@ If you can't update and need this feature after July 2018 please reach out to th
         [GeneratedEvent(
             (ushort)LogEventId.FailedToGetJournalAccessor,
             EventGenerators = EventGenerators.LocalOnly,
-            EventLevel = Level.Warning,
+            EventLevel = Level.Informational,
             Keywords = (int)Events.Keywords.UserMessage,
             EventTask = (ushort)Events.Tasks.Engine,
-            Message = "Encountered an error while checking whether process can access the journal directly. The build may still proceed but without use of change journal scanning. See log for details")]
+            Message = "Change journal cannot be accessed directly. The build may still proceed but without use of change journal scanning. See log for details")]
         internal abstract void FailedToGetJournalAccessor(LoggingContext context);
     }
 

--- a/Public/Src/Engine/Dll/Tracing/Log.cs
+++ b/Public/Src/Engine/Dll/Tracing/Log.cs
@@ -2654,6 +2654,15 @@ If you can't update and need this feature after July 2018 please reach out to th
             EventTask = (ushort)Events.Tasks.Distribution,
             Message = "Grpc settings: ThreadPoolSize {threadPoolSize}, HandlerInlining {handlerInlining}, CallTimeoutMin {callTimeoutMin}, InactiveTimeoutMin {inactiveTimeoutMin}")]
         internal abstract void GrpcSettings(LoggingContext context, int threadPoolSize, bool handlerInlining, int callTimeoutMin, int inactiveTimeoutMin);
+
+        [GeneratedEvent(
+            (ushort)LogEventId.FailedToGetJournalAccessor,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Warning,
+            Keywords = (int)Events.Keywords.UserMessage,
+            EventTask = (ushort)Events.Tasks.Engine,
+            Message = "Encountered an error while checking whether process can access the journal directly. The build may still proceed but without use of change journal scanning. See log for details")]
+        internal abstract void FailedToGetJournalAccessor(LoggingContext context);
     }
 
     /// <summary>

--- a/Public/Src/Engine/Dll/Tracing/LogEventId.cs
+++ b/Public/Src/Engine/Dll/Tracing/LogEventId.cs
@@ -218,6 +218,8 @@ namespace BuildXL.Engine.Tracing
         ResourceBasedCancellationIsEnabledWithSharedOpaquesPresent = 7119,
         BusyOrUnavailableOutputDirectoriesException = 7120,
         GrpcSettings = 7121,
+
+        FailedToGetJournalAccessor = 7122,
         // max 7200
     }
 }

--- a/Public/Src/Utilities/Storage/ChangeJournalService/InProcChangeJournalAccessor.cs
+++ b/Public/Src/Utilities/Storage/ChangeJournalService/InProcChangeJournalAccessor.cs
@@ -122,7 +122,7 @@ namespace BuildXL.Storage.ChangeJournalService
             {
                 if (!volumeOpenResult.Succeeded)
                 {
-                    string message = I($"Failed to open a volume handle for the volume '{request.VolumeGuidPath.Path}'");
+                    string message = I($"Failed to open a volume handle for the volume '{request.VolumeGuidPath.Path}': Status: {volumeOpenResult.Status.ToString()} | Error code: {volumeOpenResult.NativeErrorCode}");
                     return new MaybeResponse<QueryUsnJournalResult>(
                             new ErrorResponse(ErrorStatus.FailedToOpenVolumeHandle, message));
                 }

--- a/Public/Src/Utilities/Storage/JournalAccessorGetter.cs
+++ b/Public/Src/Utilities/Storage/JournalAccessorGetter.cs
@@ -9,6 +9,7 @@ using BuildXL.Storage.ChangeJournalService.Protocol;
 using BuildXL.Storage.Tracing;
 using BuildXL.Utilities;
 using BuildXL.Utilities.Instrumentation.Common;
+using static BuildXL.Utilities.FormattableStringEx;
 
 namespace BuildXL.Storage
 {
@@ -28,14 +29,10 @@ namespace BuildXL.Storage
 
             var inprocAccessor = new InProcChangeJournalAccessor();
 
-            // If the current process is called with elevation, it can directly access the journal.
-            if (CurrentProcess.IsElevated)
-            {
-                return inprocAccessor;
-            }
-
             try
             {
+                // When the current process runs with elevation, the process can access the journal directly. However, even with such a capability,
+                // the process may fail in opening the volume handle. Thus, we need to verify that the process is able to open the volume handle.
                 // If the operating system is Win10-RedStone2, it can directly access the journal as well.
                 using (var file = FileUtilities.CreateFileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete))
                 {
@@ -44,24 +41,31 @@ namespace BuildXL.Storage
                     {
                         // Journal accessor needs to know whether the OS allows unprivileged journal operations
                         // because some operation names (e.g., reading journal, getting volume handle) are different.
-                        inprocAccessor.IsJournalUnprivileged = true;
+                        inprocAccessor.IsJournalUnprivileged = !CurrentProcess.IsElevated;
 
                         // Attempt to access journal. Any error means that the journal operations are not unprivileged yet in the host computer.
                         var result = inprocAccessor.QueryJournal(new QueryJournalRequest(volume));
+
                         if (!result.IsError && result.Response.Succeeded)
                         {
                             return inprocAccessor;
                         }
+
+                        Logger.Log.FailedCheckingDirectJournalAccess(loggingContext, result.Error.Message);
+                    }
+                    else
+                    {
+                        Logger.Log.FailedCheckingDirectJournalAccess(loggingContext, I($"Failed to get volume path for '{path}'"));
                     }
                 }
             }
             catch (BuildXLException ex)
             {
                 Logger.Log.FailedCheckingDirectJournalAccess(loggingContext, ex.Message);
-                return default(Optional<IChangeJournalAccessor>);
+                return default;
             }
 
-            return default(Optional<IChangeJournalAccessor>);
+            return default;
         }
     }
 }

--- a/Public/Src/Utilities/Storage/JournalAccessorGetter.cs
+++ b/Public/Src/Utilities/Storage/JournalAccessorGetter.cs
@@ -46,12 +46,21 @@ namespace BuildXL.Storage
                         // Attempt to access journal. Any error means that the journal operations are not unprivileged yet in the host computer.
                         var result = inprocAccessor.QueryJournal(new QueryJournalRequest(volume));
 
-                        if (!result.IsError && result.Response.Succeeded)
+                        if (!result.IsError)
                         {
-                            return inprocAccessor;
+                            if (result.Response.Succeeded)
+                            {
+                                return inprocAccessor;
+                            }
+                            else
+                            {
+                                Logger.Log.FailedCheckingDirectJournalAccess(loggingContext, I($"Querying journal results in {result.Response.Status.ToString()}"));
+                            }
                         }
-
-                        Logger.Log.FailedCheckingDirectJournalAccess(loggingContext, result.Error.Message);
+                        else
+                        {
+                            Logger.Log.FailedCheckingDirectJournalAccess(loggingContext, result.Error.Message);
+                        }
                     }
                     else
                     {

--- a/Public/Src/Utilities/Storage/Tracing/Log.cs
+++ b/Public/Src/Utilities/Storage/Tracing/Log.cs
@@ -548,10 +548,10 @@ namespace BuildXL.Storage.Tracing
         [GeneratedEvent(
             (ushort)EventId.FailedCheckingDirectJournalAccess,
             EventGenerators = EventGenerators.LocalOnly,
-            EventLevel = Level.Warning,
+            EventLevel = Level.Verbose,
             Keywords = (int)Events.Keywords.UserMessage,
             EventTask = (ushort)Events.Tasks.Storage,
-            Message = "Encountered an error while checking whether process can access the journal directly. The build may still proceed but without use of change journal scanning. {errorMessage}")]
+            Message = "Checking direct journal access results in failure. {errorMessage}")]
         internal abstract void FailedCheckingDirectJournalAccess(LoggingContext context, string errorMessage);
 
         [GeneratedEvent(


### PR DESCRIPTION
In the past in elevated mode, we simply return the journal accessor without checking if we can query the journal. This causes a problem because then tests that require journal scan will run although the journal cannot be queried, e.g., due to failure in opening volume handle.