### PR TITLE
Translate host UNC drive path to allow journal tests in VM

### DIFF
--- a/Public/Src/Engine/Processes/ExternalVMSandboxedProcess.cs
+++ b/Public/Src/Engine/Processes/ExternalVMSandboxedProcess.cs
@@ -140,7 +140,7 @@ namespace BuildXL.Processes
             VmSerializer.SerializeToFile(RunRequestPath, runRequest);
 
             // (2) Create a process to execute VmCommandProxy.
-            string arguments = $"{VmCommand.Run} /{VmCommand.Param.InputJsonFile}:\"{RunRequestPath}\" /{VmCommand.Param.OutputJsonFile}:\"{RunOutputPath}\"";
+            string arguments = $"{VmCommands.Run} /{VmCommands.Params.InputJsonFile}:\"{RunRequestPath}\" /{VmCommands.Params.OutputJsonFile}:\"{RunOutputPath}\"";
             var process = CreateVmCommandProxyProcess(arguments);
 
             LogExternalExecution($"call {m_vmInitializer.VmCommandProxy} {arguments}");

--- a/Public/Src/Engine/Processes/FileAccessManifest.cs
+++ b/Public/Src/Engine/Processes/FileAccessManifest.cs
@@ -384,7 +384,7 @@ namespace BuildXL.Processes
         /// <summary>
         /// Directory translator.
         /// </summary>
-        public DirectoryTranslator DirectoryTranslator { get; }
+        public DirectoryTranslator DirectoryTranslator { get; set; }
 
         /// <summary>
         /// The pip's unique id.

--- a/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
@@ -2048,7 +2048,7 @@ namespace BuildXL.Processes
         {
             if (ShouldSandboxedProcessExecuteInVm)
             {
-                environmentVariables = environmentVariables.Override(new[] { new KeyValuePair<string, string>(VmSpecialEnvironmentVariable.IsInVm, "1")});
+                environmentVariables = environmentVariables.Override(new[] { new KeyValuePair<string, string>(VmSpecialEnvironmentVariables.IsInVm, "1")});
             }
         }
 
@@ -2119,7 +2119,7 @@ namespace BuildXL.Processes
                     string redirectedTempDirectoryPath = redirectedTempDirectory.ToString(m_pathTable);
                     var overridenEnvVars = DisallowedTempVariables
                         .Select(v => new KeyValuePair<string, string>(v, redirectedTempDirectoryPath))
-                        .Append(new KeyValuePair<string, string>(VmSpecialEnvironmentVariable.VmTemp, redirectedTempDirectoryPath));
+                        .Append(new KeyValuePair<string, string>(VmSpecialEnvironmentVariables.VmTemp, redirectedTempDirectoryPath));
 
                     environmentVariables = environmentVariables.Override(overridenEnvVars);
                 }

--- a/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
@@ -596,6 +596,8 @@ namespace BuildXL.Processes
                     return SandboxedProcessPipExecutionResult.PreparationFailure();
                 }
 
+                PrepareEnvironmentVariables(ref environmentVariables);
+
                 if (!PrepareTempDirectory(ref environmentVariables))
                 {
                     return SandboxedProcessPipExecutionResult.PreparationFailure();
@@ -861,6 +863,11 @@ namespace BuildXL.Processes
 
             info.RedirectedTempFolders = m_tempFolderRedirectionForVm.Select(kvp => (kvp.Key.ToString(m_pathTable), kvp.Value.ToString(m_pathTable))).ToArray();
 
+            if (m_sandboxConfig.AdminRequiredProcessExecutionMode.ExecuteExternalVm())
+            {
+                TranslateHostSharedUncDrive(info);
+            }
+
             // Preparation should be finished.
             sandboxPrepTime.Stop();
             ISandboxedProcess process = null;
@@ -905,6 +912,23 @@ namespace BuildXL.Processes
             }
 
             return await GetAndProcessResultAsync(process, allInputPathsUnderSharedOpaques, sandboxPrepTime, cancellationToken);
+        }
+
+        /// <summary>
+        /// Translates VMs' host shared drive.
+        /// </summary>
+        /// <remarks>
+        /// VMs' host net shares the drive where the enlistiment resides, e.g., D, that is net used by the VMs. When the process running in a VM 
+        /// accesses D:\E\f.txt, the process actually accesses D:\E\f.txt in the host. Thus, the file access manifest constructed in the host
+        /// is often sufficient for running pips in VMs. However, some tools, like dotnet.exe, can access the path in UNC format, i.e.,
+        /// \\192.168.0.1\D\E\f.txt. In this case, we need to supply a directory translation from that UNC path to the non-UNC path.
+        /// </remarks>
+        private void TranslateHostSharedUncDrive(SandboxedProcessInfo info)
+        {
+            DirectoryTranslator newTranslator = info.FileAccessManifest.DirectoryTranslator?.GetUnsealedClone() ?? new DirectoryTranslator();
+            newTranslator.AddTranslation($@"\\{VmIOConstants.Host.IpAddress}\{VmIOConstants.Host.NetUseDrive}", $@"{VmIOConstants.Host.NetUseDrive}:");
+            newTranslator.Seal();
+            info.FileAccessManifest.DirectoryTranslator = newTranslator;
         }
 
         private async Task<SandboxedProcessPipExecutionResult> GetAndProcessResultAsync(
@@ -2020,6 +2044,14 @@ namespace BuildXL.Processes
             return true;
         }
 
+        private void PrepareEnvironmentVariables(ref IBuildParameters environmentVariables)
+        {
+            if (ShouldSandboxedProcessExecuteInVm)
+            {
+                environmentVariables = environmentVariables.Override(new[] { new KeyValuePair<string, string>(VmSpecialEnvironmentVariable.IsInVm, "1")});
+            }
+        }
+
         /// <summary>
         /// Creates and cleans the Process's temp directory if necessary
         /// </summary>
@@ -2084,7 +2116,11 @@ namespace BuildXL.Processes
                     // However, a number of operations, like creating/accessing/enumerating junctions, will fail.
                     // Recall that junctions are evaluated locally, so that creating junction using host path is like creating junctions 
                     // on the host from the VM.
-                    var overridenEnvVars = DisallowedTempVariables.Select(v => new KeyValuePair<string, string>(v, redirectedTempDirectory.ToString(m_pathTable)));
+                    string redirectedTempDirectoryPath = redirectedTempDirectory.ToString(m_pathTable);
+                    var overridenEnvVars = DisallowedTempVariables
+                        .Select(v => new KeyValuePair<string, string>(v, redirectedTempDirectoryPath))
+                        .Append(new KeyValuePair<string, string>(VmSpecialEnvironmentVariable.VmTemp, redirectedTempDirectoryPath));
+
                     environmentVariables = environmentVariables.Override(overridenEnvVars);
                 }
             }

--- a/Public/Src/Utilities/UnitTests/Executables/MockVmCommandProxy/Program.cs
+++ b/Public/Src/Utilities/UnitTests/Executables/MockVmCommandProxy/Program.cs
@@ -30,11 +30,11 @@ namespace Test.BuildXL.Executables.MockVmCommandProxy
             string outputFile = null;
             string command = args[0];
 
-            if (string.Equals(VmCommand.InitializeVm, command, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(VmCommands.InitializeVm, command, StringComparison.OrdinalIgnoreCase))
             {
                 return InitializeVm();
             }
-            else if (string.Equals(VmCommand.Run, command, StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals(VmCommands.Run, command, StringComparison.OrdinalIgnoreCase))
             {
                 if (!TryParseArgs(args, out inputFile, out outputFile))
                 {
@@ -43,7 +43,7 @@ namespace Test.BuildXL.Executables.MockVmCommandProxy
 
                 if (string.IsNullOrWhiteSpace(inputFile) || string.IsNullOrWhiteSpace(outputFile))
                 {
-                    Console.Error.WriteLine($"{VmCommand.Run} command requires input and output");
+                    Console.Error.WriteLine($"{VmCommands.Run} command requires input and output");
                     return -1;
                 }
 
@@ -60,8 +60,8 @@ namespace Test.BuildXL.Executables.MockVmCommandProxy
         {
             inputFile = null;
             outputFile = null;
-            string inputFileArgPrefix = $"/{VmCommand.Param.InputJsonFile}:";
-            string outputFileArgPrefix = $"/{VmCommand.Param.OutputJsonFile}:";
+            string inputFileArgPrefix = $"/{VmCommands.Params.InputJsonFile}:";
+            string outputFileArgPrefix = $"/{VmCommands.Params.OutputJsonFile}:";
 
             for (int i = 1; i < args.Length; ++i)
             {

--- a/Public/Src/Utilities/Utilities/DirectoryTranslator.cs
+++ b/Public/Src/Utilities/Utilities/DirectoryTranslator.cs
@@ -204,6 +204,21 @@ namespace BuildXL.Utilities
         }
 
         /// <summary>
+        /// Gets an unsealed clone of this translator.
+        /// </summary>
+        public DirectoryTranslator GetUnsealedClone()
+        {
+            var result = new DirectoryTranslator();
+
+            foreach (var translation in m_translations)
+            {
+                result.AddTranslation(translation.SourcePath, translation.TargetPath);
+            }
+
+            return result;
+        }
+
+        /// <summary>
         /// Translates the path based on the added translations.
         /// </summary>
         public AbsolutePath Translate(AbsolutePath path, PathTable pathTable)

--- a/Public/Src/Utilities/Utilities/VmCommandProxy/VmConstants.cs
+++ b/Public/Src/Utilities/Utilities/VmCommandProxy/VmConstants.cs
@@ -8,7 +8,7 @@ namespace BuildXL.Utilities.VmCommandProxy
     /// <summary>
     /// Commands used by VmCommandProxy.
     /// </summary>
-    public static class VmCommand
+    public static class VmCommands
     {
         /// <summary>
         /// Initialize VM.
@@ -23,7 +23,7 @@ namespace BuildXL.Utilities.VmCommandProxy
         /// <summary>
         /// Commands' parameters.
         /// </summary>
-        public static class Param
+        public static class Params
         {
             /// <summary>
             /// Input JSON file.
@@ -51,7 +51,7 @@ namespace BuildXL.Utilities.VmCommandProxy
     /// <summary>
     /// Special environment variable for executions in VM.
     /// </summary>
-    public static class VmSpecialEnvironmentVariable
+    public static class VmSpecialEnvironmentVariables
     {
         /// <summary>
         /// Environment variable whose value/presence indicates that the process is running in VM.

--- a/Public/Src/Utilities/Utilities/VmCommandProxy/VmConstants.cs
+++ b/Public/Src/Utilities/Utilities/VmCommandProxy/VmConstants.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace BuildXL.Utilities.VmCommandProxy
 {
     /// <summary>
@@ -26,12 +28,12 @@ namespace BuildXL.Utilities.VmCommandProxy
             /// <summary>
             /// Input JSON file.
             /// </summary>
-            public const string InputJsonFile = "InputJsonFile";
+            public const string InputJsonFile = nameof(InputJsonFile);
 
             /// <summary>
             /// Output JSON file.
             /// </summary>
-            public const string OutputJsonFile = "OutputJsonFile";
+            public const string OutputJsonFile = nameof(OutputJsonFile);
         }
     }
 
@@ -47,8 +49,37 @@ namespace BuildXL.Utilities.VmCommandProxy
     }
 
     /// <summary>
+    /// Special environment variable for executions in VM.
+    /// </summary>
+    public static class VmSpecialEnvironmentVariable
+    {
+        /// <summary>
+        /// Environment variable whose value/presence indicates that the process is running in VM.
+        /// </summary>
+        public const string IsInVm = "[BUILDXL]IS_IN_VM";
+
+        /// <summary>
+        /// Environment variable whose value is %TEMP%, and whose presence indicates that the process in VM has relocated temporary folder.
+        /// </summary>
+        public const string VmTemp = "[BUILDXL]VM_TEMP";
+
+        /// <summary>
+        /// Property indicating if a process is running in VM.
+        /// </summary>
+        public static bool IsRunningInVm => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(IsInVm));
+
+        /// <summary>
+        /// Property indicating if the process in VM has relocated temporary folder.
+        /// </summary>
+        public static bool HasRelocatedTemp => IsRunningInVm && !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(VmTemp));
+    }
+
+    /// <summary>
     /// Constants for IO in Vm.
     /// </summary>
+    /// <remarks>
+    /// These constants constitute a kind of contract between BuildXL and VmCommandProxy.
+    /// </remarks>
     public static class VmIOConstants
     {
         /// <summary>
@@ -59,12 +90,28 @@ namespace BuildXL.Utilities.VmCommandProxy
             /// <summary>
             /// Drive for temporary folder.
             /// </summary>
-            public const string Drive = "T:";
+            public const string Drive = "T";
 
             /// <summary>
             /// Root for temporary folder.
             /// </summary>
-            public static readonly string Root = $@"{Drive}\BxlInt\Temp";
+            public static readonly string Root = $@"{Drive}:\BxlInt\Temp";
+        }
+
+        /// <summary>
+        /// IO relating VMs and their hosts.
+        /// </summary>
+        public static class Host
+        {
+            /// <summary>
+            /// Host's (net shared) drive that is net used by VM.
+            /// </summary>
+            public const string NetUseDrive = "D";
+
+            /// <summary>
+            /// Host IP address.
+            /// </summary>
+            public const string IpAddress = "192.168.0.1";
         }
     }
 }

--- a/Public/Src/Utilities/Utilities/VmCommandProxy/VmInitializer.cs
+++ b/Public/Src/Utilities/Utilities/VmCommandProxy/VmInitializer.cs
@@ -67,7 +67,7 @@ namespace BuildXL.Utilities.VmCommandProxy
         private async Task InitVmAsync()
         {
             // (1) Create a process to execute VmCommandProxy.
-            string arguments = $"{VmCommand.InitializeVm}";
+            string arguments = $"{VmCommands.InitializeVm}";
             var process = CreateVmCommandProxyProcess(arguments, Path.GetDirectoryName(Path.GetTempFileName()));
 
             m_logStartInit?.Invoke($"{VmCommandProxy} {arguments}");

--- a/config.microsoftInternal.dsc
+++ b/config.microsoftInternal.dsc
@@ -19,7 +19,7 @@ export const pkgs = isMicrosoftInternal ? [
     { id: "Aria.Cpp.SDK.osx-x64", version: "8.5.4" },
 
     { id: "CB.QTest", version: "19.5.29.221321" },
-    { id: "CloudBuild.VmCommandProxy", version: "19.5.15.220914" },
+    { id: "CloudBuild.VmCommandProxy", version: "19.6.9.150831" },
 
     { id: "BuildXL.Tracing.AriaTenantToken", version: "1.0.0" },
 


### PR DESCRIPTION
This is one of three changes required for running journal tests in VM. In this change, we translate host UNC drive path that is often access by tools like dotnet.exe. 

This change also include introduction of some special environment variables that the unit tests will use to work properly when run in VMs.