### PR TITLE
Temp cleaner disposal should wait until clean-paths thread joins

### DIFF
--- a/Public/Src/Engine/Scheduler/TempCleaner.cs
+++ b/Public/Src/Engine/Scheduler/TempCleaner.cs
@@ -123,11 +123,8 @@ namespace BuildXL.Scheduler
         {
             if (!m_disposed)
             {
-                m_disposed = true;
-
                 m_cancellationSource.Cancel();
-                m_pathsToDelete.CompleteAdding();
-                m_cleanerThread.Join();
+                WaitPendingTasksForCompletion();
 
                 Tracing.Logger.Log.PipTempCleanerSummary(
                     Events.StaticContext,
@@ -140,6 +137,8 @@ namespace BuildXL.Scheduler
 
                 m_pathsToDelete.Dispose();
                 m_cancellationSource.Dispose();
+
+                m_disposed = true;
             }
         }
 

--- a/Public/Src/Engine/Scheduler/Tracing/Log.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/Log.cs
@@ -2181,22 +2181,22 @@ namespace BuildXL.Scheduler.Tracing
         #endregion
 
         [GeneratedEvent(
-            (ushort)EventId.PipTempDirectoryCleanupWarning,
-            EventLevel = Level.Warning,
+            (ushort)EventId.PipFailedTempDirectoryCleanup,
+            EventLevel = Level.Verbose,
             EventGenerators = EventGenerators.LocalOnly,
             Keywords = (int)Events.Keywords.UserMessage,
-            EventTask = (int)Events.Tasks.PipExecutor,
+            EventTask = (int)Events.Tasks.Scheduler,
             Message = "Failed to clean temp directory at '{0}'. Reason: {1}")]
-        public abstract void PipTempDirectoryCleanupWarning(LoggingContext context, string directory, string exceptionMessage);
+        public abstract void PipFailedTempDirectoryCleanup(LoggingContext context, string directory, string exceptionMessage);
 
         [GeneratedEvent(
-            (ushort)EventId.PipTempFileCleanupWarning,
-            EventLevel = Level.Warning,
+            (ushort)EventId.PipFailedTempFileCleanup,
+            EventLevel = Level.Verbose,
             EventGenerators = EventGenerators.LocalOnly,
             Keywords = (int)Events.Keywords.UserMessage,
-            EventTask = (int)Events.Tasks.PipExecutor,
+            EventTask = (int)Events.Tasks.Scheduler,
             Message = "Failed to clean temp file at '{0}'. Reason: {1}")]
-        public abstract void PipTempFileCleanupWarning(LoggingContext context, string file, string exceptionMessage);
+        public abstract void PipFailedTempFileCleanup(LoggingContext context, string file, string exceptionMessage);
 
         [GeneratedEvent(
             (ushort)EventId.PipTempCleanerThreadSummary,
@@ -2204,8 +2204,8 @@ namespace BuildXL.Scheduler.Tracing
             EventGenerators = EventGenerators.LocalOnly,
             Keywords = (int)Events.Keywords.UserMessage,
             EventTask = (int)Events.Tasks.PipExecutor,
-            Message = "Temp cleaner thread exited with {0} cleaned, {1} remaining and {2} failed temp directories, {3} cleaned, {4} remaining and {5} failed temp files. (timed out: {6})")]
-        public abstract void PipTempCleanerSummary(LoggingContext context, long cleanedDirs, long remainingDirs, long failedDirs, long cleanedFiles, long remainingFiles, long failedFiles, bool timedout);
+            Message = "Temp cleaner thread exited with {0} cleaned, {1} remaining and {2} failed temp directories, {3} cleaned, {4} remaining and {5} failed temp files")]
+        public abstract void PipTempCleanerSummary(LoggingContext context, long cleanedDirs, long remainingDirs, long failedDirs, long cleanedFiles, long remainingFiles, long failedFiles);
 
         [GeneratedEvent(
             (int)EventId.RunningTimeAdded,

--- a/Public/Src/Utilities/Utilities/Tracing/EventId.cs
+++ b/Public/Src/Utilities/Utilities/Tracing/EventId.cs
@@ -626,11 +626,11 @@ namespace BuildXL.Utilities.Tracing
         IncrementalFrontendCache = 2108,
 
         // Temp files/directory cleanup
-        PipTempDirectoryCleanupWarning = 2200,
+        PipFailedTempDirectoryCleanup = 2200,
         PipTempDirectoryCleanupError = 2201,
         PipTempCleanerThreadSummary = 2202,
         PipTempDirectorySetupError = 2203,
-        PipTempFileCleanupWarning = 2204,
+        PipFailedTempFileCleanup = 2204,
 
         PipFailedToCreateDumpFile = 2210,
 


### PR DESCRIPTION
Temp cleaner disposal should wait until clean path thread joins.

The bug occurs due to the use of timeout in joining clean-paths thread. If joining timeouts, then the clean-paths thread still executes and tries to take an element from the blocking collection. However, the collection may get disposed by the thread disposing the temp cleaner. Taking an element from a disposed blocking collection throws an exception.

[AB#1546091](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1546091)