### PR TITLE
Enable distributed copies on BuildXL builds on macOS

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcFileCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcFileCopier.cs
@@ -76,13 +76,13 @@ namespace BuildXL.Cache.ContentStore.Distributed.Utilities
 
             var host = segments.First();
             var hashLiteral = segments.Last();
-            if (hashLiteral.EndsWith(GrpcDistributedPathTransformer.BlobFileExtension))
+            if (hashLiteral.EndsWith(GrpcDistributedPathTransformer.BlobFileExtension, StringComparison.OrdinalIgnoreCase))
             {
                 hashLiteral = hashLiteral.Substring(0, hashLiteral.Length - GrpcDistributedPathTransformer.BlobFileExtension.Length);
             }
             var hashTypeLiteral = segments.ElementAt(segments.Count - 1 - 2);
 
-            if (!Enum.TryParse(hashTypeLiteral, out HashType hashType))
+            if (!Enum.TryParse(hashTypeLiteral, true, out HashType hashType))
             {
                 throw new InvalidOperationException($"{hashTypeLiteral} is not a valid member of {nameof(HashType)}");
             }

--- a/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcFileCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcFileCopier.cs
@@ -82,7 +82,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Utilities
             }
             var hashTypeLiteral = segments.ElementAt(segments.Count - 1 - 2);
 
-            if (!Enum.TryParse(hashTypeLiteral, true, out HashType hashType))
+            if (!Enum.TryParse(hashTypeLiteral, ignoreCase: true, out HashType hashType))
             {
                 throw new InvalidOperationException($"{hashTypeLiteral} is not a valid member of {nameof(HashType)}");
             }

--- a/Public/Src/Cache/ContentStore/Library/Extensions/StringExtensions.cs
+++ b/Public/Src/Cache/ContentStore/Library/Extensions/StringExtensions.cs
@@ -6,7 +6,6 @@ using System.Diagnostics.ContractsLight;
 using System.IO;
 using System.Text;
 using BuildXL.Cache.ContentStore.Interfaces.Extensions;
-using BuildXL.Cache.ContentStore.Interfaces.Utils;
 
 namespace BuildXL.Cache.ContentStore.Extensions
 {
@@ -54,19 +53,6 @@ namespace BuildXL.Cache.ContentStore.Extensions
                 str = str.Remove(replaceIndex, oldValue.Length);
                 str = str.Insert(replaceIndex, newValue);
                 startIndex = replaceIndex += newValue.Length;
-            }
-
-            return str;
-        }
-
-        /// <summary>
-        /// Returns the upper invariant when paths are case-insensitive
-        /// </summary>
-        public static string PathToUpperInvariant(this string str)
-        {
-            if (OperatingSystemHelper.IsWindowsOS)
-            {
-                return str.ToUpperInvariant();
             }
 
             return str;

--- a/Public/Src/Cache/ContentStore/Library/Extensions/StringExtensions.cs
+++ b/Public/Src/Cache/ContentStore/Library/Extensions/StringExtensions.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.ContractsLight;
 using System.IO;
 using System.Text;
 using BuildXL.Cache.ContentStore.Interfaces.Extensions;
+using BuildXL.Cache.ContentStore.Interfaces.Utils;
 
 namespace BuildXL.Cache.ContentStore.Extensions
 {
@@ -53,6 +54,19 @@ namespace BuildXL.Cache.ContentStore.Extensions
                 str = str.Remove(replaceIndex, oldValue.Length);
                 str = str.Insert(replaceIndex, newValue);
                 startIndex = replaceIndex += newValue.Length;
+            }
+
+            return str;
+        }
+
+        /// <summary>
+        /// Returns the upper invariant when paths are case-insensitive
+        /// </summary>
+        public static string PathToUpperInvariant(this string str)
+        {
+            if (OperatingSystemHelper.IsWindowsOS)
+            {
+                return str.ToUpperInvariant();
             }
 
             return str;


### PR DESCRIPTION
Validated by building the same content on the same macOS box twice, each time using a separate local cache instance. The first build had a 0% cache hit rate, as expected. The second build also had a 0% cache hit rate, but copied ~4k files. It appears that copies are functioning as expected, but more investigation is necessary to understand the low hit rate.