### PR TITLE
Restore FILE_SHARE_DELETE in Detoured CreateFile/NtCreateFile

### DIFF
--- a/Public/Src/Sandbox/Windows/DetoursServices/DetouredFunctions.cpp
+++ b/Public/Src/Sandbox/Windows/DetoursServices/DetouredFunctions.cpp
@@ -2089,7 +2089,7 @@ HANDLE WINAPI Detoured_CreateFileW(
     // content, i.e., we need to be able to delete one of many links to a file. Unfortunately, share-mode is aggregated only per file
     // rather than per-link, so in order to keep unused links delete-able, we should ensure in-use links are delete-able as well.
     // However, adding FILE_SHARE_DELETE may be unexpected, for example, some unit tests may test for sharing violation. Thus,
-    // we only add FILE_SHARE_DELETE if the file is untracked.
+    // we only add FILE_SHARE_DELETE if the file is tracked.
     
     // We also add FILE_SHARE_READ when it is safe to do so, since some tools accidentally ask for exclusive access on their inputs.
 
@@ -5157,7 +5157,7 @@ NTSTATUS NTAPI Detoured_ZwCreateFile(
     // content, i.e., we need to be able to delete one of many links to a file. Unfortunately, share-mode is aggregated only per file
     // rather than per-link, so in order to keep unused links delete-able, we should ensure in-use links are delete-able as well.
     // However, adding FILE_SHARE_DELETE may be unexpected, for example, some unit tests may test for sharing violation. Thus,
-    // we only add FILE_SHARE_DELETE if the file is untracked.
+    // we only add FILE_SHARE_DELETE if the file is tracked.
 
     // We also add FILE_SHARE_READ when it is safe to do so, since some tools accidentally ask for exclusive access on their inputs.
 
@@ -5452,7 +5452,7 @@ NTSTATUS NTAPI Detoured_NtCreateFile(
     // content, i.e., we need to be able to delete one of many links to a file. Unfortunately, share-mode is aggregated only per file
     // rather than per-link, so in order to keep unused links delete-able, we should ensure in-use links are delete-able as well.
     // However, adding FILE_SHARE_DELETE may be unexpected, for example, some unit tests may test for sharing violation. Thus,
-    // we only add FILE_SHARE_DELETE if the file is untracked.
+    // we only add FILE_SHARE_DELETE if the file is tracked.
 
     // We also add FILE_SHARE_READ when it is safe to do so, since some tools accidentally ask for exclusive access on their inputs.
 
@@ -5728,7 +5728,7 @@ NTSTATUS NTAPI Detoured_ZwOpenFile(
     // content, i.e., we need to be able to delete one of many links to a file. Unfortunately, share-mode is aggregated only per file
     // rather than per-link, so in order to keep unused links delete-able, we should ensure in-use links are delete-able as well.
     // However, adding FILE_SHARE_DELETE may be unexpected, for example, some unit tests may test for sharing violation. Thus,
-    // we only add FILE_SHARE_DELETE if the file is untracked.
+    // we only add FILE_SHARE_DELETE if the file is tracked.
 
     // We also add FILE_SHARE_READ when it is safe to do so, since some tools accidentally ask for exclusive access on their inputs.
 

--- a/Public/Src/Sandbox/Windows/DetoursServices/DetouredFunctions.cpp
+++ b/Public/Src/Sandbox/Windows/DetoursServices/DetouredFunctions.cpp
@@ -2085,10 +2085,11 @@ HANDLE WINAPI Detoured_CreateFileW(
     // read request which may or may not have been approved (due to special exceptions for directories and non-existent files).
     // It is safe to go ahead and perform the real CreateFile() call, and then to reason about the results after the fact.
 
-    // Note that we can add FILE_SHARE_DELETE to dwShareMode. I.e., in order to leverage NTFS hardlinks to avoid copying cache
-    // content, we need to be able to delete one of many links to a file. Unfortunately, share-mode is aggregated only per file
+    // Note that we need to add FILE_SHARE_DELETE to dwShareMode to leverage NTFS hardlinks to avoid copying cache
+    // content, i.e., we need to be able to delete one of many links to a file. Unfortunately, share-mode is aggregated only per file
     // rather than per-link, so in order to keep unused links delete-able, we should ensure in-use links are delete-able as well.
-    // However, adding FILE_SHARE_DELETE may be unexpected, for example, some unit tests may test for sharing violation.
+    // However, adding FILE_SHARE_DELETE may be unexpected, for example, some unit tests may test for sharing violation. Thus,
+    // we only add FILE_SHARE_DELETE if the file is untracked.
     
     // We also add FILE_SHARE_READ when it is safe to do so, since some tools accidentally ask for exclusive access on their inputs.
 
@@ -2099,7 +2100,7 @@ HANDLE WINAPI Detoured_CreateFileW(
     {
         DWORD readSharingIfNeeded = policyResult.ShouldForceReadSharing(accessCheck) ? FILE_SHARE_READ : 0UL;
         desiredAccess = !forceReadOnlyForRequestedRWAccess ? desiredAccess : (desiredAccess & FILE_GENERIC_READ);
-        sharedAccess = sharedAccess | readSharingIfNeeded;
+        sharedAccess = sharedAccess | readSharingIfNeeded | FILE_SHARE_DELETE;
     }
 
     error = ERROR_SUCCESS;
@@ -5152,10 +5153,11 @@ NTSTATUS NTAPI Detoured_ZwCreateFile(
     // read request which may or may not have been approved (due to special exceptions for directories and non-existent files).
     // It is safe to go ahead and perform the real NtCreateFile() call, and then to reason about the results after the fact.
 
-    // Note that we can add FILE_SHARE_DELETE to dwShareMode. I.e., in order to leverage NTFS hardlinks to avoid copying cache
-    // content, we need to be able to delete one of many links to a file. Unfortunately, share-mode is aggregated only per file
+    // Note that we need to add FILE_SHARE_DELETE to dwShareMode to leverage NTFS hardlinks to avoid copying cache
+    // content, i.e., we need to be able to delete one of many links to a file. Unfortunately, share-mode is aggregated only per file
     // rather than per-link, so in order to keep unused links delete-able, we should ensure in-use links are delete-able as well.
-    // However, adding FILE_SHARE_DELETE may be unexpected, for example, some unit tests may test for sharing violation.
+    // However, adding FILE_SHARE_DELETE may be unexpected, for example, some unit tests may test for sharing violation. Thus,
+    // we only add FILE_SHARE_DELETE if the file is untracked.
 
     // We also add FILE_SHARE_READ when it is safe to do so, since some tools accidentally ask for exclusive access on their inputs.
 
@@ -5166,7 +5168,7 @@ NTSTATUS NTAPI Detoured_ZwCreateFile(
     {
         DWORD readSharingIfNeeded = policyResult.ShouldForceReadSharing(accessCheck) ? FILE_SHARE_READ : 0UL;
         desiredAccess = !forceReadOnlyForRequestedRWAccess ? desiredAccess : (desiredAccess & FILE_GENERIC_READ);
-        sharedAccess = sharedAccess | readSharingIfNeeded;
+        sharedAccess = sharedAccess | readSharingIfNeeded | FILE_SHARE_DELETE;
     }
     
     error = ERROR_SUCCESS;
@@ -5446,10 +5448,11 @@ NTSTATUS NTAPI Detoured_NtCreateFile(
     // read request which may or may not have been approved (due to special exceptions for directories and non-existent files).
     // It is safe to go ahead and perform the real NtCreateFile() call, and then to reason about the results after the fact.
 
-    // Note that we can add FILE_SHARE_DELETE to dwShareMode. I.e., in order to leverage NTFS hardlinks to avoid copying cache
-    // content, we need to be able to delete one of many links to a file. Unfortunately, share-mode is aggregated only per file
+    // Note that we need to add FILE_SHARE_DELETE to dwShareMode to leverage NTFS hardlinks to avoid copying cache
+    // content, i.e., we need to be able to delete one of many links to a file. Unfortunately, share-mode is aggregated only per file
     // rather than per-link, so in order to keep unused links delete-able, we should ensure in-use links are delete-able as well.
-    // However, adding FILE_SHARE_DELETE may be unexpected, for example, some unit tests may test for sharing violation.
+    // However, adding FILE_SHARE_DELETE may be unexpected, for example, some unit tests may test for sharing violation. Thus,
+    // we only add FILE_SHARE_DELETE if the file is untracked.
 
     // We also add FILE_SHARE_READ when it is safe to do so, since some tools accidentally ask for exclusive access on their inputs.
 
@@ -5460,7 +5463,7 @@ NTSTATUS NTAPI Detoured_NtCreateFile(
     {
         DWORD readSharingIfNeeded = policyResult.ShouldForceReadSharing(accessCheck) ? FILE_SHARE_READ : 0UL;
         desiredAccess = !forceReadOnlyForRequestedRWAccess ? desiredAccess : (desiredAccess & FILE_GENERIC_READ);
-        sharedAccess = sharedAccess | readSharingIfNeeded;
+        sharedAccess = sharedAccess | readSharingIfNeeded | FILE_SHARE_DELETE;
     }
     
     error = ERROR_SUCCESS;
@@ -5721,10 +5724,11 @@ NTSTATUS NTAPI Detoured_ZwOpenFile(
     // read request which may or may not have been approved (due to special exceptions for directories and non-existent files).
     // It is safe to go ahead and perform the real NtCreateFile() call, and then to reason about the results after the fact.
 
-    // Note that we can add FILE_SHARE_DELETE to dwShareMode. I.e., in order to leverage NTFS hardlinks to avoid copying cache
-    // content, we need to be able to delete one of many links to a file. Unfortunately, share-mode is aggregated only per file
+    // Note that we need to add FILE_SHARE_DELETE to dwShareMode to leverage NTFS hardlinks to avoid copying cache
+    // content, i.e., we need to be able to delete one of many links to a file. Unfortunately, share-mode is aggregated only per file
     // rather than per-link, so in order to keep unused links delete-able, we should ensure in-use links are delete-able as well.
-    // However, adding FILE_SHARE_DELETE may be unexpected, for example, some unit tests may test for sharing violation.
+    // However, adding FILE_SHARE_DELETE may be unexpected, for example, some unit tests may test for sharing violation. Thus,
+    // we only add FILE_SHARE_DELETE if the file is untracked.
 
     // We also add FILE_SHARE_READ when it is safe to do so, since some tools accidentally ask for exclusive access on their inputs.
 
@@ -5735,7 +5739,7 @@ NTSTATUS NTAPI Detoured_ZwOpenFile(
     {
         DWORD readSharingIfNeeded = policyResult.ShouldForceReadSharing(accessCheck) ? FILE_SHARE_READ : 0UL;
         desiredAccess = !forceReadOnlyForRequestedRWAccess ? desiredAccess : (desiredAccess & FILE_GENERIC_READ);
-        sharedAccess = sharedAccess | readSharingIfNeeded;
+        sharedAccess = sharedAccess | readSharingIfNeeded | FILE_SHARE_DELETE;
     }
 
     DWORD error = ERROR_SUCCESS;

--- a/Public/Src/Sandbox/Windows/DetoursTests/Tests.h
+++ b/Public/Src/Sandbox/Windows/DetoursTests/Tests.h
@@ -31,3 +31,5 @@ int CallDetouredCreateFileWWrite();
 int CallCreateFileWithZeroAccessOnDirectory();
 int CallCreateFileOnNtEscapedPath();
 int CallOpenFileById();
+int CallDeleteWithoutSharing();
+int CallDeleteOnOpenedHardlink();


### PR DESCRIPTION
We need to add FILE_SHARE_DELETE to dwShareMode to leverage NTFS hardlinks to avoid copying cache content, i.e., we need to be able to delete one of many links to a file. Unfortunately, share-mode is aggregated only per file rather than per-link, so in order to keep unused links delete-able, we should ensure in-use links are delete-able as well. However, adding FILE_SHARE_DELETE may be unexpected, for example, some unit tests may test for sharing violation. Thus, we only add FILE_SHARE_DELETE if the file is untracked.

[AB#1530341](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1530341)