### PR TITLE
Remove Sender information from openbond and protobuf abstractions

### DIFF
--- a/Public/Src/Engine/Cache/Fingerprints/OpenBondDistribution.bond
+++ b/Public/Src/Engine/Cache/Fingerprints/OpenBondDistribution.bond
@@ -11,20 +11,8 @@ struct ServiceLocation
     2: int32 Port;
 }
 
-struct RpcMessageBase
-{
-	/// The name of the sender of the message
-    1: string SenderName;
-
-	/// The id of the sender of the message
-    2: string SenderId;
-
-	//. The id of the build
-	3: string BuildId;
-}
-
 /// Defines initialization information needed by workers to participate in a build
-struct BuildStartData : RpcMessageBase
+struct BuildStartData
 {
     /// Scheduler State and associated data structures
     1: BuildXL.Engine.Cache.Fingerprints.PipGraphCacheDescriptor CachedGraphDescriptor;
@@ -49,7 +37,7 @@ struct BuildStartData : RpcMessageBase
 }
 
 /// Defines finalization information passed to workers at the end of the build
-struct BuildEndData : RpcMessageBase
+struct BuildEndData
 {
     /// Indicates if worker should report build fail the build and that the worker due to the given failure
     1: nullable<string> Failure;
@@ -142,7 +130,7 @@ struct EventMessage
 }
 
 /// Information about completed pips and events logged on worker
-struct WorkerNotificationArgs : RpcMessageBase
+struct WorkerNotificationArgs
 {
     /// Identifies the worker which executed the pips
     1: uint32 WorkerId;
@@ -185,7 +173,7 @@ struct SinglePipBuildRequest
 }
 
 /// A request to build pips on a worker
-struct PipBuildRequest : RpcMessageBase
+struct PipBuildRequest 
 {
     /// The pips to execute
     1: vector<SinglePipBuildRequest> Pips;
@@ -195,7 +183,7 @@ struct PipBuildRequest : RpcMessageBase
 }
 
 /// The response from an Attach event
-struct AttachCompletionInfo : RpcMessageBase
+struct AttachCompletionInfo
 {
     /// Identifies the worker which makes the callback
     1: uint32 WorkerId;

--- a/Public/Src/Engine/Distribution.Grpc/Interfaces.proto
+++ b/Public/Src/Engine/Distribution.Grpc/Interfaces.proto
@@ -27,34 +27,20 @@ service Worker
 message RpcResponse {
 }
 
-message SenderInfo
-{
-    // The name of the sender of the message
-    string SenderName = 1;
-
-    // The id of the sender of the message
-    string SenderId = 2;
-
-    // The id of the build
-    string BuildId = 3;
-}
-
 // The response from an Attach event
 message AttachCompletionInfo
 {
-    SenderInfo Sender = 1;
-
     // Identifies the worker which makes the callback
-    uint32 WorkerId = 2;
+    uint32 WorkerId = 1;
 
     // The maximum number of simultaneous pip executions for the worker
-    int32 MaxConcurrency = 3;
+    int32 MaxConcurrency = 2;
 
     // The content hash of the workers unique content
-    bytes WorkerCacheValidationContentHash = 4;
+    bytes WorkerCacheValidationContentHash = 3;
 
     // The available RAM on the worker
-    int32 AvailableRamMb = 5;
+    int32 AvailableRamMb = 4;
 }
 
 // Defines information about a completed pip and its outputs
@@ -103,49 +89,45 @@ message EventMessage
 // Information about completed pips and events logged on worker
 message WorkerNotificationArgs
 {
-    SenderInfo Sender = 1;
-
     // Identifies the worker which executed the pips
-    uint32 WorkerId = 2;
+    uint32 WorkerId = 1;
 
     // The completed pips
-    repeated PipCompletionData CompletedPips = 3;
+    repeated PipCompletionData CompletedPips = 2;
 
     // The events forwarded to the master
-    repeated EventMessage ForwardedEvents = 4;
+    repeated EventMessage ForwardedEvents = 3;
 
     // Data logged to the execution log on the worker
-    bytes ExecutionLogData = 5;
+    bytes ExecutionLogData = 4;
 
     // Sequence number of the execution log blob on the worker
-    int32 ExecutionLogBlobSequenceNumber = 6;
+    int32 ExecutionLogBlobSequenceNumber = 5;
 }
 
 // Defines initialization information needed by workers to participate in a build
 message BuildStartData 
 {
-    SenderInfo Sender = 1;
-
     // Scheduler State and associated data structures
-    PipGraphCacheDescriptor CachedGraphDescriptor = 2;
+    PipGraphCacheDescriptor CachedGraphDescriptor = 1;
 
     // Identifies the worker in the build
-    uint32 WorkerId = 3;
+    uint32 WorkerId = 2;
 
     // Salt added to fingerprints to make them unique
-    string FingerprintSalt = 4;
+    string FingerprintSalt = 3;
 
     // The session identifier
-    string SessionId = 5;
+    string SessionId = 4;
 
     // Service locations of master
-    ServiceLocation MasterLocation = 6;
+    ServiceLocation MasterLocation = 5;
 
     // Environment variables
-    map<string, string> EnvironmentVariables = 7;
+    map<string, string> EnvironmentVariables = 6;
     
     // Content hash of optional symlink file.
-    bytes SymlinkFileContentHash = 8;
+    bytes SymlinkFileContentHash = 7;
 }
 
 // Defines location at which a service can be connected to.
@@ -158,13 +140,11 @@ message ServiceLocation
 // A request to build pips on a worker
 message PipBuildRequest
 {
-    SenderInfo Sender = 1;
-
     // The pips to execute
-    repeated SinglePipBuildRequest Pips = 2;
+    repeated SinglePipBuildRequest Pips = 1;
 
     // The input files and hashes for the pip
-    repeated FileArtifactKeyedHash Hashes = 3;
+    repeated FileArtifactKeyedHash Hashes = 2;
 }
 
 message SinglePipBuildRequest
@@ -243,10 +223,8 @@ message GrpcDirectoryArtifact
 // Defines finalization information passed to workers at the end of the build
 message BuildEndData
 {
-    SenderInfo Sender = 1;
-
     // Indicates if worker should report build fail the build and that the worker due to the given failure
-    string Failure = 2;
+    string Failure = 1;
 }
 
 /// <summary>

--- a/Public/Src/Engine/Dll/Distribution/Grpc/ClientConnectionManager.cs
+++ b/Public/Src/Engine/Dll/Distribution/Grpc/ClientConnectionManager.cs
@@ -82,6 +82,7 @@ namespace BuildXL.Engine.Distribution.Grpc
             var headers = new Metadata();
             headers.Add(GrpcSettings.TraceIdKey, traceId.ToByteArray());
             headers.Add(GrpcSettings.BuildIdKey, m_buildId);
+            headers.Add(GrpcSettings.SenderKey, DistributionHelpers.MachineName);
 
             RpcCallResultState state = RpcCallResultState.Succeeded;
             Failure failure = null;

--- a/Public/Src/Engine/Dll/Distribution/Grpc/GrpcMasterClient.cs
+++ b/Public/Src/Engine/Dll/Distribution/Grpc/GrpcMasterClient.cs
@@ -15,7 +15,6 @@ namespace BuildXL.Engine.Distribution.Grpc
     {
         private readonly Master.MasterClient m_client;
         private readonly ClientConnectionManager m_connectionManager;
-        private readonly SenderInfo m_senderInfo;
         private readonly LoggingContext m_loggingContext;
 
         public GrpcMasterClient(LoggingContext loggingContext, string buildId, string ipAddress, int port)
@@ -23,12 +22,6 @@ namespace BuildXL.Engine.Distribution.Grpc
             m_loggingContext = loggingContext;
             m_connectionManager = new ClientConnectionManager(m_loggingContext, ipAddress, port, buildId);
             m_client = new Master.MasterClient(m_connectionManager.Channel);
-            m_senderInfo = new SenderInfo()
-            {
-                BuildId = buildId,
-                SenderName = DistributionHelpers.MachineName,
-                SenderId = Guid.NewGuid().ToString()
-            };
         }
 
         public void Close()
@@ -38,7 +31,7 @@ namespace BuildXL.Engine.Distribution.Grpc
 
         public Task<RpcCallResult<Unit>> AttachCompletedAsync(OpenBond.AttachCompletionInfo message)
         {
-            var grpcMessage = message.ToGrpc(m_senderInfo);
+            var grpcMessage = message.ToGrpc();
             return m_connectionManager.CallAsync(
                 (callOptions) => m_client.AttachCompletedAsync(grpcMessage, options: callOptions),
                 "AttachCompleted",
@@ -47,7 +40,7 @@ namespace BuildXL.Engine.Distribution.Grpc
 
         public Task<RpcCallResult<Unit>> NotifyAsync(OpenBond.WorkerNotificationArgs message, IList<long> semiStableHashes)
         {
-            var grpcMessage = message.ToGrpc(m_senderInfo);
+            var grpcMessage = message.ToGrpc();
             return m_connectionManager.CallAsync(
                (callOptions) => m_client.NotifyAsync(grpcMessage, options: callOptions),
                DistributionHelpers.GetNotifyDescription(message, semiStableHashes));

--- a/Public/Src/Engine/Dll/Distribution/Grpc/GrpcSettings.cs
+++ b/Public/Src/Engine/Dll/Distribution/Grpc/GrpcSettings.cs
@@ -3,6 +3,7 @@
 
 using System;
 using BuildXL.Utilities.Configuration;
+using Grpc.Core;
 
 namespace BuildXL.Engine.Distribution.Grpc
 {
@@ -10,6 +11,8 @@ namespace BuildXL.Engine.Distribution.Grpc
     {
         public const string TraceIdKey = "traceid-bin";
         public const string BuildIdKey = "buildid";
+        public const string SenderKey = "sender";
+
         public const int MaxRetry = 4;
 
         /// <summary>
@@ -43,5 +46,28 @@ namespace BuildXL.Engine.Distribution.Grpc
         /// Default: true
         /// </remarks>
         public static bool HandlerInliningEnabled => EngineEnvironmentSettings.GrpcHandlerInliningEnabled;
+
+        public static void ParseHeader(Metadata header, out string sender, out string senderBuildId, out string traceId)
+        {
+            sender = string.Empty;
+            senderBuildId = string.Empty;
+            traceId = string.Empty;
+
+            foreach (var kvp in header)
+            {
+                if (kvp.Key == GrpcSettings.TraceIdKey)
+                {
+                    traceId = new Guid(kvp.ValueBytes).ToString();
+                }
+                else if (kvp.Key == GrpcSettings.BuildIdKey)
+                {
+                    senderBuildId = kvp.Value;
+                }
+                else if (kvp.Key == GrpcSettings.SenderKey)
+                {
+                    sender = kvp.Value;
+                }
+            }
+        }
     }
 }

--- a/Public/Src/Engine/Dll/Distribution/Grpc/GrpcWorkerServer.cs
+++ b/Public/Src/Engine/Dll/Distribution/Grpc/GrpcWorkerServer.cs
@@ -56,7 +56,9 @@ namespace BuildXL.Engine.Distribution.Grpc
         {
             var bondMessage = message.ToOpenBond();
 
-            m_workerService.AttachCore(bondMessage);
+            GrpcSettings.ParseHeader(context.RequestHeaders, out string sender, out string senderBuildId, out string traceId);
+
+            m_workerService.AttachCore(bondMessage, sender);
 
             return Task.FromResult(new RpcResponse());
         }

--- a/Public/Src/Engine/Dll/Distribution/Grpc/GrpcWorkerServer.cs
+++ b/Public/Src/Engine/Dll/Distribution/Grpc/GrpcWorkerServer.cs
@@ -56,8 +56,8 @@ namespace BuildXL.Engine.Distribution.Grpc
         {
             var bondMessage = message.ToOpenBond();
 
-            GrpcSettings.ParseHeader(context.RequestHeaders, out string sender, out string senderBuildId, out string traceId);
-
+            GrpcSettings.ParseHeader(context.RequestHeaders, out string sender, out string _, out string _);
+            
             m_workerService.AttachCore(bondMessage, sender);
 
             return Task.FromResult(new RpcResponse());

--- a/Public/Src/Engine/Dll/Distribution/Grpc/OpenBondConversionUtils.cs
+++ b/Public/Src/Engine/Dll/Distribution/Grpc/OpenBondConversionUtils.cs
@@ -13,11 +13,10 @@ namespace BuildXL.Engine.Distribution.Grpc
     {
         #region AttachCompletionInfo
 
-        public static AttachCompletionInfo ToGrpc(this OpenBond.AttachCompletionInfo message, SenderInfo senderInfo)
+        public static AttachCompletionInfo ToGrpc(this OpenBond.AttachCompletionInfo message)
         {
             return new AttachCompletionInfo()
             {
-                Sender = senderInfo,
                 WorkerId = message.WorkerId,
 
                 AvailableRamMb = message.AvailableRamMb ?? 100000,
@@ -30,11 +29,8 @@ namespace BuildXL.Engine.Distribution.Grpc
         {
             return new OpenBond.AttachCompletionInfo()
             {
-                BuildId = message.Sender.BuildId,
-                SenderId = message.Sender.SenderId,
-                SenderName = message.Sender.SenderName,
                 WorkerId = message.WorkerId,
-
+                
                 AvailableRamMb = message.AvailableRamMb,
                 MaxConcurrency = message.MaxConcurrency,
                 WorkerCacheValidationContentHash = message.WorkerCacheValidationContentHash.ToBondContentHash(),
@@ -44,11 +40,10 @@ namespace BuildXL.Engine.Distribution.Grpc
 
         #region WorkerNotificationArgs
 
-        public static WorkerNotificationArgs ToGrpc(this OpenBond.WorkerNotificationArgs message, SenderInfo senderInfo)
+        public static WorkerNotificationArgs ToGrpc(this OpenBond.WorkerNotificationArgs message)
         {
             var workerNotificationArgs = new WorkerNotificationArgs()
             {
-                Sender = senderInfo,
                 WorkerId = message.WorkerId,
                 ExecutionLogBlobSequenceNumber = message.ExecutionLogBlobSequenceNumber,
                 ExecutionLogData = message.ExecutionLogData.ToByteString(),
@@ -113,9 +108,6 @@ namespace BuildXL.Engine.Distribution.Grpc
 
             return new OpenBond.WorkerNotificationArgs()
             {
-                BuildId = message.Sender.BuildId,
-                SenderId = message.Sender.SenderId,
-                SenderName = message.Sender.SenderName,
                 WorkerId = message.WorkerId,
 
                 CompletedPips = completedPips,
@@ -127,11 +119,10 @@ namespace BuildXL.Engine.Distribution.Grpc
         #endregion
 
         #region BuildStartData
-        public static BuildStartData ToGrpc(this OpenBond.BuildStartData message, SenderInfo senderInfo)
+        public static BuildStartData ToGrpc(this OpenBond.BuildStartData message)
         {
             var buildStartData = new BuildStartData()
             {
-                Sender = senderInfo,
                 WorkerId = message.WorkerId,
                 CachedGraphDescriptor = new BuildXL.Distribution.Grpc.PipGraphCacheDescriptor()
                 {
@@ -173,9 +164,6 @@ namespace BuildXL.Engine.Distribution.Grpc
         {
             return new OpenBond.BuildStartData()
             {
-                BuildId = message.Sender.BuildId,
-                SenderId = message.Sender.SenderId,
-                SenderName = message.Sender.SenderName,
                 WorkerId = message.WorkerId,
                 CachedGraphDescriptor = new Cache.Fingerprints.PipGraphCacheDescriptor()
                 {
@@ -209,12 +197,9 @@ namespace BuildXL.Engine.Distribution.Grpc
         #endregion
 
         #region PipBuildRequest
-        public static PipBuildRequest ToGrpc(this OpenBond.PipBuildRequest message, SenderInfo senderInfo)
+        public static PipBuildRequest ToGrpc(this OpenBond.PipBuildRequest message)
         {
-            var pipBuildRequest = new PipBuildRequest()
-            {
-                Sender = senderInfo,
-            };
+            var pipBuildRequest = new PipBuildRequest();
 
             foreach (var i in message.Hashes)
             {
@@ -316,10 +301,6 @@ namespace BuildXL.Engine.Distribution.Grpc
 
             return new OpenBond.PipBuildRequest()
             {
-                BuildId = message.Sender.BuildId,
-                SenderId = message.Sender.SenderId,
-                SenderName = message.Sender.SenderName,
-
                 Hashes = hashes,
                 Pips = pips
             };

--- a/Public/Src/Engine/Dll/Distribution/Grpc/ServerInterceptor.cs
+++ b/Public/Src/Engine/Dll/Distribution/Grpc/ServerInterceptor.cs
@@ -27,22 +27,9 @@ namespace BuildXL.Engine.Distribution
 
         private (string, string) InterceptCallContext(ServerCallContext context)
         {
-            string sender = context.Host;
-            string traceId = string.Empty;
             string method = context.Method;
-            string senderBuildId = string.Empty;
 
-            foreach (var kvp in context.RequestHeaders)
-            {
-                if (kvp.Key == GrpcSettings.TraceIdKey)
-                {
-                    traceId = new Guid(kvp.ValueBytes).ToString();
-                }
-                else if (kvp.Key == GrpcSettings.BuildIdKey)
-                {
-                    senderBuildId = kvp.Value;
-                }
-            }
+            GrpcSettings.ParseHeader(context.RequestHeaders, out string sender, out string senderBuildId, out string traceId);
 
             if (!string.IsNullOrEmpty(senderBuildId) && senderBuildId != m_buildId)
             {

--- a/Public/Src/Engine/Dll/Distribution/InternalBond/BondWorkerServer.cs
+++ b/Public/Src/Engine/Dll/Distribution/InternalBond/BondWorkerServer.cs
@@ -59,7 +59,7 @@ namespace BuildXL.Engine.Distribution.InternalBond
             {
                 var openBondMessage = message.ToOpenBond();
 
-                m_workerService.AttachCore(openBondMessage);
+                m_workerService.AttachCore(openBondMessage, message.SenderName);
             });
         }
 

--- a/Public/Src/Engine/Dll/Distribution/InternalBond/OpenBondConversionUtils.cs
+++ b/Public/Src/Engine/Dll/Distribution/InternalBond/OpenBondConversionUtils.cs
@@ -16,10 +16,7 @@ namespace BuildXL.Engine.Distribution.InternalBond
             return new AttachCompletionInfo()
             {
                 AvailableRamMb = message.AvailableRamMb,
-                BuildId = message.BuildId,
                 MaxConcurrency = message.MaxConcurrency,
-                SenderId = message.SenderId,
-                SenderName = message.SenderName,
                 WorkerCacheValidationContentHash = message.WorkerCacheValidationContentHash.ToDistributedContentHash(),
                 WorkerId = message.WorkerId
             };
@@ -29,11 +26,7 @@ namespace BuildXL.Engine.Distribution.InternalBond
         {
             return new OpenBond.AttachCompletionInfo()
             {
-                BuildId = message.BuildId,
-                SenderId = message.SenderId,
-                SenderName = message.SenderName,
                 WorkerId = message.WorkerId,
-
                 AvailableRamMb = message.AvailableRamMb,
                 MaxConcurrency = message.MaxConcurrency,
                 WorkerCacheValidationContentHash = message.WorkerCacheValidationContentHash.ToBondContentHash(),
@@ -47,9 +40,6 @@ namespace BuildXL.Engine.Distribution.InternalBond
         {
             var workerNotificationArgs = new WorkerNotificationArgs()
             {
-                BuildId = message.BuildId,
-                SenderId = message.SenderId,
-                SenderName = message.SenderName,
                 WorkerId = message.WorkerId,
                 ExecutionLogBlobSequenceNumber = message.ExecutionLogBlobSequenceNumber,
                 ExecutionLogData = new BondBlob(message.ExecutionLogData),
@@ -120,11 +110,7 @@ namespace BuildXL.Engine.Distribution.InternalBond
 
             return new OpenBond.WorkerNotificationArgs()
             {
-                BuildId = message.BuildId,
-                SenderId = message.SenderId,
-                SenderName = message.SenderName,
                 WorkerId = message.WorkerId,
-
                 CompletedPips = completedPips,
                 ExecutionLogBlobSequenceNumber = message.ExecutionLogBlobSequenceNumber,
                 ExecutionLogData = message.ExecutionLogData.Data,
@@ -157,9 +143,6 @@ namespace BuildXL.Engine.Distribution.InternalBond
         {
             return new OpenBond.BuildStartData()
             {
-                BuildId = message.BuildId,
-                SenderId = message.SenderId,
-                SenderName = message.SenderName,
                 WorkerId = message.WorkerId,
                 CachedGraphDescriptor = message.CachedGraphDescriptor.ToPipGraphCacheDescriptor(),
                 EnvironmentVariables = message.EnvironmentVariables,
@@ -285,9 +268,6 @@ namespace BuildXL.Engine.Distribution.InternalBond
 
             return new OpenBond.PipBuildRequest()
             {
-                BuildId = message.BuildId,
-                SenderId = message.SenderId,
-                SenderName = message.SenderName,
                 Hashes = hashes,
                 Pips = pips
             };

--- a/Public/Src/Engine/Dll/Distribution/WorkerService.cs
+++ b/Public/Src/Engine/Dll/Distribution/WorkerService.cs
@@ -202,22 +202,31 @@ namespace BuildXL.Engine.Distribution
 
                 using (m_services.Counters.StartStopwatch(DistributionCounter.ReportPipsCompletedDuration))
                 {
-                    m_masterClient.NotifyAsync(new WorkerNotificationArgs
+                    var callResult = m_masterClient.NotifyAsync(new WorkerNotificationArgs
                     {
                         WorkerId = WorkerId,
                         CompletedPips = m_executionResultList.Select(a => a.SerializedData).ToList()
                     },
                     m_executionResultList.Select(a => a.SemiStableHash).ToList()).GetAwaiter().GetResult();
 
-                    foreach (var result in m_executionResultList)
+                    if (callResult.Succeeded)
                     {
-                        m_workerPipStateManager.Transition(result.PipId, WorkerPipState.Reported);
-                        Tracing.Logger.Log.DistributionWorkerFinishedPipRequest(m_appLoggingContext, result.SemiStableHash, ((PipExecutionStep)result.SerializedData.Step).ToString());
-                    }
+                        foreach (var result in m_executionResultList)
+                        {
+                            m_workerPipStateManager.Transition(result.PipId, WorkerPipState.Reported);
+                            Tracing.Logger.Log.DistributionWorkerFinishedPipRequest(m_appLoggingContext, result.SemiStableHash, ((PipExecutionStep)result.SerializedData.Step).ToString());
+                        }
 
-                    numBatchesSent++;
+                        numBatchesSent++;
+                    }
+                    else
+                    {
+                        // Fire-forget exit call with failure.
+                        // If we fail to send notification to master, the worker should fail.
+                        ExitAsync(timedOut: false, failure: "Notify event failed to send to master");
+                        break;
+                    }
                 }
-                
             }
 
             m_services.Counters.AddToCounter(DistributionCounter.BuildResultBatchesSentToMaster, numBatchesSent);
@@ -309,6 +318,16 @@ namespace BuildXL.Engine.Distribution
             m_notifyMasterExecutionLogTarget?.Dispose();
         }
 
+
+        /// <nodoc/>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("AsyncUsage", "AsyncFixer03:FireForgetAsyncVoid")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("AsyncUsage", "AsyncFixer02:MissingAsyncOpportunity")]
+        public async void ExitAsync(bool timedOut, string failure)
+        {
+            await Task.Yield();
+            Exit(timedOut, failure);
+        }
+
         /// <nodoc/>
         public void Exit(bool timedOut, string failure)
         {
@@ -391,6 +410,7 @@ namespace BuildXL.Engine.Distribution
             m_attachCompletionSource.TrySetResult(true);
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("AsyncUsage", "AsyncFixer02:MissingAsyncOpportunity")]
         private async Task<bool> SendAttachCompletedAfterProcessBuildRequestStartedAsync()
         {
             if (!m_isGrpcEnabled)

--- a/Public/Src/Engine/Dll/Distribution/WorkerService.cs
+++ b/Public/Src/Engine/Dll/Distribution/WorkerService.cs
@@ -360,9 +360,9 @@ namespace BuildXL.Engine.Distribution
             return true;
         }
 
-        internal void AttachCore(BuildStartData buildStartData)
+        internal void AttachCore(BuildStartData buildStartData, string masterName)
         {
-            Logger.Log.DistributionAttachReceived(m_appLoggingContext, buildStartData.SessionId, buildStartData.SenderName, buildStartData.SenderId);
+            Logger.Log.DistributionAttachReceived(m_appLoggingContext, buildStartData.SessionId, masterName);
             BuildStartData = buildStartData;
 
             // The app-level logging context has a wrong session id. Fix it now that we know the right one.

--- a/Public/Src/Engine/Dll/Tracing/Log.cs
+++ b/Public/Src/Engine/Dll/Tracing/Log.cs
@@ -691,8 +691,8 @@ namespace BuildXL.Engine.Tracing
             EventLevel = Level.Informational,
             Keywords = (int)(Events.Keywords.UserMessage | Events.Keywords.Progress),
             EventTask = (ushort)Events.Tasks.Distribution,
-            Message = "Received attach request from the master. New session identifier: {sessionId}. Master Name: {masterName}. Master id: {masterId}")]
-        public abstract void DistributionAttachReceived(LoggingContext context, string sessionId, string masterName, string masterId);
+            Message = "Received attach request from the master. New session identifier: {sessionId}. Master Name: {masterName}.")]
+        public abstract void DistributionAttachReceived(LoggingContext context, string sessionId, string masterName);
 
         [GeneratedEvent(
             (ushort)LogEventId.DistributionExitReceived,


### PR DESCRIPTION
We pass sender information via grpc headers, so I do remove the explicit sender data from both openbond and protobuf abstractions. 