### PR TITLE
Cleanup: Remove PipExecutionContext from InmemoryCache

### DIFF
--- a/Public/Src/Engine/Cache/Artifacts/InMemoryArtifactContentCache.cs
+++ b/Public/Src/Engine/Cache/Artifacts/InMemoryArtifactContentCache.cs
@@ -31,7 +31,6 @@ namespace BuildXL.Engine.Cache.Artifacts
     /// </remarks>
     public sealed class InMemoryArtifactContentCache : IArtifactContentCacheForTest
     {
-        private readonly PipExecutionContext m_context;
         private readonly object m_lock;
 
         private readonly Dictionary<ContentHash, CacheEntry> m_content;
@@ -55,10 +54,9 @@ namespace BuildXL.Engine.Cache.Artifacts
         }
 
         /// <nodoc />
-        public InMemoryArtifactContentCache(PipExecutionContext context)
-            : this(context, new object(), new Dictionary<ContentHash, CacheEntry>())
+        public InMemoryArtifactContentCache()
+            : this(new object(), new Dictionary<ContentHash, CacheEntry>())
         {
-            Contract.Requires(context != null);
         }
 
         /// <inheritdoc />
@@ -75,26 +73,22 @@ namespace BuildXL.Engine.Cache.Artifacts
 
         /// <nodoc />
         private InMemoryArtifactContentCache(
-            PipExecutionContext context,
             object syncLock,
             Dictionary<ContentHash, CacheEntry> content)
         {
-            Contract.Requires(context != null);
             Contract.Requires(syncLock != null);
             Contract.Requires(content != null);
 
-            m_context = context;
             m_lock = syncLock;
             m_content = content;
-            Analysis.IgnoreArgument(m_context);
         }
 
         /// <summary>
         /// Wraps the content cache's content for use with another execution context
         /// </summary>
-        public InMemoryArtifactContentCache WrapForContext(PipExecutionContext context)
+        public InMemoryArtifactContentCache Wrap()
         {
-            return new InMemoryArtifactContentCache(context, m_lock, m_content);
+            return new InMemoryArtifactContentCache(m_lock, m_content);
         }
 
         /// <inheritdoc />

--- a/Public/Src/Engine/Dll/CacheInitializer.cs
+++ b/Public/Src/Engine/Dll/CacheInitializer.cs
@@ -60,7 +60,7 @@ namespace BuildXL.Engine
         /// from the newly installed context.
         /// The returned instance is owned by this <see cref="CacheInitializer"/> wrapper and should not outlive it.
         /// </summary>
-        public abstract EngineCache CreateCacheForContext(PipExecutionContext context);
+        public abstract EngineCache CreateCacheForContext();
 
         /// <summary>
         /// Creates a task that creates a derived <see cref="CacheInitializer"/> instance that can be used to initialize a cache
@@ -76,7 +76,7 @@ namespace BuildXL.Engine
             CancellationToken cancellationToken,
 
             // Only used for testing purposes to inject cache.
-            Func<PipExecutionContext, EngineCache> testHookCacheFactory = null)
+            Func<EngineCache> testHookCacheFactory = null)
         {
             Contract.Requires(recoveryStatus.HasValue, "Recovery attempt should have been done before initializing the cache");
             DateTime startTime = DateTime.UtcNow;
@@ -162,10 +162,10 @@ namespace BuildXL.Engine
 
     internal sealed class MemoryCacheInitializer : CacheInitializer
     {
-        private readonly Func<PipExecutionContext, EngineCache> m_cacheFactory;
+        private readonly Func<EngineCache> m_cacheFactory;
 
         public MemoryCacheInitializer(
-            Func<PipExecutionContext, EngineCache> cacheFactory,
+            Func<EngineCache> cacheFactory,
             LoggingContext loggingContext,
             List<IDisposable> acquiredDisposables,
             bool enableFingerprintLookup)
@@ -179,9 +179,9 @@ namespace BuildXL.Engine
             m_cacheFactory = cacheFactory;
         }
 
-        public override EngineCache CreateCacheForContext(PipExecutionContext context)
+        public override EngineCache CreateCacheForContext()
         {
-            var cache = m_cacheFactory(context);
+            var cache = m_cacheFactory();
 
             return new EngineCache(
                 contentCache: cache.ArtifactContentCache,
@@ -228,7 +228,7 @@ namespace BuildXL.Engine
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:DisposeObjectsBeforeLosingScope")]
-        public override EngineCache CreateCacheForContext(PipExecutionContext context)
+        public override EngineCache CreateCacheForContext()
         {
             IArtifactContentCache contentCache = new CacheCoreArtifactContentCache(
                 m_session,

--- a/Public/Src/Engine/Dll/Engine.FrontEnd.cs
+++ b/Public/Src/Engine/Dll/Engine.FrontEnd.cs
@@ -72,7 +72,7 @@ namespace BuildXL.Engine
             Func<Task<Possible<EngineCache>>> getBuildCacheTask =
                 async () =>
                 {
-                    return (await engineCacheTask).Then(engineCache => engineCache.CreateCacheForContext(Context));
+                    return (await engineCacheTask).Then(engineCache => engineCache.CreateCacheForContext());
                 };
 
             if (!FrontEndController.PopulateGraph(
@@ -267,7 +267,7 @@ namespace BuildXL.Engine
                     if (possibleCacheInitializerForFallback.Succeeded)
                     {
                         CacheInitializer cacheInitializerForFallback = possibleCacheInitializerForFallback.Result;
-                        using (EngineCache cacheForFallback = cacheInitializerForFallback.CreateCacheForContext(Context))
+                        using (EngineCache cacheForFallback = cacheInitializerForFallback.CreateCacheForContext())
                         {
                             var cacheGraphProvider = new CachedGraphProvider(
                                 loggingContext,
@@ -338,7 +338,7 @@ namespace BuildXL.Engine
                     Contract.Assume(possibleCacheInitializerForWorker.Succeeded, "Workers must have a valid cache");
                     CacheInitializer cacheInitializerForWorker = possibleCacheInitializerForWorker.Result;
 
-                    using (EngineCache cacheForWorker = cacheInitializerForWorker.CreateCacheForContext(Context))
+                    using (EngineCache cacheForWorker = cacheInitializerForWorker.CreateCacheForContext())
                     {
                         PipGraphCacheDescriptor schedulerStateDescriptor;
                         if (!m_workerService.TryGetBuildScheduleDescriptor(out schedulerStateDescriptor) ||

--- a/Public/Src/Engine/Dll/EngineSchedule.cs
+++ b/Public/Src/Engine/Dll/EngineSchedule.cs
@@ -202,7 +202,7 @@ namespace BuildXL.Engine
 
             // We have a context which should be valid for the schedule. So, we can get a context-specific
             // cache for the schedule. Note that the resultant EngineSchedule will own this cache and dispose it later.
-            EngineCache scheduleCache = cacheInitializer.CreateCacheForContext(context);
+            EngineCache scheduleCache = cacheInitializer.CreateCacheForContext();
 
             var performanceDataFingerprint = PerformanceDataUtilities.ComputePerformanceDataFingerprint(
                 loggingContext,
@@ -395,12 +395,10 @@ namespace BuildXL.Engine
             }
         }
 
-        private static async Task<Possible<EngineCache>> GetCacheForContext(
-            CacheInitializationTask cacheInitializationTask,
-            EngineContext context)
+        private static async Task<Possible<EngineCache>> GetCacheForContext(CacheInitializationTask cacheInitializationTask)
         {
             var possibleCacheInitializer = await cacheInitializationTask;
-            return possibleCacheInitializer.Then(cacheInitializer => cacheInitializer.CreateCacheForContext(context));
+            return possibleCacheInitializer.Then(cacheInitializer => cacheInitializer.CreateCacheForContext());
         }
 
         /// <summary>
@@ -1583,7 +1581,7 @@ namespace BuildXL.Engine
                         loggingContext,
                         newContext,
                         newConfiguration,
-                        GetCacheForContext(engineCacheInitializationTask, newContext),
+                        GetCacheForContext(engineCacheInitializationTask),
                         performanceDataFingerprint: performanceDataFingerprint));
             // Make sure the result of the task is observed
             runningTimeTableTask.Forget();
@@ -1603,7 +1601,7 @@ namespace BuildXL.Engine
             // newContext is the finalized EngineContext. Now we can construct anything that needs a context.
             // Note that the proper EngineCache is one such thing, and so now we are responsible for disposing it later
             // (rather than EngineCache, which is initialized before we have a context ready).
-            EngineCache scheduleCache = cacheInitializer.CreateCacheForContext(newContext);
+            EngineCache scheduleCache = cacheInitializer.CreateCacheForContext();
 
             var pathExpander = await mountPathExpanderTask;
             PipTwoPhaseCache pipTwoPhaseCache = InitTwoPhaseCache(

--- a/Public/Src/Engine/Dll/EngineTestHooksData.cs
+++ b/Public/Src/Engine/Dll/EngineTestHooksData.cs
@@ -37,7 +37,7 @@ namespace BuildXL.Engine
         /// <summary>
         /// Specifies the factory for creating the cache to use.
         /// </summary>
-        public Func<PipExecutionContext, EngineCache> CacheFactory { get; set; }
+        public Func<EngineCache> CacheFactory { get; set; }
 
         /// <summary>
         /// The scheduler used by the Engine

--- a/Public/Src/Engine/Dll/SymlinkDefinitionFileProvider.cs
+++ b/Public/Src/Engine/Dll/SymlinkDefinitionFileProvider.cs
@@ -77,7 +77,7 @@ namespace BuildXL.Engine
 
                 var possibleStore = await TryStoreToCacheAsync(
                     loggingContext,
-                    cache: possibleCacheInitializer.Result.CreateCacheForContext(context).ArtifactContentCache,
+                    cache: possibleCacheInitializer.Result.CreateCacheForContext().ArtifactContentCache,
                     symlinkFile: symlinkFile);
 
                 if (!possibleStore.Succeeded)

--- a/Public/Src/Engine/UnitTests/Cache/ArtifactContentCacheSerializationExtensionTests.cs
+++ b/Public/Src/Engine/UnitTests/Cache/ArtifactContentCacheSerializationExtensionTests.cs
@@ -27,8 +27,7 @@ namespace Test.BuildXL.Engine.Cache
         [Fact]
         public async Task RoundtripSimpleStructure()
         {
-            var context = BuildXLContext.CreateInstanceForTesting();
-            var cache = new InMemoryArtifactContentCache(context);
+            var cache = new InMemoryArtifactContentCache();
 
             var originalEntry = new PipCacheDescriptorV2Metadata()
                                 {
@@ -56,8 +55,7 @@ namespace Test.BuildXL.Engine.Cache
         [Fact]
         public async Task DeserializationReturnsNullIfUnavailable()
         {
-            var context = BuildXLContext.CreateInstanceForTesting();
-            var cache = new InMemoryArtifactContentCache(context);
+            var cache = new InMemoryArtifactContentCache();
 
             ContentHash imaginaryContent = ContentHashingUtilities.HashBytes(Encoding.UTF8.GetBytes("Imagination"));
 

--- a/Public/Src/Engine/UnitTests/Cache/ElidingArtifactContentCacheWrapperTests.cs
+++ b/Public/Src/Engine/UnitTests/Cache/ElidingArtifactContentCacheWrapperTests.cs
@@ -100,8 +100,7 @@ namespace Test.BuildXL.Engine.Cache
 
             public HarnessArtifactContentCache()
             {
-                var context = BuildXLContext.CreateInstanceForTesting();
-                m_cache = new InMemoryArtifactContentCache(context);
+                m_cache = new InMemoryArtifactContentCache();
             }
 
             public int GetLoadCount(ContentHash hash)

--- a/Public/Src/Engine/UnitTests/Cache/LocalDiskContentStoreTests.cs
+++ b/Public/Src/Engine/UnitTests/Cache/LocalDiskContentStoreTests.cs
@@ -839,7 +839,7 @@ namespace Test.BuildXL.Engine.Cache
                 FileContentTable = useDummyFileContentTable ? FileContentTable.CreateStub() : FileContentTable.CreateNew();
                 Tracker = new FileChangeTrackingRecorder(verifyKnownIdentityOnTrackingFile);
                 DisabledTracker = new FileChangeTrackingRecorder(verifyKnownIdentityOnTrackingFile);
-                ContentCache = contentCacheForTest ?? new InMemoryArtifactContentCache(Context);
+                ContentCache = contentCacheForTest ?? new InMemoryArtifactContentCache();
                 m_outputRoot = AbsolutePath.Create(Context.PathTable, outputRoot);
                 LoggingContext = new LoggingContext(nameof(Harness));
             }

--- a/Public/Src/Engine/UnitTests/Engine/BaseEngineTest.cs
+++ b/Public/Src/Engine/UnitTests/Engine/BaseEngineTest.cs
@@ -213,8 +213,8 @@ function execute(args: Transformer.ExecuteArguments): Transformer.ExecuteResult 
                               {
                                   AppDeployment = appDeployment,
                                   DoWarnForVirusScan = false,
-                                  CacheFactory = (context) => new EngineCache(
-                                     new InMemoryArtifactContentCache(context),
+                                  CacheFactory = () => new EngineCache(
+                                     new InMemoryArtifactContentCache(),
                                      new InMemoryTwoPhaseFingerprintStore())
                               };
 
@@ -266,14 +266,14 @@ function execute(args: Transformer.ExecuteArguments): Transformer.ExecuteResult 
 
         protected void ConfigureInMemoryCache(TestCache testCache)
         {
-            TestHooks.CacheFactory = (context) => new EngineCache(
-                testCache.GetArtifacts(context),
+            TestHooks.CacheFactory = () => new EngineCache(
+                testCache.GetArtifacts(),
                 testCache.Fingerprints);
         }
 
         protected void ConfigureCache(CacheInitializer cacheInitializer)
         {
-            TestHooks.CacheFactory = (context) => cacheInitializer.CreateCacheForContext(context);
+            TestHooks.CacheFactory = () => cacheInitializer.CreateCacheForContext();
         }
 
         /// <summary>

--- a/Public/Src/Engine/UnitTests/EngineTestUtilities/ConfigHelpers.cs
+++ b/Public/Src/Engine/UnitTests/EngineTestUtilities/ConfigHelpers.cs
@@ -29,19 +29,19 @@ namespace Test.BuildXL.EngineTestUtilities
 
             if (testCache != null)
             {
-                engine.TestHooks.CacheFactory = (context) =>
+                engine.TestHooks.CacheFactory = () =>
                     {
                         return new EngineCache(
-                            testCache.GetArtifacts(context),
+                            testCache.GetArtifacts(),
                             testCache.Fingerprints);
                     };
             }
             else
             {
-                engine.TestHooks.CacheFactory = (context) =>
+                engine.TestHooks.CacheFactory = () =>
                     {
                         return new EngineCache(
-                            new InMemoryArtifactContentCache(context),
+                            new InMemoryArtifactContentCache(),
                             new InMemoryTwoPhaseFingerprintStore());
                     };
             }

--- a/Public/Src/Engine/UnitTests/EngineTestUtilities/TestCache.cs
+++ b/Public/Src/Engine/UnitTests/EngineTestUtilities/TestCache.cs
@@ -29,15 +29,15 @@ namespace Test.BuildXL.EngineTestUtilities
         /// <summary>
         /// Gets an artifact cache for the given context
         /// </summary>
-        public InMemoryArtifactContentCache GetArtifacts(PipExecutionContext context)
+        public InMemoryArtifactContentCache GetArtifacts()
         {
             if (m_artifacts == null)
             {
-                m_artifacts = new InMemoryArtifactContentCache(context);
+                m_artifacts = new InMemoryArtifactContentCache();
             }
             else
             {
-                m_artifacts = m_artifacts.WrapForContext(context);
+                m_artifacts = m_artifacts.Wrap();
             }
 
             return m_artifacts;

--- a/Public/Src/Engine/UnitTests/EngineTestUtilities/TestSchedulerFactory.cs
+++ b/Public/Src/Engine/UnitTests/EngineTestUtilities/TestSchedulerFactory.cs
@@ -64,7 +64,7 @@ namespace Test.BuildXL.TestUtilities
             Contract.Requires(configuration != null);
 
             var cacheLayer = new EngineCache(
-                new InMemoryArtifactContentCache(context),
+                new InMemoryArtifactContentCache(),
                 new EmptyTwoPhaseFingerprintStore());
 
             Scheduler scheduler = CreateInternal(
@@ -96,7 +96,7 @@ namespace Test.BuildXL.TestUtilities
             Contract.Requires(queue != null);
 
             var cacheLayer = new EngineCache(
-                new InMemoryArtifactContentCache(context),
+                new InMemoryArtifactContentCache(),
                 new InMemoryTwoPhaseFingerprintStore());
 
             Scheduler scheduler = CreateInternal(

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SchedulerIntegrationTestBase.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SchedulerIntegrationTestBase.cs
@@ -76,7 +76,7 @@ namespace Test.BuildXL.Scheduler
             XAssert.IsTrue(Args.TryParseArguments(new[] { "/c:" + Path.Combine(TemporaryDirectory, "config.dc") }, Context.PathTable, null, out config), "Failed to construct arguments");
             Configuration = new CommandLineConfiguration(config);
 
-            Cache = OperatingSystemHelper.IsUnixOS ? InMemoryCacheFactory.Create(Context) : MockCacheFactory.Create(CacheRoot);
+            Cache = OperatingSystemHelper.IsUnixOS ? InMemoryCacheFactory.Create() : MockCacheFactory.Create(CacheRoot);
 
             FileContentTable = FileContentTable.CreateNew();
 

--- a/Public/Src/Engine/UnitTests/Scheduler/HistoricMetadataCacheTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/HistoricMetadataCacheTests.cs
@@ -183,7 +183,7 @@ namespace Test.BuildXL.Scheduler
             Func<HistoricMetadataCache, Task> loadTask = null)
         {
             context = BuildXLContext.CreateInstanceForTesting();
-            memoryCache = new InMemoryArtifactContentCache(context);
+            memoryCache = new InMemoryArtifactContentCache();
             cache = new HistoricMetadataCache(
                 loggingContext,
                 new EngineCache(

--- a/Public/Src/Engine/UnitTests/Scheduler/InMemoryCacheFactory.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/InMemoryCacheFactory.cs
@@ -13,10 +13,10 @@ namespace Test.BuildXL.Scheduler
     /// </summary>
     public static class InMemoryCacheFactory
     {
-        public static EngineCache Create(PipExecutionContext context)
+        public static EngineCache Create()
         {
             return new EngineCache(
-                new InMemoryArtifactContentCache(context),
+                new InMemoryArtifactContentCache(),
                 new InMemoryTwoPhaseFingerprintStore());
         }
     }

--- a/Public/Src/Engine/UnitTests/Scheduler/IncrementalSchedulingTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/IncrementalSchedulingTests.cs
@@ -1582,7 +1582,7 @@ ENDLOCAL && EXIT /b 1
             Dictionary<string, Process> processes = new Dictionary<string, Process>();
 
             // Create cache for reuse.
-            EngineCache cache = InMemoryCacheFactory.Create(Context);
+            EngineCache cache = InMemoryCacheFactory.Create();
 
             CreateGraphWithSealedDirectoryWhoseMemberIsConsumedDirectly(nodes, files, directories, processes);
 
@@ -1952,7 +1952,7 @@ ENDLOCAL && EXIT /b 1
                 new[] {StringId.Create(Context.PathTable.StringTable, "P1")});
 
             // Create cache for reuse.
-            EngineCache cache = InMemoryCacheFactory.Create(Context);
+            EngineCache cache = InMemoryCacheFactory.Create();
 
             ///////////// Scenario 1: Clean build.
 
@@ -2087,7 +2087,7 @@ ENDLOCAL && EXIT /b 1
                 new StringId[0]);
 
             // Create cache for reuse.
-            EngineCache cache = InMemoryCacheFactory.Create(Context);
+            EngineCache cache = InMemoryCacheFactory.Create();
 
             SchedulerTestHooks testHooks;
 

--- a/Public/Src/Engine/UnitTests/Scheduler/PipQueueTest.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/PipQueueTest.cs
@@ -310,7 +310,7 @@ namespace Test.BuildXL.Scheduler
                 PipFragmentRenderer = this.CreatePipFragmentRenderer();
                 IpcProvider = IpcFactory.GetProvider();
                 var tracker = FileChangeTracker.CreateDisabledTracker(LoggingContext);
-                Cache = InMemoryCacheFactory.Create(context);
+                Cache = InMemoryCacheFactory.Create();
                 LocalDiskContentStore = new LocalDiskContentStore(LoggingContext, context.PathTable, FileContentTable, tracker);
 
                 m_sandboxedKextConnection = sandboxedKextConnection;

--- a/Public/Src/Engine/UnitTests/Scheduler/SchedulerTest.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/SchedulerTest.cs
@@ -1306,7 +1306,7 @@ namespace Test.BuildXL.Scheduler
                 context: Context,
                 fileContentTable: m_fileContentTable,
                 loggingContext: LoggingContext,
-                cache: cache ?? InMemoryCacheFactory.Create(Context),
+                cache: cache ?? InMemoryCacheFactory.Create(),
                 configuration: m_configuration,
                 fileAccessWhitelist: new FileAccessWhitelist(Context),
                 successfulPips: overriddenSuccessfulPips,
@@ -2524,7 +2524,7 @@ namespace Test.BuildXL.Scheduler
                 pipGraph.Serialize(writer);
 
                 // Deserialize the schedule and run all pips using a cache.
-                var cache = InMemoryCacheFactory.Create(Context);
+                var cache = InMemoryCacheFactory.Create();
                 await DeserializeScheduleAndRun(stream, cache, null, disableLazyOutputMaterialization: true);
 
                 // Deserialize a second time with the same cache. This time run pips based on a filter.

--- a/Public/Src/Engine/UnitTests/Scheduler/Utils/DummyPipExecutionEnvironment.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/Utils/DummyPipExecutionEnvironment.cs
@@ -134,7 +134,7 @@ namespace Test.BuildXL.Scheduler.Utils
 
             if (Cache == null)
             {
-                Cache = InMemoryCacheFactory.Create(context);
+                Cache = InMemoryCacheFactory.Create();
             }
 
             var tracker = FileChangeTracker.CreateDisabledTracker(LoggingContext);

--- a/Public/Src/FrontEnd/SdkTesting/Helper/TestRunner.cs
+++ b/Public/Src/FrontEnd/SdkTesting/Helper/TestRunner.cs
@@ -180,7 +180,7 @@ export function test(args: TestArguments): TestResult {{
                         mountPathExpander);
 
                     using (var cacheLayer = new EngineCache(
-                        new InMemoryArtifactContentCache(pipContext),
+                        new InMemoryArtifactContentCache(),
                         new InMemoryTwoPhaseFingerprintStore()))
                     {
                         var cache = Task.FromResult(Possible.Create(cacheLayer));

--- a/Public/Src/FrontEnd/UnitTests/Core/FrontEndHostControllerTests.cs
+++ b/Public/Src/FrontEnd/UnitTests/Core/FrontEndHostControllerTests.cs
@@ -296,7 +296,7 @@ namespace Test.BuildXL.FrontEnd.Core
                 });
 
             var inMemoryCache = new EngineCache(
-                new InMemoryArtifactContentCache(context),
+                new InMemoryArtifactContentCache(),
                 new InMemoryTwoPhaseFingerprintStore());
             controller.InitializeInternalForTesting(
                 Task.FromResult(new Possible<EngineCache>(inMemoryCache)),

--- a/Public/Src/FrontEnd/UnitTests/Script.Ast/DsTestWithCacheBase.cs
+++ b/Public/Src/FrontEnd/UnitTests/Script.Ast/DsTestWithCacheBase.cs
@@ -109,8 +109,8 @@ namespace Test.DScript.Ast
             using (EngineTestHooksData testHooks =  new EngineTestHooksData
                                                     {
                                                        AppDeployment = appDeployment,
-                                                       CacheFactory = (context) => new EngineCache(
-                                                            testCache.GetArtifacts(context),
+                                                       CacheFactory = () => new EngineCache(
+                                                            testCache.GetArtifacts(),
                                                             testCache.Fingerprints)
                                                     })
             {

--- a/Public/Src/Tools/BxlScriptAnalyzer/WorkspaceBuilder.cs
+++ b/Public/Src/Tools/BxlScriptAnalyzer/WorkspaceBuilder.cs
@@ -157,13 +157,7 @@ namespace BuildXL.FrontEnd.Script.Analyzer
 
             using (var cache = Task.FromResult<Possible<EngineCache>>(
                 new EngineCache(
-                    new InMemoryArtifactContentCache(
-                        new SchedulerContext(
-                            CancellationToken.None,
-                            frontEndContext.StringTable,
-                            frontEndContext.PathTable,
-                            frontEndContext.SymbolTable,
-                            frontEndContext.QualifierTable)),
+                    new InMemoryArtifactContentCache(),
 
                     // Note that we have an 'empty' store (no hits ever) rather than a normal in memory one.
                     new EmptyTwoPhaseFingerprintStore())))


### PR DESCRIPTION
The inmemory cache took a context object but wasn't using it.
There was a massive amount of object passing done just for this, so I removed all the dependencies...