### PR TITLE
Don't use '-parallel all' when running XUnit tests

### DIFF
--- a/Public/Sdk/Public/Managed/Testing/XUnit/xunitframework.dsc
+++ b/Public/Sdk/Public/Managed/Testing/XUnit/xunitframework.dsc
@@ -76,7 +76,7 @@ function runTest(args : TestRunArguments) : File[] {
 
         args = Object.merge<TestRunArguments>({
             xmlFile: xmlResultFile,
-            parallel: "all",
+            parallel: "none",
             noShadow: true,
             useAppDomains: false,
             traits: args.limitGroups && args.limitGroups.map(testGroup => <NameValuePair>{name: "Category", value: testGroup}),


### PR DESCRIPTION
Using `-parallel all` only causes races and flakiness in some of our tests.  Even the XUnit team seems to be discouraging people from using this.