### PR TITLE
Don't log error when processes retry since retry could succeed

### DIFF
--- a/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
@@ -1218,12 +1218,6 @@ namespace BuildXL.Processes
 
                         if (m_pip.RetryExitCodes.Contains(result.ExitCode) && m_remainingUserRetryCount > 0)
                         {
-                            // Retry if user specifies that the exit code can be retried.
-                            if (await TrySaveAndLogStandardOutputAsync(result) && await TrySaveAndLogStandardErrorAsync(result))
-                            {
-                                await TryLogErrorAsync(result, exitedWithSuccessExitCode);
-                            }
-
                             return SandboxedProcessPipExecutionResult.RetryProcessDueToUserSpecifiedExitCode(
                                 result.NumberOfProcessLaunchRetries,
                                 result.ExitCode,

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/BaselineTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/BaselineTests.cs
@@ -1097,6 +1097,45 @@ namespace IntegrationTest.BuildXL.Scheduler
             SetExpectedFailures(2, 0);
         }
 
+
+        /// <summary>
+        /// Validates behavior with a process being retried
+        /// </summary>
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void RetryExitCodes(bool succeedOnRetry)
+        {
+            FileArtifact stateFile = FileArtifact.CreateOutputFile(ObjectRootPath.Combine(Context.PathTable, "stateFile.txt"));
+            var ops = new Operation[]
+            {
+                Operation.WriteFile(FileArtifact.CreateOutputFile(ObjectRootPath.Combine(Context.PathTable, "out.txt")), content: "Hello"),
+                succeedOnRetry ? 
+                    Operation.SucceedOnRetry(untrackedStateFilePath: stateFile, firstFailExitCode: -2) :
+                    Operation.Fail(-2),
+            };
+
+            var builder = CreatePipBuilder(ops);
+            builder.RetryExitCodes = global::BuildXL.Utilities.Collections.ReadOnlyArray<int>.From(new int[] { -2 });
+            builder.AddUntrackedFile(stateFile.Path);
+            SchedulePipBuilder(builder);
+
+            Configuration.Schedule.ProcessRetries = 1;
+
+            var result = RunScheduler();
+            if (succeedOnRetry)
+            {
+                result.AssertSuccess();
+            }
+            else
+            {
+                result.AssertFailure();
+                SetExpectedFailures(1, 0);
+            }
+
+            result.AssertSuccessMatchesLogging(LoggingContext);
+        }
+
         private Operation ProbeOp(string root, string relativePath = "")
         {
             return Operation.Probe(CreateFileArtifactWithName(root: root, name: relativePath), doNotInfer: true);

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/BaselineTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/BaselineTests.cs
@@ -1111,12 +1111,12 @@ namespace IntegrationTest.BuildXL.Scheduler
             {
                 Operation.WriteFile(FileArtifact.CreateOutputFile(ObjectRootPath.Combine(Context.PathTable, "out.txt")), content: "Hello"),
                 succeedOnRetry ? 
-                    Operation.SucceedOnRetry(untrackedStateFilePath: stateFile, firstFailExitCode: -2) :
+                    Operation.SucceedOnRetry(untrackedStateFilePath: stateFile, firstFailExitCode: 42) :
                     Operation.Fail(-2),
             };
 
             var builder = CreatePipBuilder(ops);
-            builder.RetryExitCodes = global::BuildXL.Utilities.Collections.ReadOnlyArray<int>.From(new int[] { -2 });
+            builder.RetryExitCodes = global::BuildXL.Utilities.Collections.ReadOnlyArray<int>.From(new int[] { 42 });
             builder.AddUntrackedFile(stateFile.Path);
             SchedulePipBuilder(builder);
 

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/ScheduleRunResult.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/ScheduleRunResult.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using Test.BuildXL.TestUtilities.Xunit;
 using BuildXL.Utilities.Tracing;
 using BuildXL.Scheduler.Fingerprints;
+using BuildXL.Utilities.Instrumentation.Common;
 
 namespace Test.BuildXL.Scheduler
 {
@@ -46,6 +47,27 @@ namespace Test.BuildXL.Scheduler
         {
             XAssert.IsFalse(Success, "Expected scheduler to run with at least one pip failing");
             return this;
+        }
+
+        /// <summary>
+        /// Validates that if the scheduler returns success, no errors are logged. If the scheduler returns a failure, errors mubt be logged.
+        /// </summary>
+        /// <param name="loggingContext"></param>
+        public void AssertSuccessMatchesLogging(LoggingContext loggingContext)
+        {
+            // Validate that error logging is correct
+            if (Success)
+            {
+                if (loggingContext.ErrorWasLogged)
+                {
+                    XAssert.Fail("No error should be logged if status is success. " +
+                        "Errors logged: " + string.Join(", ", loggingContext.ErrorsLoggedById.ToArray()));
+                }
+            }
+            else
+            {
+                XAssert.IsTrue(loggingContext.ErrorWasLogged, "Error should have been logged for non-success");
+            }
         }
 
         /// <summary>

--- a/Public/Src/Engine/UnitTests/Scheduler/PipExecutorTest.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/PipExecutorTest.cs
@@ -2053,7 +2053,7 @@ EXIT /b 3
                           AssertVerboseEventLogged(EventId.PipWillBeRetriedDueToExitCode, count: RetryCount);
                       });
 
-            SetExpectedFailures(4, 0);
+            SetExpectedFailures(1, 0);
         }
 
         [Fact]


### PR DESCRIPTION
We recently added some logging in SandboxedProcessPipExecutor for the exit code on retries. This logged an error which breaks assertions about no errors being logged on success since the pip sometimes succeeds on retry.

Fixes [AB#1550935](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1550935)