### PR TITLE
Reset NagleQueue timer when the event processing is resumed.

### DIFF
--- a/Public/Src/Cache/ContentStore/Library/Utils/NagleQueue.cs
+++ b/Public/Src/Cache/ContentStore/Library/Utils/NagleQueue.cs
@@ -40,9 +40,9 @@ namespace BuildXL.Cache.ContentStore.Utils
 
             _batchBlock = new BatchBlock<T>(batchSize);
             _actionBlock = new ActionBlock<T[]>(ProcessBatchAsync, new ExecutionDataflowBlockOptions()
-                                                              {
-                                                                  MaxDegreeOfParallelism = maxDegreeOfParallelism
-                                                              });
+            {
+                MaxDegreeOfParallelism = maxDegreeOfParallelism
+            });
 
             _intervalTimer = new Timer(SendIncompleteBatch, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
         }
@@ -108,6 +108,9 @@ namespace BuildXL.Cache.ContentStore.Utils
                     break;
                 }
             }
+
+            // Need to reset the timer to purge the queue on time if needed.
+            ResetTimer();
         }
 
         private class ResumeBlockDisposable : IDisposable

--- a/Public/Src/Cache/ContentStore/Library/Utils/NagleQueue.cs
+++ b/Public/Src/Cache/ContentStore/Library/Utils/NagleQueue.cs
@@ -108,9 +108,6 @@ namespace BuildXL.Cache.ContentStore.Utils
                     break;
                 }
             }
-
-            // Need to reset the timer to purge the queue on time if needed.
-            ResetTimer();
         }
 
         private class ResumeBlockDisposable : IDisposable
@@ -196,7 +193,7 @@ namespace BuildXL.Cache.ContentStore.Utils
         {
             try
             {
-                SuspendTimer(); ;
+                SuspendTimer();
                 await _processBatch(batch);
             }
             finally
@@ -207,6 +204,11 @@ namespace BuildXL.Cache.ContentStore.Utils
 
         private void SendIncompleteBatch(object obj)
         {
+            // Even though the callback (ProcessBatchAsync) resets the timer,
+            // we still need to reset the timer in the case when the batch is empty now.
+            // in this case _batchBlock.TriggerBatch won't trigger the callback at all.
+            ResetTimer();
+
             _batchBlock.TriggerBatch();
         }
 


### PR DESCRIPTION
[AB#1552616](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1552616)

This issue can cause events to get stuck in nagle queue for a long time causing CTMIS.