### PR TITLE
Add args unsafe_GlobalPassthroughEnvVars and unsafe_GlobalUntrackedScopes

### DIFF
--- a/Public/Src/App/Bxl/Args.cs
+++ b/Public/Src/App/Bxl/Args.cs
@@ -290,6 +290,12 @@ namespace BuildXL
                         OptionHandlerFactory.CreateBoolOption(
                             "debugScript",
                             opt => frontEndConfiguration.DebugScript = opt),
+                        OptionHandlerFactory.CreateOption(
+                            "globalPassthroughEnvironmentVariables",
+                            opt => sandboxConfiguration.GlobalPassthroughEnvironmentVariables.AddRange(CommandLineUtilities.ParseRepeatingOption(opt, ";", v => v ))),
+                        OptionHandlerFactory.CreateOption(
+                            "globalUntrackedScopes",
+                            opt => sandboxConfiguration.GlobalUntrackedScopes.AddRange(CommandLineUtilities.ParseRepeatingPathOption(opt, pathTable, ";"))),
                         OptionHandlerFactory.CreateBoolOption(
                             "scriptShowSlowest",
                             opt => frontEndConfiguration.ShowSlowestElementsStatistics = opt),

--- a/Public/Src/App/Bxl/Args.cs
+++ b/Public/Src/App/Bxl/Args.cs
@@ -291,11 +291,11 @@ namespace BuildXL
                             "debugScript",
                             opt => frontEndConfiguration.DebugScript = opt),
                         OptionHandlerFactory.CreateOption(
-                            "globalPassthroughEnvironmentVariables",
-                            opt => sandboxConfiguration.GlobalPassthroughEnvironmentVariables.AddRange(CommandLineUtilities.ParseRepeatingOption(opt, ";", v => v ))),
+                            "globalUnsafePassthroughEnvVars",
+                            opt => sandboxConfiguration.GlobalUnsafePassthroughEnvironmentVariables.AddRange(CommandLineUtilities.ParseRepeatingOption(opt, ";", v => v ))),
                         OptionHandlerFactory.CreateOption(
-                            "globalUntrackedScopes",
-                            opt => sandboxConfiguration.GlobalUntrackedScopes.AddRange(CommandLineUtilities.ParseRepeatingPathOption(opt, pathTable, ";"))),
+                            "globalUnsafeUntrackedScopes",
+                            opt => sandboxConfiguration.GlobalUnsafeUntrackedScopes.AddRange(CommandLineUtilities.ParseRepeatingPathOption(opt, pathTable, ";"))),
                         OptionHandlerFactory.CreateBoolOption(
                             "scriptShowSlowest",
                             opt => frontEndConfiguration.ShowSlowestElementsStatistics = opt),

--- a/Public/Src/App/Bxl/Args.cs
+++ b/Public/Src/App/Bxl/Args.cs
@@ -290,12 +290,6 @@ namespace BuildXL
                         OptionHandlerFactory.CreateBoolOption(
                             "debugScript",
                             opt => frontEndConfiguration.DebugScript = opt),
-                        OptionHandlerFactory.CreateOption(
-                            "globalUnsafePassthroughEnvVars",
-                            opt => sandboxConfiguration.GlobalUnsafePassthroughEnvironmentVariables.AddRange(CommandLineUtilities.ParseRepeatingOption(opt, ";", v => v ))),
-                        OptionHandlerFactory.CreateOption(
-                            "globalUnsafeUntrackedScopes",
-                            opt => sandboxConfiguration.GlobalUnsafeUntrackedScopes.AddRange(CommandLineUtilities.ParseRepeatingPathOption(opt, pathTable, ";"))),
                         OptionHandlerFactory.CreateBoolOption(
                             "scriptShowSlowest",
                             opt => frontEndConfiguration.ShowSlowestElementsStatistics = opt),
@@ -922,6 +916,12 @@ namespace BuildXL
                             "unsafe_ForceSkipDeps",
                             (opt, sign) => HandleForceSkipDependenciesOption(opt, sign, schedulingConfiguration),
                             isUnsafe: true),
+                        OptionHandlerFactory.CreateOption(
+                            "unsafe_GlobalPassthroughEnvVars",
+                            opt => frontEndConfiguration.GlobalUnsafePassthroughEnvironmentVariables.AddRange(CommandLineUtilities.ParseRepeatingOption(opt, ";", v => v ))),
+                        OptionHandlerFactory.CreateOption(
+                            "unsafe_GlobalUntrackedScopes",
+                            opt => sandboxConfiguration.GlobalUnsafeUntrackedScopes.AddRange(CommandLineUtilities.ParseRepeatingPathOption(opt, pathTable, ";"))),
                         OptionHandlerFactory.CreateBoolOption(
                             "unsafe_IgnoreGetFinalPathNameByHandle",
                             sign => sandboxConfiguration.UnsafeSandboxConfigurationMutable.IgnoreGetFinalPathNameByHandle = sign,

--- a/Public/Src/Engine/Dll/Engine.cs
+++ b/Public/Src/Engine/Dll/Engine.cs
@@ -2191,6 +2191,8 @@ namespace BuildXL.Engine
                 { "unsafe_DisableSharedOpaqueEmptyDirectoryScrubbing", Logger.Log.ConfigUnsafeDisableSharedOpaqueEmptyDirectoryScrubbing },
                 { "unsafe_ExistingDirectoryProbesAsEnumerations", Logger.Log.ConfigUnsafeExistingDirectoryProbesAsEnumerations },
                 { "unsafe_ForceSkipDeps", Logger.Log.ForceSkipDependenciesEnabled },
+                { "unsafe_GlobalPassthroughEnvVars",  loggingContext => { } /* Special case: unsafe option we do not want logged */ },
+                { "unsafe_GlobalUntrackedScopes",  loggingContext => { } /* Special case: unsafe option we do not want logged */ },
                 { "unsafe_IgnoreGetFinalPathNameByHandle", Logger.Log.ConfigIgnoreGetFinalPathNameByHandle },
                 { "unsafe_IgnoreNonCreateFileReparsePoints", Logger.Log.ConfigIgnoreNonCreateFileReparsePoints },
                 { "unsafe_IgnoreNtCreateFile", Logger.Log.ConfigUnsafeMonitorNtCreateFileOff },

--- a/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
@@ -1581,6 +1581,12 @@ namespace BuildXL.Processes
                 }
             }
 
+            // Untrack the globally untracked paths specified in the configuration 
+            foreach (var path in m_sandboxConfig.GlobalUntrackedScopes)
+            {
+                m_fileAccessManifest.AddScope(path, mask: m_excludeReportAccessMask, values: FileAccessPolicy.AllowAll | FileAccessPolicy.AllowRealInputTimestamps);
+            }
+
             // For some static system mounts (currently only for AppData\Roaming) we allow CreateDirectory requests for all processes.
             // This is done because many tools are using CreateDirectory to check for the existence of that directory. Since system directories
             // always exist, allowing such requests would not lead to any changes on the disk. Moreover, we are applying an exact path policy (i.e., not a scope policy).

--- a/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
@@ -1582,7 +1582,7 @@ namespace BuildXL.Processes
             }
 
             // Untrack the globally untracked paths specified in the configuration 
-            foreach (var path in m_sandboxConfig.GlobalUntrackedScopes)
+            foreach (var path in m_sandboxConfig.GlobalUnsafeUntrackedScopes)
             {
                 m_fileAccessManifest.AddScope(path, mask: m_excludeReportAccessMask, values: FileAccessPolicy.AllowAll | FileAccessPolicy.AllowRealInputTimestamps);
             }

--- a/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
+++ b/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
@@ -541,6 +541,9 @@ namespace BuildXL.FrontEnd.MsBuild
             // It'll cause full cache misses if we try to hash it as an input, however, so exclude.
             processBuilder.SetPassthroughEnvironmentVariable(StringId.Create(m_context.StringTable, BuildEnvironmentConstants.QSessionGuidEnvVar));
 
+            // GlobalUnsafePassthroughEnvironmentVariables
+            processBuilder.SetGlobalPassthroughEnvironmentVariable(m_frontEndHost.Configuration.FrontEnd.GlobalUnsafePassthroughEnvironmentVariables, m_context.StringTable);
+
             // mspdbsrv: _MSPDBSRV_ENDPOINT_ sets up one mspdbsrv.exe instance per build target execution.
             // However this process will live beyond the build.cmd or msbuild.exe call.
             // Allow the pip job object to clean the process without complaint.

--- a/Public/Src/FrontEnd/Ninja/NinjaPipConstructor.cs
+++ b/Public/Src/FrontEnd/Ninja/NinjaPipConstructor.cs
@@ -296,6 +296,7 @@ namespace BuildXL.FrontEnd.Ninja
 
             // Environment variables
             SetEnvironmentVariables(processBuilder, node);
+
             return true;
         }
 
@@ -382,6 +383,9 @@ namespace BuildXL.FrontEnd.Ninja
             {
                 processBuilder.SetPassthroughEnvironmentVariable(StringId.Create(m_context.StringTable, envVar));
             }
+
+            // GlobalUnsafePassthroughEnvironmentVariables
+            processBuilder.SetGlobalPassthroughEnvironmentVariable(m_frontEndHost.Configuration.FrontEnd.GlobalUnsafePassthroughEnvironmentVariables, m_context.StringTable);
 
             // We will specify a different MSPDBSRV endpoint for every pip.
             // This means every pip that needs to communicate to MSPDBSRV will

--- a/Public/Src/FrontEnd/Script/Ambients/Transformers/AmbientTransformer.Process.cs
+++ b/Public/Src/FrontEnd/Script/Ambients/Transformers/AmbientTransformer.Process.cs
@@ -502,11 +502,8 @@ namespace BuildXL.FrontEnd.Script.Ambients.Transformers
                 ProcessUnsafeOptions(context, processBuilder, unsafeOptions);
             }
 
-            // GlobalPassThroughEnvironmentVariables
-            foreach (var passThroughEnvironmentVariable in context.FrontEndHost.Configuration.Sandbox.GlobalUnsafePassthroughEnvironmentVariables)
-            {
-                processBuilder.SetPassthroughEnvironmentVariable(StringId.Create(context.StringTable, passThroughEnvironmentVariable));
-            }
+            // GlobalUnsafePassthroughEnvironmentVariables
+            processBuilder.SetGlobalPassthroughEnvironmentVariable(context.FrontEndHost.Configuration.FrontEnd.GlobalUnsafePassthroughEnvironmentVariables, context.StringTable);
 
             // Set outputs to remain writable.
             var keepOutputsWritable = Converter.ExtractOptionalBoolean(obj, m_executeKeepOutputsWritable);

--- a/Public/Src/FrontEnd/Script/Ambients/Transformers/AmbientTransformer.Process.cs
+++ b/Public/Src/FrontEnd/Script/Ambients/Transformers/AmbientTransformer.Process.cs
@@ -502,6 +502,12 @@ namespace BuildXL.FrontEnd.Script.Ambients.Transformers
                 ProcessUnsafeOptions(context, processBuilder, unsafeOptions);
             }
 
+            // GlobalPassThroughEnvironmentVariables
+            foreach (var passThroughEnvironmentVariable in context.FrontEndHost.Configuration.Sandbox.GlobalPassthroughEnvironmentVariables)
+            {
+                processBuilder.SetPassthroughEnvironmentVariable(StringId.Create(context.StringTable, passThroughEnvironmentVariable));
+            }
+
             // Set outputs to remain writable.
             var keepOutputsWritable = Converter.ExtractOptionalBoolean(obj, m_executeKeepOutputsWritable);
             if (keepOutputsWritable == true)

--- a/Public/Src/FrontEnd/Script/Ambients/Transformers/AmbientTransformer.Process.cs
+++ b/Public/Src/FrontEnd/Script/Ambients/Transformers/AmbientTransformer.Process.cs
@@ -503,7 +503,7 @@ namespace BuildXL.FrontEnd.Script.Ambients.Transformers
             }
 
             // GlobalPassThroughEnvironmentVariables
-            foreach (var passThroughEnvironmentVariable in context.FrontEndHost.Configuration.Sandbox.GlobalPassthroughEnvironmentVariables)
+            foreach (var passThroughEnvironmentVariable in context.FrontEndHost.Configuration.Sandbox.GlobalUnsafePassthroughEnvironmentVariables)
             {
                 processBuilder.SetPassthroughEnvironmentVariable(StringId.Create(context.StringTable, passThroughEnvironmentVariable));
             }

--- a/Public/Src/Pips/Dll/Builders/ProcessBuilder.cs
+++ b/Public/Src/Pips/Dll/Builders/ProcessBuilder.cs
@@ -447,6 +447,19 @@ namespace BuildXL.Pips.Builders
             m_environmentVariables[key] = PipData.Invalid;
         }
 
+
+        /// <summary>
+        /// Set GlobalUnsafePassthroughEnvironmentVariables for each pip.
+        /// The passthrough environment varibles will not be computed in pip fingerprint.
+        /// </summary>
+        public void SetGlobalPassthroughEnvironmentVariable(IReadOnlyList<string> globalUnsafePassthroughEnvironmentVariables, StringTable stringTable)
+        {
+            foreach (var passThroughEnvironmentVariable in globalUnsafePassthroughEnvironmentVariables)
+            {
+                SetPassthroughEnvironmentVariable(StringId.Create(stringTable, passThroughEnvironmentVariable));
+            }
+        }                    
+
         private ReadOnlyArray<EnvironmentVariable> FinishEnvironmentVariables()
         {
             if (m_environmentVariables == null)

--- a/Public/Src/Utilities/Configuration/IFrontEndConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/IFrontEndConfiguration.cs
@@ -288,5 +288,15 @@ namespace BuildXL.Utilities.Configuration
         /// Whether the frontend statistics should contain statistics about the largest files.
         /// </summary>
         bool ShowLargestFilesStatistics { get; }
+
+        /// <summary> 
+        /// Environment Variables which should be passed through for all processes 
+        /// </summary> 
+        /// <remarks>
+        /// This is an unsafe configuration.
+        /// This global configuration from cammand line will bypass cache,
+        /// which means pips and graph will be cached ignoring environment variables specified in this configure
+        /// </remarks>
+        IReadOnlyList<string> GlobalUnsafePassthroughEnvironmentVariables { get; }
     }
 }

--- a/Public/Src/Utilities/Configuration/ISandboxConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/ISandboxConfiguration.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+
 namespace BuildXL.Utilities.Configuration
 {
     /// <summary>
@@ -243,5 +245,20 @@ namespace BuildXL.Utilities.Configuration
         /// Thus, this enforcement is made opt-in.
         /// </remarks>
         bool EnsureTempDirectoriesExistenceBeforePipExecution { get; }
+
+
+        /// <summary> 
+        /// Paths which should be untracked for all processes 
+        /// </summary> 
+        /// <remarks> 
+        /// </remarks> 
+        IReadOnlyList<AbsolutePath> GlobalUntrackedScopes { get; }
+
+        /// <summary> 
+        /// EnvironmentVariables which should be passed through for all processes 
+        /// </summary> 
+        /// <remarks> 
+        /// </remarks> 
+        IReadOnlyList<string> GlobalPassthroughEnvironmentVariables { get; }
     }
 }

--- a/Public/Src/Utilities/Configuration/ISandboxConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/ISandboxConfiguration.cs
@@ -252,13 +252,13 @@ namespace BuildXL.Utilities.Configuration
         /// </summary> 
         /// <remarks> 
         /// </remarks> 
-        IReadOnlyList<AbsolutePath> GlobalUntrackedScopes { get; }
+        IReadOnlyList<AbsolutePath> GlobalUnsafeUntrackedScopes { get; }
 
         /// <summary> 
         /// EnvironmentVariables which should be passed through for all processes 
         /// </summary> 
         /// <remarks> 
         /// </remarks> 
-        IReadOnlyList<string> GlobalPassthroughEnvironmentVariables { get; }
+        IReadOnlyList<string> GlobalUnsafePassthroughEnvironmentVariables { get; }
     }
 }

--- a/Public/Src/Utilities/Configuration/ISandboxConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/ISandboxConfiguration.cs
@@ -247,13 +247,15 @@ namespace BuildXL.Utilities.Configuration
         bool EnsureTempDirectoriesExistenceBeforePipExecution { get; }
 
         /// <summary> 
-        /// Paths which should be untracked for all processes 
+        /// Paths and Directory Paths which should be untracked for all processes 
         /// </summary> 
+        /// <remarks>
+        /// When Directory Path is specified, all paths under that directory will be untracked
+        /// This is an unsafe configuration, since it allows read and write access to the paths 
+        /// which is not specified as input or output.
+        /// Moreover, this global configuration from cammand line will bypass cache,
+        /// which means pips and graph will be cached ignoring paths specified in this configure
+        /// </remarks>
         IReadOnlyList<AbsolutePath> GlobalUnsafeUntrackedScopes { get; }
-
-        /// <summary> 
-        /// Environment Variables which should be passed through for all processes 
-        /// </summary> 
-        IReadOnlyList<string> GlobalUnsafePassthroughEnvironmentVariables { get; }
     }
 }

--- a/Public/Src/Utilities/Configuration/ISandboxConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/ISandboxConfiguration.cs
@@ -246,19 +246,14 @@ namespace BuildXL.Utilities.Configuration
         /// </remarks>
         bool EnsureTempDirectoriesExistenceBeforePipExecution { get; }
 
-
         /// <summary> 
         /// Paths which should be untracked for all processes 
         /// </summary> 
-        /// <remarks> 
-        /// </remarks> 
         IReadOnlyList<AbsolutePath> GlobalUnsafeUntrackedScopes { get; }
 
         /// <summary> 
-        /// EnvironmentVariables which should be passed through for all processes 
+        /// Environment Variables which should be passed through for all processes 
         /// </summary> 
-        /// <remarks> 
-        /// </remarks> 
         IReadOnlyList<string> GlobalUnsafePassthroughEnvironmentVariables { get; }
     }
 }

--- a/Public/Src/Utilities/Configuration/Mutable/FrontEndConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/FrontEndConfiguration.cs
@@ -18,6 +18,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             // Need to initialize explicitly to avoid contract violation.
             EnabledPolicyRules = new List<string>();
             LogStatistics = true;
+            GlobalUnsafePassthroughEnvironmentVariables = new List<string>();
         }
 
         /// <nodoc />
@@ -64,6 +65,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             LogStatistics = template.LogStatistics;
             ShowSlowestElementsStatistics = template.ShowSlowestElementsStatistics;
             ShowLargestFilesStatistics = template.ShowLargestFilesStatistics;
+            GlobalUnsafePassthroughEnvironmentVariables = new List<string>(template.GlobalUnsafePassthroughEnvironmentVariables);
         }
 
         /// <inheritdoc />
@@ -185,6 +187,12 @@ namespace BuildXL.Utilities.Configuration.Mutable
 
         /// <inheritdoc/>
         public bool ShowLargestFilesStatistics { get; set; }
+
+        /// <nodoc /> 
+        public List<string> GlobalUnsafePassthroughEnvironmentVariables { get; set; }
+
+        /// <inheritdoc /> 
+        IReadOnlyList<string> IFrontEndConfiguration.GlobalUnsafePassthroughEnvironmentVariables => GlobalUnsafePassthroughEnvironmentVariables;
 
     }
 }

--- a/Public/Src/Utilities/Configuration/Mutable/SandboxConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/SandboxConfiguration.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.Diagnostics.ContractsLight;
 
 namespace BuildXL.Utilities.Configuration.Mutable
@@ -47,6 +48,8 @@ namespace BuildXL.Utilities.Configuration.Mutable
             RedirectedTempFolderRootForVmExecution = AbsolutePath.Invalid;
             RetryOnAzureWatsonExitCode = false;
             EnsureTempDirectoriesExistenceBeforePipExecution = false;
+            GlobalUntrackedScopes = new List<AbsolutePath>();
+            GlobalPassthroughEnvironmentVariables = new List<string>();
         }
 
         /// <nodoc />
@@ -92,6 +95,8 @@ namespace BuildXL.Utilities.Configuration.Mutable
             RedirectedTempFolderRootForVmExecution = pathRemapper.Remap(template.RedirectedTempFolderRootForVmExecution);
             RetryOnAzureWatsonExitCode = template.RetryOnAzureWatsonExitCode;
             EnsureTempDirectoriesExistenceBeforePipExecution = template.EnsureTempDirectoriesExistenceBeforePipExecution;
+            GlobalUntrackedScopes = pathRemapper.Remap(template.GlobalUntrackedScopes);
+            GlobalPassthroughEnvironmentVariables = new List<string>(template.GlobalPassthroughEnvironmentVariables);
         }
 
         /// <inheritdoc />
@@ -235,5 +240,17 @@ namespace BuildXL.Utilities.Configuration.Mutable
 
         /// <inheritdoc />
         public bool EnsureTempDirectoriesExistenceBeforePipExecution { get; set; }
+
+        /// <nodoc /> 
+        public List<AbsolutePath> GlobalUntrackedScopes { get; set; }
+
+        /// <inheritdoc /> 
+        IReadOnlyList<AbsolutePath> ISandboxConfiguration.GlobalUntrackedScopes => GlobalUntrackedScopes;
+
+        /// <nodoc /> 
+        public List<string> GlobalPassthroughEnvironmentVariables { get; set; }
+
+        /// <inheritdoc /> 
+        IReadOnlyList<string> ISandboxConfiguration.GlobalPassthroughEnvironmentVariables => GlobalPassthroughEnvironmentVariables;        
     }
 }

--- a/Public/Src/Utilities/Configuration/Mutable/SandboxConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/SandboxConfiguration.cs
@@ -49,7 +49,6 @@ namespace BuildXL.Utilities.Configuration.Mutable
             RetryOnAzureWatsonExitCode = false;
             EnsureTempDirectoriesExistenceBeforePipExecution = false;
             GlobalUnsafeUntrackedScopes = new List<AbsolutePath>();
-            GlobalUnsafePassthroughEnvironmentVariables = new List<string>();
         }
 
         /// <nodoc />
@@ -96,7 +95,6 @@ namespace BuildXL.Utilities.Configuration.Mutable
             RetryOnAzureWatsonExitCode = template.RetryOnAzureWatsonExitCode;
             EnsureTempDirectoriesExistenceBeforePipExecution = template.EnsureTempDirectoriesExistenceBeforePipExecution;
             GlobalUnsafeUntrackedScopes = pathRemapper.Remap(template.GlobalUnsafeUntrackedScopes);
-            GlobalUnsafePassthroughEnvironmentVariables = new List<string>(template.GlobalUnsafePassthroughEnvironmentVariables);
         }
 
         /// <inheritdoc />
@@ -245,12 +243,6 @@ namespace BuildXL.Utilities.Configuration.Mutable
         public List<AbsolutePath> GlobalUnsafeUntrackedScopes { get; set; }
 
         /// <inheritdoc /> 
-        IReadOnlyList<AbsolutePath> ISandboxConfiguration.GlobalUnsafeUntrackedScopes => GlobalUnsafeUntrackedScopes;
-
-        /// <nodoc /> 
-        public List<string> GlobalUnsafePassthroughEnvironmentVariables { get; set; }
-
-        /// <inheritdoc /> 
-        IReadOnlyList<string> ISandboxConfiguration.GlobalUnsafePassthroughEnvironmentVariables => GlobalUnsafePassthroughEnvironmentVariables;        
+        IReadOnlyList<AbsolutePath> ISandboxConfiguration.GlobalUnsafeUntrackedScopes => GlobalUnsafeUntrackedScopes;        
     }
 }

--- a/Public/Src/Utilities/Configuration/Mutable/SandboxConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/SandboxConfiguration.cs
@@ -48,8 +48,8 @@ namespace BuildXL.Utilities.Configuration.Mutable
             RedirectedTempFolderRootForVmExecution = AbsolutePath.Invalid;
             RetryOnAzureWatsonExitCode = false;
             EnsureTempDirectoriesExistenceBeforePipExecution = false;
-            GlobalUntrackedScopes = new List<AbsolutePath>();
-            GlobalPassthroughEnvironmentVariables = new List<string>();
+            GlobalUnsafeUntrackedScopes = new List<AbsolutePath>();
+            GlobalUnsafePassthroughEnvironmentVariables = new List<string>();
         }
 
         /// <nodoc />
@@ -95,8 +95,8 @@ namespace BuildXL.Utilities.Configuration.Mutable
             RedirectedTempFolderRootForVmExecution = pathRemapper.Remap(template.RedirectedTempFolderRootForVmExecution);
             RetryOnAzureWatsonExitCode = template.RetryOnAzureWatsonExitCode;
             EnsureTempDirectoriesExistenceBeforePipExecution = template.EnsureTempDirectoriesExistenceBeforePipExecution;
-            GlobalUntrackedScopes = pathRemapper.Remap(template.GlobalUntrackedScopes);
-            GlobalPassthroughEnvironmentVariables = new List<string>(template.GlobalPassthroughEnvironmentVariables);
+            GlobalUnsafeUntrackedScopes = pathRemapper.Remap(template.GlobalUnsafeUntrackedScopes);
+            GlobalUnsafePassthroughEnvironmentVariables = new List<string>(template.GlobalUnsafePassthroughEnvironmentVariables);
         }
 
         /// <inheritdoc />
@@ -242,15 +242,15 @@ namespace BuildXL.Utilities.Configuration.Mutable
         public bool EnsureTempDirectoriesExistenceBeforePipExecution { get; set; }
 
         /// <nodoc /> 
-        public List<AbsolutePath> GlobalUntrackedScopes { get; set; }
+        public List<AbsolutePath> GlobalUnsafeUntrackedScopes { get; set; }
 
         /// <inheritdoc /> 
-        IReadOnlyList<AbsolutePath> ISandboxConfiguration.GlobalUntrackedScopes => GlobalUntrackedScopes;
+        IReadOnlyList<AbsolutePath> ISandboxConfiguration.GlobalUnsafeUntrackedScopes => GlobalUnsafeUntrackedScopes;
 
         /// <nodoc /> 
-        public List<string> GlobalPassthroughEnvironmentVariables { get; set; }
+        public List<string> GlobalUnsafePassthroughEnvironmentVariables { get; set; }
 
         /// <inheritdoc /> 
-        IReadOnlyList<string> ISandboxConfiguration.GlobalPassthroughEnvironmentVariables => GlobalPassthroughEnvironmentVariables;        
+        IReadOnlyList<string> ISandboxConfiguration.GlobalUnsafePassthroughEnvironmentVariables => GlobalUnsafePassthroughEnvironmentVariables;        
     }
 }


### PR DESCRIPTION
Add Commandline arguments: unsafe_GlobalPassthroughEnvVars and unsafe_GlobalUntrackedScopes. This is part of the improvement of CB tool dependencies management.
With these two arguments, GBR can pass the CB tool paths and corresponding evn vars by command line arguments. So build specs do not need to untrack CB tool paths. 

[AB#1551286](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1551286)