### PR TITLE
Avoid using and killing VBCSCompiler.exe

### DIFF
--- a/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
+++ b/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
@@ -536,17 +536,6 @@ namespace BuildXL.FrontEnd.MsBuild
                 AddMsBuildProperty(pipDataBuilder, kvp.Key, kvp.Value);
             }
 
-            // Compilation uses VBCSCompiler.exe as a cache; this is a process that lives for longer than
-            // the pip itself does, so we will kill it as part of the clean-up. By forcefully adding the
-            // property below, we ensure that the cache is not used by any of the processes, thus making
-            // VBCSCompiler.exe safe to kill.
-            // If this isn't used, the clean-up for one pip may kill the process and cause a different pip
-            // to fail.
-            if (!project.GlobalProperties.ContainsKey("UseSharedCompilation"))
-            {
-                AddMsBuildProperty(pipDataBuilder, "UseSharedCompilation", "false");
-            }
-
             // Configure binary logger if specified
             if (m_resolverSettings.EnableBinLogTracing == true)
             {


### PR DESCRIPTION
MSBuild spawns the VBCSCompiler.exe in order to avoid repeated calls to compilers and lessen the cost of initializing them.

The problem is that the instance is a singleton, and thus many different pips may use the same instance; hence, if one pip kills it as part of its cleanup process, then a different pip may error because it was using the instance.

The solution here is to instruct MSBuild not to _use_ VBCSCompiler.exe and stop BuildXL from killing it as part of the cleanup; notably, it may still be launched even if it is instructed not to use VBCSCompiler.