### PR TITLE
Win Helium sandboxing: WCI disable and BindFlt exclusions

### DIFF
--- a/Public/Src/Engine/Processes/Containers/Container.cs
+++ b/Public/Src/Engine/Processes/Containers/Container.cs
@@ -40,6 +40,8 @@ namespace BuildXL.Processes.Containers
             Native.Processes.ProcessUtilities.AttachContainerToJobObject(
                             handle,
                             m_containerConfiguration.RedirectedDirectories,
+                            m_containerConfiguration.IsWciFilterEnabled,
+                            m_containerConfiguration.BindFltExcludedPaths,
                             out var warnings);
 
             // Log any warnings when setting up the container (at this point this is just WCI retries)

--- a/Public/Src/Utilities/Native/Processes/IProcessUtilities.cs
+++ b/Public/Src/Utilities/Native/Processes/IProcessUtilities.cs
@@ -103,7 +103,12 @@ namespace BuildXL.Native.Processes
         bool OSSupportsNestedJobs();
 
         /// <summary><see cref="ProcessUtilities.AttachContainerToJobObject"/></summary>
-        void AttachContainerToJobObject(IntPtr hJob, IReadOnlyDictionary<ExpandedAbsolutePath, IReadOnlyList<ExpandedAbsolutePath>> redirectedDirectories, out IEnumerable<string> warnings);
+        void AttachContainerToJobObject(
+            IntPtr hJob,
+            IReadOnlyDictionary<ExpandedAbsolutePath, IReadOnlyList<ExpandedAbsolutePath>> redirectedDirectories,
+            bool isWciFilterEnabled,
+            IEnumerable<string> bindFltExclusions,
+            out IEnumerable<string> warnings);
 
         /// <summary><see cref="ProcessUtilities.TryCleanUpContainer"/></summary>
         bool TryCleanUpContainer(IntPtr hJob, out IEnumerable<string> errors);

--- a/Public/Src/Utilities/Native/Processes/ProcessUtilities.cs
+++ b/Public/Src/Utilities/Native/Processes/ProcessUtilities.cs
@@ -287,21 +287,30 @@ namespace BuildXL.Native.Processes
         /// The Helium container is configured using the provided path mapping. The mapping is expected to 
         /// contain destination -> [source]. For each entry in the dictionary, two file 
         /// drivers are setup, Wci and Bind:
+        ///
         /// - WCI filter is able to virtualize source folders into destination folders via reparse points: processes
         /// running in a container will see the content of the destination folder as containing the files of the source
         /// folder. Plus, it provides full isolation from the source folder (copy-on-write semantics, tombstone files for deletion)
         /// - Bind filter is able to map a source folder into a target folder, so any process running in a container will get every access
         /// to the source path translated into an access to the target path
+        ///
         /// Working together, these filters can provide full virtualization: a process accessing a source path will be redirected under the hood
         /// to the target path, and the content that it will see there is fully controlled.
         /// </remarks>
         /// <param name="hJob">A pointer to a job object where a specific filter configuration will be associated with. 
         /// This is the result of calling CreateJobObject <see href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms682409(v=vs.85).aspx"/></param>
         /// <param name="redirectedDirectories">The collection of source paths to be virtualize to destination paths</param>
+        /// <param name="isWciFilterEnabled">Enables WCI filter for inpuit virtualization</param>
+        /// <param name="bindFltExclusions">Paths to not apply the bindflt path transformation to.</param>
         /// <param name="warnings">Any warnings that happened during the creation of the container. The container was created successfully regardless of these.</param>
         /// <exception cref="BuildXLException">If any unrecoverable error occurs when setting up the container</exception>
-        public static void AttachContainerToJobObject(IntPtr hJob, IReadOnlyDictionary<ExpandedAbsolutePath, IReadOnlyList<ExpandedAbsolutePath>> redirectedDirectories, out IEnumerable<string> warnings) 
-            => s_nativeMethods.AttachContainerToJobObject(hJob, redirectedDirectories, out warnings);
+        public static void AttachContainerToJobObject(
+            IntPtr hJob,
+            IReadOnlyDictionary<ExpandedAbsolutePath, IReadOnlyList<ExpandedAbsolutePath>> redirectedDirectories,
+            bool isWciFilterEnabled,
+            IEnumerable<string> bindFltExclusions,
+            out IEnumerable<string> warnings)
+            => s_nativeMethods.AttachContainerToJobObject(hJob, redirectedDirectories, isWciFilterEnabled, bindFltExclusions, out warnings);
 
         /// <summary>
         /// Tries to cleans up the already attached Helium container to the given job object for all the volumes

--- a/Public/Src/Utilities/Native/Processes/Unix/ProcessUtilities.Unix.cs
+++ b/Public/Src/Utilities/Native/Processes/Unix/ProcessUtilities.Unix.cs
@@ -162,7 +162,13 @@ namespace BuildXL.Native.Processes.Unix
         public bool OSSupportsNestedJobs() => true;
 
         /// <inheritdoc />
-        public void AttachContainerToJobObject(IntPtr hJob, IReadOnlyDictionary<ExpandedAbsolutePath, IReadOnlyList<ExpandedAbsolutePath>> redirectedDirectories, out IEnumerable<string> warnings) => throw new NotImplementedException();
+        public void AttachContainerToJobObject(
+            IntPtr hJob,
+            IReadOnlyDictionary<ExpandedAbsolutePath, IReadOnlyList<ExpandedAbsolutePath>> redirectedDirectories,
+            bool isWciFilterEnabled,
+            IEnumerable<string> bindFltExclusions,
+            out IEnumerable<string> warnings)
+            => throw new NotImplementedException();
 
         /// <inheritdoc />
         public bool TryCleanUpContainer(IntPtr hJob, out IEnumerable<string> errors) => throw new NotImplementedException();

--- a/Public/Src/Utilities/Native/Processes/Windows/ProcessUtilities.Win.Container.cs
+++ b/Public/Src/Utilities/Native/Processes/Windows/ProcessUtilities.Win.Container.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using BuildXL.Native.IO;
 using BuildXL.Utilities;
@@ -82,8 +83,13 @@ namespace BuildXL.Native.Processes.Windows
             }
         }
 
-        /// <summary><see cref="ProcessUtilities.AttachContainerToJobObject(IntPtr, IReadOnlyDictionary{ExpandedAbsolutePath, IReadOnlyList{ExpandedAbsolutePath}}, out IEnumerable{string})"/></summary>   
-        public void AttachContainerToJobObject(IntPtr hJob, IReadOnlyDictionary<ExpandedAbsolutePath, IReadOnlyList<ExpandedAbsolutePath>> redirectedDirectories, out IEnumerable<string> warnings)
+        /// <summary><see cref="ProcessUtilities.AttachContainerToJobObject(IntPtr, IReadOnlyDictionary{ExpandedAbsolutePath, IReadOnlyList{ExpandedAbsolutePath}}, bool, IEnumerable{string}, out IEnumerable{string})"/></summary>   
+        public void AttachContainerToJobObject(
+            IntPtr hJob,
+            IReadOnlyDictionary<ExpandedAbsolutePath, IReadOnlyList<ExpandedAbsolutePath>> redirectedDirectories,
+            bool isWciFilterEnabled,
+            IEnumerable<string> bindFltExclusions,
+            out IEnumerable<string> warnings)
         {
             try
             {
@@ -100,7 +106,7 @@ namespace BuildXL.Native.Processes.Windows
                 NativeContainerUtilities.WcDestroyDescription(description);
 
                 var wciRetries = new List<string>();
-                ConfigureContainer(hJob, redirectedDirectories, wciRetries);
+                ConfigureContainer(hJob, redirectedDirectories, isWciFilterEnabled, wciRetries, bindFltExclusions);
 
                 warnings = wciRetries;
             }
@@ -131,15 +137,24 @@ namespace BuildXL.Native.Processes.Windows
             return win32Error == 0 || win32Error == ExceptionUtilities.HResultFromWin32(ERROR_ALREADY_EXISTS) || win32Error == ExceptionUtilities.HResultFromWin32(ERROR_SERVICE_ALREADY_RUNNING);
         }
 
-        private static void ConfigureContainer(IntPtr hJob, IReadOnlyDictionary<ExpandedAbsolutePath, IReadOnlyList<ExpandedAbsolutePath>> mapping, List<string> wciRetries)
+        private static void ConfigureContainer(
+            IntPtr hJob,
+            IReadOnlyDictionary<ExpandedAbsolutePath, IReadOnlyList<ExpandedAbsolutePath>> mapping,
+            bool isWciFilterEnabled,
+            List<string> wciRetries,
+            IEnumerable<string> bindFltExclusions)
         {
             foreach (var kvp in mapping)
             {
                 IReadOnlyCollection<ExpandedAbsolutePath> sourcePaths = kvp.Value;
                 string destinationPath = kvp.Key.ExpandedPath;
 
-                ConfigureWciFilter(hJob, sourcePaths, destinationPath, wciRetries);
-                ConfigureBindFilter(hJob, sourcePaths, destinationPath);
+                if (isWciFilterEnabled)
+                {
+                    ConfigureWciFilter(hJob, sourcePaths, destinationPath, wciRetries);
+                }
+
+                ConfigureBindFilter(hJob, sourcePaths, destinationPath, bindFltExclusions);
             }
         }
 
@@ -217,8 +232,9 @@ namespace BuildXL.Native.Processes.Windows
             
         }
 
-        private static void ConfigureBindFilter(IntPtr hJob, IReadOnlyCollection<ExpandedAbsolutePath> sourcePaths, string targetPath)
+        private static void ConfigureBindFilter(IntPtr hJob, IReadOnlyCollection<ExpandedAbsolutePath> sourcePaths, string targetPath, IEnumerable<string> exclusionPaths)
         {
+            string[] exclusionsForMapping = exclusionPaths.ToArray();
             foreach (ExpandedAbsolutePath sourcePath in sourcePaths)
             {
                 var hresult = NativeContainerUtilities.BfSetupFilter(
@@ -227,8 +243,8 @@ namespace BuildXL.Native.Processes.Windows
                     NativeContainerUtilities.BfSetupFilterFlags.BINDFLT_FLAG_USE_CURRENT_SILO_MAPPING,
                     sourcePath.ExpandedPath,
                     targetPath,
-                    CollectionUtilities.EmptyArray<string>(),
-                    0);
+                    exclusionsForMapping,
+                    (ulong) exclusionsForMapping.Length);
 
                 if (hresult != 0)
                 {


### PR DESCRIPTION
Add the ability to disable WCI and pipe in BindFlt exceptions

Not used in this codebase but useful in AnyBuild prototype - on remote agent we use BuildXL as a library and Helium minus WCI sandboxing