### PR TITLE
Mark BuildXL executables 64-bit only

### DIFF
--- a/Public/Sdk/Public/Managed/managedSdk.dsc
+++ b/Public/Sdk/Public/Managed/managedSdk.dsc
@@ -173,7 +173,6 @@ export function assembly(args: Arguments, targetType: Csc.TargetType) : Result {
         out: outputFileName,
         pdb: name + ".pdb",
         debugType: framework.requiresPortablePdb ? "portable" : "full",
-        platform: args.platform || "anycpu",
         allowUnsafeBlocks: args.allowUnsafeBlocks || false,
         appConfig: appConfig,
         implicitSources: args.implicitSources,

--- a/Public/Sdk/SelfHost/BuildXL/BuildXLSdk.dsc
+++ b/Public/Sdk/SelfHost/BuildXL/BuildXLSdk.dsc
@@ -47,8 +47,6 @@ const brandingDefines = [
 
 @@public
 export interface Arguments extends Managed.Arguments {
-    cscArgs?: Csc.Arguments;
-
     /** Provide switch to turn skip tool that adds GetTypeInfo() calls to generated resource code, so the tool can be compiled */
     skipResourceTranslator?: boolean;
 
@@ -286,6 +284,7 @@ export function executable(args: Arguments): Managed.Assembly {
         ],
         tools: {
             csc: {
+                platform: <"x64">"x64",
                 win32Icon: Branding.iconFile
             },
         },


### PR DESCRIPTION
Mark BuildXL executables 64-bit only rather than AnyCpu since all our native code which all our exe's depend on are 64-bit only..