### PR TITLE
Fix FileMaterializationInfo serialization

### DIFF
--- a/Public/Src/Engine/Scheduler/Distribution/ExecutionResultSerializer.cs
+++ b/Public/Src/Engine/Scheduler/Distribution/ExecutionResultSerializer.cs
@@ -496,7 +496,7 @@ namespace BuildXL.Scheduler.Distribution
                 {
                     var output = outputContent[i];
                     WriteFileArtifact(writer, output.fileArtifact);
-                    writer.WriteCompact(output.fileMaterializationInfo.Length);
+                    writer.WriteCompact(output.fileMaterializationInfo.FileContentInfo.RawLength);
                     output.Item2.Hash.SerializeHashBytes(byteBuffer, 0);
                     writer.Write(byteBuffer, 0, ContentHashingUtilities.HashInfo.ByteLength);
                     WritePathAtom(writer, output.fileMaterializationInfo.FileName);

--- a/Public/Src/Utilities/Storage/FileMaterializationInfo.cs
+++ b/Public/Src/Utilities/Storage/FileMaterializationInfo.cs
@@ -79,6 +79,9 @@ namespace BuildXL.Storage
         /// <summary>
         /// Length of the file in bytes.
         /// </summary>
+        /// <remarks>
+        /// Do not use this value for serialization (use FileContentInfo.RawLength)
+        /// </remarks>
         public long Length => FileContentInfo.Length;
 
         /// <inheritdoc />


### PR DESCRIPTION
While serializing FileMaterializationInfo , one must use FileContentInfo.RawLength value (FileContentInfo.Length is always non-negative, i.e., serialization/deserialization trip would result in wrong data for UnknownLength entries)

[AB#1534271](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1534271)