### PR TITLE
First notarized KEXT release (1.92.99)

### DIFF
--- a/Private/macOS/notarize.sh
+++ b/Private/macOS/notarize.sh
@@ -2,8 +2,6 @@
 
 # For detailed explanation see: https://developer.apple.com/documentation/security/notarizing_your_app_before_distribution/customizing_the_notarization_workflow
 
-set -e
-
 usage() {
     cat <<EOM
 
@@ -13,7 +11,7 @@ Usage: $(basename $0) -id <apple_id> -p <password> -k <path_to_kext>
 
         -id or --appleid         # A valid Apple ID email address, account must have correct certificates available
         -p  or --password        # The password for the specified Apple ID or Apple One-Time password (to avoid 2FA)
-        -k  or --kext            # The path to the kernel extension .kext file
+        -k  or --kext            # The path to an already signed kernel extension .kext file
 
 EOM
     exit 0
@@ -94,6 +92,8 @@ if [[ $? -eq 0 ]]; then
     exit 0
 fi
 
+set -e
+
 echo "Creating zip file..."
 ditto -c -k --rsrc --keepParent "$arg_KextPath" "$kext_zip"
 
@@ -156,6 +156,6 @@ if [[ $request_id =~ ^\{?[A-F0-9a-f]{8}-[A-F0-9a-f]{4}-[A-F0-9a-f]{4}-[A-F0-9a-f
         echo -e "Stapler exit code: $? (must be zero on success!)\n"
     fi
 else
-    echo "Invalid request id" >&2
+    echo "Invalid request id found in 'altool' output, aborting!" >&2
     exit 1
 fi

--- a/Public/Src/Engine/Processes/SandboxedKextConnection.cs
+++ b/Public/Src/Engine/Processes/SandboxedKextConnection.cs
@@ -63,7 +63,7 @@ namespace BuildXL.Processes
         /// Until some automation for kernel extension building and deployment is in place, this number has to be kept in sync with the 'CFBundleVersion'
         /// inside the Info.plist file of the kernel extension code base. BuildXL will not work if a version mismatch is detected!
         /// </summary>
-        public const string RequiredKextVersionNumber = "1.90.99";
+        public const string RequiredKextVersionNumber = "1.92.99";
 
         /// <summary>
         /// See TN2420 (https://developer.apple.com/library/archive/technotes/tn2420/_index.html) on how versioning numbers are formatted in the Apple ecosystem

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>1.90.99</string>
+	<string>1.92.99</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>BuildXLSandbox</key>

--- a/config.microsoftInternal.dsc
+++ b/config.microsoftInternal.dsc
@@ -15,7 +15,7 @@ export const pkgs = isMicrosoftInternal ? [
     { id: "Microsoft.Applications.Telemetry.Desktop", version: "1.1.152" },
 
     // Runtime dependencies used for macOS deployments
-    { id: "runtime.osx-x64.BuildXL", version: "1.90.99" },
+    { id: "runtime.osx-x64.BuildXL", version: "1.92.99" },
     { id: "Aria.Cpp.SDK.osx-x64", version: "8.5.4" },
 
     { id: "CB.QTest", version: "19.5.8.161355" },


### PR DESCRIPTION
This PR bumps the version of our macOS sandbox kext, with the published KEXT being signed and notarized for our internal release infrastructure and customers.