### PR TITLE
Reduce some of the events that get sent to telemetry

### DIFF
--- a/Public/Src/App/Bxl/BuildXLApp.cs
+++ b/Public/Src/App/Bxl/BuildXLApp.cs
@@ -532,7 +532,7 @@ namespace BuildXL
                     ServerModeStatusAndPerf serverModeStatusAndPerf = m_serverModeStatusAndPerf.Value;
 
                     // There is always an up to date check related to starting server mode
-                    Logger.Log.DeploymentUpToDateCheckPerformed(pm.LoggingContext, serverModeStatusAndPerf.UpToDateCheck);
+                    Logger.Log.DeploymentUpToDateCheckPerformed(pm.LoggingContext, serverModeStatusAndPerf.UpToDateCheck, serverModeStatusAndPerf.CacheCreated.HasValue, serverModeStatusAndPerf.CacheCreated.HasValue ? serverModeStatusAndPerf.CacheCreated.Value : default(ServerDeploymentCacheCreated));
 
                     // We maybe created a deployment cache
                     if (serverModeStatusAndPerf.CacheCreated.HasValue)

--- a/Public/Src/App/Bxl/Tracing/Log.cs
+++ b/Public/Src/App/Bxl/Tracing/Log.cs
@@ -417,12 +417,12 @@ namespace BuildXL.App.Tracing
             EventGenerators = EventGenerators.LocalAndTelemetry,
             EventLevel = Level.Verbose,
             Keywords = (int)(Events.Keywords.UserMessage | Events.Keywords.Progress),
-            Message = "{ShortProductName} binary deployment up-to-date check performed in {deploymentUpToDateCheck.TimeToUpToDateCheckMilliseconds}ms.")]
-        public abstract void DeploymentUpToDateCheckPerformed(LoggingContext context, ServerDeploymentUpToDateCheck deploymentUpToDateCheck);
+            Message = "{ShortProductName} binary deployment up-to-date check performed in {deploymentUpToDateCheck.TimeToUpToDateCheckMilliseconds}ms. Deployment cache created:{deploymentCacheCreated}, deployment duration:{serverDeploymentCacheCreated.TimeToCreateServerCacheMilliseconds}ms.")]
+        public abstract void DeploymentUpToDateCheckPerformed(LoggingContext context, ServerDeploymentUpToDateCheck deploymentUpToDateCheck, bool deploymentCacheCreated, ServerDeploymentCacheCreated serverDeploymentCacheCreated);
 
         [GeneratedEvent(
             (ushort)EventId.DeploymentCacheCreated,
-            EventGenerators = EventGenerators.LocalAndTelemetry,
+            EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,
             Keywords = (int)(Events.Keywords.UserMessage | Events.Keywords.Progress),
             EventTask = (ushort)Events.Tasks.HostApplication,

--- a/Public/Src/Engine/Cache/Log.cs
+++ b/Public/Src/Engine/Cache/Log.cs
@@ -105,7 +105,7 @@ namespace BuildXL.Engine.Cache.Tracing
 
         [GeneratedEvent(
             (ushort)EventId.SerializingToPipFingerprintEntryResultInCorruptedData,
-            EventGenerators = EventGenerators.LocalAndTelemetry,
+            EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,
             Keywords = (int)Events.Keywords.UserMessage,
             EventTask = (ushort)Events.Tasks.Storage,
@@ -114,7 +114,7 @@ namespace BuildXL.Engine.Cache.Tracing
 
         [GeneratedEvent(
             (ushort)EventId.DeserializingCorruptedPipFingerprintEntry,
-            EventGenerators = EventGenerators.LocalAndTelemetry,
+            EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,
             Keywords = (int)Events.Keywords.UserMessage,
             EventTask = (ushort)Events.Tasks.Storage,
@@ -123,7 +123,7 @@ namespace BuildXL.Engine.Cache.Tracing
 
         [GeneratedEvent(
             (ushort)EventId.RetryOnLoadingAndDeserializingMetadata,
-            EventGenerators = EventGenerators.LocalAndTelemetry,
+            EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,
             Keywords = (int)Events.Keywords.UserMessage,
             EventTask = (ushort)Events.Tasks.Storage,

--- a/Public/Src/Engine/Dll/Tracing/Log.cs
+++ b/Public/Src/Engine/Dll/Tracing/Log.cs
@@ -36,7 +36,7 @@ namespace BuildXL.Engine.Tracing
 
         [GeneratedEvent(
             (ushort)LogEventId.FilterDetails,
-            EventGenerators = EventGenerators.LocalAndTelemetry,
+            EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,
             EventTask = (ushort)Events.Tasks.Engine,
             Message = "PipFilter IsEmpty:{filterStatistics.IsEmpty}, ValuesToSelectivelyEvaluate:{filterStatistics.ValuesToSelectivelyEvaluate}. PathsToSelectivelyEvaluate:{filterStatistics.PathsToSelectivelyEvaluate}. ModulesToSelectivelyEvaluate:{filterStatistics.ModulesToSelectivelyEvaluate}. Negation: Total:{filterStatistics.NegatingFilterCount}, OutputFile:{filterStatistics.OutputFileFilterCount}, PipId:{filterStatistics.PipIdFilterCount}, Spec:{filterStatistics.SpecFileFilterCount}, Tag:{filterStatistics.TagFilterCount}, Value:{filterStatistics.ValueFilterCount}, Module:{filterStatistics.ModuleFilterCount}")]

--- a/Public/Src/Engine/Scheduler/Tracing/Log.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/Log.cs
@@ -1195,7 +1195,7 @@ namespace BuildXL.Scheduler.Tracing
 
         [GeneratedEvent(
             (int)LogEventId.PipCacheMetadataBelongToAnotherPip,
-            EventGenerators = EventGenerators.LocalAndTelemetry,
+            EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Error,
             Keywords = (int)Events.Keywords.UserMessage,
             EventTask = (int)Events.Tasks.PipExecutor,

--- a/Public/Src/IDE/LanguageServer/Tracing/Log.cs
+++ b/Public/Src/IDE/LanguageServer/Tracing/Log.cs
@@ -94,7 +94,7 @@ namespace BuildXL.Ide.LanguageServer.Tracing
 
         [GeneratedEvent(
             (ushort)LogEventId.CanNotFindSourceFile,
-            EventGenerators = EventGenerators.LocalAndTelemetry,
+            EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,
             EventTask = (ushort)Events.Tasks.LanguageServer,
             Message = Events.PhasePrefix + "The file '{uri}' is not part of the workspace.",
@@ -121,7 +121,7 @@ namespace BuildXL.Ide.LanguageServer.Tracing
 
         [GeneratedEvent(
             (ushort)LogEventId.NewFileWasAdded,
-            EventGenerators = EventGenerators.LocalAndTelemetry,
+            EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Warning,
             EventTask = (ushort)Events.Tasks.LanguageServer,
             Message = Events.PhasePrefix + "New file '{path}' was added to the workspace that forces a full workspace recomputation.",
@@ -130,7 +130,7 @@ namespace BuildXL.Ide.LanguageServer.Tracing
 
         [GeneratedEvent(
             (ushort)LogEventId.FileWasRemoved,
-            EventGenerators = EventGenerators.LocalAndTelemetry,
+            EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Warning,
             EventTask = (ushort)Events.Tasks.LanguageServer,
             Message = Events.PhasePrefix + "The file '{path}' was removed from the workspace that forces a full workspace recomputation.",


### PR DESCRIPTION
This stops sending a number of events to telemetry that have dubious value.

We need to be more selective with what we send to stay under quota. It's good cleanup to do as well.