### PR TITLE
[FlakyTestFix] Ignore scrubbing warnings in DirectorySymlinkTests

### DIFF
--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/DirectorySymlinkTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/DirectorySymlinkTests.cs
@@ -69,6 +69,12 @@ namespace IntegrationTest.BuildXL.Scheduler
         {
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            AssertWarningEventLogged(EventId.ScrubbingExternalFileOrDirectoryFailed, count: 0, allowMore: true);
+            base.Dispose(disposing);
+        }
+
         /* 
          * Operations which when executed produce the following layout
 


### PR DESCRIPTION
I've seen many failures in our pipelines because of those warnings

[AB#1532445](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1532445)