### PR TITLE
Track build id via session's lifetime

### DIFF
--- a/Public/Src/Cache/ContentStore/Library/Service/LocalContentServerBase.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/LocalContentServerBase.cs
@@ -635,13 +635,13 @@ namespace BuildXL.Cache.ContentStore.Service
         private void TrySetBuildId(string sessionName)
         {
             // Domino provides build ID through session name for CB builds.
-            if (Logger is IOperationLogger operationLogger && ExtractBuildId(sessionName, out var buildId))
+            if (Logger is IOperationLogger operationLogger && TryExtractBuildId(sessionName, out var buildId))
             {
                 operationLogger.RegisterBuildId(buildId);
             }
         }
 
-        private static bool ExtractBuildId(string sessionName, out string buildId)
+        private static bool TryExtractBuildId(string sessionName, out string buildId)
         {
             if (sessionName?.Contains(Context.BuildIdPrefix) == true)
             {
@@ -659,7 +659,7 @@ namespace BuildXL.Cache.ContentStore.Service
         private void TryUnsetBuildId(string sessionName)
         {
             // Domino provides build ID through session name for CB builds.
-            if (Logger is IOperationLogger operationLogger && ExtractBuildId(sessionName, out _))
+            if (Logger is IOperationLogger operationLogger && TryExtractBuildId(sessionName, out _))
             {
                 operationLogger.UnregisterBuildId();
             }

--- a/Public/Src/Cache/ContentStore/Library/Service/LocalContentServerBase.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/LocalContentServerBase.cs
@@ -599,6 +599,7 @@ namespace BuildXL.Cache.ContentStore.Service
                 Tracer,
                 async () =>
                 {
+                    TrySetBuildId(name);
                     if (!StoresByName.TryGetValue(cacheName, out var store))
                     {
                         return Result.FromErrorMessage<TSession>($"Cache by name=[{cacheName}] is not available");
@@ -629,6 +630,39 @@ namespace BuildXL.Cache.ContentStore.Service
                     Tracer.Debug(context, $"{nameof(CreateSessionAsync)} created session {handle.ToString(id)}.");
                     return Result.Success(session);
                 });
+        }
+
+        private void TrySetBuildId(string sessionName)
+        {
+            // Domino provides build ID through session name for CB builds.
+            if (Logger is IOperationLogger operationLogger && ExtractBuildId(sessionName, out var buildId))
+            {
+                operationLogger.RegisterBuildId(buildId);
+            }
+        }
+
+        private static bool ExtractBuildId(string sessionName, out string buildId)
+        {
+            if (sessionName?.Contains(Context.BuildIdPrefix) == true)
+            {
+                var index = sessionName.IndexOf(Context.BuildIdPrefix) + Context.BuildIdPrefix.Length;
+                buildId = sessionName.Substring(index);
+
+                // Return true only if buildId is actually a guid.
+                return Guid.TryParse(buildId, out _);
+            }
+
+            buildId = null;
+            return false;
+        }
+
+        private void TryUnsetBuildId(string sessionName)
+        {
+            // Domino provides build ID through session name for CB builds.
+            if (Logger is IOperationLogger operationLogger && ExtractBuildId(sessionName, out _))
+            {
+                operationLogger.UnregisterBuildId();
+            }
         }
 
         /// <summary>
@@ -741,6 +775,9 @@ namespace BuildXL.Cache.ContentStore.Service
             }
 
             Tracer.Debug(context, $"{method} closing session {DescribeSession(sessionId, sessionHandle)}");
+
+            TryUnsetBuildId(sessionHandle.SessionName);
+
             await sessionHandle.Session.ShutdownAsync(context).ThrowIfFailure();
             sessionHandle.Session.Dispose();
         }

--- a/Public/Src/Cache/ContentStore/Test/Sessions/ServiceClientContentSessionTestBase.cs
+++ b/Public/Src/Cache/ContentStore/Test/Sessions/ServiceClientContentSessionTestBase.cs
@@ -32,7 +32,9 @@ namespace ContentStoreTest.Sessions
         protected const uint MaxConnections = 4;
         protected const uint ConnectionsPerSession = 2;
         protected const uint GracefulShutdownSeconds = ServiceConfiguration.DefaultGracefulShutdownSeconds;
-        private const string Name = "name";
+
+        protected virtual string SessionName { get; set; } = "name";
+
         protected const int ContentByteCount = 100;
         protected const HashType ContentHashType = HashType.Vso0;
         private const long DefaultMaxSize = 1 * 1024 * 1024;
@@ -49,10 +51,10 @@ namespace ContentStoreTest.Sessions
 
         protected static long MaxSize => DefaultMaxSize;
 
-        protected static async Task RunSessionTestAsync(
+        protected async Task RunSessionTestAsync(
             Context context, IContentStore store, ImplicitPin implicitPin, Func<Context, IContentSession, Task> funcAsync)
         {
-            var createResult = store.CreateSession(context, Name, implicitPin);
+            var createResult = store.CreateSession(context, SessionName, implicitPin);
             createResult.ShouldBeSuccess();
             using (var session = createResult.Session)
             {

--- a/Public/Src/Cache/ContentStore/Test/Test/TestBase.cs
+++ b/Public/Src/Cache/ContentStore/Test/Test/TestBase.cs
@@ -30,7 +30,7 @@ namespace ContentStoreTest.Test
 
         protected virtual AbsolutePath TestRootDirectoryPath => _testRootDirectory.Value.Path;
 
-        protected readonly ILogger Logger;
+        protected ILogger Logger;
 
         protected TestBase(Func<IAbsFileSystem> createFileSystemFunc, ILogger logger, ITestOutputHelper output = null)
             : this(logger, new Lazy<IAbsFileSystem>(createFileSystemFunc), output)


### PR DESCRIPTION
The logic was lost during one of the refactorings.