### PR TITLE
Fix null ref exceptions from Detours shim code

### DIFF
--- a/Public/Src/Engine/Processes/SubstituteProcessExecutionInfo.cs
+++ b/Public/Src/Engine/Processes/SubstituteProcessExecutionInfo.cs
@@ -69,7 +69,7 @@ namespace BuildXL.Processes
         public PathAtom ProcessName { get; }
 
         /// <summary>
-        /// An optional string to match in the argument of the process to further refine the match.
+        /// An optional string to match in the arguments of the process to further refine the match.
         /// Can be used for example with ProcessName="node.exe" ArgumentMatch="gulp.js" to match the
         /// Gulp build engine process.
         /// </summary>

--- a/Public/Src/Engine/UnitTests/Processes.Detours/SubstituteProcessExecutionTests.cs
+++ b/Public/Src/Engine/UnitTests/Processes.Detours/SubstituteProcessExecutionTests.cs
@@ -132,7 +132,7 @@ namespace Test.BuildXL.Processes.Detours
         /// </summary>
         [Theory]
         [InlineData(false, null)]
-y       [InlineData(true, "foo.exe")]  // Filter should not match
+        [InlineData(true, "foo.exe")]  // Filter should not match
         public async Task CmdWithTestShim_ShimNothingRunsChildProcessWithoutShim(bool shimAllProcesses, string processMatch)
         {
             var context = BuildXLContext.CreateInstanceForTesting();

--- a/Public/Src/Engine/UnitTests/Processes.Detours/SubstituteProcessExecutionTests.cs
+++ b/Public/Src/Engine/UnitTests/Processes.Detours/SubstituteProcessExecutionTests.cs
@@ -132,7 +132,7 @@ namespace Test.BuildXL.Processes.Detours
         /// </summary>
         [Theory]
         [InlineData(false, null)]
-// TODO: erikmav filtering broken generally       [InlineData(true, "foo.exe")]  // Filter should not match
+y       [InlineData(true, "foo.exe")]  // Filter should not match
         public async Task CmdWithTestShim_ShimNothingRunsChildProcessWithoutShim(bool shimAllProcesses, string processMatch)
         {
             var context = BuildXLContext.CreateInstanceForTesting();

--- a/Public/Src/Engine/UnitTests/Processes.Detours/SubstituteProcessExecutionTests.cs
+++ b/Public/Src/Engine/UnitTests/Processes.Detours/SubstituteProcessExecutionTests.cs
@@ -37,7 +37,7 @@ namespace Test.BuildXL.Processes.Detours
         [Theory]
 // TODO: erikmav fails on netcore, need an unmanaged shim to avoid exe/dll       [InlineData(false, null)]
 // TODO: erikmav        [InlineData(true, null)]
-// TODO: erikmav filtering broken generally       [InlineData(true, "cmd.exe")]  // Filter should match child
+// TODO: erikmav        [InlineData(true, "cmd.exe")]  // Filter should match child
 // TODO: erikmav        [InlineData(false, "cmd.exe")]  // Filter should match child
         public async Task CmdWithTestShim(bool useQuotesForChildCmdExe, string processMatch)
         {

--- a/Public/Src/Sandbox/Windows/DetoursServices/DetoursHelpers.cpp
+++ b/Public/Src/Sandbox/Windows/DetoursServices/DetoursHelpers.cpp
@@ -822,7 +822,6 @@ bool ParseFileAccessManifest(
 
     // Update the injector with the DLLs
     g_pDetouredProcessInjector->SetDlls(g_lpDllNameX86, g_lpDllNameX64);
-
     offset += dllBlock->GetSize();
 
     PCManifestSubstituteProcessExecutionShim pShimInfo = reinterpret_cast<PCManifestSubstituteProcessExecutionShim>(&payloadBytes[offset]);
@@ -833,7 +832,7 @@ bool ParseFileAccessManifest(
     {
         g_ProcessExecutionShimAllProcesses = pShimInfo->ShimAllProcesses != 0;
         uint32_t numProcessMatches = ParseUint32(payloadBytes, offset);
-        g_pShimProcessMatches = new vector<ShimProcessMatch*>(numProcessMatches);
+        g_pShimProcessMatches = new vector<ShimProcessMatch*>();
         for (uint32_t i = 0; i < numProcessMatches; i++)
         {
             wchar_t *processName = CreateStringFromWriteChars(payloadBytes, offset);

--- a/Public/Src/Sandbox/Windows/DetoursServices/SubstituteProcessExecution.cpp
+++ b/Public/Src/Sandbox/Windows/DetoursServices/SubstituteProcessExecution.cpp
@@ -244,7 +244,7 @@ static bool ShouldSubstituteShim(const wstring &command, const wchar_t *commandA
 
     bool foundMatch = false;
 
-    for (auto it = g_pShimProcessMatches->begin(); it != g_pShimProcessMatches->end(); ++it)
+    for (std::vector<ShimProcessMatch*>::iterator it = g_pShimProcessMatches->begin(); it != g_pShimProcessMatches->end(); ++it)
     {
         ShimProcessMatch *pMatch = *it;
 


### PR DESCRIPTION
vector ctor param is not a capacity but instead initializes null entries.