### PR TITLE
Increase process timeout period for sandboxed test cases

### DIFF
--- a/Documentation/Wiki/Advanced-Features/Process-Timeouts.md
+++ b/Documentation/Wiki/Advanced-Features/Process-Timeouts.md
@@ -1,11 +1,11 @@
 ## BuildXL Process Timeouts
-Process pips launched by BuildXL have configurable timeouts. 
-The overall timeout will cause a pip to be terminated and considered a failure if exceeded. 
+Process pips launched by BuildXL have configurable timeouts.
+The overall timeout will cause a pip to be terminated and considered a failure if exceeded.
 There is also a warning timeout that will be printed as a hint to users, to indicate that they are reaching a time limit.
 
 There are a few ways the timeouts are set:
 
-* A default timeout that applies to all pips. This defaults to 10 minutes if not specified, but can be overridden on the command line.
+* A default timeout that applies to all pips. This defaults to 15 minutes if not specified, but can be overridden on the command line.
 
   * `/pipDefaultTimeout:<ms>` - How long to wait before terminating individual processes, in milliseconds. Setting this value will only have an effect if no other timeout is specified for a process.
 
@@ -13,20 +13,20 @@ There are a few ways the timeouts are set:
 
 * Per-process timeouts are configurable at graph construction time. These override the global timeout.
    ```ts
-   /** 
-     * Provides a hard timeout after which the Process will be marked as failure due to timeout and terminated. 
+   /**
+     * Provides a hard timeout after which the Process will be marked as failure due to timeout and terminated.
      */
    timeoutInMilliseconds?: number;
 
-   /** 
+   /**
     * Sets an interval value that indicates after which time BuildXL will issue a warning that the process is running longer
-    * than anticipated 
+    * than anticipated
     */
    warningTimeoutInMilliseconds?: number;
    ```
    (see the `Transformer.execute` documentation for more details)
 
-* A timeout multiplier on the commandline, which defaults to 1. If set, the timeout from the rules above will be multiplied by this value to get the effective timeout. 
+* A timeout multiplier on the commandline, which defaults to 1. If set, the timeout from the rules above will be multiplied by this value to get the effective timeout.
 
   * `/pipTimeoutMultiplier:<float>` - Multiplier applied to the final timeout for individual processes. Setting a multiplier greater than one will increase the timeout accordingly for all pips, even those with an explicit non-default timeout set.
   * `/pipWarningTimeoutMultiplier:<float>` - Multiplier applied to the warning timeout for individual processes. Setting a multiplier greater than one will increase the warning timeout accordingly for all pips, even those with an explicit non-default warning timeout set (see command line help text).

--- a/Public/Src/Engine/Processes/SandboxedProcess.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcess.cs
@@ -81,8 +81,8 @@ namespace BuildXL.Processes
                 s_binaryPaths = new BinaryPaths(); // this can take a while; performs I/O
             }
 
-            // If unspecified make the injection timeout 10 mins. Also, make it no less than 10 mins.
-            m_timeoutMins = info.Timeout.HasValue ? ((uint)info.Timeout.Value.TotalMinutes) : 10;
+            // If unspecified make the injection timeout 15 mins. Also, make it no less than 10 mins.
+            m_timeoutMins = info.Timeout.HasValue ? ((uint)info.Timeout.Value.TotalMinutes) : 15;
             if (m_timeoutMins < 10)
             {
                 m_timeoutMins = 10;
@@ -595,7 +595,7 @@ namespace BuildXL.Processes
                     }
                 }
             }
-            
+
 
             return survivingChildProcesses;
         }

--- a/Public/Src/Engine/Processes/SandboxedProcess.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcess.cs
@@ -81,11 +81,11 @@ namespace BuildXL.Processes
                 s_binaryPaths = new BinaryPaths(); // this can take a while; performs I/O
             }
 
-            // If unspecified make the injection timeout 15 mins. Also, make it no less than 10 mins.
+            // If unspecified make the injection timeout 15 mins. Also, make it no less than 15 mins.
             m_timeoutMins = info.Timeout.HasValue ? ((uint)info.Timeout.Value.TotalMinutes) : 15;
-            if (m_timeoutMins < 10)
+            if (m_timeoutMins < 15)
             {
-                m_timeoutMins = 10;
+                m_timeoutMins = 15;
             }
 
             m_fileAccessManifest = info.FileAccessManifest;

--- a/Public/Src/Engine/Processes/SandboxedProcess.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcess.cs
@@ -18,6 +18,7 @@ using BuildXL.Pips.Operations;
 using BuildXL.Processes.Internal;
 using BuildXL.Storage;
 using BuildXL.Utilities;
+using BuildXL.Utilities.Configuration.Mutable;
 using BuildXL.Utilities.Tasks;
 using BuildXL.Utilities.Threading;
 using Microsoft.Win32.SafeHandles;
@@ -81,11 +82,11 @@ namespace BuildXL.Processes
                 s_binaryPaths = new BinaryPaths(); // this can take a while; performs I/O
             }
 
-            // If unspecified make the injection timeout 15 mins. Also, make it no less than 15 mins.
-            m_timeoutMins = info.Timeout.HasValue ? ((uint)info.Timeout.Value.TotalMinutes) : 15;
-            if (m_timeoutMins < 15)
+            // If unspecified make the injection timeout the DefaultProcessTimeoutInMinutes. Also, make it no less than DefaultProcessTimeoutInMinutes.
+            m_timeoutMins = info.Timeout.HasValue ? ((uint)info.Timeout.Value.TotalMinutes) : SandboxConfiguration.DefaultProcessTimeoutInMinutes;
+            if (m_timeoutMins < SandboxConfiguration.DefaultProcessTimeoutInMinutes)
             {
-                m_timeoutMins = 15;
+                m_timeoutMins = SandboxConfiguration.DefaultProcessTimeoutInMinutes;
             }
 
             m_fileAccessManifest = info.FileAccessManifest;

--- a/Public/Src/Engine/Processes/UnSandboxedProcess.cs
+++ b/Public/Src/Engine/Processes/UnSandboxedProcess.cs
@@ -29,7 +29,7 @@ namespace BuildXL.Processes
     public class UnSandboxedProcess : ISandboxedProcess
     {
         private static readonly ISet<ReportedFileAccess> s_emptyFileAccessesSet = new HashSet<ReportedFileAccess>();
-        private static readonly TimeSpan DefaultProcessTimeout = TimeSpan.FromMinutes(10);
+        private static readonly TimeSpan DefaultProcessTimeout = TimeSpan.FromMinutes(15);
 
         private readonly SandboxedProcessOutputBuilder m_output;
         private readonly SandboxedProcessOutputBuilder m_error;

--- a/Public/Src/Engine/Processes/UnSandboxedProcess.cs
+++ b/Public/Src/Engine/Processes/UnSandboxedProcess.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using BuildXL.Interop;
 using BuildXL.Utilities;
+using BuildXL.Utilities.Configuration.Mutable;
 using static BuildXL.Utilities.FormattableStringEx;
 using JetBrains.Annotations;
 #if FEATURE_SAFE_PROCESS_HANDLE
@@ -29,7 +30,7 @@ namespace BuildXL.Processes
     public class UnSandboxedProcess : ISandboxedProcess
     {
         private static readonly ISet<ReportedFileAccess> s_emptyFileAccessesSet = new HashSet<ReportedFileAccess>();
-        private static readonly TimeSpan DefaultProcessTimeout = TimeSpan.FromMinutes(15);
+        private static readonly TimeSpan DefaultProcessTimeout = TimeSpan.FromMinutes(SandboxConfiguration.DefaultProcessTimeoutInMinutes);
 
         private readonly SandboxedProcessOutputBuilder m_output;
         private readonly SandboxedProcessOutputBuilder m_error;

--- a/Public/Src/Engine/Processes/UnSandboxedProcess.cs
+++ b/Public/Src/Engine/Processes/UnSandboxedProcess.cs
@@ -29,6 +29,7 @@ namespace BuildXL.Processes
     public class UnSandboxedProcess : ISandboxedProcess
     {
         private static readonly ISet<ReportedFileAccess> s_emptyFileAccessesSet = new HashSet<ReportedFileAccess>();
+        private static readonly TimeSpan DefaultProcessTimeout = TimeSpan.FromMinutes(10);
 
         private readonly SandboxedProcessOutputBuilder m_output;
         private readonly SandboxedProcessOutputBuilder m_error;
@@ -94,8 +95,7 @@ namespace BuildXL.Processes
         {
             Contract.Requires(info != null);
 
-            info.Timeout = info.Timeout ?? TimeSpan.FromMinutes(10);
-
+            info.Timeout = info.Timeout ?? DefaultProcessTimeout;
             ProcessInfo = info;
 
             m_output = new SandboxedProcessOutputBuilder(
@@ -134,7 +134,7 @@ namespace BuildXL.Processes
 
             m_processExecutor = new AsyncProcessExecutor(
                 CreateProcess(),
-                ProcessInfo.Timeout ?? TimeSpan.FromMinutes(10),
+                ProcessInfo.Timeout ?? DefaultProcessTimeout,
                 line => FeedStdOut(m_output, line),
                 line => FeedStdErr(m_error, line),
                 ProcessInfo.Provenance,

--- a/Public/Src/Engine/UnitTests/Processes.Detours/SandboxedProcessInfoTest.cs
+++ b/Public/Src/Engine/UnitTests/Processes.Detours/SandboxedProcessInfoTest.cs
@@ -58,7 +58,7 @@ namespace Test.BuildXL.Processes.Detours
                 Arguments = @"/arg1:val1 /arg2:val2",
                 WorkingDirectory = A("C", "Source"),
                 EnvironmentVariables = buildParameters,
-                Timeout = TimeSpan.FromMinutes(10),
+                Timeout = TimeSpan.FromMinutes(15),
                 PipSemiStableHash = 0x12345678,
                 PipDescription = nameof(SerializeSandboxedProcessInfo),
                 ProcessIdListener = null,

--- a/Public/Src/Engine/UnitTests/Processes/SandboxedProcessTestBase.cs
+++ b/Public/Src/Engine/UnitTests/Processes/SandboxedProcessTestBase.cs
@@ -52,7 +52,7 @@ namespace Test.BuildXL.Processes
                 PipDescription = pipDescription,
                 WorkingDirectory = TemporaryDirectory,
                 Arguments = process.Arguments.ToString(Context.PathTable),
-                Timeout = TimeSpan.FromMinutes(10),
+                Timeout = TimeSpan.FromMinutes(15),
                 EnvironmentVariables = BuildParameters.GetFactory().PopulateFromDictionary(envVars)
             };
 

--- a/Public/Src/Tools/SandboxExec/Program.cs
+++ b/Public/Src/Tools/SandboxExec/Program.cs
@@ -25,7 +25,7 @@ namespace BuildXL.SandboxExec
     public class SandboxExecRunner : ISandboxedProcessFileStorage
     {
         private const string AccessOutput = "accesses.out";
-        private static readonly double s_defaultProcessTimeOut = TimeSpan.FromMinutes(10).TotalSeconds;
+        private static readonly double s_defaultProcessTimeOut = TimeSpan.FromMinutes(15).TotalSeconds;
         private static readonly double s_defaultProcessTimeOutMax = TimeSpan.FromHours(4).TotalSeconds;
         private static readonly LoggingContext s_loggingContext = new LoggingContext("BuildXL.SandboxExec");
         private static CrashCollectorMacOS s_crashCollector;

--- a/Public/Src/Utilities/Configuration/Mutable/SandboxConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/SandboxConfiguration.cs
@@ -16,7 +16,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             m_unsafeSandboxConfig = new UnsafeSandboxConfiguration();
 
             FailUnexpectedFileAccesses = true;
-            DefaultTimeout = 10 * 60 * 1000;
+            DefaultTimeout = 15 * 60 * 1000;
             DefaultWarningTimeout = (int)(.85 * DefaultTimeout);
             TimeoutMultiplier = 1;
             WarningTimeoutMultiplier = 1;

--- a/Public/Src/Utilities/Configuration/Mutable/SandboxConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/SandboxConfiguration.cs
@@ -8,6 +8,9 @@ namespace BuildXL.Utilities.Configuration.Mutable
     /// <nodoc />
     public sealed class SandboxConfiguration : ISandboxConfiguration
     {
+        /// <nodoc />
+        public static readonly uint DefaultProcessTimeoutInMinutes = 15;
+
         private IUnsafeSandboxConfiguration m_unsafeSandboxConfig;
 
         /// <nodoc />
@@ -16,7 +19,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             m_unsafeSandboxConfig = new UnsafeSandboxConfiguration();
 
             FailUnexpectedFileAccesses = true;
-            DefaultTimeout = 15 * 60 * 1000;
+            DefaultTimeout = ((int)DefaultProcessTimeoutInMinutes) * 60 * 1000;
             DefaultWarningTimeout = (int)(.85 * DefaultTimeout);
             TimeoutMultiplier = 1;
             WarningTimeoutMultiplier = 1;

--- a/Public/Src/Utilities/Utilities/VmCommandProxy/VmInitializer.cs
+++ b/Public/Src/Utilities/Utilities/VmCommandProxy/VmInitializer.cs
@@ -25,7 +25,7 @@ namespace BuildXL.Utilities.VmCommandProxy
         /// <remarks>
         /// According to CB team, VM initialization roughly takes 2-3 minutes.
         /// </remarks>
-        private const int InitVmTimeoutInMinute = 10;
+        private const int InitVmTimeoutInMinute = 15;
 
         /// <summary>
         /// Path to VmCommandProxy executable.

--- a/Public/Src/Utilities/Utilities/VmCommandProxy/VmInitializer.cs
+++ b/Public/Src/Utilities/Utilities/VmCommandProxy/VmInitializer.cs
@@ -25,7 +25,7 @@ namespace BuildXL.Utilities.VmCommandProxy
         /// <remarks>
         /// According to CB team, VM initialization roughly takes 2-3 minutes.
         /// </remarks>
-        private const int InitVmTimeoutInMinute = 15;
+        private const int InitVmTimeoutInMinute = 10;
 
         /// <summary>
         /// Path to VmCommandProxy executable.


### PR DESCRIPTION
Some of our tests are timing out and failing our CI pipelines with runtimes slightly above 10 minutes. This PR pumps the timeout as a measure to not fail tests on slight deviations.