### PR TITLE
Escape environment variables in ProcessRunScript

### DIFF
--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/ProcessRunScriptAnalyzer.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/ProcessRunScriptAnalyzer.cs
@@ -313,7 +313,7 @@ namespace BuildXL.Execution.Analyzer
                 writer.WriteLine(":: Setting PIP Environment Variables");
                 foreach (var environmentVariable in environment)
                 {
-                    writer.WriteLine("set {0}={1}", environmentVariable.Key, SanitizeEnvironmentVariableValue(environmentVariable.Value));
+                    writer.WriteLine("set {0}={1}", SanitizeEnvironmentVariableValue(environmentVariable.Key), SanitizeEnvironmentVariableValue(environmentVariable.Value));
                 }
             }
             else

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/ProcessRunScriptAnalyzer.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/ProcessRunScriptAnalyzer.cs
@@ -344,6 +344,8 @@ namespace BuildXL.Execution.Analyzer
                 new Tuple<string, string>(@"(", @"^("),
                 new Tuple<string, string>(@")", @"^)"),
                 new Tuple<string, string>(@"&", @"^&"),
+                new Tuple<string, string>(@">", @"^>"),
+                new Tuple<string, string>(@"<", @"^<"),
             };
 
             foreach (var replacement in replacements)

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/ProcessRunScriptAnalyzer.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/ProcessRunScriptAnalyzer.cs
@@ -313,7 +313,7 @@ namespace BuildXL.Execution.Analyzer
                 writer.WriteLine(":: Setting PIP Environment Variables");
                 foreach (var environmentVariable in environment)
                 {
-                    writer.WriteLine("set {0}={1}", environmentVariable.Key, environmentVariable.Value);
+                    writer.WriteLine("set {0}={1}", environmentVariable.Key, SanitizeEnvironmentVariableValue(environmentVariable.Value));
                 }
             }
             else
@@ -336,6 +336,23 @@ namespace BuildXL.Execution.Analyzer
             writer.WriteLine();
         }
 
+        private static string SanitizeEnvironmentVariableValue(string value)
+        {
+            var replacements = new List<Tuple<string, string>>()
+            {
+                new Tuple<string, string>(@"|", @"^|"),
+                new Tuple<string, string>(@"(", @"^("),
+                new Tuple<string, string>(@")", @"^)"),
+                new Tuple<string, string>(@"&", @"^&"),
+            };
+
+            foreach (var replacement in replacements)
+            {
+                value = value.Replace(replacement.Item1, replacement.Item2);
+            }
+
+            return value;
+        }
 
         private IEnumerable<Process> GetProcessPipDependents(Pip pip)
         {


### PR DESCRIPTION
Some characters need to be escaped in the ProcessRunScript created by the execution analyzer.

Fixes [AB#1474160](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1474160)