### PR TITLE
Trace PinBulk and PlaceFileBulk in ContentSessionBase

### DIFF
--- a/Public/Src/Cache/ContentStore/Library/Sessions/ContentSessionBase.cs
+++ b/Public/Src/Cache/ContentStore/Library/Sessions/ContentSessionBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BuildXL.Cache.ContentStore.Hashing;
@@ -91,21 +92,31 @@ namespace BuildXL.Cache.ContentStore.Sessions
             Counter retryCounter);
 
         /// <inheritdoc />
-        public async Task<IEnumerable<Task<Indexed<PinResult>>>> PinAsync(
+        public Task<IEnumerable<Task<Indexed<PinResult>>>> PinAsync(
             Context context,
             IReadOnlyList<ContentHash> contentHashes,
             CancellationToken token,
             UrgencyHint urgencyHint = UrgencyHint.Nominal)
         {
-            // TODO: add support for PerformOperation with Task<IEnumerable<Task<Indexed<ResultBase>>>>
+            return WithOperationContext(
+                context,
+                token,
+                operationContext => operationContext.PerformNonResultOperationAsync(
+                    Tracer,
+                    () => PinCoreAsync(operationContext, contentHashes, urgencyHint, _counters[ContentSessionBaseCounters.PinBulkRetries], _counters[ContentSessionBaseCounters.PinBulkFileCount]),
+                    extraEndMessage: results =>
+                    {
+                        var resultString = string.Join(",", results.Select(task =>
+                        {
+                            // Since all bulk operations are constructed with Task.FromResult, it is safe to just access the result;
+                            var result = task.Result;
+                            return $"{contentHashes[result.Index]}:{result.Item}";
+                        }));
 
-            using (var cancellableContext = TrackShutdown(context, token))
-            {
-                using (_counters[ContentSessionBaseCounters.PinBulk].Start())
-                {
-                    return await PinCoreAsync(cancellableContext, contentHashes, urgencyHint, _counters[ContentSessionBaseCounters.PinBulkRetries], _counters[ContentSessionBaseCounters.PinBulkFileCount]);
-                }
-            }
+                        return $"Hashes=[{resultString}]";
+                    },
+                    traceOperationStarted: false,
+                    counter: _counters[ContentSessionBaseCounters.PinBulk]));
         }
 
         /// <nodoc />

--- a/Public/Src/Cache/ContentStore/Library/Utils/StartupShutdownSlimBase.cs
+++ b/Public/Src/Cache/ContentStore/Library/Utils/StartupShutdownSlimBase.cs
@@ -114,7 +114,6 @@ namespace BuildXL.Cache.ContentStore.Utils
         /// Runs a given function within a newly created operation context.
         /// </summary>
         protected async Task<T> WithOperationContext<T>(Context context, CancellationToken token, Func<OperationContext, Task<T>> func)
-            where T : ResultBase
         {
             using (var operationContext = TrackShutdown(context, token))
             {

--- a/Public/Src/Cache/ContentStore/Vsts/BlobReadOnlyContentSession.cs
+++ b/Public/Src/Cache/ContentStore/Vsts/BlobReadOnlyContentSession.cs
@@ -344,8 +344,6 @@ namespace BuildXL.Cache.ContentStore.Vsts
                 innerCts => BlobStoreHttpClient.TryReferenceAsync(references, cancellationToken: innerCts),
                 context.Token).ConfigureAwait(false);
 
-            _counters[BackingContentStore.SessionCounters.PinSatisfiedFromRemote].Increment();
-
             // There's 1-1 mapping between given content hashes and blob ids
             var remoteResults = blobIds
                 .Select((blobId, i) =>
@@ -354,12 +352,13 @@ namespace BuildXL.Cache.ContentStore.Vsts
                         ? PinResult.ContentNotFound
                         : PinResult.Success;
                     if (pinResult.Succeeded)
-                        {
-                            BackingContentStoreExpiryCache.Instance.AddExpiry(contentHashes[i], endDateTime);
-                        }
+                    {
+                        BackingContentStoreExpiryCache.Instance.AddExpiry(contentHashes[i], endDateTime);
+                        _counters[BackingContentStore.SessionCounters.PinSatisfiedFromRemote].Increment();
+                    }
 
-                        return pinResult.WithIndex(i);
-                    });
+                    return pinResult.WithIndex(i);
+                });
 
             return remoteResults.AsTasks();
         }

--- a/Public/Src/Cache/ContentStore/Vsts/DedupReadOnlyContentSession.cs
+++ b/Public/Src/Cache/ContentStore/Vsts/DedupReadOnlyContentSession.cs
@@ -317,7 +317,6 @@ namespace BuildXL.Cache.ContentStore.Vsts
         {
             try
             {
-
                 return await Workflows.RunWithFallback(
                     contentHashes,
                     hashes => CheckInMemoryCache(hashes),


### PR DESCRIPTION
Previously PerformOperationAsync only supported operations which returned a ResultBase.

PerformNonResultOperationAsync was created, which accepts any return type, with an additional method resultBaseFatory which gives the option to translate the result into a ResultBase for telemetry purposes.

PinBulk and PlaceFileBulk now call PerformNonResultOperationAsync. This should allow for better telemetry and logging.