### PR TITLE
Update Nuget hash versions to force specs to be generated

### DIFF
--- a/Public/Src/FrontEnd/Core/PackageHashFile.cs
+++ b/Public/Src/FrontEnd/Core/PackageHashFile.cs
@@ -30,8 +30,8 @@ namespace BuildXL.FrontEnd.Core
 
         // The file format change will force specs regeneration.
         // Change the version if the nuget spec generation has changed in a backward incompatible way.
-        private const string HashFileFormatVersion = "8";
-        private const string GeneratedSpecsVersion = "14";
+        private const string HashFileFormatVersion = "9";
+        private const string GeneratedSpecsVersion = "15";
 
         /// <summary>
         /// The minimal number of lines for the hash file.


### PR DESCRIPTION
We sometimes see unreliable nuget spec generation, bumping version to force regeneration