### PR TITLE
Remove unneded first chance exception on DotNetCoreApp3.0

### DIFF
--- a/Public/Src/App/Bxl/MachineInfo.cs
+++ b/Public/Src/App/Bxl/MachineInfo.cs
@@ -69,15 +69,18 @@ namespace BuildXL
             mi.ProcessorName = OperatingSystemHelper.GetProcessorName();
             mi.ProcessorIdentifier = OperatingSystemHelper.GetProcessorIdentifier();
 
+#if !FEATURE_CORECLR
             try {
                 mi.EnvironmentVersion = Environment.Version.ToString(4);
             }
             catch (ArgumentException)
             {
+#endif
                 // Fallback for .NETCore3.0, which currently reports "3.0.0" only
                 mi.EnvironmentVersion = Environment.Version.ToString();
+#if !FEATURE_CORECLR
             }
-
+#endif
             mi.InstalledMemoryMB = OperatingSystemHelper.GetPhysicalMemorySize().MB;
 
             char currentDrive = Environment.CurrentDirectory[0];


### PR DESCRIPTION
I like to debug processes with first chance exceptions turned on to discover perf issues and catch bugs in my code early. This was always firing, so conditionalizing the code so we run the codepath that would have run direclty.