### PR TITLE
Do not declare as input files predictions under output directories

### DIFF
--- a/Public/Src/Pips/Dll/Builders/ProcessBuilder.cs
+++ b/Public/Src/Pips/Dll/Builders/ProcessBuilder.cs
@@ -258,6 +258,14 @@ namespace BuildXL.Pips.Builders
             return ReadOnlyArray<DirectoryArtifact>.From(m_inputDirectories.Instance);
         }
 
+        /// <summary>
+        /// Returns the untracked directory scopes that have been added so far.
+        /// </summary>
+        public ReadOnlyArray<DirectoryArtifact> GetUntrackedDirectoryScopesSoFar()
+        {
+            return ReadOnlyArray<DirectoryArtifact>.From(m_untrackedDirectoryScopes.Instance);
+        }
+
         /// <nodoc />
         public void AddOutputFile(AbsolutePath file, FileExistence attribute)
         {


### PR DESCRIPTION
Input predictions on intermediates are problematic since the MSBuildResolver will add those as source files, however, they will also be part of shared opaque dependencies, showing up as a source rewrite for the violation analyzer.
This PR add some basic heuristics to block adding intermediates as input files based on output directories. Even though this is not bullet proof, it catches most cases.