### PR TITLE
Orchestrator error handling adjustments

### DIFF
--- a/Public/Src/Tools/Orchestrator/Vsts/Api.cs
+++ b/Public/Src/Tools/Orchestrator/Vsts/Api.cs
@@ -208,9 +208,9 @@ namespace BuildXL.Orchestrator.Vsts
             while (!otherAgentsAreReady && elapsedTime < Constants.MaxWaitingPeriodBeforeFailingInSeconds)
             {
                 List<TimelineRecord> records = await GetTimelineRecords();
-                if (records.Any(r => r.State.HasValue && r.State.Value == TimelineRecordState.Completed))
+                if (records.Any(r => r.ErrorCount.HasValue && r.ErrorCount.Value != 0))
                 {
-                    throw new ApplicationException("One of the agents failed setting up the orchestration, aborting build!");
+                    throw new ApplicationException("One of the agents failed during the orchestration task with errors, aborting build!");
                 }
 
                 var filteredMachines = records.Where(r =>


### PR DESCRIPTION
Only allow orchestration task errors to flag orchestrated build as failures no completion. When running multiple invocations previous completions are expected and the DevOps APIs don't differentiate between a status that is `Completed` with or without errors unfortunately.