### PR TITLE
Fix IndexOutOfRange error when content snapshot takes hash that starts with FF

### DIFF
--- a/Public/Src/Cache/ContentStore/Library/Stores/ContentDirectorySnapshot.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/ContentDirectorySnapshot.cs
@@ -17,11 +17,11 @@ namespace BuildXL.Cache.ContentStore.Stores
     /// <typeparam name="T">Type held inside the snapshot</typeparam>
     public class ContentDirectorySnapshot<T> : IEnumerable<PayloadFromDisk<T>>
     {
-        private List<PayloadFromDisk<T>>[] _snapshot;
-        private BitArray _sorted;
+        private readonly List<PayloadFromDisk<T>>[] _snapshot;
+        private readonly BitArray _sorted;
 
         /// <nodoc />
-        public long Count { get; private set; } = 0;
+        public long Count { get; private set; }
 
         /// <nodoc />
         public ContentDirectorySnapshot()
@@ -34,7 +34,7 @@ namespace BuildXL.Cache.ContentStore.Stores
         
         private List<PayloadFromDisk<T>>[] InitializeSnapshot()
         {
-            var snapshot = new List<PayloadFromDisk<T>>[byte.MaxValue];
+            var snapshot = new List<PayloadFromDisk<T>>[byte.MaxValue + 1];
             for (var i = 0; i < snapshot.Length; i++)
             {
                 snapshot[i] = new List<PayloadFromDisk<T>>();

--- a/Public/Src/Cache/ContentStore/Test/Stores/ContentDirectorySnapshotTests.cs
+++ b/Public/Src/Cache/ContentStore/Test/Stores/ContentDirectorySnapshotTests.cs
@@ -10,7 +10,6 @@ namespace BuildXL.Cache.ContentStore.Test.Stores
     // TODO: fix bug 1541363
     public class ContentDirectorySnapshotTests
     {
-        
         [Fact]
         public void SnapshotShouldNotFailWithOutOfRange()
         {

--- a/Public/Src/Cache/ContentStore/Test/Stores/ContentDirectorySnapshotTests.cs
+++ b/Public/Src/Cache/ContentStore/Test/Stores/ContentDirectorySnapshotTests.cs
@@ -1,19 +1,30 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using BuildXL.Cache.ContentStore.Hashing;
 using BuildXL.Cache.ContentStore.Stores;
 using Xunit;
-using Xunit.Abstractions;
 using FluentAssertions;
 
 namespace BuildXL.Cache.ContentStore.Test.Stores
 {
     // TODO: fix bug 1541363
-    class ContentDirectorySnapshotTests
+    public class ContentDirectorySnapshotTests
     {
+        
+        [Fact]
+        public void SnapshotShouldNotFailWithOutOfRange()
+        {
+            var snapshot = new ContentDirectorySnapshot<int>();
+
+            for (short b = 0; b <= byte.MaxValue; b++)
+            {
+                var data = new byte[33];
+                data[0] = (byte)b;
+                var hash = new ContentHash(HashType.Vso0, data);
+                snapshot.Add(new PayloadFromDisk<int>(hash, 42));
+            }
+        }
+
         [Theory]
         [InlineData(100)]
         public void OrderedEnumerationIsCorrect(int snapshotSize)


### PR DESCRIPTION
Fixing of by one error.