### PR TITLE
Remove unspecified TRP warnings for projects without ProjectReferences

### DIFF
--- a/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
+++ b/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
@@ -560,13 +560,25 @@ namespace BuildXL.FrontEnd.MsBuild
                     pipDataBuilder.Add(PipDataAtom.FromString($"/t:{target}"));
                 }
             }
-            else if (project.ProjectReferences.Count > 0)
+            else
             {
-                // The prediction for the targets to execute is not available. Just log this as a warning for now, defaults targets will be used.
-                Tracing.Logger.Log.ProjectIsNotSpecifyingTheProjectReferenceProtocol(
-                    m_context.LoggingContext,
-                    Location.FromFile(project.FullPath.ToString(PathTable)),
-                    project.FullPath.GetName(m_context.PathTable).ToString(m_context.StringTable));
+                // The prediction for the targets to execute is not available. We need to log this.
+                if (project.ProjectReferences.Count > 0)
+                {
+                    Tracing.Logger.Log.ProjectIsNotSpecifyingTheProjectReferenceProtocol(
+                        m_context.LoggingContext,
+                        Location.FromFile(project.FullPath.ToString(PathTable)),
+                        project.FullPath.GetName(m_context.PathTable).ToString(m_context.StringTable));
+                }
+                else
+                {
+                    // If the project has no references, then we log it as an informational message rather than a warning.
+                    Tracing.Logger.Log.LeafProjectIsNotSpecifyingTheProjectReferenceProtocol(
+                        m_context.LoggingContext,
+                        Location.FromFile(project.FullPath.ToString(PathTable)),
+                        project.FullPath.GetName(m_context.PathTable).ToString(m_context.StringTable));
+                }
+
             }
 
             // Pass the output result cache file if present

--- a/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
+++ b/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
@@ -560,7 +560,7 @@ namespace BuildXL.FrontEnd.MsBuild
                     pipDataBuilder.Add(PipDataAtom.FromString($"/t:{target}"));
                 }
             }
-            else
+            else if (project.ProjectReferences.Count > 0)
             {
                 // The prediction for the targets to execute is not available. Just log this as a warning for now, defaults targets will be used.
                 Tracing.Logger.Log.ProjectIsNotSpecifyingTheProjectReferenceProtocol(

--- a/Public/Src/FrontEnd/MsBuild/Tracing/Log.cs
+++ b/Public/Src/FrontEnd/MsBuild/Tracing/Log.cs
@@ -234,6 +234,18 @@ namespace BuildXL.FrontEnd.MsBuild.Tracing
         public abstract void ProjectIsNotSpecifyingTheProjectReferenceProtocol(LoggingContext context, Location location, string projectName);
 
         [GeneratedEvent(
+            (ushort)LogEventId.LeafProjectIsNotSpecifyingTheProjectReferenceProtocol,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Informational,
+            Message = Events.LabeledProvenancePrefix + "Project '{projectName}' is a leaf project and not specifying its project reference protocol, and therefore the targets to call cannot " +
+                      " be inferred; this will be an issue in the future if references are added. Falling back to calling the project default targets. For more details, see " + 
+                      "https://github.com/Microsoft/msbuild/blob/master/documentation/specs/static-graph.md",
+            EventTask = (ushort)Events.Tasks.Engine,
+            EventOpcode = (byte)Events.Tasks.Parser,
+            Keywords = (int)(Events.Keywords.UserMessage | Events.Keywords.Diagnostics))]
+        public abstract void LeafProjectIsNotSpecifyingTheProjectReferenceProtocol(LoggingContext context, Location location, string projectName);
+
+        [GeneratedEvent(
             (ushort)LogEventId.GraphBuilderFilesAreNotRemoved,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.LogAlways,

--- a/Public/Src/FrontEnd/MsBuild/Tracing/LogEventId.cs
+++ b/Public/Src/FrontEnd/MsBuild/Tracing/LogEventId.cs
@@ -37,5 +37,6 @@ namespace BuildXL.FrontEnd.MsBuild.Tracing
         ProjectWithEmptyTargetsIsNotScheduled = 11421,
         ProjectIsNotSpecifyingTheProjectReferenceProtocol = 11422,
         GraphBuilderFilesAreNotRemoved = 11423,
+        LeafProjectIsNotSpecifyingTheProjectReferenceProtocol = 11424,
     }
 }

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/SchedulingTests/MsBuildTargetsTests.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/SchedulingTests/MsBuildTargetsTests.cs
@@ -35,7 +35,8 @@ namespace Test.BuildXL.FrontEnd.MsBuild
 
             // No targets should be explicitly passed (so MSBuild will pick defaults)
             Assert.DoesNotContain("/t", arguments);
-            // The project doesn't have any references, so there shouldn't be any logging
+            // The project doesn't have any references, so there should be an informational log
+            AssertInformationalEventLogged(LogEventId.LeafProjectIsNotSpecifyingTheProjectReferenceProtocol, 1);
             AssertWarningEventLogged(LogEventId.ProjectIsNotSpecifyingTheProjectReferenceProtocol, 0);
             AssertWarningCount();
         }

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/SchedulingTests/MsBuildTargetsTests.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/SchedulingTests/MsBuildTargetsTests.cs
@@ -35,6 +35,28 @@ namespace Test.BuildXL.FrontEnd.MsBuild
 
             // No targets should be explicitly passed (so MSBuild will pick defaults)
             Assert.DoesNotContain("/t", arguments);
+            // The project doesn't have any references, so there shouldn't be any logging
+            AssertWarningEventLogged(LogEventId.ProjectIsNotSpecifyingTheProjectReferenceProtocol, 0);
+            AssertWarningCount();
+        }
+
+        [Fact]
+        public void ProjectWithNoPredictedTargetsAndReferencesGetScheduledWithDefaultTargetsAndWarn()
+        {
+            var referencedProject = CreateProjectWithPredictions(predictedTargetsToExecute: PredictedTargetsToExecute.PredictionNotAvailable);
+            var noPredictionProject = CreateProjectWithPredictions(predictedTargetsToExecute: PredictedTargetsToExecute.PredictionNotAvailable, references: new [] { referencedProject });
+            var process =
+                Start()
+                    .Add(referencedProject)
+                    .Add(noPredictionProject)
+                    .ScheduleAll()
+                    .AssertSuccess()
+                    .RetrieveSuccessfulProcess(noPredictionProject);
+
+            var arguments = RetrieveProcessArguments(process);
+
+            // No targets should be explicitly passed (so MSBuild will pick defaults)
+            Assert.DoesNotContain("/t", arguments);
             // We should warn when this is the case
             AssertWarningEventLogged(LogEventId.ProjectIsNotSpecifyingTheProjectReferenceProtocol);
         }


### PR DESCRIPTION
When an MSBuild project does not have any ProjectReferences, no warnings due to a missing Target Reference Protocol should be emitted.