### PR TITLE
Retry process if exits with Azure Watson 0xDEAD exit code

### DIFF
--- a/Public/Src/Engine/Dll/Engine.cs
+++ b/Public/Src/Engine/Dll/Engine.cs
@@ -1066,7 +1066,7 @@ namespace BuildXL.Engine
                 }
 
                 mutableConfig.Logging.StoreFingerprints = initialCommandLineConfiguration.Logging.StoreFingerprints ?? false;
-                mutableConfig.Sandbox.RetryOnDeadExitCode = true;
+                mutableConfig.Sandbox.RetryOnAzureWatsonExitCode = true;
             }
             else
             {

--- a/Public/Src/Engine/Dll/Engine.cs
+++ b/Public/Src/Engine/Dll/Engine.cs
@@ -1066,6 +1066,7 @@ namespace BuildXL.Engine
                 }
 
                 mutableConfig.Logging.StoreFingerprints = initialCommandLineConfiguration.Logging.StoreFingerprints ?? false;
+                mutableConfig.Sandbox.RetryOnDeadExitCode = true;
             }
             else
             {

--- a/Public/Src/Engine/Processes/SandboxedProcessPipExecutionResult.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessPipExecutionResult.cs
@@ -57,9 +57,9 @@ namespace BuildXL.Processes
         ShouldBeRetriedDueToUserSpecifiedExitCode,
 
         /// <summary>
-        /// The sandboxed process should be retried due to exit code.
+        /// The sandboxed process should be retried due to Azure Watson's 0xDEAD exit code.
         /// </summary>
-        ShouldBeRetriedDueToDeadExitCode,
+        ShouldBeRetriedDueToAzureWatsonExitCode,
     }
 
     /// <summary>
@@ -160,7 +160,7 @@ namespace BuildXL.Processes
                 containerConfiguration: containerConfiguration);
         }
 
-        internal static SandboxedProcessPipExecutionResult RetryProcessDueToDeadExitCode(
+        internal static SandboxedProcessPipExecutionResult RetryProcessDueToAzureWatsonExitCode(
             int numberOfProcessLaunchRetries,
             int exitCode,
             ProcessTimes primaryProcessTimes,
@@ -173,7 +173,7 @@ namespace BuildXL.Processes
             ContainerConfiguration containerConfiguration)
         {
             return new SandboxedProcessPipExecutionResult(
-                SandboxedProcessPipExecutionStatus.ShouldBeRetriedDueToDeadExitCode,
+                SandboxedProcessPipExecutionStatus.ShouldBeRetriedDueToAzureWatsonExitCode,
                 observedFileAccesses: default(SortedReadOnlyArray<ObservedFileAccess, ObservedFileAccessExpandedPathComparer>),
                 sharedDynamicDirectoryWriteAccesses: default(Dictionary<AbsolutePath, IReadOnlyCollection<AbsolutePath>>),
                 encodedStandardError: null,

--- a/Public/Src/Engine/Processes/SandboxedProcessPipExecutionResult.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessPipExecutionResult.cs
@@ -54,7 +54,12 @@ namespace BuildXL.Processes
         /// <summary>
         /// The sandboxed process should be retried due to exit code.
         /// </summary>
-        ShouldBeRetriedDueToExitCode,
+        ShouldBeRetriedDueToUserSpecifiedExitCode,
+
+        /// <summary>
+        /// The sandboxed process should be retried due to exit code.
+        /// </summary>
+        ShouldBeRetriedDueToDeadExitCode,
     }
 
     /// <summary>
@@ -122,7 +127,7 @@ namespace BuildXL.Processes
                 containerConfiguration: result.ContainerConfiguration);
         }
 
-        internal static SandboxedProcessPipExecutionResult RetryProcessDueToExitCode(
+        internal static SandboxedProcessPipExecutionResult RetryProcessDueToUserSpecifiedExitCode(
             int numberOfProcessLaunchRetries,
             int exitCode,
             ProcessTimes primaryProcessTimes,
@@ -135,7 +140,40 @@ namespace BuildXL.Processes
             ContainerConfiguration containerConfiguration)
         {
             return new SandboxedProcessPipExecutionResult(
-                SandboxedProcessPipExecutionStatus.ShouldBeRetriedDueToExitCode,
+                SandboxedProcessPipExecutionStatus.ShouldBeRetriedDueToUserSpecifiedExitCode,
+                observedFileAccesses: default(SortedReadOnlyArray<ObservedFileAccess, ObservedFileAccessExpandedPathComparer>),
+                sharedDynamicDirectoryWriteAccesses: default(Dictionary<AbsolutePath, IReadOnlyCollection<AbsolutePath>>),
+                encodedStandardError: null,
+                encodedStandardOutput: null,
+                numberOfWarnings: 0,
+                unexpectedFileAccesses: null,
+                primaryProcessTimes: primaryProcessTimes,
+                jobAccountingInformation: jobAccountingInformation,
+                numberOfProcessLaunchRetries: numberOfProcessLaunchRetries,
+                exitCode: exitCode,
+                sandboxPrepMs: sandboxPrepMs,
+                processSandboxedProcessResultMs: processSandboxedProcessResultMs,
+                processStartTime: processStartTime,
+                allReportedFileAccesses: null,
+                detouringStatuses: detouringStatuses,
+                maxDetoursHeapSize: maxDetoursHeapSize,
+                containerConfiguration: containerConfiguration);
+        }
+
+        internal static SandboxedProcessPipExecutionResult RetryProcessDueToDeadExitCode(
+            int numberOfProcessLaunchRetries,
+            int exitCode,
+            ProcessTimes primaryProcessTimes,
+            JobObject.AccountingInformation? jobAccountingInformation,
+            IReadOnlyList<ProcessDetouringStatusData> detouringStatuses,
+            long sandboxPrepMs,
+            long processSandboxedProcessResultMs,
+            long processStartTime,
+            long maxDetoursHeapSize,
+            ContainerConfiguration containerConfiguration)
+        {
+            return new SandboxedProcessPipExecutionResult(
+                SandboxedProcessPipExecutionStatus.ShouldBeRetriedDueToDeadExitCode,
                 observedFileAccesses: default(SortedReadOnlyArray<ObservedFileAccess, ObservedFileAccessExpandedPathComparer>),
                 sharedDynamicDirectoryWriteAccesses: default(Dictionary<AbsolutePath, IReadOnlyCollection<AbsolutePath>>),
                 encodedStandardError: null,
@@ -274,10 +312,10 @@ namespace BuildXL.Processes
             ContainerConfiguration containerConfiguration)
         {
             Contract.Requires(
-                (status == SandboxedProcessPipExecutionStatus.PreparationFailed || status == SandboxedProcessPipExecutionStatus.ShouldBeRetriedDueToExitCode) ||
+                (status == SandboxedProcessPipExecutionStatus.PreparationFailed || status == SandboxedProcessPipExecutionStatus.ShouldBeRetriedDueToUserSpecifiedExitCode) ||
                 observedFileAccesses.IsValid);
             Contract.Requires(
-                (status == SandboxedProcessPipExecutionStatus.PreparationFailed || status == SandboxedProcessPipExecutionStatus.ShouldBeRetriedDueToExitCode) ||
+                (status == SandboxedProcessPipExecutionStatus.PreparationFailed || status == SandboxedProcessPipExecutionStatus.ShouldBeRetriedDueToUserSpecifiedExitCode) ||
                 unexpectedFileAccesses != null);
             Contract.Requires((status == SandboxedProcessPipExecutionStatus.PreparationFailed) || primaryProcessTimes != null);
             Contract.Requires(encodedStandardOutput == null || (encodedStandardOutput.Item1.IsValid && encodedStandardOutput.Item2 != null));

--- a/Public/Src/Engine/Processes/Tracing/Log.cs
+++ b/Public/Src/Engine/Processes/Tracing/Log.cs
@@ -603,6 +603,20 @@ namespace BuildXL.Processes.Tracing
             int numSurvivingChildErrors);
 
         [GeneratedEvent(
+            (int)EventId.PipRetryDueToExitedWithDeadExitCode,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Verbose,
+            Keywords = (int)Events.Keywords.UserMessage,
+            EventTask = (int)Events.Tasks.PipExecutor,
+            Message = Events.PipPrefix + "Pip will be retried because its reported process '{process}' with pid '{processId}' exited with 0xDEAD exit code")]
+        public abstract void PipRetryDueToExitedWithDeadExitCode(
+            LoggingContext context,
+            long pipSemiStableHash,
+            string pipDescription,
+            string process,
+            uint processId);
+
+        [GeneratedEvent(
             (int)EventId.PipProcessStandardInputException,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,

--- a/Public/Src/Engine/Processes/Tracing/Log.cs
+++ b/Public/Src/Engine/Processes/Tracing/Log.cs
@@ -603,13 +603,13 @@ namespace BuildXL.Processes.Tracing
             int numSurvivingChildErrors);
 
         [GeneratedEvent(
-            (int)EventId.PipRetryDueToExitedWithDeadExitCode,
+            (int)EventId.PipRetryDueToExitedWithAzureWatsonExitCode,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,
             Keywords = (int)Events.Keywords.UserMessage,
             EventTask = (int)Events.Tasks.PipExecutor,
-            Message = Events.PipPrefix + "Pip will be retried because its reported process '{process}' with pid '{processId}' exited with 0xDEAD exit code")]
-        public abstract void PipRetryDueToExitedWithDeadExitCode(
+            Message = Events.PipPrefix + "Pip will be retried because its reported process '{process}' with pid '{processId}' exited with Azure Watson's 0xDEAD exit code")]
+        public abstract void PipRetryDueToExitedWithAzureWatsonExitCode(
             LoggingContext context,
             long pipSemiStableHash,
             string pipDescription,

--- a/Public/Src/Engine/Scheduler/PipExecutor.cs
+++ b/Public/Src/Engine/Scheduler/PipExecutor.cs
@@ -1398,7 +1398,7 @@ namespace BuildXL.Scheduler
 
                                 if (result.Status == SandboxedProcessPipExecutionStatus.OutputWithNoFileAccessFailed ||
                                     result.Status == SandboxedProcessPipExecutionStatus.MismatchedMessageCount ||
-                                    result.Status == SandboxedProcessPipExecutionStatus.ShouldBeRetriedDueToDeadExitCode)
+                                    result.Status == SandboxedProcessPipExecutionStatus.ShouldBeRetriedDueToAzureWatsonExitCode)
                                 {
                                     if (remainingInternalSandboxedProcessExecutionFailureRetries > 0)
                                     {
@@ -1414,8 +1414,8 @@ namespace BuildXL.Scheduler
                                                 counters.IncrementCounter(PipExecutorCounter.MismatchMessageRetriesCount);
                                                 break;
 
-                                            case SandboxedProcessPipExecutionStatus.ShouldBeRetriedDueToDeadExitCode:
-                                                counters.IncrementCounter(PipExecutorCounter.DeadExitCodeRetriesCount);
+                                            case SandboxedProcessPipExecutionStatus.ShouldBeRetriedDueToAzureWatsonExitCode:
+                                                counters.IncrementCounter(PipExecutorCounter.AzureWatsonExitCodeRetriesCount);
                                                 break;
 
                                             default:
@@ -1442,8 +1442,8 @@ namespace BuildXL.Scheduler
                                                 processDescription);
                                             break;
 
-                                        case SandboxedProcessPipExecutionStatus.ShouldBeRetriedDueToDeadExitCode:
-                                            Logger.Log.PipExitedWithDeadExitCode(
+                                        case SandboxedProcessPipExecutionStatus.ShouldBeRetriedDueToAzureWatsonExitCode:
+                                            Logger.Log.PipExitedWithAzureWatsonExitCode(
                                                 operationContext,
                                                 pip.SemiStableHash,
                                                 processDescription);

--- a/Public/Src/Engine/Scheduler/PipExecutorCounter.cs
+++ b/Public/Src/Engine/Scheduler/PipExecutorCounter.cs
@@ -612,9 +612,14 @@ namespace BuildXL.Scheduler
         OutputsWithNoFileAccessRetriesCount,
 
         /// <summary>
-        /// Counts the number of retries for pips because of mismatche of detours message count.
+        /// Counts the number of retries for pips because of mismatches of detours message count.
         /// </summary>
         MismatchMessageRetriesCount,
+
+        /// <summary>
+        /// Counts the number of retries for pips because of dead exit code.
+        /// </summary>
+        DeadExitCodeRetriesCount,
 
         /// <summary>
         /// Counts the number of retries for pips because users allow them to be retried, e.g., based on their exit codes.

--- a/Public/Src/Engine/Scheduler/PipExecutorCounter.cs
+++ b/Public/Src/Engine/Scheduler/PipExecutorCounter.cs
@@ -617,9 +617,9 @@ namespace BuildXL.Scheduler
         MismatchMessageRetriesCount,
 
         /// <summary>
-        /// Counts the number of retries for pips because of dead exit code.
+        /// Counts the number of retries for pips because of Azure Watson's 0xDEAD exit code.
         /// </summary>
-        DeadExitCodeRetriesCount,
+        AzureWatsonExitCodeRetriesCount,
 
         /// <summary>
         /// Counts the number of retries for pips because users allow them to be retried, e.g., based on their exit codes.

--- a/Public/Src/Engine/Scheduler/Tracing/Log.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/Log.cs
@@ -1211,13 +1211,13 @@ namespace BuildXL.Scheduler.Tracing
         public abstract void LogMismatchedDetoursErrorCount(LoggingContext context, long pipSemiStableHash, string pipDescription);
 
         [GeneratedEvent(
-            (int)EventId.PipExitedWithDeadExitCode,
+            (int)EventId.PipExitedWithAzureWatsonExitCode,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Error,
             Keywords = (int)Events.Keywords.UserMessage,
             EventTask = (int)Events.Tasks.PipExecutor,
-            Message = Events.PipPrefix + "Pip exited with 0xDEAD exit code. Refer to the {ShortProductName} log for more information.")]
-        public abstract void PipExitedWithDeadExitCode(LoggingContext context, long pipSemiStableHash, string pipDescription);
+            Message = Events.PipPrefix + "Pip exited with Azure Watson's 0xDEAD exit code. Refer to the {ShortProductName} log for more information.")]
+        public abstract void PipExitedWithAzureWatsonExitCode(LoggingContext context, long pipSemiStableHash, string pipDescription);
 
         [GeneratedEvent(
             (int)EventId.FailPipOutputWithNoAccessed,

--- a/Public/Src/Engine/Scheduler/Tracing/Log.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/Log.cs
@@ -1211,6 +1211,15 @@ namespace BuildXL.Scheduler.Tracing
         public abstract void LogMismatchedDetoursErrorCount(LoggingContext context, long pipSemiStableHash, string pipDescription);
 
         [GeneratedEvent(
+            (int)EventId.PipExitedWithDeadExitCode,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Error,
+            Keywords = (int)Events.Keywords.UserMessage,
+            EventTask = (int)Events.Tasks.PipExecutor,
+            Message = Events.PipPrefix + "Pip exited with 0xDEAD exit code. Refer to the {ShortProductName} log for more information.")]
+        public abstract void PipExitedWithDeadExitCode(LoggingContext context, long pipSemiStableHash, string pipDescription);
+
+        [GeneratedEvent(
             (int)EventId.FailPipOutputWithNoAccessed,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Error,

--- a/Public/Src/Utilities/Configuration/ISandboxConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/ISandboxConfiguration.cs
@@ -222,13 +222,13 @@ namespace BuildXL.Utilities.Configuration
         AbsolutePath RedirectedTempFolderRootForVmExecution { get; }
 
         /// <summary>
-        /// Retries process whose exit code or its children's exit code is 0xDEAD.
+        /// Retries process whose exit code or its children's exit code is Azure Watson's special exit code, i.e., 0xDEAD.
         /// </summary>
         /// <remarks>
-        /// Process can nondeterministically exit with 0xDEAD exit code in CB. This is the exit code
-        /// returned by Azure Watson dump after catching the process crash. The root cause
-        /// of the crash is unknown, but the primary suspect is the way Detours handle NtClose.
+        /// When running in CloudBuild, Process nondeterministically sometimes exits with 0xDEAD exit code. This is the exit code
+        /// returned by Azure Watson dump after catching the process crash. The root cause of the crash is unknown,
+        /// but the primary suspect is the way Detours handle NtClose.
         /// </remarks>
-        bool RetryOnDeadExitCode { get; }
+        bool RetryOnAzureWatsonExitCode { get; }
     }
 }

--- a/Public/Src/Utilities/Configuration/ISandboxConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/ISandboxConfiguration.cs
@@ -220,5 +220,15 @@ namespace BuildXL.Utilities.Configuration
         /// This is used mainly for testing.
         /// </remarks>
         AbsolutePath RedirectedTempFolderRootForVmExecution { get; }
+
+        /// <summary>
+        /// Retries process whose exit code or its children's exit code is 0xDEAD.
+        /// </summary>
+        /// <remarks>
+        /// Process can suddenly exit with 0xDEAD exist code in CB. This is the exit code
+        /// returned by Azure Watson dump after catching the process crash. The root cause
+        /// of the crash is unknown, but the primary suspect is the way Detours handle NtClose.
+        /// </remarks>
+        bool RetryOnDeadExitCode { get; }
     }
 }

--- a/Public/Src/Utilities/Configuration/ISandboxConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/ISandboxConfiguration.cs
@@ -225,7 +225,7 @@ namespace BuildXL.Utilities.Configuration
         /// Retries process whose exit code or its children's exit code is 0xDEAD.
         /// </summary>
         /// <remarks>
-        /// Process can suddenly exit with 0xDEAD exist code in CB. This is the exit code
+        /// Process can nondeterministically exit with 0xDEAD exit code in CB. This is the exit code
         /// returned by Azure Watson dump after catching the process crash. The root cause
         /// of the crash is unknown, but the primary suspect is the way Detours handle NtClose.
         /// </remarks>

--- a/Public/Src/Utilities/Configuration/Mutable/SandboxConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/SandboxConfiguration.cs
@@ -42,6 +42,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             ContainerConfiguration = new SandboxContainerConfiguration();
             AdminRequiredProcessExecutionMode = AdminRequiredProcessExecutionMode.Internal;
             RedirectedTempFolderRootForVmExecution = AbsolutePath.Invalid;
+            RetryOnDeadExitCode = false;
         }
 
         /// <nodoc />
@@ -85,6 +86,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             ContainerConfiguration = new SandboxContainerConfiguration(template.ContainerConfiguration);
             AdminRequiredProcessExecutionMode = template.AdminRequiredProcessExecutionMode;
             RedirectedTempFolderRootForVmExecution = pathRemapper.Remap(template.RedirectedTempFolderRootForVmExecution);
+            RetryOnDeadExitCode = template.RetryOnDeadExitCode;
         }
 
         /// <inheritdoc />
@@ -222,5 +224,8 @@ namespace BuildXL.Utilities.Configuration.Mutable
 
         /// <inheritdoc />
         public AbsolutePath RedirectedTempFolderRootForVmExecution { get; set; }
+
+        /// <inheritdoc />
+        public bool RetryOnDeadExitCode { get; set; }
     }
 }

--- a/Public/Src/Utilities/Configuration/Mutable/SandboxConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/SandboxConfiguration.cs
@@ -42,7 +42,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             ContainerConfiguration = new SandboxContainerConfiguration();
             AdminRequiredProcessExecutionMode = AdminRequiredProcessExecutionMode.Internal;
             RedirectedTempFolderRootForVmExecution = AbsolutePath.Invalid;
-            RetryOnDeadExitCode = false;
+            RetryOnAzureWatsonExitCode = false;
         }
 
         /// <nodoc />
@@ -86,7 +86,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             ContainerConfiguration = new SandboxContainerConfiguration(template.ContainerConfiguration);
             AdminRequiredProcessExecutionMode = template.AdminRequiredProcessExecutionMode;
             RedirectedTempFolderRootForVmExecution = pathRemapper.Remap(template.RedirectedTempFolderRootForVmExecution);
-            RetryOnDeadExitCode = template.RetryOnDeadExitCode;
+            RetryOnAzureWatsonExitCode = template.RetryOnAzureWatsonExitCode;
         }
 
         /// <inheritdoc />
@@ -226,6 +226,6 @@ namespace BuildXL.Utilities.Configuration.Mutable
         public AbsolutePath RedirectedTempFolderRootForVmExecution { get; set; }
 
         /// <inheritdoc />
-        public bool RetryOnDeadExitCode { get; set; }
+        public bool RetryOnAzureWatsonExitCode { get; set; }
     }
 }

--- a/Public/Src/Utilities/Utilities/Tracing/EventId.cs
+++ b/Public/Src/Utilities/Utilities/Tracing/EventId.cs
@@ -309,7 +309,7 @@ namespace BuildXL.Utilities.Tracing
         CacheMissAnalysisException = 315,
         PipStandardIOFailed = 316,
 
-        PipRetryDueToExitedWithDeadExitCode = 317,
+        PipRetryDueToExitedWithAzureWatsonExitCode = 317,
         // Reserved = 318,
 
         // Free slot 319,
@@ -722,7 +722,7 @@ namespace BuildXL.Utilities.Tracing
 
         LogMismatchedDetoursErrorCount = 2922,
         LogMessageCountSemaphoreExists = 2923,
-        PipExitedWithDeadExitCode = 2924,
+        PipExitedWithAzureWatsonExitCode = 2924,
         LogFailedToCreateDirectoryForInternalDetoursFailureFile = 2925,
         // RESERVED 2926
         LogMismatchedDetoursVerboseCount = 2927,

--- a/Public/Src/Utilities/Utilities/Tracing/EventId.cs
+++ b/Public/Src/Utilities/Utilities/Tracing/EventId.cs
@@ -309,7 +309,7 @@ namespace BuildXL.Utilities.Tracing
         CacheMissAnalysisException = 315,
         PipStandardIOFailed = 316,
 
-        // Free slot 317,
+        PipRetryDueToExitedWithDeadExitCode = 317,
         // Reserved = 318,
 
         // Free slot 319,
@@ -722,7 +722,7 @@ namespace BuildXL.Utilities.Tracing
 
         LogMismatchedDetoursErrorCount = 2922,
         LogMessageCountSemaphoreExists = 2923,
-        // RESERVED 2924
+        PipExitedWithDeadExitCode = 2924,
         LogFailedToCreateDirectoryForInternalDetoursFailureFile = 2925,
         // RESERVED 2926
         LogMismatchedDetoursVerboseCount = 2927,


### PR DESCRIPTION
Process can nondeterministically  exit with 0xDEAD exit code in CB. This is the exit code returned by Azure Watson dump after catching the process crash. The root cause of the crash is unknown, but the primary suspect is the way Detours handle NtClose.  One needs to have a deep investigation on detoured NtClose.

This change is an attempt to improve reliability by retrying the process.