### PR TITLE
Revert regression in QTest SDK's dependency specification

### DIFF
--- a/Public/Sdk/SelfHost/BuildXL/Tools/QTest/Tool.QTestRunner.dsc
+++ b/Public/Sdk/SelfHost/BuildXL/Tools/QTest/Tool.QTestRunner.dsc
@@ -205,6 +205,7 @@ export function runQTest(args: QTestArguments): Result {
             ...(args.qTestInputs ? args.qTestInputs.filter(
                 f => f.name.hasExtension && f.name.extension === a`.pdb`
             ) : []),
+            ...(args.qTestRuntimeDependencies || []),
         ],
         unsafe: unsafeOptions
     });


### PR DESCRIPTION
This line of code was wiped by another PR, add it back.