### PR TITLE
[MacSandbox] skip unnecessarily creating trie nodes on lookups

### DIFF
--- a/Private/macOS/publish-buildxl-runtime.sh
+++ b/Private/macOS/publish-buildxl-runtime.sh
@@ -6,7 +6,7 @@ readonly sandboxSrcDir="${buildxlDir}/Public/Src/Sandbox/MacOs"
 
 readonly nugetExe=${buildxlDir}/Shared/Tools/NuGet.exe
 readonly nugetTemplateDir=$MYDIR/runtime.osx-x64.BuildXL.template
-readonly nugetFeed="https://pkgs.dev.azure.com/cloudbuild/_packaging/BuildXL.Selfhost/nuget/v3/index.json"
+readonly nugetFeed="https://cloudbuild.pkgs.visualstudio.com/_packaging/BuildXL.Selfhost/nuget/v3/index.json"
 
 if [[ ! -d $nugetTemplateDir ]]; then
     echo "[ERROR] Expected to find nuget template folder at '$nugetTemplateDir' but no such directory exists"

--- a/Public/Src/Engine/Processes/SandboxedKextConnection.cs
+++ b/Public/Src/Engine/Processes/SandboxedKextConnection.cs
@@ -63,7 +63,7 @@ namespace BuildXL.Processes
         /// Until some automation for kernel extension building and deployment is in place, this number has to be kept in sync with the 'CFBundleVersion'
         /// inside the Info.plist file of the kernel extension code base. BuildXL will not work if a version mismatch is detected!
         /// </summary>
-        public const string RequiredKextVersionNumber = "1.89.0";
+        public const string RequiredKextVersionNumber = "1.89.99";
 
         /// <summary>
         /// See TN2420 (https://developer.apple.com/library/archive/technotes/tn2420/_index.html) on how versioning numbers are formatted in the Apple ecosystem

--- a/Public/Src/Engine/Processes/SandboxedKextConnection.cs
+++ b/Public/Src/Engine/Processes/SandboxedKextConnection.cs
@@ -63,7 +63,7 @@ namespace BuildXL.Processes
         /// Until some automation for kernel extension building and deployment is in place, this number has to be kept in sync with the 'CFBundleVersion'
         /// inside the Info.plist file of the kernel extension code base. BuildXL will not work if a version mismatch is detected!
         /// </summary>
-        public const string RequiredKextVersionNumber = "1.88.99";
+        public const string RequiredKextVersionNumber = "1.89.0";
 
         /// <summary>
         /// See TN2420 (https://developer.apple.com/library/archive/technotes/tn2420/_index.html) on how versioning numbers are formatted in the Apple ecosystem

--- a/Public/Src/Sandbox/MacOs/Interop/Interop.xcodeproj/project.pbxproj
+++ b/Public/Src/Sandbox/MacOs/Interop/Interop.xcodeproj/project.pbxproj
@@ -87,7 +87,7 @@
 		F58E9204220B5B3C0083C57E /* utf8proc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = utf8proc.c; sourceTree = "<group>"; };
 		F58E9205220B5B3C0083C57E /* utf8proc_data.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = utf8proc_data.c; sourceTree = "<group>"; };
 		F58E9206220B5B3C0083C57E /* utf8proc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utf8proc.h; sourceTree = "<group>"; };
-		F598838E22527E8700A7A2D9 /* BundleInfoTest.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = BundleInfoTest.xcconfig; path = ../BundleInfoTest.xcconfig; sourceTree = "<group>"; };
+		F598838E22527E8700A7A2D9 /* BundleInfoDebug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = BundleInfoDebug.xcconfig; path = ../BundleInfoDebug.xcconfig; sourceTree = "<group>"; };
 		F598838F22527E8700A7A2D9 /* BundleInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = BundleInfo.xcconfig; path = ../BundleInfo.xcconfig; sourceTree = "<group>"; };
 		F5CF3B0820C1E3C500DC1B2E /* FileAccessManifestParser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FileAccessManifestParser.cpp; path = ../Sandbox/Src/FileAccessManifest/FileAccessManifestParser.cpp; sourceTree = "<group>"; };
 		F5CF3B0920C1E3C500DC1B2E /* FileAccessManifestParser.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = FileAccessManifestParser.hpp; path = ../Sandbox/Src/FileAccessManifest/FileAccessManifestParser.hpp; sourceTree = "<group>"; };
@@ -149,7 +149,7 @@
 			isa = PBXGroup;
 			children = (
 				F598838F22527E8700A7A2D9 /* BundleInfo.xcconfig */,
-				F598838E22527E8700A7A2D9 /* BundleInfoTest.xcconfig */,
+				F598838E22527E8700A7A2D9 /* BundleInfoDebug.xcconfig */,
 				3C6495C021A6E2E20083FD3A /* Aria */,
 				F55A72F020D412F100069365 /* CLI */,
 				3CD2972920D173D900399B9B /* External */,

--- a/Public/Src/Sandbox/MacOs/Sandbox/Sandbox.xcodeproj/project.pbxproj
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Sandbox.xcodeproj/project.pbxproj
@@ -345,7 +345,7 @@
 		F58E91FD220B595B0083C57E /* utf8proc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = utf8proc.c; sourceTree = "<group>"; };
 		F58E91FE220B595B0083C57E /* utf8proc_data.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = utf8proc_data.c; sourceTree = "<group>"; };
 		F58E91FF220B595B0083C57E /* utf8proc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utf8proc.h; sourceTree = "<group>"; };
-		F598838C22527E7400A7A2D9 /* BundleInfoTest.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = BundleInfoTest.xcconfig; path = ../BundleInfoTest.xcconfig; sourceTree = "<group>"; };
+		F598838C22527E7400A7A2D9 /* BundleInfoDebug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = BundleInfoDebug.xcconfig; path = ../BundleInfoDebug.xcconfig; sourceTree = "<group>"; };
 		F598838D22527E7400A7A2D9 /* BundleInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = BundleInfo.xcconfig; path = ../BundleInfo.xcconfig; sourceTree = "<group>"; };
 		F5A804C42182937400626B9C /* Checkers.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Checkers.cpp; sourceTree = "<group>"; };
 		F5A804C52182937400626B9C /* Checkers.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Checkers.hpp; sourceTree = "<group>"; };
@@ -443,7 +443,7 @@
 			isa = PBXGroup;
 			children = (
 				F598838D22527E7400A7A2D9 /* BundleInfo.xcconfig */,
-				F598838C22527E7400A7A2D9 /* BundleInfoTest.xcconfig */,
+				F598838C22527E7400A7A2D9 /* BundleInfoDebug.xcconfig */,
 				3CCA66C720D15BBD0051F984 /* Src */,
 				F58E912F220B562A0083C57E /* External */,
 				3CCA66C620D15BBD0051F984 /* Products */,

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>1.89.0</string>
+	<string>1.89.99</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>BuildXLSandbox</key>

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>1.88.99</string>
+	<string>1.89.0</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>BuildXLSandbox</key>

--- a/config.microsoftInternal.dsc
+++ b/config.microsoftInternal.dsc
@@ -15,7 +15,7 @@ export const pkgs = isMicrosoftInternal ? [
     { id: "Microsoft.Applications.Telemetry.Desktop", version: "1.1.152" },
 
     // Runtime dependencies used for macOS deployments
-    { id: "runtime.osx-x64.BuildXL", version: "1.88.99" },
+    { id: "runtime.osx-x64.BuildXL", version: "1.89.0" },
     { id: "Aria.Cpp.SDK.osx-x64", version: "8.5.4" },
 
     { id: "CB.QTest", version: "19.4.28.1057" },

--- a/config.microsoftInternal.dsc
+++ b/config.microsoftInternal.dsc
@@ -15,7 +15,7 @@ export const pkgs = isMicrosoftInternal ? [
     { id: "Microsoft.Applications.Telemetry.Desktop", version: "1.1.152" },
 
     // Runtime dependencies used for macOS deployments
-    { id: "runtime.osx-x64.BuildXL", version: "1.89.0" },
+    { id: "runtime.osx-x64.BuildXL", version: "1.89.99" },
     { id: "Aria.Cpp.SDK.osx-x64", version: "8.5.4" },
 
     { id: "CB.QTest", version: "19.4.28.1057" },


### PR DESCRIPTION
Before this PR, on every trie operation a leaf node corresponding to a given key is retrieved, creating any intermediate nodes along the way. 

This is unnecessary for lookup operations.  When the key does not exist in the trie, instead of traversing the trie until a leaf node is found and creating all intermediate nodes along the way, the lookup should fail as soon as an intermediate node is not found.

As a consequence of the previous implementation, a process could connect to the kext and then immediately disconnect, which would cause the size of the [`connectedClients_`](https://github.com/Microsoft/BuildXL/blob/2054bd1bf5e790119dfe979d8897e0aeca493045/Public/Src/Sandbox/MacOs/Sandbox/Src/BuildXLSandbox.hpp#L48) dictionary to monotonically grow.  This can become a problem because those nodes are released only when the kext is unloaded.  