### PR TITLE
Update README.md to reflect defaults in bxl.cmd

### DIFF
--- a/Public/Src/Cache/ContentStore/Test/Stores/ContentDirectorySnapshotTests.cs
+++ b/Public/Src/Cache/ContentStore/Test/Stores/ContentDirectorySnapshotTests.cs
@@ -13,7 +13,8 @@ namespace BuildXL.Cache.ContentStore.Test.Stores
 {
     public class ContentDirectorySnapshotTests
     {
-        [Theory]
+        // TODO: fix bug 1541363
+        [TheoryIfSupported(requiresWindowsBasedOperatingSystem: true)]
         [InlineData(100)]
         public void OrderedEnumerationIsCorrect(int snapshotSize)
         {
@@ -26,7 +27,8 @@ namespace BuildXL.Cache.ContentStore.Test.Stores
             hashesFromStore.SequenceEqual(snapshot.Select(x => x.Hash)).Should().BeTrue();
         }
 
-        [Theory]
+        // TODO: fix bug 1541363
+        [TheoryIfSupported(requiresWindowsBasedOperatingSystem: true)]
         [InlineData(100)]
         public void GroupsByHashProperly(int snapshotSize)
         {

--- a/Public/Src/Cache/ContentStore/Test/Stores/ContentDirectorySnapshotTests.cs
+++ b/Public/Src/Cache/ContentStore/Test/Stores/ContentDirectorySnapshotTests.cs
@@ -11,10 +11,10 @@ using FluentAssertions;
 
 namespace BuildXL.Cache.ContentStore.Test.Stores
 {
-    public class ContentDirectorySnapshotTests
+    // TODO: fix bug 1541363
+    class ContentDirectorySnapshotTests
     {
-        // TODO: fix bug 1541363
-        [TheoryIfSupported(requiresWindowsBasedOperatingSystem: true)]
+        [Theory]
         [InlineData(100)]
         public void OrderedEnumerationIsCorrect(int snapshotSize)
         {
@@ -27,8 +27,7 @@ namespace BuildXL.Cache.ContentStore.Test.Stores
             hashesFromStore.SequenceEqual(snapshot.Select(x => x.Hash)).Should().BeTrue();
         }
 
-        // TODO: fix bug 1541363
-        [TheoryIfSupported(requiresWindowsBasedOperatingSystem: true)]
+        [Theory]
         [InlineData(100)]
         public void GroupsByHashProperly(int snapshotSize)
         {

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ This repo uses DScript files for its own build. From the root of the enlistment 
 1. Download the latest self-host engine release.
 1. Pull all needed packages from NuGet.org and other package sources.
 1. Run a debug build as well as the unit tests locally.
-1. Deploy a runnable bxl.exe to: `out\bin\debug\net472`.
+1. Deploy a runnable bxl.exe to: `out\bin\debug\win-x64`.
 
 Note you do not need administrator (elevated) privileges for your console window.
 
-If you just want to do a 'compile' without running tests you can use: `bxl.cmd -minimal` after which you can find the binaries in `out\bin\debug\net472`.
+If you just want to compile BuildXL without running tests you can use: `bxl.cmd -minimal` after which you can find the binaries in `out\bin\debug\win-x64`.
 
 Other build types can be performed as well:
 * `bxl -deployConfig release` : Retail build


### PR DESCRIPTION
Reflect recent changes in bxl.cmd defaults (namely, that a win-x64 flavor is built by default, instead of net472)