### PR TITLE
Add some debugging info to Contracts in BitSet

### DIFF
--- a/Public/Src/Utilities/Collections/BitSet.cs
+++ b/Public/Src/Utilities/Collections/BitSet.cs
@@ -100,7 +100,10 @@ namespace BuildXL.Utilities.Collections
         /// </summary>
         public void Add(int index)
         {
-            Contract.Requires(index >= 0 && index < Length);
+            if (index < 0 || index >= Length)
+            {
+                Contract.Requires(false, $"index={index} must be within [0, {Length}) range.");
+            }            
 
             ulong newEntry = GetEntry(index) | (1UL << (index % 64));
             SetEntry(index, newEntry);
@@ -112,7 +115,10 @@ namespace BuildXL.Utilities.Collections
         /// </summary>
         public void AddAtomic(int index)
         {
-            Contract.Requires(index >= 0 && index < Length);
+            if (index < 0 || index >= Length)
+            {
+                Contract.Requires(false, $"index={index} must be within [0, {Length}) range.");
+            }
 
             int entryIndex = index / 64;
             ulong targetEntry;
@@ -131,7 +137,10 @@ namespace BuildXL.Utilities.Collections
         /// </summary>
         public void Remove(int index)
         {
-            Contract.Requires(index >= 0 && index < Length);
+            if (index < 0 || index >= Length)
+            {
+                Contract.Requires(false, $"index={index} must be within [0, {Length}) range.");
+            }
 
             ulong newEntry = GetEntry(index) & ~(1UL << (index % 64));
             SetEntry(index, newEntry);
@@ -142,7 +151,10 @@ namespace BuildXL.Utilities.Collections
         /// </summary>
         public bool Contains(int index)
         {
-            Contract.Requires(index >= 0 && index < Length);
+            if (index < 0 || index >= Length)
+            {
+                Contract.Requires(false, $"index={index} must be within [0, {Length}) range.");
+            }
 
             return (GetEntry(index) & 1UL << (index % 64)) != 0;
         }

--- a/Public/Src/Utilities/Collections/BitSet.cs
+++ b/Public/Src/Utilities/Collections/BitSet.cs
@@ -102,7 +102,7 @@ namespace BuildXL.Utilities.Collections
         {
             if (index < 0 || index >= Length)
             {
-                Contract.Requires(false, $"index={index} must be within [0, {Length}) range.");
+                Contract.Assert(false, $"index={index} must be within [0, {Length}) range.");
             }            
 
             ulong newEntry = GetEntry(index) | (1UL << (index % 64));
@@ -117,7 +117,7 @@ namespace BuildXL.Utilities.Collections
         {
             if (index < 0 || index >= Length)
             {
-                Contract.Requires(false, $"index={index} must be within [0, {Length}) range.");
+                Contract.Assert(false, $"index={index} must be within [0, {Length}) range.");
             }
 
             int entryIndex = index / 64;
@@ -139,7 +139,7 @@ namespace BuildXL.Utilities.Collections
         {
             if (index < 0 || index >= Length)
             {
-                Contract.Requires(false, $"index={index} must be within [0, {Length}) range.");
+                Contract.Assert(false, $"index={index} must be within [0, {Length}) range.");
             }
 
             ulong newEntry = GetEntry(index) & ~(1UL << (index % 64));
@@ -153,7 +153,7 @@ namespace BuildXL.Utilities.Collections
         {
             if (index < 0 || index >= Length)
             {
-                Contract.Requires(false, $"index={index} must be within [0, {Length}) range.");
+                Contract.Assert(false, $"index={index} must be within [0, {Length}) range.");
             }
 
             return (GetEntry(index) & 1UL << (index % 64)) != 0;


### PR DESCRIPTION
It appears that GetIndexByPath(path) might return values bigger than PathTable.Count. Adding debugging info to the contracts to confirm that this is the case.

[AB#1532584](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1532584)