### PR TITLE
Fixed a bug in Drop directories due to lazily materialized output directories

### DIFF
--- a/Public/Src/Tools/DropDaemon/Program.cs
+++ b/Public/Src/Tools/DropDaemon/Program.cs
@@ -769,12 +769,6 @@ namespace Tool.DropDaemon
             Contract.Requires(!string.IsNullOrEmpty(directoryId));
             Contract.Requires(dropPath != null);
 
-            // TODO: can be removed when the IPC lazy directory dependencies feature is implemented 
-            if (!System.IO.Directory.Exists(directoryPath))
-            {
-                return (null, Inv("directory '{0}' does not exist", directoryPath));
-            }
-
             if (daemon.ApiClient == null)
             {
                 return (null, "ApiClient is not initialized");


### PR DESCRIPTION
There're 3 lines of code that require directories to drop to exist on disk before the drop method is called. We already have lazily materialized output directories. Thus, the existence requirement is no longer needed. In fact it's causing an error because when the output directories are lazily materialized, then those directories may not be on disk yet.