### PR TITLE
Avoid NRE when GRPC layer is not initialized properly

### DIFF
--- a/Public/Src/Cache/ContentStore/Library/Service/LocalContentServerBase.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/LocalContentServerBase.cs
@@ -450,7 +450,10 @@ namespace BuildXL.Cache.ContentStore.Service
 
             _portDisposer?.Dispose();
 
-            await _grpcServer.KillAsync();
+            if (_grpcServer != null)
+            {
+                await _grpcServer.KillAsync();
+            }
 
             _logIncrementalStatsTimer?.Dispose();
             await LogIncrementalStatsAsync(context);


### PR DESCRIPTION
If a content directory fails to initialize then the grpc part remains uninitialized causing NRE during shutdown.