### PR TITLE
Compile and publish new runtime.osx-x64.BuildXL

### DIFF
--- a/Public/Src/Engine/Processes/SandboxedKextConnection.cs
+++ b/Public/Src/Engine/Processes/SandboxedKextConnection.cs
@@ -63,7 +63,7 @@ namespace BuildXL.Processes
         /// Until some automation for kernel extension building and deployment is in place, this number has to be kept in sync with the 'CFBundleVersion'
         /// inside the Info.plist file of the kernel extension code base. BuildXL will not work if a version mismatch is detected!
         /// </summary>
-        public const string RequiredKextVersionNumber = "1.89.99";
+        public const string RequiredKextVersionNumber = "1.90.99";
 
         /// <summary>
         /// See TN2420 (https://developer.apple.com/library/archive/technotes/tn2420/_index.html) on how versioning numbers are formatted in the Apple ecosystem

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>1.89.99</string>
+	<string>1.90.99</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>BuildXLSandbox</key>

--- a/config.microsoftInternal.dsc
+++ b/config.microsoftInternal.dsc
@@ -15,7 +15,7 @@ export const pkgs = isMicrosoftInternal ? [
     { id: "Microsoft.Applications.Telemetry.Desktop", version: "1.1.152" },
 
     // Runtime dependencies used for macOS deployments
-    { id: "runtime.osx-x64.BuildXL", version: "1.89.99" },
+    { id: "runtime.osx-x64.BuildXL", version: "1.90.99" },
     { id: "Aria.Cpp.SDK.osx-x64", version: "8.5.4" },
 
     { id: "CB.QTest", version: "19.5.8.161355" },


### PR DESCRIPTION
PR #279 made changes to runtime.osx-x64.BuildXL but didn't publish a new version of it