### PR TITLE
Prevent Detours from modifying access parameters for untracked files

### DIFF
--- a/Public/Src/Engine/UnitTests/Processes.Detours/SandboxedProcessPipExecutorTest.cs
+++ b/Public/Src/Engine/UnitTests/Processes.Detours/SandboxedProcessPipExecutorTest.cs
@@ -20,6 +20,7 @@ using BuildXL.Utilities.Configuration.Mutable;
 using Test.BuildXL.TestUtilities;
 using Test.BuildXL.TestUtilities.Xunit;
 using Xunit;
+using BuildXL.Native.IO;
 
 #pragma warning disable AsyncFixer02
 
@@ -2034,14 +2035,19 @@ namespace Test.BuildXL.Processes.Detours
         private static void VerifyNormalSuccess(BuildXLContext context, SandboxedProcessPipExecutionResult result)
         {
             VerifyExecutionStatus(context, result, SandboxedProcessPipExecutionStatus.Succeeded);
-            VerifyExitCode(context, result, 0);
+            VerifyExitCode(context, result, NativeIOConstants.ErrorSuccess);
         }
 
         private static void VerifyAccessDenied(BuildXLContext context, SandboxedProcessPipExecutionResult result)
         {
             VerifyExecutionStatus(context, result, SandboxedProcessPipExecutionStatus.ExecutionFailed);
-            VerifyExitCode(context, result, 5);
+            VerifyExitCode(context, result, NativeIOConstants.ErrorAccessDenied);
         }
 
+        private static void VerifySharingViolation(BuildXLContext context, SandboxedProcessPipExecutionResult result)
+        {
+            VerifyExecutionStatus(context, result, SandboxedProcessPipExecutionStatus.ExecutionFailed);
+            VerifyExitCode(context, result, NativeIOConstants.ErrorSharingViolation);
+        }
     }
 }

--- a/Public/Src/Sandbox/Windows/DetoursServices/DetouredFunctions.cpp
+++ b/Public/Src/Sandbox/Windows/DetoursServices/DetouredFunctions.cpp
@@ -2067,17 +2067,23 @@ HANDLE WINAPI Detoured_CreateFileW(
     // read request which may or may not have been approved (due to special exceptions for directories and non-existent files).
     // It is safe to go ahead and perform the real CreateFile() call, and then to reason about the results after the fact.
 
-    // Note that we always add FILE_SHARE_DELETE to dwShareMode. In order to leverage NTFS hardlinks to avoid copying cache
+    // Note that we can add FILE_SHARE_DELETE to dwShareMode. I.e., in order to leverage NTFS hardlinks to avoid copying cache
     // content, we need to be able to delete one of many links to a file. Unfortunately, share-mode is aggregated only per file
-    // rather than per-link, so in order to keep unused links delete-able, we must ensure in-use links are delete-able as well.
+    // rather than per-link, so in order to keep unused links delete-able, we should ensure in-use links are delete-able as well.
+    // However, adding FILE_SHARE_DELETE may be unexpected, for example, some unit tests may test for sharing violation.
     
     // We also add FILE_SHARE_READ when it is safe to do so, since some tools accidentally ask for exclusive access on their inputs.
 
-    DWORD readSharingIfNeeded = policyResult.ShouldForceReadSharing(accessCheck) ? FILE_SHARE_READ : 0UL;
+    DWORD desiredAccess = dwDesiredAccess;
+    DWORD sharedAccess = dwShareMode;
 
-    DWORD desiredAccess = !forceReadOnlyForRequestedRWAccess ? dwDesiredAccess : (dwDesiredAccess & FILE_GENERIC_READ);
-    DWORD sharedAccess = !forceReadOnlyForRequestedRWAccess ? (dwShareMode | FILE_SHARE_DELETE | readSharingIfNeeded) : FILE_SHARE_READ | FILE_SHARE_DELETE;
-    
+    if (!policyResult.IndicateUntracked())
+    {
+        DWORD readSharingIfNeeded = policyResult.ShouldForceReadSharing(accessCheck) ? FILE_SHARE_READ : 0UL;
+        desiredAccess = !forceReadOnlyForRequestedRWAccess ? desiredAccess : (desiredAccess & FILE_GENERIC_READ);
+        sharedAccess = sharedAccess | readSharingIfNeeded;
+    }
+
     error = ERROR_SUCCESS;
 
     HANDLE handle = Real_CreateFileW(
@@ -5128,15 +5134,22 @@ NTSTATUS NTAPI Detoured_ZwCreateFile(
     // read request which may or may not have been approved (due to special exceptions for directories and non-existent files).
     // It is safe to go ahead and perform the real NtCreateFile() call, and then to reason about the results after the fact.
 
-    // Note that we always add FILE_SHARE_DELETE to dwShareMode. In order to leverage NTFS hardlinks to avoid copying cache
+    // Note that we can add FILE_SHARE_DELETE to dwShareMode. I.e., in order to leverage NTFS hardlinks to avoid copying cache
     // content, we need to be able to delete one of many links to a file. Unfortunately, share-mode is aggregated only per file
-    // rather than per-link, so in order to keep unused links delete-able, we must ensure in-use links are delete-able as well.
+    // rather than per-link, so in order to keep unused links delete-able, we should ensure in-use links are delete-able as well.
+    // However, adding FILE_SHARE_DELETE may be unexpected, for example, some unit tests may test for sharing violation.
 
     // We also add FILE_SHARE_READ when it is safe to do so, since some tools accidentally ask for exclusive access on their inputs.
 
-    DWORD readSharingIfNeeded = policyResult.ShouldForceReadSharing(accessCheck) ? FILE_SHARE_READ : 0UL;
-    DWORD desiredAccess = !forceReadOnlyForRequestedRWAccess ? DesiredAccess : (DesiredAccess & FILE_GENERIC_READ);
-    DWORD sharedAccess = !forceReadOnlyForRequestedRWAccess ? (ShareAccess | FILE_SHARE_DELETE | readSharingIfNeeded) : FILE_SHARE_READ | FILE_SHARE_DELETE;
+    DWORD desiredAccess = DesiredAccess;
+    DWORD sharedAccess = ShareAccess;
+
+    if (!policyResult.IndicateUntracked())
+    {
+        DWORD readSharingIfNeeded = policyResult.ShouldForceReadSharing(accessCheck) ? FILE_SHARE_READ : 0UL;
+        desiredAccess = !forceReadOnlyForRequestedRWAccess ? desiredAccess : (desiredAccess & FILE_GENERIC_READ);
+        sharedAccess = sharedAccess | readSharingIfNeeded;
+    }
     
     error = ERROR_SUCCESS;
 
@@ -5415,15 +5428,22 @@ NTSTATUS NTAPI Detoured_NtCreateFile(
     // read request which may or may not have been approved (due to special exceptions for directories and non-existent files).
     // It is safe to go ahead and perform the real NtCreateFile() call, and then to reason about the results after the fact.
 
-    // Note that we always add FILE_SHARE_DELETE to dwShareMode. In order to leverage NTFS hardlinks to avoid copying cache
+    // Note that we can add FILE_SHARE_DELETE to dwShareMode. I.e., in order to leverage NTFS hardlinks to avoid copying cache
     // content, we need to be able to delete one of many links to a file. Unfortunately, share-mode is aggregated only per file
-    // rather than per-link, so in order to keep unused links delete-able, we must ensure in-use links are delete-able as well.
+    // rather than per-link, so in order to keep unused links delete-able, we should ensure in-use links are delete-able as well.
+    // However, adding FILE_SHARE_DELETE may be unexpected, for example, some unit tests may test for sharing violation.
 
     // We also add FILE_SHARE_READ when it is safe to do so, since some tools accidentally ask for exclusive access on their inputs.
 
-    DWORD readSharingIfNeeded = policyResult.ShouldForceReadSharing(accessCheck) ? FILE_SHARE_READ : 0UL;
-    DWORD desiredAccess = !forceReadOnlyForRequestedRWAccess ? DesiredAccess : (DesiredAccess & FILE_GENERIC_READ);
-    DWORD sharedAccess = !forceReadOnlyForRequestedRWAccess ? (ShareAccess | FILE_SHARE_DELETE | readSharingIfNeeded) : FILE_SHARE_READ | FILE_SHARE_DELETE;
+    DWORD desiredAccess = DesiredAccess;
+    DWORD sharedAccess = ShareAccess;
+
+    if (!policyResult.IndicateUntracked())
+    {
+        DWORD readSharingIfNeeded = policyResult.ShouldForceReadSharing(accessCheck) ? FILE_SHARE_READ : 0UL;
+        desiredAccess = !forceReadOnlyForRequestedRWAccess ? desiredAccess : (desiredAccess & FILE_GENERIC_READ);
+        sharedAccess = sharedAccess | readSharingIfNeeded;
+    }
     
     error = ERROR_SUCCESS;
 
@@ -5683,15 +5703,23 @@ NTSTATUS NTAPI Detoured_ZwOpenFile(
     // read request which may or may not have been approved (due to special exceptions for directories and non-existent files).
     // It is safe to go ahead and perform the real NtCreateFile() call, and then to reason about the results after the fact.
 
-    // Note that we always add FILE_SHARE_DELETE to dwShareMode. In order to leverage NTFS hardlinks to avoid copying cache
+    // Note that we can add FILE_SHARE_DELETE to dwShareMode. I.e., in order to leverage NTFS hardlinks to avoid copying cache
     // content, we need to be able to delete one of many links to a file. Unfortunately, share-mode is aggregated only per file
-    // rather than per-link, so in order to keep unused links delete-able, we must ensure in-use links are delete-able as well.
+    // rather than per-link, so in order to keep unused links delete-able, we should ensure in-use links are delete-able as well.
+    // However, adding FILE_SHARE_DELETE may be unexpected, for example, some unit tests may test for sharing violation.
 
     // We also add FILE_SHARE_READ when it is safe to do so, since some tools accidentally ask for exclusive access on their inputs.
 
-    DWORD readSharingIfNeeded = policyResult.ShouldForceReadSharing(accessCheck) ? FILE_SHARE_READ : 0UL;
-    DWORD desiredAccess = !forceReadOnlyForRequestedRWAccess ? DesiredAccess : (DesiredAccess & FILE_GENERIC_READ);
-    DWORD sharedAccess = !forceReadOnlyForRequestedRWAccess ? (ShareAccess | FILE_SHARE_DELETE | readSharingIfNeeded) : FILE_SHARE_READ | FILE_SHARE_DELETE;
+    DWORD desiredAccess = DesiredAccess;
+    DWORD sharedAccess = ShareAccess;
+
+    if (!policyResult.IndicateUntracked())
+    {
+        DWORD readSharingIfNeeded = policyResult.ShouldForceReadSharing(accessCheck) ? FILE_SHARE_READ : 0UL;
+        desiredAccess = !forceReadOnlyForRequestedRWAccess ? desiredAccess : (desiredAccess & FILE_GENERIC_READ);
+        sharedAccess = sharedAccess | readSharingIfNeeded;
+    }
+
     DWORD error = ERROR_SUCCESS;
 
     NTSTATUS result = Real_ZwOpenFile(

--- a/Public/Src/Sandbox/Windows/DetoursServices/MetadataOverrides.h
+++ b/Public/Src/Sandbox/Windows/DetoursServices/MetadataOverrides.h
@@ -15,27 +15,27 @@ void OverrideTimestampsForInputFile(TResult* result) {
     static_assert(std::is_same<decltype(result->ftLastAccessTime), FILETIME>::value, "result->ftLastAccessTime must be a FILETIME");
     static_assert(std::is_same<decltype(result->ftLastWriteTime), FILETIME>::value, "result->ftLastWriteTime must be a FILETIME");
     
-	if (NormalizeReadTimestamps())
-	{
-		result->ftCreationTime = NewInputTimestamp;
-		result->ftLastAccessTime = NewInputTimestamp;
-		result->ftLastWriteTime = NewInputTimestamp;
-	}
-	else
-	{
-		if (CompareFileTime(&(result->ftCreationTime), &NewInputTimestamp) == -1)
-		{
-			result->ftCreationTime = NewInputTimestamp;
-		}
-		if (CompareFileTime(&(result->ftLastAccessTime), &NewInputTimestamp) == -1)
-		{
-			result->ftLastAccessTime = NewInputTimestamp;
-		}
-		if (CompareFileTime(&(result->ftLastWriteTime), &NewInputTimestamp) == -1)
-		{
-			result->ftLastWriteTime = NewInputTimestamp;
-		}
-	}
+    if (NormalizeReadTimestamps())
+    {
+        result->ftCreationTime = NewInputTimestamp;
+        result->ftLastAccessTime = NewInputTimestamp;
+        result->ftLastWriteTime = NewInputTimestamp;
+    }
+    else
+    {
+        if (CompareFileTime(&(result->ftCreationTime), &NewInputTimestamp) == -1)
+        {
+            result->ftCreationTime = NewInputTimestamp;
+        }
+        if (CompareFileTime(&(result->ftLastAccessTime), &NewInputTimestamp) == -1)
+        {
+            result->ftLastAccessTime = NewInputTimestamp;
+        }
+        if (CompareFileTime(&(result->ftLastWriteTime), &NewInputTimestamp) == -1)
+        {
+            result->ftLastWriteTime = NewInputTimestamp;
+        }
+    }
 }
 
 void OverrideTimestampsForInputFile(FILE_BASIC_INFO* result);

--- a/Public/Src/Sandbox/Windows/DetoursServices/PolicyResult.h
+++ b/Public/Src/Sandbox/Windows/DetoursServices/PolicyResult.h
@@ -164,6 +164,7 @@ public:
 	bool AllowRealInputTimestamps() const { return (m_policy & FileAccessPolicy_AllowRealInputTimestamps) != 0; }
     bool ReportUsnAfterOpen() const { return (m_policy & FileAccessPolicy_ReportUsnAfterOpen) != 0; }
     bool ReportDirectoryEnumeration() const { return (m_policy & FileAccessPolicy_ReportDirectoryEnumerationAccess) != 0; }
+    bool IndicateUntracked() const { return ((m_policy & FileAccessPolicy_AllowAll) == FileAccessPolicy_AllowAll) && ((m_policy & FileAccessPolicy_ReportAccess) == 0); }
     DWORD GetPathId() const { return m_policySearchCursor.IsValid() ? m_policySearchCursor.Record->GetPathId() : 0; }
     FileAccessPolicy GetPolicy() const { return m_policy; }
     USN GetExpectedUsn() const { return m_policySearchCursor.GetExpectedUsn(); }
@@ -171,7 +172,7 @@ public:
     bool IsIndeterminate() const { return m_isIndeterminate; }
 
     // Indicates if a file-open should have FILE_SHARE_READ implicitly added (as a hack to workaround tools accidentally
-    // asking for exclusive read. We are conservative here:
+    // asking for exclusive read). We are conservative here:
     // - If the process is allowed to write the file, we leave it to their discretion (even if they did not ask for write access on a particular handle).
     // - If the access result is Warn or Deny, we leave it to their discretion (maybe the access is whitelisted, and the policy should really have AllowWrite).
     bool ShouldForceReadSharing(AccessCheckResult const& accessCheck) {

--- a/Public/Src/Sandbox/Windows/DetoursTests/Main.cpp
+++ b/Public/Src/Sandbox/Windows/DetoursTests/Main.cpp
@@ -1070,6 +1070,43 @@ int CallOpenFileById()
     return (int)RtlNtStatusToDosError(status);
 }
 
+int CallDeleteWithoutSharing()
+{
+    HANDLE hFile1 = CreateFile(
+        L"untracked.txt",
+        DELETE,
+        0,
+        NULL,
+        OPEN_EXISTING,
+        FILE_ATTRIBUTE_NORMAL | FILE_FLAG_RANDOM_ACCESS,
+        NULL);
+
+    if (hFile1 == INVALID_HANDLE_VALUE)
+    {
+        return (int)GetLastError();
+    }
+
+    HANDLE hFile2 = CreateFile(
+        L"untracked.txt",
+        DELETE,
+        FILE_SHARE_DELETE,
+        NULL,
+        OPEN_EXISTING,
+        FILE_ATTRIBUTE_NORMAL | FILE_FLAG_RANDOM_ACCESS,
+        NULL);
+
+    int lastError = (int)GetLastError();
+
+    if (hFile2 != INVALID_HANDLE_VALUE)
+    {
+        CloseHandle(hFile2);
+    }
+
+    CloseHandle(hFile1);
+
+    return lastError;
+}
+
 // ----------------------------------------------------------------------------
 // STATIC FUNCTION DEFINITIONS
 // ----------------------------------------------------------------------------
@@ -1102,6 +1139,7 @@ static void GenericTests(const string& verb)
     IF_COMMAND(CallCreateFileWithZeroAccessOnDirectory);
     IF_COMMAND(CallCreateFileOnNtEscapedPath);
     IF_COMMAND(CallOpenFileById);
+    IF_COMMAND(CallDeleteWithoutSharing);
 
 #undef IF_COMMAND1
 #undef IF_COMMAND2


### PR DESCRIPTION
BuildXL modifies access parameters on CreateFile-like functions even when the file passed to those functions is untracked. For example, we explicitly always add `FILE_SHARE_DELETE` or, on certain condition, downgrade desired access to `GENERIC_READ`. Such modifications are undesirable for unit tests, for example, tests that expect to have sharing violation. Good news is, those tests are typically run in a sandbox where the files are untracked. 

This change prevents Detours from modifying access parameters for untracked file.

[AB#1530341](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1530341)