### PR TITLE
Use custom xUnit packages with bugfixes

### DIFF
--- a/config.dsc
+++ b/config.dsc
@@ -171,12 +171,12 @@ config({
                 // xUnit
                 { id: "xunit.abstractions", version: "2.0.3", tfm: ".NETStandard2.0" },
                 { id: "xunit.analyzers", version: "0.10.0" },
-                { id: "xunit.assert", version: "2.4.1" },
-                { id: "xunit.core", version: "2.4.1" },
-                { id: "xunit.extensibility.core", version: "2.4.1" },
-                { id: "xunit.extensibility.execution", version: "2.4.1" },
-                { id: "xunit.runner.utility", version: "2.4.1" },
-                { id: "xunit.runner.console", version: "2.4.1" },
+                { id: "xunit.assert", version: "2.4.1-ms" },
+                { id: "xunit.core", version: "2.4.1-ms" },
+                { id: "xunit.extensibility.core", version: "2.4.1-ms" },
+                { id: "xunit.extensibility.execution", version: "2.4.1-ms" },
+                { id: "xunit.runner.console", version: "2.4.1-ms" },
+                { id: "xunit.runner.utility", version: "2.4.1-ms" },
                 { id: "xunit.runner.visualstudio", version: "2.4.1" },
 
                 { id: "Microsoft.IdentityModel.Clients.ActiveDirectory", version: "3.17.2" },


### PR DESCRIPTION
Change to custom compiled xUnit packages for CI crash mitigation attempt. We'll use this for several days (or 1-2 weeks maybe) and see if our "concurrent dictionary access violation" crashes are fixed before we contribute the changes back to the official xUnit repos.