### PR TITLE
Use FindFirstFile as a fallback in getting file attributes

### DIFF
--- a/Public/Src/Utilities/Native/IO/Windows/FileSystem.Win.cs
+++ b/Public/Src/Utilities/Native/IO/Windows/FileSystem.Win.cs
@@ -2920,6 +2920,10 @@ namespace BuildXL.Native.IO.Windows
                 else
                 {
                     // Fall back using more expensive FindFirstFile.
+                    // Getting file attributes for probing file existence with GetFileAttributesW sometimes results in "access denied". 
+                    // This causes problem especially during file materialization. Because such a probe is interpreted as probing non-existent path, 
+                    // the materialization target is not deleted. However, cache, using .NET File.Exist, is able to determine that the file exists. 
+                    // Thus, cache refuses to materialize the file
                     if (!TryGetFileAttributesViaFindFirstFile(path, out fileAttributes, out hr))
                     {
                         if (IsHresultNonesixtent(hr))


### PR DESCRIPTION
Getting file attributes for probing file existence with `GetFileAttributesW` sometimes results in "access denied". This causes problem especially during file materialization. Because such a probe is interpreted as probing non-existent path, the materialization target is not deleted. However, cache, using .NET `File.Exist`, is able to determine that the file exists. Thus, cache refuses to materialize the file.

```
DominoMessage
| where PreciseTimeStamp >= ago(20d)
| where message contains "but cache decided it as"
| project PreciseTimeStamp-8h, RoleInstance, RelatedActivityId, message
```

This PR tries to address `TryProbePathExistence` to do the same as .NET `File.Exist`, i.e, call `GetFileAttributesW` first, and fall back to `FindFirstFile`. 

One reason for fixing `TryProbePathExistence` is because it is used at many places in BuildXL codebase.

[AB#1410450](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1410450)