### PR TITLE
ExecutionLog events are now processed asynchronously on master

### DIFF
--- a/Public/Src/App/Bxl/BuildXLApp.cs
+++ b/Public/Src/App/Bxl/BuildXLApp.cs
@@ -330,7 +330,8 @@ namespace BuildXL
                         (int)EventId.EndFilterApplyTraversal,
                         (int)EventId.EndAssigningPriorities,
                         (int)Engine.Tracing.LogEventId.DeserializedFile,
-                        (int)EventId.PipQueueConcurrency
+                        (int)EventId.PipQueueConcurrency,
+                        (int)Engine.Tracing.LogEventId.GrpcSettings
                     });
 
                 // Distribution related messages are disabled in default text log and routed to special log file

--- a/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcEnvironment.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcEnvironment.cs
@@ -29,8 +29,11 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
         {
             if (Interlocked.CompareExchange(ref _isInitialized, 1, 0) == 0)
             {
-                global::Grpc.Core.GrpcEnvironment.SetThreadPoolSize(numThreads);
-                global::Grpc.Core.GrpcEnvironment.SetCompletionQueueCount(numThreads);
+                if (handlerInliningEnabled)
+                {
+                    global::Grpc.Core.GrpcEnvironment.SetThreadPoolSize(numThreads);
+                    global::Grpc.Core.GrpcEnvironment.SetCompletionQueueCount(numThreads);
+                }
 
                 // By default, gRPC's internal event handlers get offloaded to .NET default thread pool thread (inlineHandlers=false).
                 // Setting inlineHandlers to true will allow scheduling the event handlers directly to GrpcThreadPool internal threads.

--- a/Public/Src/Engine/Dll/Distribution/Grpc/GrpcSettings.cs
+++ b/Public/Src/Engine/Dll/Distribution/Grpc/GrpcSettings.cs
@@ -24,7 +24,7 @@ namespace BuildXL.Engine.Distribution.Grpc
         /// Maximum time to wait for the master to connect to a worker.
         /// </summary>
         /// <remarks>
-        /// Default: 30 minutes
+        /// Default: 60 minutes
         /// </remarks>
         public static TimeSpan InactiveTimeout => EngineEnvironmentSettings.DistributionInactiveTimeout;
 
@@ -40,7 +40,7 @@ namespace BuildXL.Engine.Distribution.Grpc
         /// Maximum time to wait for the master to connect to a worker.
         /// </summary>
         /// <remarks>
-        /// Default: true
+        /// Default: false
         /// </remarks>
         public static bool HandlerInliningEnabled => EngineEnvironmentSettings.GrpcHandlerInliningEnabled;
     }

--- a/Public/Src/Engine/Dll/Distribution/MasterService.cs
+++ b/Public/Src/Engine/Dll/Distribution/MasterService.cs
@@ -174,12 +174,11 @@ namespace BuildXL.Engine.Distribution
 
             if (notification.ExecutionLogData != null && notification.ExecutionLogData.Count != 0)
             {
-                // NOTE: We need to log the execution blob synchronously as the order of the execution log events
-                // must be retained for proper deserialization
-                worker.LogExecutionBlob(notification.ExecutionLogData, notification.ExecutionLogBlobSequenceNumber);
+                // The channel is unblocked and ACK is sent after we put the execution blob to the queue in 'LogExecutionBlobAsync' method.
+                await worker.LogExecutionBlobAsync(notification);
             }
 
-            // Return immediately to unblock worker
+            // Return immediately to unblock the channel so that worker can receive the ACK for the sent message
             await Task.Yield();
 
             foreach (var forwardedEvent in notification.ForwardedEvents)

--- a/Public/Src/Engine/Dll/Distribution/RemoteWorker.cs
+++ b/Public/Src/Engine/Dll/Distribution/RemoteWorker.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.ContractsLight;
 using System.IO;
 using System.Linq;
@@ -64,6 +65,8 @@ namespace BuildXL.Engine.Distribution
         public override bool EverAvailable => Volatile.Read(ref m_everAvailable);
 
         private readonly TaskSourceSlim<bool> m_attachCompletion;
+        private readonly TaskSourceSlim<bool> m_executionBlobCompletion;
+        private BlockingCollection<WorkerNotificationArgs> m_executionBlobQueue = new BlockingCollection<WorkerNotificationArgs>(new ConcurrentQueue<WorkerNotificationArgs>());
 
         private readonly Thread m_sendThread;
         private readonly BlockingCollection<ValueTuple<PipCompletionTask, SinglePipBuildRequest>> m_buildRequests;
@@ -101,6 +104,8 @@ namespace BuildXL.Engine.Distribution
             m_masterService = masterService;
             m_buildRequests = new BlockingCollection<ValueTuple<PipCompletionTask, SinglePipBuildRequest>>();
             m_attachCompletion = TaskSourceSlim.Create<bool>();
+            m_executionBlobCompletion = TaskSourceSlim.Create<bool>();
+
             m_serviceLocation = serviceLocation;
 
             if (isGrpcEnabled)
@@ -214,11 +219,30 @@ namespace BuildXL.Engine.Distribution
             }
         }
 
-        public void LogExecutionBlob(ArraySegment<byte> executionLogBlob, int blobSequenceNumber)
+        [SuppressMessage("AsyncUsage", "AsyncFixer02:awaitinsteadofwait")]
+        public async Task LogExecutionBlobAsync(WorkerNotificationArgs notification)
         {
+            Contract.Requires(notification.ExecutionLogData != null || notification.ExecutionLogData.Count != 0)
+
+            m_executionBlobQueue.Add(notification);
+
+            // After we put the executionBlob in a queue, we can unblock the caller and give an ACK to the worker.
+            await Task.Yield();
+
             // Execution log events cannot be logged by multiple threads concurrently since they must be ordered
             lock (m_logBlobLock)
             {
+                // We need to dequeue and process the blobs in order. 
+                // Here, we do not necessarily process the blob that is just added to the queue above.
+                // There might be another thread that adds the next blob to the queue after the current thread, 
+                // and that thread might acquire the lock earlier. 
+
+                WorkerNotificationArgs executionBlobNotification = null;
+                Contract.Assert(m_executionBlobQueue.TryTake(out executionBlobNotification), "The executionBlob queue cannot be empty");
+                
+                int blobSequenceNumber = executionBlobNotification.ExecutionLogBlobSequenceNumber;
+                ArraySegment<byte> executionLogBlob = executionBlobNotification.ExecutionLogData;
+
                 if (m_workerExecutionLogTarget == null)
                 {
                     return;
@@ -263,7 +287,7 @@ namespace BuildXL.Engine.Distribution
                     // Read all events into worker execution log target
                     if (!m_executionLogReader.ReadAllEvents())
                     {
-                        Logger.Log.DistributionCallMasterCodeException(m_appLoggingContext, nameof(LogExecutionBlob), "Failed to read all worker events");
+                        Logger.Log.DistributionCallMasterCodeException(m_appLoggingContext, nameof(LogExecutionBlobAsync), "Failed to read all worker events");
                         // Disable further processing of execution log since an error was encountered during processing
                         m_workerExecutionLogTarget = null;
                     }
@@ -274,12 +298,17 @@ namespace BuildXL.Engine.Distribution
                 }
                 catch (Exception ex)
                 {
-                    Logger.Log.DistributionCallMasterCodeException(m_appLoggingContext, nameof(LogExecutionBlob), ex.ToStringDemystified() + Environment.NewLine
+                    Logger.Log.DistributionCallMasterCodeException(m_appLoggingContext, nameof(LogExecutionBlobAsync), ex.ToStringDemystified() + Environment.NewLine
                                                                     + "Message sequence number: " + blobSequenceNumber
                                                                     + " Last sequence number logged: " + m_lastBlobSeqNumber);
                     // Disable further processing of execution log since an exception was encountered during processing
                     m_workerExecutionLogTarget = null;
                 }
+            }
+
+            if (m_executionBlobQueue.IsCompleted)
+            {
+                m_executionBlobCompletion.TrySetResult(true);
             }
         }
 
@@ -348,8 +377,7 @@ namespace BuildXL.Engine.Distribution
         }
 
         /// <inheritdoc />
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("AsyncUsage", "AsyncFixer03:FireForgetAsyncVoid")]
-        public override async void Finish(string buildFailure)
+        public override async Task FinishAsync(string buildFailure)
         {
             m_buildRequests.CompleteAdding();
             if (m_sendThread.IsAlive)
@@ -389,6 +417,17 @@ namespace BuildXL.Engine.Distribution
                 };
 
                 await m_workerClient.ExitAsync(buildEndData, exitCancellation.Token);
+
+                m_executionBlobQueue.CompleteAdding();
+
+                using (m_masterService.Environment.Counters.StartStopwatch(PipExecutorCounter.RemoteWorker_AwaitExecutionBlobCompletionDuration))
+                {
+                    if (!m_executionBlobQueue.IsCompleted)
+                    {
+                        // Wait for execution blobs to be processed.
+                        await m_executionBlobCompletion.Task;
+                    }
+                }
 
                 ChangeStatus(WorkerNodeStatus.Stopping, WorkerNodeStatus.Stopped);
             }
@@ -805,7 +844,7 @@ namespace BuildXL.Engine.Distribution
             }
             else
             {
-                Finish("ValidateCacheConnection failed");
+                await FinishAsync("ValidateCacheConnection failed");
             }
         }
 

--- a/Public/Src/Engine/Dll/Distribution/RemoteWorker.cs
+++ b/Public/Src/Engine/Dll/Distribution/RemoteWorker.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.ContractsLight;
 using System.IO;
 using System.Linq;
@@ -219,7 +218,7 @@ namespace BuildXL.Engine.Distribution
             }
         }
 
-        [SuppressMessage("AsyncUsage", "AsyncFixer02:awaitinsteadofwait")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("AsyncUsage", "AsyncFixer02:awaitinsteadofwait")]
         public async Task LogExecutionBlobAsync(WorkerNotificationArgs notification)
         {
             Contract.Requires(notification.ExecutionLogData != null || notification.ExecutionLogData.Count != 0);

--- a/Public/Src/Engine/Dll/Distribution/RemoteWorker.cs
+++ b/Public/Src/Engine/Dll/Distribution/RemoteWorker.cs
@@ -222,7 +222,7 @@ namespace BuildXL.Engine.Distribution
         [SuppressMessage("AsyncUsage", "AsyncFixer02:awaitinsteadofwait")]
         public async Task LogExecutionBlobAsync(WorkerNotificationArgs notification)
         {
-            Contract.Requires(notification.ExecutionLogData != null || notification.ExecutionLogData.Count != 0)
+            Contract.Requires(notification.ExecutionLogData != null || notification.ExecutionLogData.Count != 0);
 
             m_executionBlobQueue.Add(notification);
 

--- a/Public/Src/Engine/Scheduler/Distribution/Worker.cs
+++ b/Public/Src/Engine/Scheduler/Distribution/Worker.cs
@@ -262,7 +262,7 @@ namespace BuildXL.Scheduler.Distribution
         /// <summary>
         /// Signals that build is finished and that worker should exit
         /// </summary>
-#pragma warning disable 1998
+#pragma warning disable 1998 // Disable the warning for "This async method lacks 'await'"
         public virtual async Task FinishAsync(string buildFailure)
         {
             Status = WorkerNodeStatus.Stopped;

--- a/Public/Src/Engine/Scheduler/Distribution/Worker.cs
+++ b/Public/Src/Engine/Scheduler/Distribution/Worker.cs
@@ -262,10 +262,12 @@ namespace BuildXL.Scheduler.Distribution
         /// <summary>
         /// Signals that build is finished and that worker should exit
         /// </summary>
-        public virtual void Finish(string buildFailure)
+#pragma warning disable 1998
+        public virtual async Task FinishAsync(string buildFailure)
         {
             Status = WorkerNodeStatus.Stopped;
         }
+#pragma warning restore 1998
 
         /// <summary>
         /// Returns if true if the worker holds a local node; false otherwise.

--- a/Public/Src/Engine/Scheduler/PipExecutorCounter.cs
+++ b/Public/Src/Engine/Scheduler/PipExecutorCounter.cs
@@ -1020,6 +1020,10 @@ namespace BuildXL.Scheduler
         RemoteWorker_BuildRequestSendDuration,
 
         /// <nodoc/>
+        [CounterType(CounterType.Stopwatch)]
+        RemoteWorker_AwaitExecutionBlobCompletionDuration,
+
+        /// <nodoc/>
         BuildRequestBatchesSentToWorkers,
 
         /// <nodoc/>

--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -1325,7 +1325,7 @@ namespace BuildXL.Scheduler
 
                 foreach (var worker in m_workers)
                 {
-                    worker.Finish(HasFailed ? "Distributed build failed. See errors on master." : null);
+                    await worker.FinishAsync(HasFailed ? "Distributed build failed. See errors on master." : null);
                 }
 
                 // Wait for all workers to confirm that they have stopped.

--- a/Public/Src/Utilities/Configuration/EngineEnvironmentSettings.cs
+++ b/Public/Src/Utilities/Configuration/EngineEnvironmentSettings.cs
@@ -133,7 +133,7 @@ namespace BuildXL.Utilities.Configuration
         ///     - Worker - if it doesn't receive any call from the master within this interval, decides that the master is dead and exits
         /// </summary>
         public static readonly Setting<TimeSpan> DistributionInactiveTimeout = CreateSetting("BuildXLDistribInactiveTimeoutMin", value => ParseTimeSpan(value, ts => TimeSpan.FromMinutes(ts)) ??
-            TimeSpan.FromMinutes(30));
+            TimeSpan.FromMinutes(60));
 
         /// <summary>
         /// The number of threads in the grpc thread pool.
@@ -147,9 +147,9 @@ namespace BuildXL.Utilities.Configuration
         /// Whether HandlerInlining is enabled for grpc.
         /// </summary>
         /// <remarks>
-        /// Default enabled
+        /// Default disabled
         /// </remarks>
-        public static readonly Setting<bool> GrpcHandlerInliningEnabled = CreateSetting("BuildXLGrpcHandlerInliningEnabled", value => string.IsNullOrWhiteSpace(value) ? true : value == "1");
+        public static readonly Setting<bool> GrpcHandlerInliningEnabled = CreateSetting("BuildXLGrpcHandlerInliningEnabled", value => string.IsNullOrWhiteSpace(value) ? false : value == "1");
 
         /// <summary>
         /// An artificial delay in reporting notifications to force batching


### PR DESCRIPTION
Processing some executionlog events on master can take more than 5 minutes. Because we do not send an ACK to the worker before the master completes processing the event, the worker assumes that the message failed to send, so the worker attempts to re-send the message. With changes below, master sends an ACK before processing the events. 