### PR TITLE
Deploy Sdk.Drop even for win-x64 target runtime

### DIFF
--- a/Public/Src/App/Deployment.InBoxSdks.dsc
+++ b/Public/Src/App/Deployment.InBoxSdks.dsc
@@ -43,7 +43,7 @@ function createSdkDeploymentDefinition(serverDeployment: boolean) : Deployment.D
                     {
                         subfolder: "Sdk.Drop",
                         contents: [
-                            ...addIfLazy(!serverDeployment && BuildXLSdk.isDropToolingEnabled, () => [
+                            ...addIfLazy(!serverDeployment && !BuildXLSdk.isTargetRuntimeOsx, () => [
                                 importFrom("BuildXL.Tools.DropDaemon").withQualifier({
                                     configuration: qualifier.configuration,
                                     targetFramework: "net472",


### PR DESCRIPTION
The DropDaemon tool currently only works in full .NET Framework.  But since that's a standalone process (which BuildXL may launch for certain builds) it doesn't mean we shouldn't deploy for the win-x64 flavor of BuildXL