### PR TITLE
Add a way to exclude BuildXL.Explorer through env var

### DIFF
--- a/Public/Sdk/SelfHost/BuildXL/BuildXLSdk.dsc
+++ b/Public/Sdk/SelfHost/BuildXL/BuildXLSdk.dsc
@@ -143,7 +143,7 @@ namespace Flags {
 
     /**
      * Temporary flag to exclude building BuildXL.Explorer.
-     * BuildXL.Explorer is broken but building it can take 1h in CB.
+     * BuildXL.Explorer is broken but building it can take a long time in CB environment.
      */
     @@public
     export const excludeBuildXLExplorer = Environment.getFlag("[Sdk.BuildXL]ExcludeBuildXLExplorer");

--- a/Public/Sdk/SelfHost/BuildXL/BuildXLSdk.dsc
+++ b/Public/Sdk/SelfHost/BuildXL/BuildXLSdk.dsc
@@ -140,6 +140,13 @@ namespace Flags {
      */
     @@public
     export const genVSSolution = Environment.getFlag("[Sdk.BuildXL]GenerateVSSolution");
+
+    /**
+     * Temporary flag to exclude building BuildXL.Explorer.
+     * BuildXL.Explorer is broken but building it can take 1h in CB.
+     */
+    @@public
+    export const excludeBuildXLExplorer = Environment.getFlag("[Sdk.BuildXL]ExcludeBuildXLExplorer");
 }
 
 @@public

--- a/Public/Src/Deployment/buildXL.dsc
+++ b/Public/Src/Deployment/buildXL.dsc
@@ -30,17 +30,19 @@ namespace BuildXL {
             ...addIfLazy(qualifier.targetRuntime !== "osx-x64", () => [{
                 subfolder: r`tools`,
                 contents: [
-                    {
-                        subfolder: r`bxp`,
-                        contents: [
-                            importFrom("BuildXL.Explorer").App.app.appFolder
-                        ]
-                    },
-                    ...(BuildXLSdk.Flags.genVSSolution
+                    ...(BuildXLSdk.Flags.excludeBuildXLExplorer
+                        ? []
+                        : [ {
+                                subfolder: r`bxp`,
+                                contents: [
+                                    importFrom("BuildXL.Explorer").App.app.appFolder
+                                ]
+                            } ] ),
+                    ...(BuildXLSdk.Flags.genVSSolution || BuildXLSdk.Flags.excludeBuildXLExplorer
                         ? []
                         : [ {
                                 subfolder: r`bxp-server`,
-                                    contents: [
+                                contents: [
                                     importFrom("BuildXL.Explorer").Server.withQualifier(
                                         Object.merge<BuildXLSdk.NetCoreAppQualifier>(qualifier, {targetFramework: "netcoreapp3.0"})
                                     ).exe

--- a/Public/Src/Explorer/App/BuildXL.Explorer.App.dsc
+++ b/Public/Src/Explorer/App/BuildXL.Explorer.App.dsc
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+import * as BuildXLSdk from "Sdk.BuildXL";
 import * as Electron from "Sdk.NodeJs.Electron";
 import * as Branding from "BuildXL.Branding";
 
@@ -8,7 +9,7 @@ namespace App {
     export declare const qualifier: {targetRuntime: "win-x64"};
 
     @@public
-    export const app = Electron.publish({
+    export const app = BuildXLSdk.Flags.excludeBuildXLExplorer ? undefined : Electron.publish({
         name: "bxp",
         winIcon: Branding.iconFile,
         projectFolder: d`.`,

--- a/Public/Src/Explorer/Server/BuildXL.Explorer.Server.dsc
+++ b/Public/Src/Explorer/Server/BuildXL.Explorer.Server.dsc
@@ -10,7 +10,7 @@ namespace Server {
     export declare const qualifier: BuildXLSdk.NetCoreAppQualifier;
 
     @@public
-    export const exe = BuildXLSdk.executable({
+    export const exe = BuildXLSdk.Flags.excludeBuildXLExplorer ? undefined : BuildXLSdk.executable({
         assemblyName: "bxp-server",
         rootNamespace: "BuildXL.Explorer.Server",
         skipDocumentationGeneration: true,


### PR DESCRIPTION
BuildXL.Explorer takes a long time to build, and is currently in broken state.

Building it can take a long time in CB environment. This change introduces an env var that one can use to exclude building BuildXL.Explorer.

[AB#1532701](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1532701)