### PR TITLE
Fix the printout of bxl command line arguments

### DIFF
--- a/Public/Src/App/Bxl/AppServer.cs
+++ b/Public/Src/App/Bxl/AppServer.cs
@@ -669,16 +669,9 @@ namespace BuildXL
                     return null;
                 }
 
-                Assembly rootAssembly = Assembly.GetEntryAssembly();
-                Contract.Assert(rootAssembly != null, "Could not look up entry assembly");
-
-                string pathToProcess = Path.Combine(serverDeployment.DeploymentPath, new FileInfo(AssemblyHelper.GetAssemblyLocation(rootAssembly)).Name);
-                if (pathToProcess.EndsWith(".dll"))
-                {
-                    pathToProcess = OperatingSystemHelper.IsUnixOS
-                        ? Path.GetFileNameWithoutExtension(pathToProcess)
-                        : Path.ChangeExtension(pathToProcess, "exe");
-                }
+                string pathToProcess = Path.Combine(
+                    serverDeployment.DeploymentPath,
+                    new FileInfo(AssemblyHelper.GetThisProgramExeLocation()).Name);
 
                 StartupParameters newServerParameters = StartupParameters.CreateForNewAppServer(
                     uniqueAppName,

--- a/Public/Src/App/Bxl/BuildXLApp.cs
+++ b/Public/Src/App/Bxl/BuildXLApp.cs
@@ -224,14 +224,16 @@ namespace BuildXL
             m_startTimeUtc = startTimeUtc ?? Process.GetCurrentProcess().StartTime.ToUniversalTime();
 
             // Allow the client to override the command line that gets logged which will be different from the server
-            m_commandLineArguments = commandLineArguments ?? Environment.GetCommandLineArgs();
+            m_commandLineArguments = commandLineArguments ?? AssemblyHelper.GetCommandLineArgs();
             m_pathTable = pathTable;
 
             // This app was requested to be launched in server mode, but the server cannot be started
             // We store this to log it once the appropriate listeners are set up
             m_serverModeStatusAndPerf = serverModeStatusAndPerf;
 
-            m_crashCollector = OperatingSystemHelper.IsUnixOS ? new CrashCollectorMacOS(new[] { CrashType.BuildXL, CrashType.Kernel }) : null;
+            m_crashCollector = OperatingSystemHelper.IsUnixOS 
+                ? new CrashCollectorMacOS(new[] { CrashType.BuildXL, CrashType.Kernel })
+                : null;
         }
 
         private static void ConfigureCacheMissLogging(PathTable pathTable, BuildXL.Utilities.Configuration.Mutable.CommandLineConfiguration mutableConfig)

--- a/Public/Src/App/Bxl/BuildXLAppServerData.cs
+++ b/Public/Src/App/Bxl/BuildXLAppServerData.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Diagnostics.ContractsLight;
 using System.IO;
 using BuildXL.App.Tracing;
+using BuildXL.Utilities;
 
 namespace BuildXL
 {
@@ -94,7 +95,7 @@ namespace BuildXL
                 environmentVariables,
                 serverModeStatusAndPerf,
                 Directory.GetCurrentDirectory(),
-                Environment.GetCommandLineArgs()[0],
+                AssemblyHelper.GetThisProgramExeLocation(),
                 Process.GetCurrentProcess().StartTime);
         }
 

--- a/Public/Src/App/Bxl/Program.cs
+++ b/Public/Src/App/Bxl/Program.cs
@@ -146,7 +146,7 @@ namespace BuildXL
                     return ExitKind.InvalidCommandLine;
                 }
 
-                string clientPath = Environment.GetCommandLineArgs()[0];
+                string clientPath = AssemblyHelper.GetThisProgramExeLocation();
                 var rawArgsWithExe = new List<string>(rawArgs.Count + 1) { clientPath };
                 rawArgsWithExe.AddRange(rawArgs);
 

--- a/Public/Src/Utilities/UnitTests/Utilities/OperatingSystemHelperTests.cs
+++ b/Public/Src/Utilities/UnitTests/Utilities/OperatingSystemHelperTests.cs
@@ -31,15 +31,11 @@ namespace Test.BuildXL.Utilities
         [Fact]
         public void TestExeName()
         {
-            var ext = Path.GetExtension(AssemblyHelper.GetThisProgramExeLocation());
-            if (OperatingSystemHelper.IsUnixOS)
-            {
-                Assert.Equal("", ext);
-            }
-            else
-            {
-                Assert.Equal(".exe", ext);
-            }
+            var name = AssemblyHelper.AdjustExeExtension("bxl.dll");
+            var expected = OperatingSystemHelper.IsUnixOS
+                ? "bxl"
+                : "bxl.exe";
+            Assert.Equal(expected, name);
         }
     }
 }

--- a/Public/Src/Utilities/UnitTests/Utilities/OperatingSystemHelperTests.cs
+++ b/Public/Src/Utilities/UnitTests/Utilities/OperatingSystemHelperTests.cs
@@ -4,6 +4,7 @@
 //  
 // --------------------------------------------------------------------
 
+using System.IO;
 using BuildXL.Utilities;
 using Xunit;
 
@@ -25,7 +26,20 @@ namespace Test.BuildXL.Utilities
             {
                 Assert.NotEqual(noNetFrameworkIsDetected, frameworkAsText);
             }
+        }
 
+        [Fact]
+        public void TestExeName()
+        {
+            var ext = Path.GetExtension(AssemblyHelper.GetThisProgramExeLocation());
+            if (OperatingSystemHelper.IsUnixOS)
+            {
+                Assert.Equal("", ext);
+            }
+            else
+            {
+                Assert.Equal(".exe", ext);
+            }
         }
     }
 }

--- a/Public/Src/Utilities/UnitTests/Utilities/OperatingSystemHelperTests.cs
+++ b/Public/Src/Utilities/UnitTests/Utilities/OperatingSystemHelperTests.cs
@@ -4,7 +4,6 @@
 //  
 // --------------------------------------------------------------------
 
-using System.IO;
 using BuildXL.Utilities;
 using Xunit;
 

--- a/Public/Src/Utilities/UnitTests/Utilities/Test.BuildXL.Utilities.dsc
+++ b/Public/Src/Utilities/UnitTests/Utilities/Test.BuildXL.Utilities.dsc
@@ -14,6 +14,7 @@ namespace Core {
             importFrom("BuildXL.Utilities").Native.dll,
             importFrom("BuildXL.Utilities").ToolSupport.dll,
             importFrom("BuildXL.Utilities").Collections.dll,
+            importFrom("BuildXL.Utilities").Configuration.dll,
         ],
     });
 }

--- a/Public/Src/Utilities/Utilities/AssemblyHelper.cs
+++ b/Public/Src/Utilities/Utilities/AssemblyHelper.cs
@@ -98,7 +98,7 @@ namespace BuildXL.Utilities
             if (entryAssemblyLocation.EndsWith(".dll"))
             {
                 return OperatingSystemHelper.IsUnixOS
-                    ? Path.GetFileNameWithoutExtension(entryAssemblyLocation)
+                    ? entryAssemblyLocation.Substring(0, entryAssemblyLocation.Length - 4)
                     : Path.ChangeExtension(entryAssemblyLocation, "exe");
             }
             else

--- a/Public/Src/Utilities/Utilities/AssemblyHelper.cs
+++ b/Public/Src/Utilities/Utilities/AssemblyHelper.cs
@@ -109,7 +109,7 @@ namespace BuildXL.Utilities
 
         /// <summary>
         /// Returns the same as <see cref="Environment.GetCommandLineArgs"/> except that the first
-        /// element (which is executable name) has its extension adjusted by calling
+        /// element (which is the name of the executable) is adjusted by calling
         /// <see cref="AdjustExeExtension(string)"/> on it.
         /// </summary>
         public static string[] GetCommandLineArgs()

--- a/Public/Src/Utilities/Utilities/AssemblyHelper.cs
+++ b/Public/Src/Utilities/Utilities/AssemblyHelper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -78,6 +79,45 @@ namespace BuildXL.Utilities
         public static string GetLocation(this Assembly assembly, bool computeAssemblyLocation = false)
         {
             return GetAssemblyLocation(assembly, computeAssemblyLocation);
+        }
+
+        /// <summary>
+        /// Calls <see cref="AdjustExeExtension(string)"/> for the location of the entry assembly
+        /// </summary>
+        public static string GetThisProgramExeLocation() => AdjustExeExtension(Assembly.GetEntryAssembly().GetLocation());
+
+        /// <summary>
+        /// Adjusts the extension of the supplied path:
+        ///   - if the extension is .dll and we are running on Windows --> change extension to .exe
+        ///   - if the extension is .dll and we are running on non-Windows --> drop the extension
+        ///   - else --> return as is
+        /// </summary>
+        /// <param name="entryAssemblyLocation">Absolute path the the executing assembly</param>
+        public static string AdjustExeExtension(string entryAssemblyLocation)
+        {
+            if (entryAssemblyLocation.EndsWith(".dll"))
+            {
+                return OperatingSystemHelper.IsUnixOS
+                    ? Path.GetFileNameWithoutExtension(entryAssemblyLocation)
+                    : Path.ChangeExtension(entryAssemblyLocation, "exe");
+            }
+            else
+            {
+                return entryAssemblyLocation;
+            }
+        }
+
+        /// <summary>
+        /// Returns the same as <see cref="Environment.GetCommandLineArgs"/> except that the first
+        /// element (which is executable name) has its extension adjusted by calling
+        /// <see cref="AdjustExeExtension(string)"/> on it.
+        /// </summary>
+        public static string[] GetCommandLineArgs()
+        {
+            var cmdLineArgs = Environment.GetCommandLineArgs();
+            return new[] { AdjustExeExtension(cmdLineArgs[0]) }
+                .Concat(cmdLineArgs.Skip(1))
+                .ToArray();
         }
     }
 }


### PR DESCRIPTION
When printed out, the extension of the entry assembly is adjusted as follows:
  - if the extension is .dll and we are running on Windows --> the extension is changed to .exe
  - if the extension is .dll and we are running on non-Windows --> the extension is dropped
  - else --> no adjustment needed

[AB#1547983](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1547983)