### PR TITLE
Flight consistent temp directory creation behind a flag

### DIFF
--- a/Public/Src/App/Bxl/Args.cs
+++ b/Public/Src/App/Bxl/Args.cs
@@ -366,6 +366,9 @@ namespace BuildXL
                         OptionHandlerFactory.CreateBoolOption(
                             "enableGrpc",
                             sign => distributionConfiguration.IsGrpcEnabled = sign),
+                        OptionHandlerFactory.CreateBoolOption(
+                            "enableIncrementalFrontEnd",
+                            sign => frontEndConfiguration.EnableIncrementalFrontEnd = sign),
                         OptionHandlerFactory.CreateBoolOptionWithValue(
                             "enableLazyOutputs",
                             (opt, sign) => HandleLazyOutputMaterializationOption(opt, sign, schedulingConfiguration)),
@@ -373,11 +376,8 @@ namespace BuildXL
                             "engineCacheDirectory",
                             opt => layoutConfiguration.EngineCacheDirectory = CommandLineUtilities.ParsePathOption(opt, pathTable)),
                         OptionHandlerFactory.CreateBoolOption(
-                            "enableIncrementalFrontEnd",
-                            sign => frontEndConfiguration.EnableIncrementalFrontEnd = sign),
-                        OptionHandlerFactory.CreateBoolOption(
-                            "respectWeakFingerprintForNugetUpToDateCheck",
-                            sign => frontEndConfiguration.RespectWeakFingerprintForNugetUpToDateCheck = sign),
+                            "ensureTempDirectoriesExistenceBeforePipExecution",
+                            sign => sandboxConfiguration.EnsureTempDirectoriesExistenceBeforePipExecution = sign),
                         OptionHandlerFactory.CreateOption(
                             "environment",
                             opt => loggingConfiguration.Environment = CommandLineUtilities.ParseEnumOption<ExecutionEnvironment>(opt)),
@@ -722,7 +722,7 @@ namespace BuildXL
                             "redirectUserProfile",
                             opt => enableProfileRedirect = opt),
                         OptionHandlerFactory.CreateOption(
-                            "RedirectedUserProfileJunctionRoot",
+                            "redirectedUserProfileJunctionRoot",
                             opt => layoutConfiguration.RedirectedUserProfileJunctionRoot = CommandLineUtilities.ParsePathOption(opt, pathTable)),
                         OptionHandlerFactory.CreateOption(
                             "relatedActivityId",
@@ -742,6 +742,9 @@ namespace BuildXL
                         OptionHandlerFactory.CreateBoolOption(
                             "replicateOutputsToWorkers",
                             sign => distributionConfiguration.ReplicateOutputsToWorkers = sign),
+                        OptionHandlerFactory.CreateBoolOption(
+                            "respectWeakFingerprintForNugetUpToDateCheck",
+                            sign => frontEndConfiguration.RespectWeakFingerprintForNugetUpToDateCheck = sign),
                         OptionHandlerFactory.CreateBoolOption(
                             "reuseEngineState",
                             sign => engineConfiguration.ReuseEngineState = sign),

--- a/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
@@ -2078,7 +2078,9 @@ namespace BuildXL.Processes
             {
                 // Temp directories are lazily, best effort cleaned after the pip finished. The previous build may not
                 // have finished this work before exiting so we must double check.
-                PreparePathForDirectory(tempDirectoryPath.ToString(m_pathTable), createIfNonExistent: true);
+                PreparePathForDirectory(
+                    tempDirectoryPath.ToString(m_pathTable), 
+                    createIfNonExistent: m_sandboxConfig.EnsureTempDirectoriesExistenceBeforePipExecution);
             }
             catch (BuildXLException ex)
             {

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SchedulerIntegrationTestBase.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SchedulerIntegrationTestBase.cs
@@ -85,6 +85,7 @@ namespace Test.BuildXL.Scheduler
             Configuration.Logging.LogExecution = false;
             Configuration.Engine.TrackBuildsInUserFolder = false;
             Configuration.Engine.CleanTempDirectories = false;
+            Configuration.Sandbox.EnsureTempDirectoriesExistenceBeforePipExecution = true;
 
             // Skip hash source file pips
             // Some error becomes a contract exception when SkipHashSourceFile is enabled.

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/TempDirectoryTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/TempDirectoryTests.cs
@@ -432,6 +432,44 @@ namespace IntegrationTest.Domino.Scheduler
         }
 
         /// <summary>
+        /// This tests shows an inconsistent behavior regarding temp directories creation as mentioned in Bug 1549282.
+        /// </summary>
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void InconsistentTempDirectoriesCreation(bool ensureTempDirectoriesCreation)
+        {
+            Configuration.Sandbox.EnsureTempDirectoriesExistenceBeforePipExecution = ensureTempDirectoriesCreation;
+
+            AbsolutePath additionalTempDirectory = TempRootPath.Combine(
+                Context.PathTable, 
+                nameof(InconsistentTempDirectoriesCreation) + "_" + ensureTempDirectoriesCreation);
+
+            var pipBuilder = CreatePipBuilder(new[]
+            {
+                Operation.ReadFile(CreateSourceFile()),
+                Operation.CreateDir(DirectoryArtifact.CreateWithZeroPartialSealId(additionalTempDirectory), additionalArgs: "--failedIfExists"),
+                Operation.WriteFile(CreateOutputFileArtifact())
+            });
+
+            pipBuilder.EnableTempDirectory();
+            pipBuilder.AdditionalTempDirectories = ReadOnlyArray<AbsolutePath>.FromWithoutCopy(new AbsolutePath[] { additionalTempDirectory });
+
+            var processWithOutputs = SchedulePipBuilder(pipBuilder);
+            var result = RunScheduler();
+
+            if (ensureTempDirectoriesCreation)
+            {
+                result.AssertFailure();
+                AssertErrorEventLogged(EventId.PipProcessError, 1);
+            }
+            else
+            {
+                result.AssertSuccess();
+            }
+        }
+
+        /// <summary>
         /// Creates and schedules a pip that writes a file to a temp file or folder location as specified.
         /// </summary>
         /// <param name="tempArtifactType">

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/TempDirectoryTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/TempDirectoryTests.cs
@@ -448,7 +448,7 @@ namespace IntegrationTest.Domino.Scheduler
             var pipBuilder = CreatePipBuilder(new[]
             {
                 Operation.ReadFile(CreateSourceFile()),
-                Operation.CreateDir(DirectoryArtifact.CreateWithZeroPartialSealId(additionalTempDirectory), additionalArgs: "--failedIfExists"),
+                Operation.CreateDir(DirectoryArtifact.CreateWithZeroPartialSealId(additionalTempDirectory), additionalArgs: "--failIfExists"),
                 Operation.WriteFile(CreateOutputFileArtifact())
             });
 

--- a/Public/Src/Utilities/Configuration/ISandboxConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/ISandboxConfiguration.cs
@@ -220,5 +220,18 @@ namespace BuildXL.Utilities.Configuration
         /// This is used mainly for testing.
         /// </remarks>
         AbsolutePath RedirectedTempFolderRootForVmExecution { get; }
+
+        /// <summary>
+        /// Ensures temp directories existence before pip execution.
+        /// </summary>
+        /// <remarks>
+        /// This is a temporary flag for enforcing consistent behavior in temp directories creation.
+        /// If this flag is set to false, then only directories specified in %TMP% and %TEMP% are 
+        /// ensured to exist, but additional temp directories are not. The current default is false. 
+        /// Eventually, BuildXL will always ensure temp directory creation. However, currently, such a change
+        /// can break customers who assume that additional temp directories are not created before the pip executes.
+        /// Thus, this enforcement is made opt-in.
+        /// </remarks>
+        bool EnsureTempDirectoriesExistenceBeforePipExecution { get; }
     }
 }

--- a/Public/Src/Utilities/Configuration/Mutable/SandboxConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/SandboxConfiguration.cs
@@ -42,6 +42,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             ContainerConfiguration = new SandboxContainerConfiguration();
             AdminRequiredProcessExecutionMode = AdminRequiredProcessExecutionMode.Internal;
             RedirectedTempFolderRootForVmExecution = AbsolutePath.Invalid;
+            EnsureTempDirectoriesExistenceBeforePipExecution = false;
         }
 
         /// <nodoc />
@@ -85,6 +86,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             ContainerConfiguration = new SandboxContainerConfiguration(template.ContainerConfiguration);
             AdminRequiredProcessExecutionMode = template.AdminRequiredProcessExecutionMode;
             RedirectedTempFolderRootForVmExecution = pathRemapper.Remap(template.RedirectedTempFolderRootForVmExecution);
+            EnsureTempDirectoriesExistenceBeforePipExecution = template.EnsureTempDirectoriesExistenceBeforePipExecution;
         }
 
         /// <inheritdoc />
@@ -222,5 +224,8 @@ namespace BuildXL.Utilities.Configuration.Mutable
 
         /// <inheritdoc />
         public AbsolutePath RedirectedTempFolderRootForVmExecution { get; set; }
+
+        /// <inheritdoc />
+        public bool EnsureTempDirectoriesExistenceBeforePipExecution { get; set; }
     }
 }

--- a/Public/Src/Utilities/UnitTests/Executables/TestProcess/Operation.cs
+++ b/Public/Src/Utilities/UnitTests/Executables/TestProcess/Operation.cs
@@ -404,9 +404,9 @@ namespace Test.BuildXL.Executables.TestProcess
         /// <summary>
         /// Creates a create directory operation (uses WinAPI)
         /// </summary>
-        public static Operation CreateDir(FileOrDirectoryArtifact path, bool doNotInfer = false)
+        public static Operation CreateDir(FileOrDirectoryArtifact path, bool doNotInfer = false, string additionalArgs = null)
         {
-            return new Operation(Type.CreateDir, path, doNotInfer: doNotInfer);
+            return new Operation(Type.CreateDir, path, doNotInfer: doNotInfer, additionalArgs: additionalArgs);
         }
 
         /// <summary>
@@ -629,6 +629,28 @@ namespace Test.BuildXL.Executables.TestProcess
         private void DoCreateDir()
         {
             string directoryPath = FileOrDirectoryToString(Path);
+
+            bool failedIfExists = false;
+
+            if (!string.IsNullOrEmpty(AdditionalArgs))
+            {
+                string[] args = AdditionalArgs.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                foreach (var arg in args)
+                {
+                    if (string.Equals(arg, "--failedIfExists", StringComparison.OrdinalIgnoreCase))
+                    {
+                        failedIfExists = true;
+                    }
+                }
+            }
+
+            if (FileUtilities.DirectoryExistsNoFollow(directoryPath) || FileUtilities.FileExistsNoFollow(directoryPath))
+            {
+                if (failedIfExists)
+                {
+                    throw new InvalidOperationException($"Directory creation failed because '{directoryPath}' exists");
+                }
+            }
 
             if (OperatingSystemHelper.IsUnixOS)
             {

--- a/Public/Src/Utilities/UnitTests/Executables/TestProcess/Operation.cs
+++ b/Public/Src/Utilities/UnitTests/Executables/TestProcess/Operation.cs
@@ -630,23 +630,23 @@ namespace Test.BuildXL.Executables.TestProcess
         {
             string directoryPath = FileOrDirectoryToString(Path);
 
-            bool failedIfExists = false;
+            bool failIfExists = false;
 
             if (!string.IsNullOrEmpty(AdditionalArgs))
             {
                 string[] args = AdditionalArgs.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
                 foreach (var arg in args)
                 {
-                    if (string.Equals(arg, "--failedIfExists", StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals(arg, "--failIfExists", StringComparison.OrdinalIgnoreCase))
                     {
-                        failedIfExists = true;
+                        failIfExists = true;
                     }
                 }
             }
 
             if (FileUtilities.DirectoryExistsNoFollow(directoryPath) || FileUtilities.FileExistsNoFollow(directoryPath))
             {
-                if (failedIfExists)
+                if (failIfExists)
                 {
                     throw new InvalidOperationException($"Directory creation failed because '{directoryPath}' exists");
                 }


### PR DESCRIPTION
Changes that made temp directory creation consistent break customers. Here, we put it (hopefully temporarily) behind a flag

[AB#1549282](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1549282)