### PR TITLE
Fix Microsoft/BuildXL#376 Shared\Scripts contains unicode BOM trash.

### DIFF
--- a/Shared/Scripts/BuildXLLkgVersion.cmd
+++ b/Shared/Scripts/BuildXLLkgVersion.cmd
@@ -1,4 +1,4 @@
-﻿REM @echo off
+REM @echo off
 set BUILDXL_LKG_NAME=BuildXL.win-x64
 set BUILDXL_LKG_VERSION=0.1.0-20190524.5
 set BUILDXL_LKG_FEED_1=https://pkgs.dev.azure.com/1essharedassets/_packaging/BuildXL/nuget/v3/index.json

--- a/Shared/Scripts/BuildXLLkgVersionPublic.cmd
+++ b/Shared/Scripts/BuildXLLkgVersionPublic.cmd
@@ -1,4 +1,4 @@
-﻿REM @echo off
+REM @echo off
 set BUILDXL_LKG_NAME=Microsoft.BuildXL.win-x64
 set BUILDXL_LKG_VERSION=0.1.0-20190524.5
 set BUILDXL_LKG_FEED_1=https://dotnet.myget.org/F/buildxl-selfhost/api/v3/index.json


### PR DESCRIPTION
Removed the BOM's from BuildXLLkgVersion.cmd and BuildXLLkgVerionPublic.cmd files.  Saved as UTF-8 no BOM.