### PR TITLE
Restore 10 min sandboxed process timeouts

### DIFF
--- a/Documentation/Wiki/Advanced-Features/Process-Timeouts.md
+++ b/Documentation/Wiki/Advanced-Features/Process-Timeouts.md
@@ -5,7 +5,7 @@ There is also a warning timeout that will be printed as a hint to users, to indi
 
 There are a few ways the timeouts are set:
 
-* A default timeout that applies to all pips. This defaults to 15 minutes if not specified, but can be overridden on the command line.
+* A default timeout that applies to all pips. This defaults to 10 minutes if not specified, but can be overridden on the command line.
 
   * `/pipDefaultTimeout:<ms>` - How long to wait before terminating individual processes, in milliseconds. Setting this value will only have an effect if no other timeout is specified for a process.
 

--- a/Public/Src/Tools/SandboxExec/Program.cs
+++ b/Public/Src/Tools/SandboxExec/Program.cs
@@ -25,7 +25,7 @@ namespace BuildXL.SandboxExec
     public class SandboxExecRunner : ISandboxedProcessFileStorage
     {
         private const string AccessOutput = "accesses.out";
-        private static readonly double s_defaultProcessTimeOut = TimeSpan.FromMinutes(15).TotalSeconds;
+        private static readonly double s_defaultProcessTimeOut = TimeSpan.FromMinutes(10).TotalSeconds;
         private static readonly double s_defaultProcessTimeOutMax = TimeSpan.FromHours(4).TotalSeconds;
         private static readonly LoggingContext s_loggingContext = new LoggingContext("BuildXL.SandboxExec");
         private static CrashCollectorMacOS s_crashCollector;

--- a/Public/Src/Utilities/Configuration/Mutable/SandboxConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/SandboxConfiguration.cs
@@ -9,7 +9,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
     public sealed class SandboxConfiguration : ISandboxConfiguration
     {
         /// <nodoc />
-        public static readonly uint DefaultProcessTimeoutInMinutes = 15;
+        public static readonly uint DefaultProcessTimeoutInMinutes = 10;
 
         private IUnsafeSandboxConfiguration m_unsafeSandboxConfig;
 


### PR DESCRIPTION
Reverts microsoft/BuildXL#409, the timeouts will be handled via additional flags in our CI pipeline to avoid changing the known BuildXL default behavior (10 minute timeouts).