### PR TITLE
Correctly compute priority by separating critical path priority from a given spec priority

### DIFF
--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -84,7 +84,7 @@ namespace BuildXL.Scheduler
         /// The max priority assigned to pips in the initial critical path
         /// prioritization
         /// </summary>
-        private const int MaxInitialPipPriority = int.MaxValue - 1;
+        private const int MaxInitialPipPriority = (1 << 24) - 1;
 
         /// <summary>
         /// The priority of IPC pips when entering the ChooseWorker queue. This is greater than
@@ -5013,14 +5013,18 @@ namespace BuildXL.Scheduler
                             // Below, we add one or more quanitites in the uint range.
                             // We use a long here to trivially avoid any overflow, and saturate to uint.MaxValue if needed as the last step.
                             long criticalPath = 0;
+                            int priorityBase = 0;
 
                             // quick check to avoid allocation of enumerator (as we are going through an interface, and where everything gets boxed!)
                             if (!graph.IsSinkNode(node))
                             {
                                 foreach (var edge in graph.GetOutgoingEdges(node))
                                 {
-                                    var otherCriticalPath = GetPipRuntimeInfo(edge.OtherNode).Priority;
-                                    criticalPath = Math.Max(criticalPath, otherCriticalPath);
+                                    var otherPriority = GetPipRuntimeInfo(edge.OtherNode).Priority;
+
+                                    // Priority consists of given priority in the specs (bits 24-31, and the critical path priority (bits 0-23)
+                                    criticalPath = Math.Max(criticalPath, otherPriority & ((1 << 24) - 1));
+                                    priorityBase = Math.Max(priorityBase, otherPriority >> 24);
                                 }
                             }
 
@@ -5082,10 +5086,9 @@ namespace BuildXL.Scheduler
                                 }
                             }
 
-                            int priorityBase = m_pipTable.GetPipPriority(pipId) << 24;
+                            priorityBase = Math.Max(m_pipTable.GetPipPriority(pipId), priorityBase) << 24;
                             int criticalPathPriority = (criticalPath < 0 || criticalPath > MaxInitialPipPriority) ? MaxInitialPipPriority : unchecked((int)criticalPath);
-                            criticalPathPriority = Math.Min(criticalPathPriority, (1 << 24) - 1);
-                            pipRuntimeInfo.Priority = priorityBase | criticalPathPriority;
+                            pipRuntimeInfo.Priority = priorityBase + criticalPathPriority;
 
                             Contract.Assert(pipType != PipType.HashSourceFile);
                             pipRuntimeInfo.Transition(m_pipStateCounters, pipType, PipState.Waiting);


### PR DESCRIPTION
When priority was first added, the computation was done incorrectly.  There are two pieces to priority, the one specified in the spec file and the one computed by critical path.  To compute the new values for these, the outgoing pips priority needs to be separated into the specified priority and the critical path priority.  Each of these values in then maxxed to find the largest priority that the pip should have.