### PR TITLE
[.NET Core] EventWaitHandle.TryOpenExisting with Synchronize rights only

### DIFF
--- a/Public/Src/Cache/ContentStore/Library/Utils/IpcUtilities.cs
+++ b/Public/Src/Cache/ContentStore/Library/Utils/IpcUtilities.cs
@@ -137,13 +137,17 @@ namespace BuildXL.Cache.ContentStore.Utils
         [DllImport("kernel32", EntryPoint = "OpenEventW", SetLastError = true, CharSet = CharSet.Unicode)]
         internal static extern SafeWaitHandle OpenEvent(uint desiredAccess, bool inheritHandle, string name);
 
-        private static ConstructorInfo EventWaitHandleConstructor =
-            typeof(EventWaitHandle).GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null, new[] { typeof(SafeWaitHandle) }, null);
+        private static ConstructorInfo EventWaitHandleConstructor = typeof(EventWaitHandle).GetConstructor(
+            BindingFlags.NonPublic | BindingFlags.Instance,
+            null,
+            new[] { typeof(SafeWaitHandle) },
+            null);
 
         private static bool EventWaitHandleTryOpenExisting(string name, out EventWaitHandle handle)
         {
             // In .NET Core, only EventWaitHandle.TryOpenExisting(name, out handle) is supported,
-            // which requires both Synchronize and Modify rights on the handle (see: https://github.com/dotnet/corefx/blob/b86783ef9525f22b0576278939264897464f9bbd/src/Common/src/CoreLib/System/Threading/EventWaitHandle.Windows.cs#L14)
+            // which requires both Synchronize and Modify rights on the handle
+            // (see: https://github.com/dotnet/corefx/blob/b86783ef9525f22b0576278939264897464f9bbd/src/Common/src/CoreLib/System/Threading/EventWaitHandle.Windows.cs#L14)
             //
             // When we create this handle, we grant only Synchronize, which is why here we have
             // to work around this issue by directly p-invoking OpenEvent from kernel32.dll.

--- a/Public/Src/Cache/ContentStore/Library/Utils/IpcUtilities.cs
+++ b/Public/Src/Cache/ContentStore/Library/Utils/IpcUtilities.cs
@@ -22,6 +22,9 @@ namespace BuildXL.Cache.ContentStore.Utils
         private const string DefaultReadyEventName = @"Global\ContentServerReadyEvent";
         private const string DefaultShutdownEventName = @"Global\ContentServerShutdownEvent";
 
+        private const int ERROR_FILE_NOT_FOUND = 0x2;
+        private const int ERROR_PATH_NOT_FOUND = 0x3;
+
         /// <summary>
         /// Get the shutdown handle for the given scenario.
         /// </summary>
@@ -156,6 +159,9 @@ namespace BuildXL.Cache.ContentStore.Utils
             SafeWaitHandle myHandle = OpenEvent((uint)EventWaitHandleRights.Synchronize, false, name);
             if (myHandle.IsInvalid)
             {
+                var errorCode = Marshal.GetLastWin32Error();
+                if (errorCode == ERROR_FILE_NOT_FOUND || errorCode == ERROR_PATH_NOT_FOUND)
+                    return false;
                 throw Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error());
             }
 


### PR DESCRIPTION
.NET Core does not have a method for opening an existing `EventWaitHandle` with access rights explicitly specified, i.e., `EventWaitHandle` doesn't have a static method like
```csharp
bool TryOpenExisting(string name, EventWaitHandleRights rights, out EventWaitHandle result)
```
Both .NET Core and .NET Framework do have 
```csharp
bool TryOpenExisting(string name, out EventWaitHandle result)
```
which implicitly requests the `EventWaitHandleRights.Synchronize | EventWaitHandleRights.Modify` rights (see [EventWaitHandle.OpenExistingWorker](https://github.com/dotnet/corefx/blob/b86783ef9525f22b0576278939264897464f9bbd/src/Common/src/CoreLib/System/Threading/EventWaitHandle.Windows.cs#L14)).

Currently, when we create an `EventWaitHandle`, we only allow `EventWaitHandleRights.Synchronize`.  Consequently, if we try to open that same event handle from a .NET Core process, we get an access denied error:
```
System.UnauthorizedAccessException: Access to the path 'Global\ContentServerReadyEvent' is denied.
```

This PR:
  - implements a workaround where a lower-level `OpenEventW` (from "kernel32.dll") is p-invoked to achieve the existing behavior of opening an existing `EventWaitHandle` with `Synchronize` rights only.

[AB#1541060](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1541060)