### PR TITLE
Remove unused copyfile logs

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
@@ -133,6 +133,9 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
                 var badContentLocations = new HashSet<MachineLocation>();
                 var missingContentLocations = new HashSet<MachineLocation>();
                 int attemptCount = 0;
+
+                Tracer.Debug(operationContext, $"Copying {hashInfo.ContentHash} with {hashInfo.Locations.Count} locations");
+
                 while (attemptCount < _retryIntervals.Count && (putResult == null || !putResult))
                 {
                     bool retry;

--- a/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
@@ -135,7 +135,6 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
                 int attemptCount = 0;
                 while (attemptCount < _retryIntervals.Count && (putResult == null || !putResult))
                 {
-                    Tracer.Debug(operationContext, $"Attempt #{attemptCount}: Copying {hashInfo.ContentHash} with {hashInfo.Locations.Count} locations");
                     bool retry;
 
                     (putResult, retry) = await WalkLocationsAndCopyAndPutAsync(
@@ -284,8 +283,9 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
                                     reportImmediately: false,
                                     reportAtEnd: false);
                             },
+                            traceOperationStarted: false,
+                            traceOperationFinished: true,
                             // _ioGate.CurrentCount returns the number of free slots, but we need to print the number of occupied slots instead.
-                            extraStartMessage: $"({hashInfo.ContentHash} size={hashInfo.Size} from=[{sourcePath}]) to=[{tempLocation}] trusted={_settings.UseTrustedHash}.",
                             extraEndMessage: (result) =>
                                 $"contentHash=[{hashInfo.ContentHash}] " +
                                 $"from=[{sourcePath}] " +

--- a/Public/Src/Cache/ContentStore/Library/Stores/FileSystemContentStoreInternal.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/FileSystemContentStoreInternal.cs
@@ -1664,7 +1664,6 @@ namespace BuildXL.Cache.ContentStore.Stores
 
             try
             {
-                _tracer.HashContentFileStart(context, path);
                 stopwatch.Start();
 
                 ContentHash contentHash = await _hashers[hashType].GetContentHashAsync(stream);

--- a/Public/Src/Cache/ContentStore/Library/Tracing/ContentStoreInternalTracer.cs
+++ b/Public/Src/Cache/ContentStore/Library/Tracing/ContentStoreInternalTracer.cs
@@ -489,21 +489,11 @@ namespace BuildXL.Cache.ContentStore.Tracing
             }
         }
 
-        public void HashContentFileStart(Context context, AbsolutePath path)
-        {
-            if (context.IsEnabled)
-            {
-                Debug(context, $"{Name}.{HashContentFileCallName}({path}) start");
-            }
-
-            _hashContentFileCallCounter.Started();
-        }
-
         public void HashContentFileStop(Context context, AbsolutePath path, TimeSpan duration)
         {
             if (context.IsEnabled)
             {
-                Debug(context, $"{Name}.{HashContentFileCallName}({path}) stop {duration.TotalMilliseconds}ms");
+                Debug(context, $"{Name}.{HashContentFileCallName}({path}) {duration.TotalMilliseconds}ms");
             }
 
             _hashContentFileCallCounter.Completed(duration.Ticks);


### PR DESCRIPTION
Removing:

* Attempt #0: Copying VSO0:5190E226C8606C2CE7CD1BB9BF03DED3C740155D5FD60999BFF8A4A38483871F00 with 1 locations
  * Copies are already groups by attempt, and location count is given by Redis' GetBulk call

* DistributedContentCopier.RemoteCopyFile start. (VSO0:5190E226C8606C2CE7CD1BB9BF03DED3C740155D5FD60999BFF8A4A38483871F00 size=230511 from=[...
  * While removing this stops us from tracking incomplete copies, this hasn't been an issue. I am confident in our copy error logging to catch all related issues.