### PR TITLE
Cleanup: Declare runtime deps where used, not final layouts

### DIFF
--- a/Public/Src/App/Deployment.dsc
+++ b/Public/Src/App/Deployment.dsc
@@ -34,7 +34,6 @@ function createDeploymentManifest(isServerDeployment: boolean) : Deployment.Defi
 
             ...addIfLazy(qualifier.targetRuntime === "win-x64", () => [
                 RunInSubst.withQualifier({configuration: qualifier.configuration, platform: "x86"}).deployment,
-                DetoursServices.Deployment.definition
             ]),
 
             ...addIfLazy(MacServices.Deployment.macBinaryUsage !== "none" && qualifier.targetRuntime === "osx-x64", () => [

--- a/Public/Src/Deployment/privatePackages.dsc
+++ b/Public/Src/Deployment/privatePackages.dsc
@@ -47,14 +47,16 @@ namespace PrivatePackages {
                 {
                     subfolder: r`content`,
                     contents: [
-                        DetoursServices.Deployment.definition,
+                        DetoursServices.Deployment.detours,
+                        DetoursServices.Deployment.natives,
                         importFrom("BuildXL.Utilities").withQualifier(net472Qualifier).Branding.brandingManifest
                     ]
                 },
                 {
                     subfolder: r`contentFiles/any/any`,
                     contents: [
-                        DetoursServices.Deployment.definition,
+                        DetoursServices.Deployment.detours,
+                        DetoursServices.Deployment.natives,
                         importFrom("BuildXL.Utilities").withQualifier(net472Qualifier).Branding.brandingManifest
                     ]
                 }
@@ -85,7 +87,8 @@ namespace PrivatePackages {
                 {
                     subfolder: r`content`,
                     contents: [
-                        DetoursServices.Deployment.definition
+                        DetoursServices.Deployment.detours,
+                        DetoursServices.Deployment.natives
                     ]
                 }
             ]

--- a/Public/Src/Deployment/tools.dsc
+++ b/Public/Src/Deployment/tools.dsc
@@ -16,9 +16,6 @@ namespace Tools {
 
         export const deployment : Deployment.Definition = {
             contents: [
-                ...addIfLazy(qualifier.targetRuntime !== "osx-x64", () => [
-                    DetoursServices.Deployment.definition
-                ]),
                 ...addIfLazy(MacServices.Deployment.macBinaryUsage !== "none" && qualifier.targetRuntime === "osx-x64", () => [
                     MacServices.Deployment.kext,
                     MacServices.Deployment.sandboxMonitor,

--- a/Public/Src/Engine/Processes/BuildXL.Processes.dsc
+++ b/Public/Src/Engine/Processes/BuildXL.Processes.dsc
@@ -40,5 +40,10 @@ namespace Processes {
             "Test.BuildXL.Processes.Detours",
             "Test.BuildXL.Scheduler",
         ],
+        runtimeContent: [
+            ...addIfLazy(qualifier.targetRuntime === "win-x64", () => [
+                importFrom("BuildXL.Sandbox.Windows").Deployment.detours,
+            ]),
+        ],
     });
 }

--- a/Public/Src/Engine/UnitTests/Engine/Test.BuildXL.Engine.dsc
+++ b/Public/Src/Engine/UnitTests/Engine/Test.BuildXL.Engine.dsc
@@ -83,7 +83,6 @@ namespace Engine {
         ],
         runtimeContent: [
             ...libsUsedForTesting,
-            DetoursServices.Deployment.definition,
             importFrom("BuildXL.Cache.VerticalStore").MemoizationStoreAdapter.dll,
         ],
     });

--- a/Public/Src/Engine/UnitTests/FingerprintStore/Test.BuildXL.FingerprintStore.dsc
+++ b/Public/Src/Engine/UnitTests/FingerprintStore/Test.BuildXL.FingerprintStore.dsc
@@ -34,7 +34,6 @@ namespace Test.BuildXL.FingerprintStore {
             importFrom("BuildXL.Utilities.UnitTests").StorageTestUtilities.dll,
         ],
         runtimeContent: [
-            importFrom("BuildXL.Sandbox.Windows").Deployment.definition,
             importFrom("BuildXL.Utilities.UnitTests").TestProcess.deploymentDefinition
         ],
     });

--- a/Public/Src/Engine/UnitTests/Processes.Detours/Test.BuildXL.Processes.Detours.dsc
+++ b/Public/Src/Engine/UnitTests/Processes.Detours/Test.BuildXL.Processes.Detours.dsc
@@ -44,7 +44,6 @@ namespace Processes.Detours {
             runtimeContent: [
                 TestSubstituteProcessExecutionShim.exe,
                 ...addIfLazy(qualifier.targetRuntime === "win-x64", () => [
-                    importFrom("BuildXL.Sandbox.Windows").Deployment.definition,
                     {
                         subfolder: a`${platform}`,
                         contents: [

--- a/Public/Src/Engine/UnitTests/Processes/Test.BuildXL.Processes.dsc
+++ b/Public/Src/Engine/UnitTests/Processes/Test.BuildXL.Processes.dsc
@@ -37,11 +37,9 @@ namespace Processes {
         runtimeContent: [
             ...addIfLazy(qualifier.targetRuntime === "win-x64", () => [
                 // Note that detoursservice is deployed both in root and in the detourscrossbit tests to handle dotnetcore tests not being fully netstandard2.0
-                importFrom("BuildXL.Sandbox.Windows").Deployment.definition,
                 {
                     subfolder: a`DetoursCrossBitTests`,
                     contents: [
-                        importFrom("BuildXL.Sandbox.Windows").Deployment.definition,
                         DetoursCrossBitTests.withQualifier(BuildXLSdk.LatestFullFrameworkQualifier).x64,
                         DetoursCrossBitTests.withQualifier(BuildXLSdk.LatestFullFrameworkQualifier).x86,
                         {

--- a/Public/Src/Engine/UnitTests/Scheduler/Test.BuildXL.Scheduler.dsc
+++ b/Public/Src/Engine/UnitTests/Scheduler/Test.BuildXL.Scheduler.dsc
@@ -53,7 +53,6 @@ namespace Scheduler {
             importFrom("BuildXL.Utilities").Configuration.dll,
         ],
         runtimeContent: [
-            importFrom("BuildXL.Sandbox.Windows").Deployment.definition,
             importFrom("BuildXL.Utilities.UnitTests").testProcessExe
         ],
     });

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/Test.BuildXL.FrontEnd.MsBuild.dsc
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/Test.BuildXL.FrontEnd.MsBuild.dsc
@@ -39,8 +39,6 @@ namespace Test.MsBuild {
             ...BuildXLSdk.tplPackages,
         ],
         runtimeContent: [
-            importFrom("BuildXL.Sandbox.Windows").Deployment.definition,
-            
             ...MSBuild.msbuildRuntimeContent,
             ...MSBuild.msbuildReferences,
             {

--- a/Public/Src/FrontEnd/UnitTests/Ninja/Test.BuildXL.FrontEnd.Ninja.dsc
+++ b/Public/Src/FrontEnd/UnitTests/Ninja/Test.BuildXL.FrontEnd.Ninja.dsc
@@ -41,7 +41,6 @@ namespace Test.Ninja {
             importFrom("BuildXL.Pips").dll,
         ],
         runtimeContent: [
-            importFrom("BuildXL.Sandbox.Windows").Deployment.definition,
             {
                 subfolder: a`tools`,
                 contents: [

--- a/Public/Src/IDE/VsCode/BuildXL.IDE.VsCode.dsc
+++ b/Public/Src/IDE/VsCode/BuildXL.IDE.VsCode.dsc
@@ -62,10 +62,6 @@ namespace LanguageService.Server {
                             subfolder: a`bin`,
                             contents: [
                                 serverAssembly,
-                                // Language server could start nuget download and in this case
-                                // the nuget.exe is detoured.
-                                // This requires detours to be deployed with the language server
-                                DetoursServices.Deployment.definition,
                             ]
                         },
                         {

--- a/Public/Src/Sandbox/Windows/deployment.dsc
+++ b/Public/Src/Sandbox/Windows/deployment.dsc
@@ -5,22 +5,20 @@ import {Transformer} from "Sdk.Transformers";
 import * as SdkDeployment from "Sdk.Deployment";
 
 namespace Deployment {
-    export declare const qualifier: {configuration: "debug" | "release"};
+    export declare const qualifier: {configuration: "debug" | "release", targetRuntime: "win-x64"};
 
     const Core64 = Core.withQualifier({platform: "x64", configuration: qualifier.configuration});
     const Core86 = Core.withQualifier({platform: "x86", configuration: qualifier.configuration});
 
     @@public
-    export const definition: SdkDeployment.Definition = {
+    export const detours: SdkDeployment.Definition = {
         contents: [
-            ...addIfLazy(Context.getCurrentHost().os === "win", () => [{
+            {
                 subfolder: "x64",
                 contents: [{
                     contents: [
                         Core64.detoursDll.binaryFile,
                         Core64.detoursDll.debugFile,
-                        Core64.nativesDll.binaryFile,
-                        Core64.nativesDll.debugFile,
                     ]
                 }]
             },
@@ -33,7 +31,22 @@ namespace Deployment {
                         // BuildXL is only x64 process. No x86.
                     ]
                 }],
-            }]),
+            },
+        ]
+    };
+
+    @@public
+    export const natives: SdkDeployment.Definition = {
+        contents: [
+            {
+                subfolder: "x64",
+                contents: [{
+                    contents: [
+                        Core64.nativesDll.binaryFile,
+                        Core64.nativesDll.debugFile,
+                    ]
+                }]
+            },
         ]
     };
 }

--- a/Public/Src/Tools/SandboxedProcessExecutor/SandboxedProcessExecutor.dsc
+++ b/Public/Src/Tools/SandboxedProcessExecutor/SandboxedProcessExecutor.dsc
@@ -4,7 +4,6 @@
 import { NetFx } from "Sdk.BuildXL";
 import * as Managed from "Sdk.Managed";
 import * as BuildXLSdk from "Sdk.BuildXL";
-import * as DetoursServices from "BuildXL.Sandbox.Windows";
 
 namespace SandboxedProcessExecutor {
 
@@ -27,9 +26,6 @@ namespace SandboxedProcessExecutor {
             importFrom("BuildXL.Utilities.Instrumentation").Common.dll,
             importFrom("BuildXL.Utilities.Instrumentation").Tracing.dll,
             importFrom("BuildXL.Engine").Processes.dll,
-        ],
-        runtimeContent: [
-            DetoursServices.Deployment.definition,
         ],
     });
 }

--- a/Public/Src/Tools/UnitTests/Analyzers/Test.Tool.Analyzers.dsc
+++ b/Public/Src/Tools/UnitTests/Analyzers/Test.Tool.Analyzers.dsc
@@ -36,7 +36,6 @@ namespace Test.Tool.Analyzers {
             importFrom("BuildXL.Utilities.UnitTests").StorageTestUtilities.dll,
         ],
         runtimeContent: [
-            importFrom("BuildXL.Sandbox.Windows").Deployment.definition,
             importFrom("BuildXL.Utilities.UnitTests").testProcessExe
         ],
     });

--- a/Public/Src/Utilities/Native/BuildXL.Native.dsc
+++ b/Public/Src/Utilities/Native/BuildXL.Native.dsc
@@ -50,6 +50,9 @@ namespace Native {
                 MacServices.Deployment.ariaLibrary,
                 MacServices.Deployment.interopLibrary
             ]),
+            ...addIfLazy(qualifier.targetRuntime === "win-x64", () => [
+                importFrom("BuildXL.Sandbox.Windows").Deployment.natives,
+            ]),
         ]
     });
 }


### PR DESCRIPTION
Deploy native bits with code that refers to it, not all final deployments