### PR TITLE
Add intermediate output path predictor

### DIFF
--- a/Public/External/BuildPrediction/BuildPrediction/StandardPredictors/IntermediateOutputPathIsOutputDir.cs
+++ b/Public/External/BuildPrediction/BuildPrediction/StandardPredictors/IntermediateOutputPathIsOutputDir.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Execution;
+
+namespace Microsoft.Build.Prediction.StandardPredictors
+{
+    /// <summary>
+    /// Scrapes the $(IntermediateOutputPath) if not found.
+    /// </summary>
+    internal class IntermediateOutputPathIsOutputDir : IProjectStaticPredictor
+    {
+        internal const string IntermediateOutputPathMacro = "IntermediateOutputPath";
+
+        public bool TryPredictInputsAndOutputs(
+            Project project,
+            ProjectInstance projectInstance,
+            string repositoryRootDirectory,
+            out StaticPredictions predictions)
+        {
+            string intermediateOutputPath = project.GetPropertyValue(IntermediateOutputPathMacro);
+
+            if (string.IsNullOrWhiteSpace(intermediateOutputPath))
+            {
+                // It is not defined, so we don't return a result.
+                predictions = null;
+                return false;
+            }
+
+            // If the path is relative, it is interpreted as relative to the project directory path
+            string predictedOutputDirectory;
+            if (!Path.IsPathRooted(intermediateOutputPath))
+            {
+                predictedOutputDirectory = Path.Combine(project.DirectoryPath, intermediateOutputPath);
+            }
+            else
+            {
+                predictedOutputDirectory = intermediateOutputPath;
+            }
+
+            predictions = new StaticPredictions(
+                buildInputs: null,
+                buildOutputDirectories: new[] { new BuildOutputDirectory(Path.GetFullPath(predictedOutputDirectory)) });
+            return true;
+        }
+    }
+}

--- a/Public/External/BuildPrediction/BuildPrediction/StandardPredictors/IntermediateOutputPathIsOutputDir.cs
+++ b/Public/External/BuildPrediction/BuildPrediction/StandardPredictors/IntermediateOutputPathIsOutputDir.cs
@@ -8,7 +8,7 @@ using Microsoft.Build.Execution;
 namespace Microsoft.Build.Prediction.StandardPredictors
 {
     /// <summary>
-    /// Scrapes the $(IntermediateOutputPath) if not found.
+    /// Scrapes the $(IntermediateOutputPath) if found.
     /// </summary>
     internal class IntermediateOutputPathIsOutputDir : IProjectStaticPredictor
     {

--- a/Public/External/BuildPrediction/BuildPredictionTests/StandardPredictors/IntermediateOutputPathIsOutputDirTests.cs
+++ b/Public/External/BuildPrediction/BuildPredictionTests/StandardPredictors/IntermediateOutputPathIsOutputDirTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
@@ -27,6 +28,18 @@ namespace Microsoft.Build.Prediction.Tests.StandardPredictors
             bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, @"C:\repo", out StaticPredictions predictions);
             Assert.True(hasPredictions);
             predictions.AssertPredictions(null, new[] { new BuildOutputDirectory(IntermediateOutputPath) });
+        }
+
+        [Fact]
+        public void RelativeIntermediateOutputPathFoundAsOutputDir()
+        {
+            const string IntermediateOutputPath = @"bin\x64";
+            Project project = CreateTestProject(IntermediateOutputPath);
+            ProjectInstance projectInstance = project.CreateProjectInstance(ProjectInstanceSettings.ImmutableWithFastItemLookup);
+            var predictor = new IntermediateOutputPathIsOutputDir();
+            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, @"C:\repo", out StaticPredictions predictions);
+            Assert.True(hasPredictions);
+            predictions.AssertPredictions(null, new[] { new BuildOutputDirectory(Path.Combine(Directory.GetCurrentDirectory(), IntermediateOutputPath)) });
         }
 
         [Fact]

--- a/Public/External/BuildPrediction/BuildPredictionTests/StandardPredictors/IntermediateOutputPathIsOutputDirTests.cs
+++ b/Public/External/BuildPrediction/BuildPredictionTests/StandardPredictors/IntermediateOutputPathIsOutputDirTests.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Prediction.StandardPredictors;
+using Xunit;
+
+namespace Microsoft.Build.Prediction.Tests.StandardPredictors
+{
+    public class IntermediateOutputPathIsOutputDirTests
+    {
+        static IntermediateOutputPathIsOutputDirTests()
+        {
+            MsBuildEnvironment.Setup(TestHelpers.GetAssemblyLocation());
+        }
+
+        [Fact]
+        public void IntermediateOutputPathFoundAsOutputDir()
+        {
+            const string IntermediateOutputPath = @"C:\repo\bin\x64";
+            Project project = CreateTestProject(IntermediateOutputPath);
+            ProjectInstance projectInstance = project.CreateProjectInstance(ProjectInstanceSettings.ImmutableWithFastItemLookup);
+            var predictor = new IntermediateOutputPathIsOutputDir();
+            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, @"C:\repo", out StaticPredictions predictions);
+            Assert.True(hasPredictions);
+            predictions.AssertPredictions(null, new[] { new BuildOutputDirectory(IntermediateOutputPath) });
+        }
+
+        [Fact]
+        public void NoOutputsReportedIfNoIntermediateOutputPath()
+        {
+            Project project = CreateTestProject(null);
+            ProjectInstance projectInstance = project.CreateProjectInstance(ProjectInstanceSettings.ImmutableWithFastItemLookup);
+            var predictor = new IntermediateOutputPathIsOutputDir();
+            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, @"C:\repo", out _);
+            Assert.False(hasPredictions, "Predictor should have fallen back to returning no predictions if IntermediateOutputDir is not defined in project");
+        }
+
+        private static Project CreateTestProject(string intermediateOutDir)
+        {
+            ProjectRootElement projectRootElement = ProjectRootElement.Create();
+            if (intermediateOutDir != null)
+            {
+                projectRootElement.AddProperty(IntermediateOutputPathIsOutputDir.IntermediateOutputPathMacro, intermediateOutDir);
+            }
+
+            return TestHelpers.CreateProjectFromRootElement(projectRootElement);
+        }
+    }
+}


### PR DESCRIPTION
The copy task predictor is predicting as a source file a path that is actually an output. This is because the copy task is publishing the produced exe to the publish location, so even though the exe is indeed a source file for the task, it is not really a source file for the project. But this causes bxl to block writes on that path, since it believes it is an input.
This PR adds a predictor for the intermediate output path. This makes the current heuristic about inputs (which discards predicted inputs on output paths) kick in and avoid this problem.
Additionally, predicting the intermediate output path is a nice to have as well.