### PR TITLE
Stop using paths known to the graph as a safety net when deleting shared opaque outputs

### DIFF
--- a/Public/Src/Engine/Dll/EngineSchedule.cs
+++ b/Public/Src/Engine/Dll/EngineSchedule.cs
@@ -810,8 +810,6 @@ namespace BuildXL.Engine
                     loggingConfiguration: configuration.Logging,
                     // Everything that is not an output under a shared opaque is considered part of the build. 
                     isPathInBuild: path =>
-                        // Scheduler.PipGraph.IsPathInBuild is used for extra safety.
-                        scheduler.PipGraph.IsPathInBuild(AbsolutePath.Create(scheduler.Context.PathTable, path)) ||
                         !SharedOpaqueOutputHelper.IsSharedOpaqueOutput(path) ||
                         ShouldRemoveEmptyDirectories(configuration, path),
                     pathsToScrub: sharedOpaqueDirectories.Select(directory => directory.Path.ToString(scheduler.Context.PathTable)),


### PR DESCRIPTION
Whenever a directory under the set of paths to scrub is known to the build, scrubbing stops there. This was originally designed for exclusive opaque outputs. But this can be problematic for shared opaques, since some files may not be deleted. In particular, if any folder is declared as a input, that will block removing shared outputs underneath it.
This PR removes the use of paths known to the build graph as a safety net to not delete user/extraneous files, and rely solely on the shared opaque magic timestamp.