### PR TITLE
Proper handling of MSBuild projects which don't implement the target protocol

### DIFF
--- a/Public/Sdk/Public/Prelude/Prelude.Configuration.Resolvers.dsc
+++ b/Public/Sdk/Public/Prelude/Prelude.Configuration.Resolvers.dsc
@@ -218,6 +218,12 @@ interface MsBuildResolver extends ResolverBase, UntrackingSettings {
      * Policy to apply when a double write occurs. By default double writes are only allowed if the produced content is the same.
      */
     doubleWritePolicy?: DoubleWritePolicy;
+
+    /**
+     * Whether projects are allowed to not specify their target protocol.
+     * When true, default targets will be used as a heuristic. Defaults to false.
+     */
+    allowProjectsToNotSpecifyTargetProtocol?: boolean;
 }
 
 

--- a/Public/Sdk/Public/Prelude/Prelude.Configuration.Resolvers.dsc
+++ b/Public/Sdk/Public/Prelude/Prelude.Configuration.Resolvers.dsc
@@ -221,7 +221,7 @@ interface MsBuildResolver extends ResolverBase, UntrackingSettings {
 
     /**
      * Whether projects are allowed to not specify their target protocol.
-     * When true, default targets will be used as a heuristic. Defaults to false.
+     * When true, default targets will be used as heuristics. Defaults to false.
      */
     allowProjectsToNotSpecifyTargetProtocol?: boolean;
 }

--- a/Public/Src/FrontEnd/MsBuild.Serialization/MSBuildGraphBuilderArguments.cs
+++ b/Public/Src/FrontEnd/MsBuild.Serialization/MSBuildGraphBuilderArguments.cs
@@ -57,10 +57,10 @@ namespace BuildXL.FrontEnd.MsBuild.Serialization
         public IReadOnlyCollection<string> EntryPointTargets { get; }
 
         /// <summary>
-        /// Whether projects are allows to not implement the target protocol
+        /// Whether projects are allowed to not implement the target protocol
         /// </summary>
         /// <remarks>
-        /// If true, default targets are used as a heuristics
+        /// If true, default targets are used as heuristics
         /// </remarks>
         public bool AllowProjectsWithoutTargetProtocol { get; }
 

--- a/Public/Src/FrontEnd/MsBuild.Serialization/MSBuildGraphBuilderArguments.cs
+++ b/Public/Src/FrontEnd/MsBuild.Serialization/MSBuildGraphBuilderArguments.cs
@@ -56,6 +56,14 @@ namespace BuildXL.FrontEnd.MsBuild.Serialization
         /// </remarks>
         public IReadOnlyCollection<string> EntryPointTargets { get; }
 
+        /// <summary>
+        /// Whether projects are allows to not implement the target protocol
+        /// </summary>
+        /// <remarks>
+        /// If true, default targets are used as a heuristics
+        /// </remarks>
+        public bool AllowProjectsWithoutTargetProtocol { get; }
+
         /// <nodoc/>
         public MSBuildGraphBuilderArguments(
             string enlistmentRoot,
@@ -64,7 +72,8 @@ namespace BuildXL.FrontEnd.MsBuild.Serialization
             GlobalProperties globalProperties,
             IReadOnlyCollection<string> mSBuildSearchLocations, 
             IReadOnlyCollection<string> entryPointTargets,
-            IReadOnlyCollection<GlobalProperties> requestedQualifiers)
+            IReadOnlyCollection<GlobalProperties> requestedQualifiers,
+            bool allowProjectsWithoutTargetProtocol)
         {
             Contract.Requires(!string.IsNullOrEmpty(enlistmentRoot));
             Contract.Requires(projectsToParse?.Count > 0);
@@ -81,6 +90,7 @@ namespace BuildXL.FrontEnd.MsBuild.Serialization
             MSBuildSearchLocations = mSBuildSearchLocations;
             EntryPointTargets = entryPointTargets;
             RequestedQualifiers = requestedQualifiers;
+            AllowProjectsWithoutTargetProtocol = allowProjectsWithoutTargetProtocol;
         }
 
         /// <inheritdoc/>
@@ -92,7 +102,8 @@ Project entry points: [{string.Join(", ", ProjectsToParse)}]
 Serialized graph path: {OutputPath}
 Global properties: {string.Join(" ", GlobalProperties.Select(kvp => $"[{kvp.Key}]={kvp.Value}"))}
 Search locations: {string.Join(" ", MSBuildSearchLocations)}
-Requested qualifiers: {string.Join(" ", RequestedQualifiers.Select(qualifier => string.Join(";", qualifier.Select(kvp => $"[{kvp.Key}]={kvp.Value}"))))}";
+Requested qualifiers: {string.Join(" ", RequestedQualifiers.Select(qualifier => string.Join(";", qualifier.Select(kvp => $"[{kvp.Key}]={kvp.Value}"))))}
+Allow projects without target protocol: {AllowProjectsWithoutTargetProtocol}";
         }
     }
 }

--- a/Public/Src/FrontEnd/MsBuild.Serialization/PredictedTargetsToExecute.cs
+++ b/Public/Src/FrontEnd/MsBuild.Serialization/PredictedTargetsToExecute.cs
@@ -25,18 +25,27 @@ namespace BuildXL.FrontEnd.MsBuild.Serialization
         /// <nodoc/>
         public IReadOnlyCollection<string> Targets { get; }
 
+        /// <summary>
+        /// If <see cref="IsDefaultTargetsAppended"/>, the collection of default targets already appended to <see cref="Targets"/>. Null otherwise.
+        /// </summary>
+        /// <remarks>
+        /// Intended for error reporting purposes
+        /// </remarks>
+        public IReadOnlyCollection<string> AppendedDefaultTargets { get; }
+
         [JsonConstructor]
-        private PredictedTargetsToExecute(bool isDefaultTargetsAppended, IReadOnlyCollection<string> targets)
+        private PredictedTargetsToExecute(bool isDefaultTargetsAppended, IReadOnlyCollection<string> targets, IReadOnlyCollection<string> appendedDefaultTargets)
         {
             IsDefaultTargetsAppended = isDefaultTargetsAppended;
             Targets = targets;
+            AppendedDefaultTargets = appendedDefaultTargets;
         }
 
         /// <nodoc/>
         public static PredictedTargetsToExecute Create(IReadOnlyCollection<string> targets)
         {
             Contract.Requires(targets != null);
-            return new PredictedTargetsToExecute(isDefaultTargetsAppended: false, targets: targets);
+            return new PredictedTargetsToExecute(isDefaultTargetsAppended: false, targets: targets, appendedDefaultTargets: null);
         }
 
         /// <summary>
@@ -53,7 +62,7 @@ namespace BuildXL.FrontEnd.MsBuild.Serialization
                 return this;
             }
 
-            return new PredictedTargetsToExecute(isDefaultTargetsAppended: true, Targets.Union(defaultTargets).ToList());
+            return new PredictedTargetsToExecute(isDefaultTargetsAppended: true, Targets.Union(defaultTargets).ToList(), defaultTargets);
         }
     }
 }

--- a/Public/Src/FrontEnd/MsBuild/MsBuildWorkspaceResolver.cs
+++ b/Public/Src/FrontEnd/MsBuild/MsBuildWorkspaceResolver.cs
@@ -527,7 +527,8 @@ namespace BuildXL.FrontEnd.MsBuild
                 new GlobalProperties(m_resolverSettings.GlobalProperties ?? CollectionUtilities.EmptyDictionary<string, string>()),
                 searchLocations.Select(location => location.ToString(m_context.PathTable)).ToList(),
                 entryPointTargets,
-                requestedQualifiers);
+                requestedQualifiers,
+                m_resolverSettings.AllowProjectsToNotSpecifyTargetProtocol == true);
 
             var responseFilePath = responseFile.ToString(m_context.PathTable);
             SerializeResponseFile(responseFilePath, arguments);

--- a/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
+++ b/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
@@ -277,7 +277,8 @@ namespace BuildXL.FrontEnd.MsBuild
                     Tracing.Logger.Log.ProjectPredictedTargetsAlsoContainDefaultTargets(
                             m_context.LoggingContext,
                             Location.FromFile(project.FullPath.ToString(PathTable)),
-                            project.FullPath.GetName(m_context.PathTable).ToString(m_context.StringTable));
+                            project.FullPath.GetName(m_context.PathTable).ToString(m_context.StringTable),
+                            $"[{string.Join(";", project.PredictedTargetsToExecute.AppendedDefaultTargets)}]");
                 }
 
                 m_processOutputsPerProject[project] = projectOutputs;

--- a/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
+++ b/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
@@ -250,6 +250,36 @@ namespace BuildXL.FrontEnd.MsBuild
                     projectOutputs = MSBuildProjectOutputs.CreateIsolated(outputDirectories, cacheFileArtifact);
                 }
                 
+                // If the project is not implementing the target protocol, emit corresponding warn/verbose 
+                if (!project.ImplementsTargetProtocol)
+                {
+                    if (project.ProjectReferences.Count != 0)
+                    {
+                        // Let's warn about this. Targets of the referenced projects may not be accurate
+                        Tracing.Logger.Log.ProjectIsNotSpecifyingTheProjectReferenceProtocol(
+                            m_context.LoggingContext,
+                            Location.FromFile(project.FullPath.ToString(PathTable)),
+                            project.FullPath.GetName(m_context.PathTable).ToString(m_context.StringTable));
+                    }
+                    else
+                    { 
+                        // Just a verbose message in this case
+                        Tracing.Logger.Log.LeafProjectIsNotSpecifyingTheProjectReferenceProtocol(
+                            m_context.LoggingContext,
+                            Location.FromFile(project.FullPath.ToString(PathTable)),
+                            project.FullPath.GetName(m_context.PathTable).ToString(m_context.StringTable));
+                    }
+                }
+
+                // Warn if default targets were appended to the targets to execute
+                if (project.PredictedTargetsToExecute.IsDefaultTargetsAppended)
+                {
+                    Tracing.Logger.Log.ProjectPredictedTargetsAlsoContainDefaultTargets(
+                            m_context.LoggingContext,
+                            Location.FromFile(project.FullPath.ToString(PathTable)),
+                            project.FullPath.GetName(m_context.PathTable).ToString(m_context.StringTable));
+                }
+
                 m_processOutputsPerProject[project] = projectOutputs;
 
                 failureDetail = string.Empty;
@@ -311,7 +341,7 @@ namespace BuildXL.FrontEnd.MsBuild
                 // Add all known explicit inputs from project references. But rule out
                 // projects that have a known empty list of targets: those projects are not scheduled, so
                 // there is nothing to consume from them.
-                references = project.ProjectReferences.Where(projectReference => !projectReference.PredictedTargetsToExecute.TargetsAreKnownToBeEmpty);
+                references = project.ProjectReferences.Where(projectReference => projectReference.PredictedTargetsToExecute.Targets.Count != 0);
             }
 
             var argumentsBuilder = processBuilder.ArgumentsBuilder;
@@ -354,7 +384,7 @@ namespace BuildXL.FrontEnd.MsBuild
                 return;
             }
 
-            foreach (ProjectWithPredictions dependency in project.ProjectReferences.Where(projectReference => !projectReference.PredictedTargetsToExecute.TargetsAreKnownToBeEmpty))
+            foreach (ProjectWithPredictions dependency in project.ProjectReferences.Where(projectReference => projectReference.PredictedTargetsToExecute.Targets.Count != 0))
             {
                 accumulatedDependencies.Add(dependency);
                 ComputeTransitiveDependenciesFor(dependency, accumulatedDependencies);
@@ -570,39 +600,13 @@ namespace BuildXL.FrontEnd.MsBuild
             }
 
             // Targets to execute.
-            // If the prediction is available, there should be at least one target (otherwise it makes no sense to schedule the project, and we should have caught this earlier)
-            // If the prediction is not available, we fallback to call default targets (which means not passing any specific /t:). A more strict policy would be to bail out
-            // here saying that the project is not complying to the target protocol specification. We leave it relaxed for now, but we log it.
-            // https://github.com/Microsoft/msbuild/blob/master/documentation/specs/static-graph.md
-            if (project.PredictedTargetsToExecute.IsPredictionAvailable)
+            var targets = project.PredictedTargetsToExecute.Targets;
+            Contract.Assert(targets.Count > 0);
+            foreach (string target in targets)
             {
-                var targets = project.PredictedTargetsToExecute.Targets;
-                Contract.Assert(targets.Count > 0);
-                foreach (string target in targets)
-                {
-                    pipDataBuilder.Add(PipDataAtom.FromString($"/t:{target}"));
-                }
+                pipDataBuilder.Add(PipDataAtom.FromString($"/t:{target}"));
             }
-            else
-            {
-                // The prediction for the targets to execute is not available. We need to log this.
-                if (project.ProjectReferences.Count > 0)
-                {
-                    Tracing.Logger.Log.ProjectIsNotSpecifyingTheProjectReferenceProtocol(
-                        m_context.LoggingContext,
-                        Location.FromFile(project.FullPath.ToString(PathTable)),
-                        project.FullPath.GetName(m_context.PathTable).ToString(m_context.StringTable));
-                }
-                else
-                {
-                    // If the project has no references, then we log it as an informational message rather than a warning.
-                    Tracing.Logger.Log.LeafProjectIsNotSpecifyingTheProjectReferenceProtocol(
-                        m_context.LoggingContext,
-                        Location.FromFile(project.FullPath.ToString(PathTable)),
-                        project.FullPath.GetName(m_context.PathTable).ToString(m_context.StringTable));
-                }
 
-            }
 
             // Pass the output result cache file if present
             if (outputResultCacheFile != AbsolutePath.Invalid)
@@ -829,12 +833,8 @@ namespace BuildXL.FrontEnd.MsBuild
                 StringBuilder builder = builderWrapper.Instance;
                 builder.Append(projectWithPredictions.FullPath.ToString(PathTable));
                 builder.Append("|");
-                var predictionsAvailable = projectWithPredictions.PredictedTargetsToExecute.IsPredictionAvailable;
-                builder.Append(predictionsAvailable);
-                if (predictionsAvailable)
-                {
-                    builder.Append(string.Join("|", projectWithPredictions.PredictedTargetsToExecute.Targets));
-                }
+                builder.Append(projectWithPredictions.PredictedTargetsToExecute.IsDefaultTargetsAppended);
+                builder.Append(string.Join("|", projectWithPredictions.PredictedTargetsToExecute.Targets));
  
                 builder.Append("|");
                 builder.Append(string.Join("|", projectWithPredictions.GlobalProperties.Select(kvp => kvp.Key + "|" + kvp.Value)));

--- a/Public/Src/FrontEnd/MsBuild/PipGraphConstructor.cs
+++ b/Public/Src/FrontEnd/MsBuild/PipGraphConstructor.cs
@@ -70,8 +70,8 @@ namespace BuildXL.FrontEnd.MsBuild
                 return new ActionBlock<ProjectWithPredictions>(
                     project =>
                     {
-                        // We only schedule the project if targets to execute couldn't be predicted, or the predicted target collection is non-empty
-                        if (!project.PredictedTargetsToExecute.TargetsAreKnownToBeEmpty)
+                        // We only schedule the project if predicted target collection is non-empty
+                        if (project.PredictedTargetsToExecute.Targets.Count != 0)
                         {
                             if (!m_pipConstructor.TrySchedulePipForFile(project, qualifierId, out _, out _))
                             {

--- a/Public/Src/FrontEnd/MsBuild/Tracing/Log.cs
+++ b/Public/Src/FrontEnd/MsBuild/Tracing/Log.cs
@@ -226,7 +226,7 @@ namespace BuildXL.FrontEnd.MsBuild.Tracing
             (ushort)LogEventId.ProjectIsNotSpecifyingTheProjectReferenceProtocol,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Warning,
-            Message = Events.LabeledProvenancePrefix + "Project '{projectName}' is not specifying its project reference protocol, and therefore the targets to call cannot be inferred. " +
+            Message = Events.LabeledProvenancePrefix + "Project '{projectName}' is not specifying its project reference protocol, and therefore the targets to call on its dependencies cannot be inferred. " +
                       "Falling back to calling the project default targets. For more details, see https://github.com/Microsoft/msbuild/blob/master/documentation/specs/static-graph.md",
             EventTask = (ushort)Events.Tasks.Engine,
             EventOpcode = (byte)Events.Tasks.Parser,
@@ -234,12 +234,22 @@ namespace BuildXL.FrontEnd.MsBuild.Tracing
         public abstract void ProjectIsNotSpecifyingTheProjectReferenceProtocol(LoggingContext context, Location location, string projectName);
 
         [GeneratedEvent(
+            (ushort)LogEventId.ProjectPredictedTargetsAlsoContainDefaultTargets,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Warning,
+            Message = Events.LabeledProvenancePrefix + "Default targets were appended to the predicted target of project '{projectName}'. " +
+                        "This is because there is a direct dependency of this project that is not specifying the reference protocol, so default targets were added as a way to guess the right targets to call.",
+            EventTask = (ushort)Events.Tasks.Engine,
+            EventOpcode = (byte)Events.Tasks.Parser,
+            Keywords = (int)(Events.Keywords.UserMessage | Events.Keywords.Diagnostics))]
+        public abstract void ProjectPredictedTargetsAlsoContainDefaultTargets(LoggingContext context, Location location, string projectName);
+
+        [GeneratedEvent(
             (ushort)LogEventId.LeafProjectIsNotSpecifyingTheProjectReferenceProtocol,
             EventGenerators = EventGenerators.LocalOnly,
-            EventLevel = Level.Informational,
-            Message = Events.LabeledProvenancePrefix + "Project '{projectName}' is a leaf project and not specifying its project reference protocol, and therefore the targets to call cannot " +
-                      " be inferred; this will be an issue in the future if references are added. Falling back to calling the project default targets. For more details, see " + 
-                      "https://github.com/Microsoft/msbuild/blob/master/documentation/specs/static-graph.md",
+            EventLevel = Level.Verbose,
+            Message = Events.LabeledProvenancePrefix + "Project '{projectName}' is not specifying its project reference protocol. This project does not have any references, so the lack of protocol does not have any impact." +
+                      "However, this may be an issue in the future if references are added. For more details, see https://github.com/Microsoft/msbuild/blob/master/documentation/specs/static-graph.md",
             EventTask = (ushort)Events.Tasks.Engine,
             EventOpcode = (byte)Events.Tasks.Parser,
             Keywords = (int)(Events.Keywords.UserMessage | Events.Keywords.Diagnostics))]

--- a/Public/Src/FrontEnd/MsBuild/Tracing/Log.cs
+++ b/Public/Src/FrontEnd/MsBuild/Tracing/Log.cs
@@ -237,12 +237,12 @@ namespace BuildXL.FrontEnd.MsBuild.Tracing
             (ushort)LogEventId.ProjectPredictedTargetsAlsoContainDefaultTargets,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Warning,
-            Message = Events.LabeledProvenancePrefix + "Default targets were appended to the predicted target of project '{projectName}'. " +
+            Message = Events.LabeledProvenancePrefix + "Default targets '{defaultTargets}' were appended to the predicted target of project '{projectName}'. " +
                         "This is because there is a direct dependency of this project that is not specifying the reference protocol, so default targets were added as a way to guess the right targets to call.",
             EventTask = (ushort)Events.Tasks.Engine,
             EventOpcode = (byte)Events.Tasks.Parser,
             Keywords = (int)(Events.Keywords.UserMessage | Events.Keywords.Diagnostics))]
-        public abstract void ProjectPredictedTargetsAlsoContainDefaultTargets(LoggingContext context, Location location, string projectName);
+        public abstract void ProjectPredictedTargetsAlsoContainDefaultTargets(LoggingContext context, Location location, string projectName, string defaultTargets);
 
         [GeneratedEvent(
             (ushort)LogEventId.LeafProjectIsNotSpecifyingTheProjectReferenceProtocol,

--- a/Public/Src/FrontEnd/MsBuild/Tracing/LogEventId.cs
+++ b/Public/Src/FrontEnd/MsBuild/Tracing/LogEventId.cs
@@ -38,5 +38,6 @@ namespace BuildXL.FrontEnd.MsBuild.Tracing
         ProjectIsNotSpecifyingTheProjectReferenceProtocol = 11422,
         GraphBuilderFilesAreNotRemoved = 11423,
         LeafProjectIsNotSpecifyingTheProjectReferenceProtocol = 11424,
+        ProjectPredictedTargetsAlsoContainDefaultTargets = 11425,
     }
 }

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/Infrastructure/MsBuildPipExecutionTestBase.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/Infrastructure/MsBuildPipExecutionTestBase.cs
@@ -218,7 +218,8 @@ $@"<?xml version='1.0' encoding='utf-8'?>
             Dictionary<string, string> globalProperties = null,
             bool enableBinLogTracing = false,
             bool enableEngineTracing = false,
-            string logVerbosity = null) => $@"
+            string logVerbosity = null,
+            bool allowProjectsToNotSpecifyTargetProtocol = true) => $@"
 config({{
     disableDefaultSourceResolver: true,
     resolvers: [
@@ -227,6 +228,7 @@ config({{
             moduleName: 'Test',
             msBuildSearchLocations: [d`{TestDeploymentDir}`],
             root: d`.`,
+            allowProjectsToNotSpecifyTargetProtocol: {(allowProjectsToNotSpecifyTargetProtocol ? "true" : "false")},
             runInContainer: {(runInContainer ? "true" : "false")},
             {DictionaryToExpression("environment", environment)}
             {DictionaryToExpression("globalProperties", globalProperties)}
@@ -247,6 +249,7 @@ config({{
             moduleName: 'Test',
             msBuildSearchLocations: [d`{TestDeploymentDir}`],
             root: d`.`,
+            allowProjectsToNotSpecifyTargetProtocol: true,
             {DictionaryToExpression("environment", new Dictionary<string, string>())}
             {extraArguments ?? string.Empty}
         }},

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/Infrastructure/MsBuildPipSchedulingTestBase.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/Infrastructure/MsBuildPipSchedulingTestBase.cs
@@ -96,17 +96,19 @@ namespace Test.BuildXL.FrontEnd.MsBuild.Infrastructure
             IReadOnlyCollection<AbsolutePath> outputs = null, 
             IEnumerable<ProjectWithPredictions> references = null,
             GlobalProperties globalProperties = null,
-            PredictedTargetsToExecute predictedTargetsToExecute = null)
+            PredictedTargetsToExecute predictedTargetsToExecute = null,
+            bool implementsTargetProtocol = true)
         {
             var projectNameRelative = RelativePath.Create(StringTable, projectName ?? "testProj.proj");
 
             var projectWithPredictions = new ProjectWithPredictions(
                 TestPath.Combine(PathTable, projectNameRelative), 
+                implementsTargetProtocol,
                 globalProperties ?? GlobalProperties.Empty, 
                 inputs ?? CollectionUtilities.EmptyArray<AbsolutePath>(), 
                 outputs ?? CollectionUtilities.EmptyArray<AbsolutePath>(), 
                 projectReferences: references?.ToArray() ?? CollectionUtilities.EmptyArray<ProjectWithPredictions>(),
-                predictedTargetsToExecute: predictedTargetsToExecute ?? PredictedTargetsToExecute.CreatePredictedTargetsToExecute(new[] { "Build" }));
+                predictedTargetsToExecute: predictedTargetsToExecute ?? PredictedTargetsToExecute.Create(new[] { "Build" }));
 
             return projectWithPredictions;
         }

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/SchedulingTests/MsBuildTargetsTests.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/SchedulingTests/MsBuildTargetsTests.cs
@@ -3,6 +3,7 @@
 
 using BuildXL.FrontEnd.MsBuild.Serialization;
 using BuildXL.FrontEnd.MsBuild.Tracing;
+using BuildXL.Utilities.Configuration.Mutable;
 using Test.BuildXL.FrontEnd.MsBuild.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -21,52 +22,42 @@ namespace Test.BuildXL.FrontEnd.MsBuild
         }
 
         [Fact]
-        public void ProjectWithNoPredictedTargetsGetScheduledWithDefaultTargets()
+        public void LeafProjectNotImplementingTargetProtocolIsSuccesfullyScheduled()
         {
-            var noPredictionProject = CreateProjectWithPredictions(predictedTargetsToExecute: PredictedTargetsToExecute.PredictionNotAvailable);
+            var noTargetProtocolProject = CreateProjectWithPredictions(predictedTargetsToExecute: PredictedTargetsToExecute.Create(new string[] { "Build" }), implementsTargetProtocol: false);
             var process =
                 Start()
-                    .Add(noPredictionProject)
+                    .Add(noTargetProtocolProject)
                     .ScheduleAll()
-                    .AssertSuccess()
-                    .RetrieveSuccessfulProcess(noPredictionProject);
+                    .AssertSuccess();
 
-            var arguments = RetrieveProcessArguments(process);
-
-            // No targets should be explicitly passed (so MSBuild will pick defaults)
-            Assert.DoesNotContain("/t", arguments);
             // The project doesn't have any references, so there should be an informational log
-            AssertInformationalEventLogged(LogEventId.LeafProjectIsNotSpecifyingTheProjectReferenceProtocol, 1);
-            AssertWarningEventLogged(LogEventId.ProjectIsNotSpecifyingTheProjectReferenceProtocol, 0);
+            AssertVerboseEventLogged(LogEventId.LeafProjectIsNotSpecifyingTheProjectReferenceProtocol, 1);
             AssertWarningCount();
         }
 
         [Fact]
-        public void ProjectWithNoPredictedTargetsAndReferencesGetScheduledWithDefaultTargetsAndWarn()
+        public void NonLeafProjectNotImplementingTargetProtocolIsSuccesfullBasedOnConfig()
         {
-            var referencedProject = CreateProjectWithPredictions(predictedTargetsToExecute: PredictedTargetsToExecute.PredictionNotAvailable);
-            var noPredictionProject = CreateProjectWithPredictions(predictedTargetsToExecute: PredictedTargetsToExecute.PredictionNotAvailable, references: new [] { referencedProject });
-            var process =
-                Start()
-                    .Add(referencedProject)
-                    .Add(noPredictionProject)
+            var leafProject = CreateProjectWithPredictions(predictedTargetsToExecute: PredictedTargetsToExecute.Create(new[] { "Build" }));
+            var nonLeafProject = CreateProjectWithPredictions(implementsTargetProtocol: false, references: new[] { leafProject });
+
+            Start(new MsBuildResolverSettings { AllowProjectsToNotSpecifyTargetProtocol = true })
+                    .Add(leafProject)
+                    .Add(nonLeafProject)
                     .ScheduleAll()
-                    .AssertSuccess()
-                    .RetrieveSuccessfulProcess(noPredictionProject);
-
-            var arguments = RetrieveProcessArguments(process);
-
-            // No targets should be explicitly passed (so MSBuild will pick defaults)
-            Assert.DoesNotContain("/t", arguments);
-            // We should warn when this is the case
+                    .AssertSuccess();
+            
+            // if not specifying the protocol is allowed, we should succeed but log a warning
             AssertWarningEventLogged(LogEventId.ProjectIsNotSpecifyingTheProjectReferenceProtocol);
+            AssertWarningCount();
         }
 
         [Fact]
         public void ProjectWithPredictedTargetsAreHonored()
         {
             var targetPredictedProject = CreateProjectWithPredictions(
-                predictedTargetsToExecute: PredictedTargetsToExecute.CreatePredictedTargetsToExecute(new[] {"foo"}));
+                predictedTargetsToExecute: PredictedTargetsToExecute.Create(new[] {"foo"}));
             var process =
                 Start()
                     .Add(targetPredictedProject)

--- a/Public/Src/Tools/Tool.MsBuildGraphBuilder/Tool.MsBuildGraphBuilder.dsc
+++ b/Public/Src/Tools/Tool.MsBuildGraphBuilder/Tool.MsBuildGraphBuilder.dsc
@@ -20,6 +20,7 @@ namespace MsBuildGraphBuilder {
         references:[
             importFrom("Newtonsoft.Json").pkg,
             importFrom("BuildXL.FrontEnd").MsBuild.Serialization.dll,
+            importFrom("BuildXL.Utilities").Collections.dll,
             importFrom("BuildXL.Utilities.Instrumentation").Common.dll,
             importFrom("System.Collections.Immutable").pkg,
             importFrom("DataflowForMSBuildRuntime").pkg,

--- a/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphConstructionTests.cs
+++ b/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphConstructionTests.cs
@@ -159,6 +159,64 @@ namespace Test.ProjectGraphBuilder
             Assert.All(nodes, node => Assert.Equal("x86", node.GlobalProperties["platform"]));
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void NonLeafProjectNotImplementingProtocolFailsOnConstructionBasedOnConfiguration(bool allowProjectsWithoutTargetProtocol)
+        {
+            var entryPointPath = m_builder.WriteProjectsWithReferences("[A.proj] -> B.proj");
+
+            var arguments = CreateBuilderArguments(entryPointPath, allowProjectsWithoutTargetProtocol: allowProjectsWithoutTargetProtocol);
+
+            var projectGraphWithPredictionsResult = BuildGraphAndDeserialize(arguments);
+
+            if (allowProjectsWithoutTargetProtocol)
+            {
+                // If projects are allowed to not implement the protocol, then everything should succeed
+                Assert.True(projectGraphWithPredictionsResult.Succeeded);
+            }
+            else
+            {
+                // Otherwise, there should be a failure involving A.proj (the non-leaf project)
+                Assert.False(projectGraphWithPredictionsResult.Succeeded);
+                Assert.Contains("A.proj", projectGraphWithPredictionsResult.Failure.Message);
+            }
+        }
+
+        [Fact]
+        public void DefaultTargetsAreAppendedWhenDependencyDoesNotImplementProtocol()
+        {
+            // Project A does not implement the target protocol and references B
+            // Project B default targets are Build and Pack
+            var entryPointPath = m_builder.WriteProjectsWithReferences(
+                ("A.proj", @"
+<Project>
+  <ItemGroup>
+    <ProjectReference Include='B.proj'/>
+  </ItemGroup>
+  <Target Name='Build'/>
+</Project>"), 
+                ("B.proj", @"
+<Project DefaultTargets='Build;Pack'>
+  <Target Name='Build'/>
+  <Target Name='Pack'/>
+</Project>"));
+
+            // The only way in which the above situation is allowed is if we allow projects without target protocol
+            var arguments = CreateBuilderArguments(entryPointPath, allowProjectsWithoutTargetProtocol: true);
+
+            var projectGraphWithPredictionsResult = BuildGraphAndDeserialize(arguments);
+
+            Assert.True(projectGraphWithPredictionsResult.Succeeded);
+            var projectB = projectGraphWithPredictionsResult.Result.ProjectNodes.First(projectNode => projectNode.FullPath.Contains("B.proj"));
+
+            // The targets of B should be flagged so we know default targets were appended, 
+            // and B targets should contain the default targets
+            Assert.True(projectB.PredictedTargetsToExecute.IsDefaultTargetsAppended);
+            Assert.Contains("Build", projectB.PredictedTargetsToExecute.Targets);
+            Assert.Contains("Pack", projectB.PredictedTargetsToExecute.Targets);
+        }
+
         private ProjectGraphWithPredictionsResult<string> BuildGraphAndDeserialize(MSBuildGraphBuilderArguments arguments)
         {
             MsBuildGraphBuilder.BuildGraphAndSerialize(arguments);
@@ -182,23 +240,25 @@ namespace Test.ProjectGraphBuilder
                     globalProperties: GlobalProperties.Empty,
                     mSBuildSearchLocations: new[] {TestDeploymentDir},
                     entryPointTargets: new string[0],
-                    requestedQualifiers: new GlobalProperties[] { GlobalProperties.Empty });
+                    requestedQualifiers: new GlobalProperties[] { GlobalProperties.Empty },
+                    allowProjectsWithoutTargetProtocol: true);
 
             return BuildGraphAndDeserialize(arguments);
             
         }
 
-        private MSBuildGraphBuilderArguments CreateBuilderArguments(string entryPointPath, GlobalProperties[] requestedQualifiers, GlobalProperties globalProperties)
+        private MSBuildGraphBuilderArguments CreateBuilderArguments(string entryPointPath, GlobalProperties[] requestedQualifiers = null, GlobalProperties globalProperties = null, bool allowProjectsWithoutTargetProtocol = true)
         {
             string outputFile = Path.Combine(TemporaryDirectory, Guid.NewGuid().ToString());
             var arguments = new MSBuildGraphBuilderArguments(
                     TestOutputDirectory,
                     new string[] { entryPointPath },
                     outputFile,
-                    globalProperties: globalProperties,
+                    globalProperties: globalProperties ?? GlobalProperties.Empty,
                     mSBuildSearchLocations: new[] { TestDeploymentDir },
                     entryPointTargets: new string[0],
-                    requestedQualifiers: requestedQualifiers);
+                    requestedQualifiers: requestedQualifiers ?? new GlobalProperties[] { GlobalProperties.Empty },
+                    allowProjectsWithoutTargetProtocol: allowProjectsWithoutTargetProtocol);
             return arguments;
         }
     }

--- a/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphDecorationTests.cs
+++ b/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphDecorationTests.cs
@@ -84,7 +84,8 @@ namespace Test.ProjectGraphBuilder
                     globalProperties: GlobalProperties.Empty,
                     mSBuildSearchLocations: new string[] {TestDeploymentDir},
                     entryPointTargets: new string[0],
-                    requestedQualifiers: new GlobalProperties[] { GlobalProperties.Empty});
+                    requestedQualifiers: new GlobalProperties[] { GlobalProperties.Empty},
+                    allowProjectsWithoutTargetProtocol: false);
 
                 MsBuildGraphBuilder.BuildGraphAndSerializeForTesting(assemblyLoader, reporter, arguments);
             }

--- a/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphProgressTests.cs
+++ b/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphProgressTests.cs
@@ -76,7 +76,8 @@ namespace Test.ProjectGraphBuilder
                 globalProperties: GlobalProperties.Empty,
                 mSBuildSearchLocations: new[] {TestDeploymentDir},
                 entryPointTargets: new string[0],
-                requestedQualifiers: new GlobalProperties[] { GlobalProperties.Empty });
+                requestedQualifiers: new GlobalProperties[] { GlobalProperties.Empty },
+                allowProjectsWithoutTargetProtocol: false);
 
             MsBuildGraphBuilder.BuildGraphAndSerializeForTesting(MsBuildAssemblyLoader.Instance, reporter, arguments);
             var result = SimpleDeserializer.Instance.DeserializeGraph(outputFile);

--- a/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphStaticPredictionTests.cs
+++ b/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphStaticPredictionTests.cs
@@ -51,7 +51,8 @@ namespace Test.ProjectGraphBuilder
                     globalProperties: GlobalProperties.Empty,
                     mSBuildSearchLocations: new[] { TestDeploymentDir },
                     entryPointTargets: new string[0],
-                    requestedQualifiers: new GlobalProperties[] { GlobalProperties.Empty }));
+                    requestedQualifiers: new GlobalProperties[] { GlobalProperties.Empty },
+                    allowProjectsWithoutTargetProtocol: false));
 
             var result = SimpleDeserializer.Instance.DeserializeGraph(outputFile);
 
@@ -79,7 +80,8 @@ namespace Test.ProjectGraphBuilder
                     globalProperties: GlobalProperties.Empty,
                     mSBuildSearchLocations: new[] { TestDeploymentDir },
                     entryPointTargets: new string[0],
-                    requestedQualifiers: new GlobalProperties[] { GlobalProperties.Empty });
+                    requestedQualifiers: new GlobalProperties[] { GlobalProperties.Empty },
+                    allowProjectsWithoutTargetProtocol: false);
 
                 MsBuildGraphBuilder.BuildGraphAndSerializeForTesting(
                     MsBuildAssemblyLoader.Instance, 

--- a/Public/Src/Utilities/Configuration/Resolvers/IMsBuildResolverSettings.cs
+++ b/Public/Src/Utilities/Configuration/Resolvers/IMsBuildResolverSettings.cs
@@ -135,6 +135,14 @@ namespace BuildXL.Utilities.Configuration
         /// <remarks>
         /// By default double writes are only allowed if the produced content is the same.
         /// </remarks>
-        DoubleWritePolicy? DoubleWritePolicy { get; set; }
+        DoubleWritePolicy? DoubleWritePolicy { get; }
+
+        /// <summary>
+        /// Whether projects are allowed to not specify their target protocol.
+        /// </summary>
+        /// <remarks>
+        /// When true, default targets will be used as a heuristic. Defaults to false.
+        /// </remarks>
+        bool? AllowProjectsToNotSpecifyTargetProtocol { get; }
     }
 }

--- a/Public/Src/Utilities/Configuration/Resolvers/Mutable/MsBuildResolverSettings.cs
+++ b/Public/Src/Utilities/Configuration/Resolvers/Mutable/MsBuildResolverSettings.cs
@@ -44,6 +44,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             EnableTransitiveProjectReferences = resolverSettings.EnableTransitiveProjectReferences;
             UseLegacyProjectIsolation = resolverSettings.UseLegacyProjectIsolation;
             DoubleWritePolicy = resolverSettings.DoubleWritePolicy;
+            AllowProjectsToNotSpecifyTargetProtocol = resolverSettings.AllowProjectsToNotSpecifyTargetProtocol;
         }
 
         /// <inheritdoc/>
@@ -105,5 +106,8 @@ namespace BuildXL.Utilities.Configuration.Mutable
 
         /// <inheritdoc/>
         public DoubleWritePolicy? DoubleWritePolicy { get; set; }
+
+        /// <inheritdoc/>
+        public bool? AllowProjectsToNotSpecifyTargetProtocol { get; set; }
     }
 }


### PR DESCRIPTION
This PR implements the following behavior regarding projects not implementing the target protocol:
* Leaf projects are always allowed. Only a verbose message is logged. Rationale: a leaf project doesn't need a target protocol.
* Non-leaf projects are blocked by default. A configuration option is added to opt-in to allow projects to not implement the protocol.
* If the user opted in to allow projects to not implement the protocol, a warning is issued for each project found in this scenario. Default targets are appended to the statically predicted list of targets of the reference as a heuristic to guess what targets the dependency needs. A warning is also issued for each project where non-empty default targets are appended due to this.