### PR TITLE
ClientConnectionManager becoming aware of channel state transitions

### DIFF
--- a/Public/Src/Engine/Dll/Distribution/Grpc/ClientConnectionManager.cs
+++ b/Public/Src/Engine/Dll/Distribution/Grpc/ClientConnectionManager.cs
@@ -25,6 +25,8 @@ namespace BuildXL.Engine.Distribution.Grpc
         internal readonly Channel Channel;
         private readonly LoggingContext m_loggingContext;
         private readonly string m_buildId;
+        private readonly Task m_monitorConnectionTask;
+        public event EventHandler OnConnectionTimeOut;
 
         private string GenerateLog(string traceId, string status, uint numTry, string description)
         {
@@ -43,11 +45,34 @@ namespace BuildXL.Engine.Distribution.Grpc
                     port,
                     ChannelCredentials.Insecure,
                     DefaultChannelOptions);
+            m_monitorConnectionTask = MonitorConnectionAsync();
+        }
+
+        public async Task MonitorConnectionAsync()
+        {
+            await Task.Yield();
+
+            ChannelState state = ChannelState.Idle;
+            while (state != ChannelState.Shutdown)
+            {
+                await Channel.WaitForStateChangedAsync(state);
+
+                Logger.Log.GrpcTrace(m_loggingContext, $"Channel state: {state} -> {Channel.State}");
+
+                state = Channel.State;
+
+                if (state == ChannelState.Idle)
+                {
+                    OnConnectionTimeOut?.Invoke(this, EventArgs.Empty);
+                    break;
+                }
+            }
         }
 
         public void Close()
         {
             Channel.ShutdownAsync().GetAwaiter().GetResult();
+            m_monitorConnectionTask.GetAwaiter().GetResult();
         }
 
         public async Task<RpcCallResult<Unit>> CallAsync(
@@ -63,19 +88,13 @@ namespace BuildXL.Engine.Distribution.Grpc
 
             if (waitForConnection)
             {
-                try
-                {
-                    Logger.Log.GrpcTrace(m_loggingContext, $"Attempt to connect to {Channel.Target}. ChannelState {Channel.State}. Operation {operation}");
-                    await Channel.ConnectAsync(DateTime.UtcNow.Add(GrpcSettings.InactiveTimeout));
-                    Logger.Log.GrpcTrace(m_loggingContext, $"Connected to {Channel.Target}. Duration {watch.ElapsedMilliseconds}ms");
-                }
-                catch (OperationCanceledException e)
-                {
-                    Logger.Log.GrpcTrace(m_loggingContext, $"Failed to connect to {Channel.Target}. Duration {watch.ElapsedMilliseconds}ms. Failure {e.Message}");
-                    return new RpcCallResult<Unit>(RpcCallResultState.Cancelled, attempts: 1, duration: TimeSpan.Zero, waitForConnectionDuration: watch.Elapsed);
-                }
-
+                bool connectionSucceeded = await TryConnectChannelAsync(operation, watch);
                 waitForConnectionDuration = watch.Elapsed;
+
+                if (!connectionSucceeded)
+                {
+                    return new RpcCallResult<Unit>(RpcCallResultState.Cancelled, attempts: 1, duration: TimeSpan.Zero, waitForConnectionDuration);
+                }
             }
 
             Guid traceId = Guid.NewGuid();
@@ -98,7 +117,7 @@ namespace BuildXL.Engine.Distribution.Grpc
                     var callOptions = new CallOptions(
                         deadline: DateTime.UtcNow.Add(GrpcSettings.CallTimeout),
                         cancellationToken: cancellationToken,
-                        headers: headers);
+                        headers: headers).WithWaitForReady();
 
                     Logger.Log.GrpcTrace(m_loggingContext, GenerateLog(traceId.ToString(), "Call", numTry, operation));
                     await func(callOptions);
@@ -111,7 +130,7 @@ namespace BuildXL.Engine.Distribution.Grpc
                 {
                     state = e.Status.StatusCode == StatusCode.Cancelled ? RpcCallResultState.Cancelled : RpcCallResultState.Failed;
 
-                    Logger.Log.GrpcTrace(m_loggingContext, GenerateLog(traceId.ToString(), "Fail", numTry, $"Duration: {watch.ElapsedMilliseconds}ms. Failure: {e.Message}"));
+                    Logger.Log.GrpcTrace(m_loggingContext, GenerateLog(traceId.ToString(), "Fail", numTry, $"Duration: {watch.ElapsedMilliseconds}ms. Failure: {e.Message}. ChannelState: {Channel.State}."));
 
                     failure = state == RpcCallResultState.Failed ? new RecoverableExceptionFailure(new BuildXLException(e.Message, e)) : null;
 
@@ -119,6 +138,16 @@ namespace BuildXL.Engine.Distribution.Grpc
                     if (state == RpcCallResultState.Cancelled)
                     {
                         break;
+                    }
+
+                    if (numTry == GrpcSettings.MaxRetry - 1)
+                    {
+                        // If this is the last retry, try to attempt reconnecting. If the connection fails, do not attempt to retry the call.
+                        bool connectionSucceeded = await TryConnectChannelAsync(operation);
+                        if (!connectionSucceeded)
+                        {
+                            break;
+                        }
                     }
                 }
                 finally
@@ -138,6 +167,25 @@ namespace BuildXL.Engine.Distribution.Grpc
                 duration: totalCallDuration,
                 waitForConnectionDuration: waitForConnectionDuration,
                 lastFailure: failure);
+        }
+
+        private async Task<bool> TryConnectChannelAsync(string operation, Stopwatch watch = null)
+        {
+            watch = watch ?? Stopwatch.StartNew();
+
+            try
+            {
+                Logger.Log.GrpcTrace(m_loggingContext, $"Attempt to connect to {Channel.Target}. ChannelState {Channel.State}. Operation {operation}");
+                await Channel.ConnectAsync(DateTime.UtcNow.Add(GrpcSettings.InactiveTimeout));
+                Logger.Log.GrpcTrace(m_loggingContext, $"Connected to {Channel.Target}. Duration {watch.ElapsedMilliseconds}ms");
+            }
+            catch (OperationCanceledException e)
+            {
+                Logger.Log.GrpcTrace(m_loggingContext, $"Failed to connect to {Channel.Target}. Duration {watch.ElapsedMilliseconds}ms. Failure {e.Message}");
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/Public/Src/Engine/Dll/Distribution/Grpc/GrpcMasterClient.cs
+++ b/Public/Src/Engine/Dll/Distribution/Grpc/GrpcMasterClient.cs
@@ -17,17 +17,17 @@ namespace BuildXL.Engine.Distribution.Grpc
         private readonly ClientConnectionManager m_connectionManager;
         private readonly LoggingContext m_loggingContext;
 
-        public GrpcMasterClient(LoggingContext loggingContext, string buildId, string ipAddress, int port, EventHandler onConnectionTimeOut)
+        public GrpcMasterClient(LoggingContext loggingContext, string buildId, string ipAddress, int port, EventHandler onConnectionTimeOutAsync)
         {
             m_loggingContext = loggingContext;
             m_connectionManager = new ClientConnectionManager(m_loggingContext, ipAddress, port, buildId);
-            m_connectionManager.OnConnectionTimeOut += onConnectionTimeOut;
+            m_connectionManager.OnConnectionTimeOutAsync += onConnectionTimeOutAsync;
             m_client = new Master.MasterClient(m_connectionManager.Channel);
         }
 
-        public void Close()
+        public Task CloseAsync()
         {
-            m_connectionManager.Close();
+            return m_connectionManager.CloseAsync();
         }
 
         public Task<RpcCallResult<Unit>> AttachCompletedAsync(OpenBond.AttachCompletionInfo message)

--- a/Public/Src/Engine/Dll/Distribution/Grpc/GrpcMasterClient.cs
+++ b/Public/Src/Engine/Dll/Distribution/Grpc/GrpcMasterClient.cs
@@ -17,10 +17,11 @@ namespace BuildXL.Engine.Distribution.Grpc
         private readonly ClientConnectionManager m_connectionManager;
         private readonly LoggingContext m_loggingContext;
 
-        public GrpcMasterClient(LoggingContext loggingContext, string buildId, string ipAddress, int port)
+        public GrpcMasterClient(LoggingContext loggingContext, string buildId, string ipAddress, int port, EventHandler onConnectionTimeOut)
         {
             m_loggingContext = loggingContext;
             m_connectionManager = new ClientConnectionManager(m_loggingContext, ipAddress, port, buildId);
+            m_connectionManager.OnConnectionTimeOut += onConnectionTimeOut;
             m_client = new Master.MasterClient(m_connectionManager.Channel);
         }
 

--- a/Public/Src/Engine/Dll/Distribution/Grpc/GrpcWorkerClient.cs
+++ b/Public/Src/Engine/Dll/Distribution/Grpc/GrpcWorkerClient.cs
@@ -19,17 +19,17 @@ namespace BuildXL.Engine.Distribution.Grpc
         private readonly ClientConnectionManager m_connectionManager;
         private readonly Worker.WorkerClient m_client;
 
-        public GrpcWorkerClient(LoggingContext loggingContext, string buildId, string ipAddress, int port, EventHandler onConnectionTimeOut)
+        public GrpcWorkerClient(LoggingContext loggingContext, string buildId, string ipAddress, int port, EventHandler onConnectionTimeOutAsync)
         {
             m_loggingContext = loggingContext;
             m_connectionManager = new ClientConnectionManager(loggingContext, ipAddress, port, buildId);
-            m_connectionManager.OnConnectionTimeOut += onConnectionTimeOut;
+            m_connectionManager.OnConnectionTimeOutAsync += onConnectionTimeOutAsync;
             m_client = new Worker.WorkerClient(m_connectionManager.Channel);
         }
 
-        public void Close()
+        public Task CloseAsync()
         {
-            m_connectionManager.Close();
+            return m_connectionManager.CloseAsync();
         }
 
         public void Dispose()

--- a/Public/Src/Engine/Dll/Distribution/Grpc/GrpcWorkerClient.cs
+++ b/Public/Src/Engine/Dll/Distribution/Grpc/GrpcWorkerClient.cs
@@ -19,10 +19,11 @@ namespace BuildXL.Engine.Distribution.Grpc
         private readonly ClientConnectionManager m_connectionManager;
         private readonly Worker.WorkerClient m_client;
 
-        public GrpcWorkerClient(LoggingContext loggingContext, string buildId, string ipAddress, int port)
+        public GrpcWorkerClient(LoggingContext loggingContext, string buildId, string ipAddress, int port, EventHandler onConnectionTimeOut)
         {
             m_loggingContext = loggingContext;
             m_connectionManager = new ClientConnectionManager(loggingContext, ipAddress, port, buildId);
+            m_connectionManager.OnConnectionTimeOut += onConnectionTimeOut;
             m_client = new Worker.WorkerClient(m_connectionManager.Channel);
         }
 

--- a/Public/Src/Engine/Dll/Distribution/IMasterClient.cs
+++ b/Public/Src/Engine/Dll/Distribution/IMasterClient.cs
@@ -12,6 +12,6 @@ namespace BuildXL.Engine.Distribution
     {
         Task<RpcCallResult<Unit>> AttachCompletedAsync(AttachCompletionInfo attachCompletionInfo);
         Task<RpcCallResult<Unit>> NotifyAsync(WorkerNotificationArgs notificationArgs, IList<long> semiStableHashes);
-        void Close();
+        Task CloseAsync();
     }
 }

--- a/Public/Src/Engine/Dll/Distribution/IWorkerClient.cs
+++ b/Public/Src/Engine/Dll/Distribution/IWorkerClient.cs
@@ -18,6 +18,6 @@ namespace BuildXL.Engine.Distribution
 
         Task<RpcCallResult<Unit>> ExitAsync(BuildEndData buildEndData, CancellationToken cancellationToken);
 
-        void Close();
+        Task CloseAsync();
     }
 }

--- a/Public/Src/Engine/Dll/Distribution/InternalBond/BondMasterClient.cs
+++ b/Public/Src/Engine/Dll/Distribution/InternalBond/BondMasterClient.cs
@@ -80,8 +80,9 @@ namespace BuildXL.Engine.Distribution.InternalBond
         }
 
         /// <nodoc/>
-        public void Close()
+        public async Task CloseAsync()
         {
+            await Task.Yield();
             m_proxyManager?.Terminate();
         }
 

--- a/Public/Src/Engine/Dll/Distribution/InternalBond/BondWorkerClient.cs
+++ b/Public/Src/Engine/Dll/Distribution/InternalBond/BondWorkerClient.cs
@@ -89,19 +89,19 @@ namespace BuildXL.Engine.Distribution.InternalBond
             m_proxyManager.Start(ipAddress, port, this);
         }
 
-        public void Close()
+        public async Task CloseAsync()
         {
+            await Task.Yield();
+
             lock (m_proxyManagerLock)
             {
                 // The proxy manager may be null if the RemoteWorker has been disposed. This can happen if everything
                 // happened on the master and the Scheduler & Engine are disposed before the worker's acknowledgement for
                 // the final state transition comes in. If that happens, just noop here.
-                if (m_proxyManager == null)
+                if (m_proxyManager != null)
                 {
-                    return;
+                    m_proxyManager.Terminate();
                 }
-
-                m_proxyManager.Terminate();
             }
         }
 

--- a/Public/Src/Engine/Dll/Distribution/RemoteWorker.cs
+++ b/Public/Src/Engine/Dll/Distribution/RemoteWorker.cs
@@ -932,7 +932,7 @@ namespace BuildXL.Engine.Distribution
 
         private void Stop(bool isLostConnection)
         {
-            m_workerClient.CloseAsync();
+            Analysis.IgnoreResult(m_workerClient.CloseAsync(), justification: "Okay to ignore close");
 
             // The worker goes in a stopped state either by a scheduler request or because it lost connection with the
             // remote machine. Check which one applies.

--- a/Public/Src/Engine/Dll/Distribution/RemoteWorker.cs
+++ b/Public/Src/Engine/Dll/Distribution/RemoteWorker.cs
@@ -109,12 +109,12 @@ namespace BuildXL.Engine.Distribution
 
             if (isGrpcEnabled)
             {
-                m_workerClient = new Grpc.GrpcWorkerClient(m_appLoggingContext, masterService.DistributionServices.BuildId, serviceLocation.IpAddress, serviceLocation.Port, OnConnectionTimeOut);
+                m_workerClient = new Grpc.GrpcWorkerClient(m_appLoggingContext, masterService.DistributionServices.BuildId, serviceLocation.IpAddress, serviceLocation.Port, OnConnectionTimeOutAsync);
             }
             else
             {
 #if !DISABLE_FEATURE_BOND_RPC
-                m_workerClient = new InternalBond.BondWorkerClient(m_appLoggingContext, Name, serviceLocation.IpAddress, serviceLocation.Port, masterService.DistributionServices, OnActivateConnection, OnDeactivateConnection, OnConnectionTimeOut);
+                m_workerClient = new InternalBond.BondWorkerClient(m_appLoggingContext, Name, serviceLocation.IpAddress, serviceLocation.Port, masterService.DistributionServices, OnActivateConnection, OnDeactivateConnection, OnConnectionTimeOutAsync);
 #endif
             }
 
@@ -311,8 +311,11 @@ namespace BuildXL.Engine.Distribution
             }
         }
 
-        private void OnConnectionTimeOut(object sender, EventArgs e)
-        {
+        private async void OnConnectionTimeOutAsync(object sender, EventArgs e)
+        {           
+            // Unblock caller to make it a fire&forget event handler.
+            await Task.Yield();
+
             // Stop using the worker if the connect times out
             while (!ChangeStatus(Status, WorkerNodeStatus.Stopped) && Status != WorkerNodeStatus.Stopped)
             {
@@ -929,7 +932,7 @@ namespace BuildXL.Engine.Distribution
 
         private void Stop(bool isLostConnection)
         {
-            m_workerClient.Close();
+            m_workerClient.CloseAsync();
 
             // The worker goes in a stopped state either by a scheduler request or because it lost connection with the
             // remote machine. Check which one applies.

--- a/Public/Src/Engine/Dll/Distribution/RemoteWorker.cs
+++ b/Public/Src/Engine/Dll/Distribution/RemoteWorker.cs
@@ -109,7 +109,7 @@ namespace BuildXL.Engine.Distribution
 
             if (isGrpcEnabled)
             {
-                m_workerClient = new Grpc.GrpcWorkerClient(m_appLoggingContext, masterService.DistributionServices.BuildId, serviceLocation.IpAddress, serviceLocation.Port);
+                m_workerClient = new Grpc.GrpcWorkerClient(m_appLoggingContext, masterService.DistributionServices.BuildId, serviceLocation.IpAddress, serviceLocation.Port, OnConnectionTimeOut);
             }
             else
             {

--- a/Public/Src/Engine/Dll/Distribution/WorkerService.cs
+++ b/Public/Src/Engine/Dll/Distribution/WorkerService.cs
@@ -348,7 +348,7 @@ namespace BuildXL.Engine.Distribution
                 m_notifyMasterExecutionLogTarget.Dispose();
             }
 
-            m_masterClient?.Close();
+            m_masterClient?.CloseAsync().GetAwaiter().GetResult();
 
             m_attachCompletionSource.TrySetResult(false);
             bool reportSuccess = string.IsNullOrEmpty(failure);
@@ -394,7 +394,7 @@ namespace BuildXL.Engine.Distribution
 
             if (m_isGrpcEnabled)
             {
-                m_masterClient = new Grpc.GrpcMasterClient(m_appLoggingContext, m_services.BuildId, buildStartData.MasterLocation.IpAddress, buildStartData.MasterLocation.Port, OnConnectionTimeOut);
+                m_masterClient = new Grpc.GrpcMasterClient(m_appLoggingContext, m_services.BuildId, buildStartData.MasterLocation.IpAddress, buildStartData.MasterLocation.Port, OnConnectionTimeOutAsync);
             }
             else
             {
@@ -416,7 +416,7 @@ namespace BuildXL.Engine.Distribution
             if (!m_isGrpcEnabled)
             {
 #if !DISABLE_FEATURE_BOND_RPC
-                m_bondMasterClient.Start(m_services, OnConnectionTimeOut);
+                m_bondMasterClient.Start(m_services, OnConnectionTimeOutAsync);
 #endif
             }
 
@@ -466,10 +466,12 @@ namespace BuildXL.Engine.Distribution
             return true;
         }
 
-        private void OnConnectionTimeOut(object sender, EventArgs e)
+        private async void OnConnectionTimeOutAsync(object sender, EventArgs e)
         {
+            // Unblock caller to make it a fire&forget event handler.
+            await Task.Yield();
             Logger.Log.DistributionInactiveMaster(m_appLoggingContext, (int)EngineEnvironmentSettings.DistributionInactiveTimeout.Value.TotalMinutes);
-            Exit(timedOut: true, "Connection timed out");
+            ExitAsync(timedOut: true, "Connection timed out");
         }
 
         internal void SetLastHeartbeatTimestamp()

--- a/Public/Src/Engine/Dll/Distribution/WorkerService.cs
+++ b/Public/Src/Engine/Dll/Distribution/WorkerService.cs
@@ -394,7 +394,7 @@ namespace BuildXL.Engine.Distribution
 
             if (m_isGrpcEnabled)
             {
-                m_masterClient = new Grpc.GrpcMasterClient(m_appLoggingContext, m_services.BuildId, buildStartData.MasterLocation.IpAddress, buildStartData.MasterLocation.Port);
+                m_masterClient = new Grpc.GrpcMasterClient(m_appLoggingContext, m_services.BuildId, buildStartData.MasterLocation.IpAddress, buildStartData.MasterLocation.Port, OnConnectionTimeOut);
             }
             else
             {


### PR DESCRIPTION
If the worker gets disconnected in an unexpected way, the master is timing out. These changes fix that. 