### PR TITLE
Classify failure to load BuildXL.FrontEnd.Workspaces assembly as MissingRuntimeDependency

### DIFF
--- a/Public/Src/Utilities/UnitTests/Utilities/ExceptionUtilitiesTests.cs
+++ b/Public/Src/Utilities/UnitTests/Utilities/ExceptionUtilitiesTests.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using BuildXL.Utilities;
+using Xunit;
+
+namespace Test.BuildXL.Utilities
+{
+    public class ExceptionUtilitiesTests
+    {
+        [Fact]
+        public void ClassifyMissingRuntimeDependencyTest()
+        {
+            Assert.Equal(ExceptionRootCause.MissingRuntimeDependency, ExceptionUtilities.AnalyzeExceptionRootCause(new FileLoadException()));
+            Assert.Equal(ExceptionRootCause.MissingRuntimeDependency, ExceptionUtilities.AnalyzeExceptionRootCause(new FileNotFoundException("Could not load file or assembly")));
+            Assert.Equal(ExceptionRootCause.MissingRuntimeDependency, ExceptionUtilities.AnalyzeExceptionRootCause(new DllNotFoundException()));
+            Assert.Equal(ExceptionRootCause.MissingRuntimeDependency, ExceptionUtilities.AnalyzeExceptionRootCause(new TypeLoadException()));
+        }
+    }
+}

--- a/Public/Src/Utilities/Utilities/ExceptionUtilities.cs
+++ b/Public/Src/Utilities/Utilities/ExceptionUtilities.cs
@@ -279,7 +279,8 @@ namespace BuildXL.Utilities
 
             if (ex is FileLoadException ||
                 (ex is FileNotFoundException && ex.Message.Contains(Strings.ExceptionUtilities_MissingDependencyPattern)) ||
-                ex is DllNotFoundException)
+                ex is DllNotFoundException ||
+                ex is TypeLoadException)
             {
                 return ExceptionRootCause.MissingRuntimeDependency;
             }


### PR DESCRIPTION
Fixes [AB#1511556](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1511556)