### PR TITLE
Refactor TestProcess to not use PathTable to speed up tests

### DIFF
--- a/Public/Src/Utilities/UnitTests/Executables/TestProcess/Executable.cs
+++ b/Public/Src/Utilities/UnitTests/Executables/TestProcess/Executable.cs
@@ -9,6 +9,9 @@ namespace Test.BuildXL.Executables.TestProcess
     /// <summary>
     /// Encapsulates an executable process that can perform filesystem operations
     /// </summary>
+    /// <remarks>
+    /// Keep this process simple and avoid referencing complex datastructures like the PathTable to avoid JIT overhead.
+    /// </remarks>
     public sealed class Executable
     {
         // Queue of ops the process will run
@@ -19,13 +22,10 @@ namespace Test.BuildXL.Executables.TestProcess
         /// </summary>
         public Executable(string[] args)
         {
-            // The process as a test executable doesn't require a PathTable, so pass a dummy
-            var pathTable = new PathTable();
-
             // Add all the process operations in order to queue
             for (int i = 0; i < args.Length; i++)
             {
-                m_opQueue.Enqueue(Operation.CreateFromCommandLine(pathTable, args[i]));
+                m_opQueue.Enqueue(Operation.CreateFromCommandLine(args[i]));
             }
         }
 

--- a/Public/Src/Utilities/UnitTests/Executables/TestProcess/Operation.cs
+++ b/Public/Src/Utilities/UnitTests/Executables/TestProcess/Operation.cs
@@ -240,7 +240,7 @@ namespace Test.BuildXL.Executables.TestProcess
         public Type OpType { get; private set; }
 
         /// <summary>
-        /// Path to file. NOTE: This will not be accessable within TestProcess.exe
+        /// Path to file. NOTE: This will not be accessible within TestProcess.exe
         /// </summary>
         public FileOrDirectoryArtifact Path { get; private set; }
 

--- a/Public/Src/Utilities/UnitTests/Executables/TestProcess/Operation.cs
+++ b/Public/Src/Utilities/UnitTests/Executables/TestProcess/Operation.cs
@@ -239,30 +239,34 @@ namespace Test.BuildXL.Executables.TestProcess
         /// </summary>
         public Type OpType { get; private set; }
 
+#if TestProcess
+        /// <summary>
+        /// Should only be used in the context of TestProcess.exe
+        /// </summary>
+        private string PathAsString { get; set; }
+#endif
+
         /// <summary>
         /// Path to file. NOTE: This will not be accessible within TestProcess.exe
         /// </summary>
         public FileOrDirectoryArtifact Path { get; private set; }
 
         /// <summary>
-        /// Should only be used in the context of TestProcess.exe
-        /// </summary>
-        private string PathAsString { get; set; }
-
-        /// <summary>
         /// Content to write to file
         /// </summary>
         public string Content { get; private set; }
+
+#if TestProcess
+        /// <summary>
+        /// Should only be used in the context of TestProcess.exe
+        /// </summary>
+        private string LinkPathAsString { get; set; }
+#endif
 
         /// <summary>
         /// Path of new symlink or hardlink to create. NOTE: This will not be accessible within TestProcess.exe
         /// </summary>
         public FileOrDirectoryArtifact LinkPath { get; private set; }
-
-        /// <summary>
-        /// Should only be used in the context of TestProcess.exe
-        /// </summary>
-        private string LinkPathAsString { get; set; }
 
         /// <summary>
         /// Flag for correcting file or directory symlink
@@ -298,6 +302,7 @@ namespace Test.BuildXL.Executables.TestProcess
             AdditionalArgs = additionalArgs;
         }
 
+#if TestProcess
         private static Operation FromCommandLine(Type type, string path = null, string content = null, string linkPath = null, SymbolicLinkFlag? symLinkFlag = null, string additionalArgs = null)
         {
             Contract.Requires(content == null || !content.Contains(Environment.NewLine));
@@ -312,6 +317,7 @@ namespace Test.BuildXL.Executables.TestProcess
 
             return result;
         }
+#endif
 
         /// <summary>
         /// Executes the associated filesystem operation
@@ -1041,9 +1047,9 @@ namespace Test.BuildXL.Executables.TestProcess
             }
 
             Type opType;
-            string pathAsString = null;
+            string pathAsString = "{Invalid}";
             SymbolicLinkFlag symLinkFlag;
-            string linkPathAsString = null;
+            string linkPathAsString = "{Invalid}";
 
             if (!Enum.TryParse<Type>(opArgs[0], out opType))
             {

--- a/Public/Src/Utilities/UnitTests/Executables/TestProcess/Operation.cs
+++ b/Public/Src/Utilities/UnitTests/Executables/TestProcess/Operation.cs
@@ -324,6 +324,17 @@ namespace Test.BuildXL.Executables.TestProcess
         /// </summary>
         public void Run()
         {
+            // Make sure the string version of the paths are set in case the operation is run outside of the context of
+            // TestProcess.exe
+            if (LinkPath.IsValid)
+            {
+                LinkPathAsString = LinkPath.Path.ToString(PathTable);
+            }
+            if (Path.IsValid)
+            {
+                PathAsString = Path.Path.ToString(PathTable);
+            }
+
             try
             {
                 switch (OpType)

--- a/Public/Src/Utilities/UnitTests/Executables/TestProcess/Operation.cs
+++ b/Public/Src/Utilities/UnitTests/Executables/TestProcess/Operation.cs
@@ -240,9 +240,14 @@ namespace Test.BuildXL.Executables.TestProcess
         public Type OpType { get; private set; }
 
         /// <summary>
-        /// Path to file
+        /// Path to file. NOTE: This will not be accessable within TestProcess.exe
         /// </summary>
         public FileOrDirectoryArtifact Path { get; private set; }
+
+        /// <summary>
+        /// Should only be used in the context of TestProcess.exe
+        /// </summary>
+        private string PathAsString { get; set; }
 
         /// <summary>
         /// Content to write to file
@@ -250,9 +255,14 @@ namespace Test.BuildXL.Executables.TestProcess
         public string Content { get; private set; }
 
         /// <summary>
-        /// Path of new symlink or hardlink to create
+        /// Path of new symlink or hardlink to create. NOTE: This will not be accessable within TestProcess.exe
         /// </summary>
         public FileOrDirectoryArtifact LinkPath { get; private set; }
+
+        /// <summary>
+        /// Should only be used in the context of TestProcess.exe
+        /// </summary>
+        private string LinkPathAsString { get; set; }
 
         /// <summary>
         /// Flag for correcting file or directory symlink
@@ -286,6 +296,21 @@ namespace Test.BuildXL.Executables.TestProcess
             SymLinkFlag = symLinkFlag ?? SymbolicLinkFlag.None;
             DoNotInfer = doNotInfer ?? true;
             AdditionalArgs = additionalArgs;
+        }
+
+        private static Operation FromCommandLine(Type type, string path = null, string content = null, string linkPath = null, SymbolicLinkFlag? symLinkFlag = null, string additionalArgs = null)
+        {
+            Contract.Requires(content == null || !content.Contains(Environment.NewLine));
+
+            var result = new Operation(type: type,
+                content: content,
+                symLinkFlag: symLinkFlag,
+                doNotInfer: false,
+                additionalArgs: additionalArgs);
+            result.PathAsString = path;
+            result.LinkPathAsString = linkPath;
+
+            return result;
         }
 
         /// <summary>
@@ -647,8 +672,6 @@ namespace Test.BuildXL.Executables.TestProcess
 
         private void DoCreateDir()
         {
-            string directoryPath = FileOrDirectoryToString(Path);
-
             bool failIfExists = false;
 
             if (!string.IsNullOrEmpty(AdditionalArgs))
@@ -663,24 +686,24 @@ namespace Test.BuildXL.Executables.TestProcess
                 }
             }
 
-            if (FileUtilities.DirectoryExistsNoFollow(directoryPath) || FileUtilities.FileExistsNoFollow(directoryPath))
+            if (FileUtilities.DirectoryExistsNoFollow(PathAsString) || FileUtilities.FileExistsNoFollow(PathAsString))
             {
                 if (failIfExists)
                 {
-                    throw new InvalidOperationException($"Directory creation failed because '{directoryPath}' exists");
+                    throw new InvalidOperationException($"Directory creation failed because '{PathAsString}' exists");
                 }
             }
 
             if (OperatingSystemHelper.IsUnixOS)
             {
-                Directory.CreateDirectory(directoryPath);
+                Directory.CreateDirectory(PathAsString);
             }
             else
             {
                 // .NET's Directory.CreateDirectory first checks for directory existence, so when a directory
                 // exists it does nothing; to test a specific Detours access policy, we want to issue a "create directory"
                 // operation regardless of whether the directory exists, hence p-invoking Windows native CreateDirectory.
-                if (!ExternWinCreateDirectory(directoryPath, IntPtr.Zero))
+                if (!ExternWinCreateDirectory(PathAsString, IntPtr.Zero))
                 {
                     int errorCode = Marshal.GetLastWin32Error();
 
@@ -691,19 +714,19 @@ namespace Test.BuildXL.Executables.TestProcess
                         return;
                     }
 
-                    throw new InvalidOperationException($"Directory creation (native) for path '{directoryPath}' failed with error {errorCode}.");
+                    throw new InvalidOperationException($"Directory creation (native) for path '{PathAsString}' failed with error {errorCode}.");
                 }
             }
         }
 
         private void DoDeleteFile()
         {
-            File.Delete(FileOrDirectoryToString(Path));
+            File.Delete(PathAsString);
         }
 
         private void DoDeleteDir()
         {
-            Directory.Delete(FileOrDirectoryToString(Path));
+            Directory.Delete(PathAsString);
         }
 
         // Writes random Content if Content not specified
@@ -717,7 +740,7 @@ namespace Test.BuildXL.Executables.TestProcess
             string content = DoReadFile();
             try
             {
-                File.WriteAllText(FileOrDirectoryToString(LinkPath), content == string.Empty ? Guid.NewGuid().ToString() : content);
+                File.WriteAllText(LinkPathAsString, content == string.Empty ? Guid.NewGuid().ToString() : content);
             }
             catch (UnauthorizedAccessException)
             {
@@ -740,7 +763,7 @@ namespace Test.BuildXL.Executables.TestProcess
 
         private void DoWriteFile(string content)
         {
-            DoWriteFile(FileOrDirectoryToString(Path), content);
+            DoWriteFile(PathAsString, content);
         }
 
         private void DoWriteFile(string file, string content)
@@ -783,7 +806,7 @@ namespace Test.BuildXL.Executables.TestProcess
         {
             try
             {
-                var content = File.ReadAllText(FileOrDirectoryToString(Path));
+                var content = File.ReadAllText(PathAsString);
                 return content;
             }
             catch (FileNotFoundException)
@@ -803,32 +826,32 @@ namespace Test.BuildXL.Executables.TestProcess
 
         private void DoReadRequiredFile()
         {
-            File.ReadAllText(FileOrDirectoryToString(Path));
+            File.ReadAllText(PathAsString);
         }
 
         private void DoCopyFile()
         {
-            File.Copy(FileOrDirectoryToString(Path), FileOrDirectoryToString(LinkPath), overwrite: true);
+            File.Copy(PathAsString, LinkPathAsString, overwrite: true);
         }
 
         private void DoMoveDir()
         {
-            if (Directory.Exists(FileOrDirectoryToString(LinkPath)))
+            if (Directory.Exists(LinkPathAsString))
             {
-                Directory.Delete(FileOrDirectoryToString(LinkPath), true);
+                Directory.Delete(LinkPathAsString, true);
             }
 
-            Directory.Move(FileOrDirectoryToString(Path), FileOrDirectoryToString(LinkPath));
+            Directory.Move(PathAsString, LinkPathAsString);
         }
 
         private void DoMoveFile()
         {
-            File.Move(FileOrDirectoryToString(Path), FileOrDirectoryToString(LinkPath));
+            File.Move(PathAsString, LinkPathAsString);
         }
 
         private void DoProbe()
         {
-            File.Exists(FileOrDirectoryToString(Path));
+            File.Exists(PathAsString);
         }
 
         private void DoEnumerateDir()
@@ -838,11 +861,11 @@ namespace Test.BuildXL.Executables.TestProcess
                 string enumeratePattern = AdditionalArgs;
                 if (enumeratePattern == null)
                 {
-                    Directory.EnumerateFileSystemEntries(FileOrDirectoryToString(Path));
+                    Directory.EnumerateFileSystemEntries(PathAsString);
                 }
                 else
                 {
-                    Directory.EnumerateFileSystemEntries(FileOrDirectoryToString(Path), enumeratePattern);
+                    Directory.EnumerateFileSystemEntries(PathAsString, enumeratePattern);
                 }
             }
             catch (DirectoryNotFoundException)
@@ -853,10 +876,10 @@ namespace Test.BuildXL.Executables.TestProcess
 
         private void DoCreateSymlink()
         {
-            string target = AdditionalArgs ?? FileOrDirectoryToString(Path);
+            string target = AdditionalArgs ?? PathAsString;
 
             // delete whatever might exist at the link location
-            var linkPath = FileOrDirectoryToString(LinkPath);
+            var linkPath = LinkPathAsString;
             FileUtilities.DeleteFile(linkPath);
             var maybeSymlink = FileUtilities.TryCreateSymbolicLink(linkPath, target, SymLinkFlag == SymbolicLinkFlag.FILE);
             if (!maybeSymlink.Succeeded)
@@ -867,11 +890,11 @@ namespace Test.BuildXL.Executables.TestProcess
 
         private void DoCreateHardlink()
         {
-            var status = FileUtilities.TryCreateHardLink(FileOrDirectoryToString(Path), FileOrDirectoryToString(LinkPath));
+            var status = FileUtilities.TryCreateHardLink(PathAsString, LinkPathAsString);
             if (status != CreateHardLinkStatus.Success)
             {
                 int error = Marshal.GetLastWin32Error();
-                throw new InvalidOperationException("Failed to create hard link at '" + Path.Path.ToString(PathTable) + "' pointing to '" + LinkPath.Path.ToString(PathTable) + "'. Error: " + error + ".");
+                throw new InvalidOperationException("Failed to create hard link at '" + PathAsString + "' pointing to '" + LinkPathAsString + "'. Error: " + error + ".");
             }
         }
 
@@ -985,15 +1008,14 @@ namespace Test.BuildXL.Executables.TestProcess
         private void DoSucceedOnRetry()
         {
             // Use this state file to differentiate between the first run and the second run. The file will contain the exit code for the second run
-            string stateFilePath = FileOrDirectoryToString(Path);
-            if (File.Exists(stateFilePath))
+            if (File.Exists(PathAsString))
             {
-                int thisRunExitCode = int.Parse(File.ReadAllText(stateFilePath));
+                int thisRunExitCode = int.Parse(File.ReadAllText(PathAsString));
                 Environment.Exit(thisRunExitCode);
             }
             else
             {
-                File.WriteAllText(stateFilePath, "0");
+                File.WriteAllText(PathAsString, "0");
                 Environment.Exit(int.Parse(Content));
             }
         }
@@ -1004,7 +1026,11 @@ namespace Test.BuildXL.Executables.TestProcess
         /// Converts command line arg input to process ops
         /// Input format: "OpType?Path?Content?LinkPath?SymLinkFlag"
         /// </summary>
-        public static Operation CreateFromCommandLine(PathTable pathTable, string commandLineArg)
+        /// <remarks>
+        /// This and the execution of Operations within the context of TestProcess.exe should not utilize the PathTable
+        /// since this adds an appreciable amount of JIT overhead to our test execution
+        /// </remarks>
+        public static Operation CreateFromCommandLine(string commandLineArg)
         {
             var opArgs = commandLineArg.Split(OperationArgsDelimiter);
             if (opArgs.Length != NumArgsExpected)
@@ -1015,41 +1041,25 @@ namespace Test.BuildXL.Executables.TestProcess
             }
 
             Type opType;
-            AbsolutePath absolutePath = AbsolutePath.Invalid;
+            string pathAsString = null;
             SymbolicLinkFlag symLinkFlag;
-            AbsolutePath absoluteLinkPath = AbsolutePath.Invalid;
+            string linkPathAsString = null;
 
             if (!Enum.TryParse<Type>(opArgs[0], out opType))
             {
                 throw new InvalidCastException("A malformed or invalid input argument was passed for the Operation type enum.");
             }
 
-            if (opArgs[1].Length != 0 && !AbsolutePath.TryCreate(pathTable, opArgs[1], out absolutePath))
+            if (opArgs[1].Length != 0)
             {
-                throw new InvalidCastException("A malformed or invalid input argument was passed for the Operation path. Could not convert to absolute path.");
-            }
-
-            // This might be a directory, but since the running executable only cares about the string path,
-            // arbitrarily choose to store it in a FileArtifact
-            FileArtifact? path = null;
-            if (absolutePath.IsValid)
-            {
-                path = new FileArtifact(absolutePath);
+                pathAsString = opArgs[1];
             }
 
             string content = opArgs[2].Length == 0 ? null : opArgs[2];
 
-            if (opArgs[3].Length != 0 && !AbsolutePath.TryCreate(pathTable, opArgs[3], out absoluteLinkPath))
+            if (opArgs[3].Length != 0)
             {
-                throw new InvalidCastException("A malformed or invalid input argument was passed for the Operation link path. Could not convert to absolute path.");
-            }
-
-            // This might be a directory, but since the running executable only cares about the string path,
-            // arbitrarily choose to store it in a FileArtifact
-            FileArtifact? linkPath = null;
-            if (absoluteLinkPath.IsValid)
-            {
-                linkPath = new FileArtifact(absoluteLinkPath);
+                linkPathAsString = opArgs[3];
             }
 
             if (!Enum.TryParse<SymbolicLinkFlag>(opArgs[4], out symLinkFlag))
@@ -1059,12 +1069,13 @@ namespace Test.BuildXL.Executables.TestProcess
 
             string additionalArgs = opArgs[5].Length == 0 ? null : opArgs[5];
 
-            var op = new Operation(opType, path, content, linkPath, symLinkFlag)
-            {
-                PathTable = pathTable,
-                AdditionalArgs = additionalArgs
-            };
-            return op;
+            return Operation.FromCommandLine(
+                type: opType, 
+                path: pathAsString, 
+                content: content, 
+                linkPath: linkPathAsString, 
+                symLinkFlag: symLinkFlag, 
+                additionalArgs: additionalArgs);
         }
 
         /// <summary>

--- a/Public/Src/Utilities/UnitTests/Executables/TestProcess/Operation.cs
+++ b/Public/Src/Utilities/UnitTests/Executables/TestProcess/Operation.cs
@@ -255,7 +255,7 @@ namespace Test.BuildXL.Executables.TestProcess
         public string Content { get; private set; }
 
         /// <summary>
-        /// Path of new symlink or hardlink to create. NOTE: This will not be accessable within TestProcess.exe
+        /// Path of new symlink or hardlink to create. NOTE: This will not be accessible within TestProcess.exe
         /// </summary>
         public FileOrDirectoryArtifact LinkPath { get; private set; }
 

--- a/Public/Src/Utilities/UnitTests/Executables/TestProcess/Test.BuildXL.Executables.TestProcess.dsc
+++ b/Public/Src/Utilities/UnitTests/Executables/TestProcess/Test.BuildXL.Executables.TestProcess.dsc
@@ -9,6 +9,7 @@ namespace TestProcess {
     export const exe = BuildXLSdk.nativeExecutable({
         assemblyName: "Test.BuildXL.Executables.TestProcess",
         sources: globR(d`.`, "*.cs"),
+        defineConstants: [ "TestProcess" ],
         references: [
             importFrom("BuildXL.Utilities").dll,
             importFrom("BuildXL.Utilities").Collections.dll,


### PR DESCRIPTION
The SchedulerIntegrationTests call TestProcess.exe hundreds of times. Tweaking it to not use the PathTable shaves off about 100ms of JIT per invocation which really adds up in our test suite. The end result is a bit inelegant but I think it's worth it for the faster test execution time.