### PR TITLE
Use regular locking in ConcurrentBoundedSortedCollection

### DIFF
--- a/RunCheckInTests.cmd
+++ b/RunCheckInTests.cmd
@@ -72,7 +72,7 @@ if EXIST %ENLISTMENTROOT%\Out\frontend\Nuget\specs (
 set start=%time%
 set stepName=Building 'debug\net472' and 'debug\win-x64' using Lkg and deploying to RunCheckinTests
 call :StatusMessage %stepName%
-    call :RunBxl -Use LKG -Deploy RunCheckinTests -DeployRuntime net472 /q:DebugNet472 /q:DebugDotNetCore /f:output='%ENLISTMENTROOT%\Out\Bin\debug\net472\*'oroutput='%ENLISTMENTROOT%\Out\Bin\debug\win-x64\*'oroutput='%ENLISTMENTROOT%\Out\Bin\tests\debug\*' %BUILDXL_ARGS% /enableLazyOutputs- /TraceInfo:RunCheckinTests=LKG /useCustomPipDescriptionOnConsole-
+    call :RunBxl -Use LKG -Deploy RunCheckinTests /q:DebugNet472 /q:DebugDotNetCore /f:output='%ENLISTMENTROOT%\Out\Bin\debug\net472\*'oroutput='%ENLISTMENTROOT%\Out\Bin\debug\win-x64\*'oroutput='%ENLISTMENTROOT%\Out\Bin\tests\debug\*' %BUILDXL_ARGS% /enableLazyOutputs- /TraceInfo:RunCheckinTests=LKG /useCustomPipDescriptionOnConsole-
     if %ERRORLEVEL% NEQ 0 goto BadLKGMessage
 call :RecordStep "%stepName%" %start%
 
@@ -170,7 +170,9 @@ endlocal && exit /b 0
         REM Incremental scheduling is disabled so we can deterministically get all pip fingerprints exported.
         REM This build and the next are disconnected from the shared cache to ensure that they don't converge with a remote build happening at the same time.
         set COMPARE_FINGERPRINTS_LOGS_DIR=%ENLISTMENTROOT%\Out\Logs\CompareFingerprints\
-        call :RunBxl -Use RunCheckinTests -minimal %BUILDXL_ARGS% /incrementalScheduling- /TraceInfo:RunCheckinTests=CompareFingerprints1 /logsDirectory:!COMPARE_FINGERPRINTS_LOGS_DIR! -SharedCacheMode disable
+        REM Neither /cacheGraph- nor /scriptShowSlowest need be used here (and in the next step).
+        REM The reason why they are used here is to exercise DScript front end on .NET Core
+        call :RunBxl /cacheGraph- /scriptShowSlowest -Use RunCheckinTests -minimal %BUILDXL_ARGS% /incrementalScheduling- /TraceInfo:RunCheckinTests=CompareFingerprints1 /logsDirectory:!COMPARE_FINGERPRINTS_LOGS_DIR! -SharedCacheMode disable
         if !ERRORLEVEL! NEQ 0 (exit /b 1)
 
         REM Produce a fingerprint file of the first run.
@@ -187,7 +189,7 @@ endlocal && exit /b 0
         REM Graph caching is disabled in case there is nondeterminism during graph construction.
         REM We use the same logs directory but with different prefix.
         set SECOND_PREFIX=BuildXL.2
-        call :RunBxl -Use RunCheckinTests -minimal %BUILDXL_ARGS% /incrementalScheduling- /TraceInfo:RunCheckinTests=CompareFingerprints2 /logsDirectory:!COMPARE_FINGERPRINTS_LOGS_DIR! -SharedCacheMode disable /logPrefix:!SECOND_PREFIX!
+        call :RunBxl /cacheGraph- /scriptShowSlowest -Use RunCheckinTests -minimal %BUILDXL_ARGS% /incrementalScheduling- /TraceInfo:RunCheckinTests=CompareFingerprints2 /logsDirectory:!COMPARE_FINGERPRINTS_LOGS_DIR! -SharedCacheMode disable /logPrefix:!SECOND_PREFIX!
         if !ERRORLEVEL! NEQ 0 (exit /b 1)
 
         REM Produce a fingerprint file of the second run.


### PR DESCRIPTION
Previously, a `ReaderWriterLock` was used.  

On .NET Core, errors like "Attempt to release a lock that is not owned by the calling thread" were happening regularly in our CI validations.

This PR replaces this lock with a regular exclusive lock, since in our particular uses of `ConcurrentBoundedSortedCollection` we never have only concurrent reads, so it's questionable if we were getting any benefits from use a read-write lock.

[AB#1533036](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1533036)