### PR TITLE
Add a way to specify passthrough environment variables for the MSBuild resolver

### DIFF
--- a/Public/Sdk/Public/Prelude/Prelude.Configuration.Resolvers.dsc
+++ b/Public/Sdk/Public/Prelude/Prelude.Configuration.Resolvers.dsc
@@ -91,6 +91,9 @@ interface DownloadSettings {
     hash?: string,
 }
 
+/** We represent a passthrough environment variable with the value unit */ 
+type PassthroughEnvironmentVariable = Unit;
+
 /**
  * Resolver for MSBuild project-level build execution, utilizing the MsBuild static graph API to
  * find MSBuild files and convert them to a pip graph
@@ -160,8 +163,11 @@ interface MsBuildResolver extends ResolverBase, UntrackingSettings {
      * Note: if this field is not specified any change in an environment variable will potentially cause
      * cache misses for all pips. This is because there is no way to know which variables were actually used during the build.
      * Therefore, it is recommended to specify the environment explicitly.
+     * The value can be either a string or a PassthroughEnvironmentVariable, the latter representing that the associated variable will be exposed
+     * but its value won't be considered part of the build inputs for tracking purposes. This means that any change in the value of the 
+     * variable won't cause a rebuild.
      */
-    environment?: Map<string, string>;
+    environment?: Map<string, (PassthroughEnvironmentVariable | string)>;
 
     /**
      * Global properties to use for all projects.

--- a/Public/Sdk/Public/Prelude/Prelude.Core.dsc
+++ b/Public/Sdk/Public/Prelude/Prelude.Core.dsc
@@ -582,3 +582,13 @@ namespace Math {
     /** Euclidian division */
     export declare function div(dividend: number, divisor: number): number;
 }
+
+/** Type that only allows one value */
+interface Unit {
+    __unitBrand: any;
+}
+
+namespace Unit {
+    /** Returns the (only) value of type Unit*/
+    export declare function unit(): Unit;
+}

--- a/Public/Sdk/UnitTests/Testing/Test.Unit.dsc
+++ b/Public/Sdk/UnitTests/Testing/Test.Unit.dsc
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import {Assert, Testing} from "Sdk.Testing";
+
+namespace Sdk.Tests {
+    @@Testing.unitTest()
+    export function unitGetIsNotUndefined() {
+        const unit = Unit.unit();
+        Assert.isTrue(
+            unit !== undefined
+        );
+    }
+    
+    @@Testing.unitTest()
+    export function unitIsSingleton() {
+        const unit1 = Unit.unit();
+        const unit2 = Unit.unit();
+        Assert.isTrue(
+            unit1 === unit2
+        );
+    }
+}

--- a/Public/Src/FrontEnd/MsBuild/MsBuildResolver.cs
+++ b/Public/Src/FrontEnd/MsBuild/MsBuildResolver.cs
@@ -153,7 +153,15 @@ namespace BuildXL.FrontEnd.MsBuild
                             .Where(project => ProjectMatchesQualifier(project, qualifier))
                             .ToReadOnlySet();
 
-            var graphConstructor = new PipGraphConstructor(m_context, m_host, result.ModuleDefinition, m_msBuildResolverSettings, result.MsBuildExeLocation, m_frontEndName);
+            var graphConstructor = new PipGraphConstructor(
+                m_context, 
+                m_host, 
+                result.ModuleDefinition, 
+                m_msBuildResolverSettings, 
+                result.MsBuildExeLocation, 
+                m_frontEndName, 
+                m_msBuildWorkspaceResolver.UserDefinedEnvironment, 
+                m_msBuildWorkspaceResolver.UserDefinedPassthroughVariables);
 
             return graphConstructor.TrySchedulePipsForFilesAsync(filteredBuildFiles, qualifierId);
         }

--- a/Public/Src/FrontEnd/MsBuild/PipGraphConstructor.cs
+++ b/Public/Src/FrontEnd/MsBuild/PipGraphConstructor.cs
@@ -13,6 +13,7 @@ using BuildXL.Utilities;
 using BuildXL.Utilities.Collections;
 using BuildXL.Utilities.Configuration;
 using BuildXL.Utilities.Instrumentation.Common;
+using JetBrains.Annotations;
 using ProjectWithPredictions = BuildXL.FrontEnd.MsBuild.Serialization.ProjectWithPredictions<BuildXL.Utilities.AbsolutePath>;
 
 namespace BuildXL.FrontEnd.MsBuild
@@ -35,7 +36,9 @@ namespace BuildXL.FrontEnd.MsBuild
             ModuleDefinition moduleDefinition,
             IMsBuildResolverSettings resolverSettings,
             AbsolutePath pathToMsBuildExe,
-            string frontEndName)
+            string frontEndName,
+            [CanBeNull] IEnumerable<KeyValuePair<string, string>> userDefinedEnvironment,
+            [CanBeNull] IEnumerable<string> userDefinedPassthroughVariables)
         {
             Contract.Requires(context != null);
             Contract.Requires(frontEndHost != null);
@@ -46,7 +49,7 @@ namespace BuildXL.FrontEnd.MsBuild
 
             m_context = context;
             m_frontEndHost = frontEndHost;
-            m_pipConstructor = new PipConstructor(context, frontEndHost, moduleDefinition, resolverSettings, pathToMsBuildExe, frontEndName);
+            m_pipConstructor = new PipConstructor(context, frontEndHost, moduleDefinition, resolverSettings, pathToMsBuildExe, frontEndName, userDefinedEnvironment, userDefinedPassthroughVariables);
         }
 
         /// <summary>

--- a/Public/Src/FrontEnd/Script/Ambients/AmbientUnit.cs
+++ b/Public/Src/FrontEnd/Script/Ambients/AmbientUnit.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using BuildXL.FrontEnd.Script.Core;
+using BuildXL.FrontEnd.Script.Evaluator;
+using BuildXL.FrontEnd.Script.Types;
+using BuildXL.FrontEnd.Script.Values;
+using BuildXL.Utilities;
+
+namespace BuildXL.FrontEnd.Script.Ambients
+{
+    /// <summary>
+    /// Ambient definition for type Unit.
+    /// </summary>
+    public sealed class AmbientUnit : AmbientDefinition<UnitValue>
+    {
+        internal const string UnitName = "Unit";
+
+        /// <nodoc />
+        public AmbientUnit(PrimitiveTypes knownTypes)
+            : base(UnitName, knownTypes)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override Dictionary<StringId, CallableMember<UnitValue>> CreateMembers()
+        {
+            // Unit does not have any member functions.
+            return new Dictionary<StringId, CallableMember<UnitValue>>();
+        }
+
+        /// <inheritdoc />
+        protected override AmbientNamespaceDefinition? GetNamespaceDefinition()
+        {
+            return new AmbientNamespaceDefinition(
+                UnitName,
+                new[]
+                {
+                    Function("unit", Get, GetSignature),
+                });
+        }
+
+        private CallSignature GetSignature => CreateSignature(
+            returnType: AmbientTypes.UnitType);
+
+        private static EvaluationResult Get(Context context, ModuleLiteral env, EvaluationStackFrame args)
+        {
+            return EvaluationResult.Create(UnitValue.Unit);
+        }
+    }
+}

--- a/Public/Src/FrontEnd/Script/Ambients/Core/AmbientDefinition.cs
+++ b/Public/Src/FrontEnd/Script/Ambients/Core/AmbientDefinition.cs
@@ -48,7 +48,7 @@ namespace BuildXL.FrontEnd.Script.Ambients
         }
 
         /// <summary>
-        /// Resolves and returns a bound memmber member for receiver and a specified name.
+        /// Resolves and returns a bound member for receiver and a specified name.
         /// </summary>
         public CallableValue<T> ResolveMember(T receiver, SymbolAtom name)
         {

--- a/Public/Src/FrontEnd/Script/Ambients/Core/PredefinedTypes.cs
+++ b/Public/Src/FrontEnd/Script/Ambients/Core/PredefinedTypes.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.ContractsLight;
 using BuildXL.FrontEnd.Script.Ambients.Map;
 using BuildXL.FrontEnd.Script.Ambients.Set;
 using BuildXL.FrontEnd.Script.Ambients.Transformers;
+using BuildXL.FrontEnd.Script.Core;
 using BuildXL.FrontEnd.Script.Values;
 using BuildXL.Pips;
 using BuildXL.Utilities;
@@ -34,6 +35,7 @@ namespace BuildXL.FrontEnd.Script.Ambients
         private readonly AmbientMath m_ambientMath;
         private readonly AmbientMap m_ambientMap;
         private readonly AmbientNumber m_ambientNumber;
+        private readonly AmbientUnit m_ambientUnit;
         private readonly AmbientBoolean m_ambientBoolean;
         private readonly AmbientKeyForm m_ambientKeyForm;
         private readonly AmbientPath m_ambientPath;
@@ -78,6 +80,7 @@ namespace BuildXL.FrontEnd.Script.Ambients
                 [typeof(string)] = m_ambientString = new AmbientString(knownTypes),
                 [typeof(AmbientStringBuilder.StringBuilderWrapper)] = m_ambientStringBuilder = new AmbientStringBuilder(knownTypes),
                 [typeof(int)] = m_ambientNumber = new AmbientNumber(knownTypes),
+                [typeof(UnitValue)] = m_ambientUnit = new AmbientUnit(knownTypes),
                 [typeof(bool)] = m_ambientBoolean = new AmbientBoolean(knownTypes),
                 [typeof(OrderedMap)] = m_ambientMap = new AmbientMap(knownTypes),
                 [typeof(OrderedSet)] = m_ambientSet = new AmbientSet(knownTypes),
@@ -145,6 +148,7 @@ namespace BuildXL.FrontEnd.Script.Ambients
             m_ambientTransformerHack.Initialize(global);
             m_ambientNumber.Initialize(global);
             m_ambientBoolean.Initialize(global);
+            m_ambientUnit.Initialize(global);
             m_ambientEnvironment.Initialize(global);
             m_ambientArgumentKind.Initialize(global);
             m_ambientArtifactKind.Initialize(global);

--- a/Public/Src/FrontEnd/Script/Ast/Types/PrimitiveType.cs
+++ b/Public/Src/FrontEnd/Script/Ast/Types/PrimitiveType.cs
@@ -12,29 +12,22 @@ namespace BuildXL.FrontEnd.Script.Types
     /// </summary>
     public sealed class PrimitiveType : Type
     {
-        /// <summary>
-        /// Any type.
-        /// </summary>
+        /// <nodoc/>
         public static readonly PrimitiveType AnyType = new PrimitiveType(PrimitiveTypeKind.Any);
 
-        /// <summary>
-        /// Boolean type.
-        /// </summary>
+        /// <nodoc/>
+        public static readonly PrimitiveType UnitType = new PrimitiveType(PrimitiveTypeKind.Unit);
+
+        /// <nodoc/>
         public static readonly PrimitiveType BooleanType = new PrimitiveType(PrimitiveTypeKind.Boolean);
 
-        /// <summary>
-        /// Number type.
-        /// </summary>
+        /// <nodoc/>
         public static readonly PrimitiveType NumberType = new PrimitiveType(PrimitiveTypeKind.Number);
 
-        /// <summary>
-        /// String type.
-        /// </summary>
+        /// <nodoc/>
         public static readonly PrimitiveType StringType = new PrimitiveType(PrimitiveTypeKind.String);
 
-        /// <summary>
-        /// Void type.
-        /// </summary>
+        /// <nodoc/>
         public static readonly PrimitiveType VoidType = new PrimitiveType(PrimitiveTypeKind.Void);
 
         private PrimitiveTypeKind TypeKind { get; }
@@ -84,6 +77,8 @@ namespace BuildXL.FrontEnd.Script.Types
                     return "number";
                 case PrimitiveTypeKind.Boolean:
                     return "boolean";
+                case PrimitiveTypeKind.Unit:
+                    return "unit";
                 case PrimitiveTypeKind.String:
                     return "string";
                 case PrimitiveTypeKind.Void:

--- a/Public/Src/FrontEnd/Script/Ast/Types/PrimitiveTypeKind.cs
+++ b/Public/Src/FrontEnd/Script/Ast/Types/PrimitiveTypeKind.cs
@@ -8,29 +8,22 @@ namespace BuildXL.FrontEnd.Script.Types
     /// </summary>
     public enum PrimitiveTypeKind : byte
     {
-        /// <summary>
-        /// Any.
-        /// </summary>
+        /// <nodoc/>
         Any,
 
-        /// <summary>
-        /// Number.
-        /// </summary>
+        /// <nodoc/>
         Number,
 
-        /// <summary>
-        /// Boolean.
-        /// </summary>
+        /// <nodoc/>
         Boolean,
 
-        /// <summary>
-        /// String.
-        /// </summary>
+        /// <nodoc/>
         String,
 
-        /// <summary>
-        /// Void.
-        /// </summary>
+        /// <nodoc/>
         Void,
+
+        /// <nodoc/>
+        Unit,
     }
 }

--- a/Public/Src/FrontEnd/Script/Ast/Values/PrimitiveTypes.cs
+++ b/Public/Src/FrontEnd/Script/Ast/Values/PrimitiveTypes.cs
@@ -113,6 +113,11 @@ namespace BuildXL.FrontEnd.Script.Values
         public Type AmbientType { get; }
 
         /// <summary>
+        /// Unit type.
+        /// </summary>
+        public Type UnitType { get; }
+
+        /// <summary>
         /// Boolean type.
         /// </summary>
         public Type BooleanType { get; }
@@ -178,6 +183,7 @@ namespace BuildXL.FrontEnd.Script.Values
             EnumType = CreateNamedTypeReference("Enum");
             ClosureType = CreateNamedTypeReference("Closure");
             AmbientType = CreateNamedTypeReference("Ambient");
+            UnitType = PrimitiveType.UnitType;
             BooleanType = PrimitiveType.BooleanType;
             StringType = PrimitiveType.StringType;
             NumberType = PrimitiveType.NumberType;

--- a/Public/Src/FrontEnd/Script/BuildXL.FrontEnd.Script.dsc
+++ b/Public/Src/FrontEnd/Script/BuildXL.FrontEnd.Script.dsc
@@ -35,6 +35,7 @@ namespace Script {
             importFrom("BuildXL.Utilities").Ipc.dll,
             importFrom("BuildXL.Utilities").Storage.dll,
             importFrom("BuildXL.Utilities").Script.Constants.dll,
+            importFrom("BuildXL.Utilities").Configuration.dll,
             
             // When we can split apmbients in different assemblies we can move the Json ambients into seperate assembly and remove this reference.
             importFrom("Newtonsoft.Json").pkg,

--- a/Public/Src/FrontEnd/Script/Util/TypeExtensions.cs
+++ b/Public/Src/FrontEnd/Script/Util/TypeExtensions.cs
@@ -6,9 +6,12 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.ContractsLight;
 using System.Reflection;
+using BuildXL.FrontEnd.Script.Core;
 using BuildXL.FrontEnd.Script.Literals;
+using BuildXL.FrontEnd.Script.Types;
 using BuildXL.FrontEnd.Script.Values;
 using BuildXL.Utilities;
+using BuildXL.Utilities.Configuration;
 
 namespace BuildXL.FrontEnd.Script.Util
 {
@@ -42,6 +45,13 @@ namespace BuildXL.FrontEnd.Script.Util
         public static bool IsNumberType(this RuntimeTypeHandle type)
         {
             return s_primitiveTypes.Contains(type);
+        }
+
+        /// <nodoc />
+        [Pure]
+        public static bool IsUnitType(this RuntimeTypeHandle type)
+        {
+            return type.Equals(typeof(UnitValue).TypeHandle);
         }
 
         /// <nodoc />
@@ -99,6 +109,13 @@ namespace BuildXL.FrontEnd.Script.Util
         public static bool IsRelativePath(this RuntimeTypeHandle type)
         {
             return type.Equals(typeof(RelativePath).TypeHandle);
+        }
+
+        /// <nodoc />
+        [Pure]
+        public static bool IsUnionType(this TypeInfo type)
+        {
+            return typeof(DiscriminatingUnion).IsAssignableFrom(type);
         }
 
         /// <nodoc />

--- a/Public/Src/FrontEnd/UnitTests/Libs/Prelude.Configuration.Resolvers.ts
+++ b/Public/Src/FrontEnd/UnitTests/Libs/Prelude.Configuration.Resolvers.ts
@@ -56,6 +56,9 @@ interface NuGetResolver {
     doNotEnforceDependencyVersions?: boolean;
 }
 
+// We represent a passthrough environment variable with unit
+type PassthroughEnvironmentVariable = Unit;
+
 /**
  * Resolver for MSBuild project-level build execution, utilizing the MsBuild static graph API to
  * find MSBuild files and convert them to a pip graph
@@ -137,7 +140,7 @@ interface MsBuildResolver {
      * cache misses for all pips. This is because there is no way to know which variables were actually used during the build.
      * Therefore, it is recommended to specify the environment explicitly.
      */
-    environment?: Map<string, string>;
+    environment?: Map<string, (PassthroughEnvironmentVariable | string)>;
 
     /**
      * Global properties to use for all projects.

--- a/Public/Src/FrontEnd/UnitTests/Libs/Prelude.Core.ts
+++ b/Public/Src/FrontEnd/UnitTests/Libs/Prelude.Core.ts
@@ -546,3 +546,13 @@ namespace Math {
     /** Euclidian division */
     export declare function div(dividend: number, divisor: number): number;
 }
+
+/** Type that only allows one value */
+interface Unit {
+    __unitBrand: any;
+}
+
+namespace Unit {
+    /** Returns the (only) value of type Unit*/
+    export declare function unit(): Unit;
+}

--- a/Public/Src/FrontEnd/UnitTests/Libs/lib.core.d.ts
+++ b/Public/Src/FrontEnd/UnitTests/Libs/lib.core.d.ts
@@ -4044,3 +4044,13 @@ const enum ContainerIsolationLevel {
     isolateAllOutputs = isolateOutputFiles | isolateOutputDirectories,
     isolateAll = isolateAllOutputs | isolateInputs,
 }
+
+/** Type that only allows one value */
+interface Unit {
+    __unitBrand: any;
+}
+
+namespace Unit {
+    /** Returns the (only) value of type Unit*/
+    export declare function unit(): Unit;
+}

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/ExecutionTests/MsBuildGraphConstructionTests.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/ExecutionTests/MsBuildGraphConstructionTests.cs
@@ -202,7 +202,13 @@ namespace Test.BuildXL.FrontEnd.MsBuild
 
         private Process CreateDummyProjectWithEnvironment(Dictionary<string, string> environment)
         {
-            var config = BuildWithEnvironment(environment: environment)
+            Dictionary<string, DiscriminatingUnion<string, UnitValue>> fullEnvironment = null;
+            if (environment != null)
+            {
+                fullEnvironment = environment.ToDictionary(kvp => kvp.Key, kvp => new DiscriminatingUnion<string, UnitValue>(kvp.Value));
+            }
+
+            var config = BuildWithEnvironment(environment: fullEnvironment)
                     .AddSpec(R("TestProject.proj"), CreateHelloWorldProject())
                     .PersistSpecsAndGetConfiguration();
 

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/Infrastructure/MsBuildPipSchedulingTestBase.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/Infrastructure/MsBuildPipSchedulingTestBase.cs
@@ -123,13 +123,17 @@ namespace Test.BuildXL.FrontEnd.MsBuild.Infrastructure
 
             using (var controller = CreateFrontEndHost(GetDefaultCommandLine(), frontEndFactory, workspaceFactory, moduleRegistry, AbsolutePath.Invalid, out _, out _, requestedQualifiers))
             {
+                resolverSettings.TryComputeEnvironment(out var trackedEnv, out var passthroughVars);
+
                 var pipConstructor = new PipConstructor(
                     FrontEndContext,
                     controller,
                     m_testModule,
                     resolverSettings,
                     AbsolutePath.Create(PathTable, TestDeploymentDir).Combine(PathTable, "MSBuild.exe"),
-                    nameof(MsBuildFrontEnd));
+                    nameof(MsBuildFrontEnd),
+                    trackedEnv,
+                    passthroughVars);
 
                 var schedulingResults = new Dictionary<ProjectWithPredictions, (bool, string, Process)>();
 

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/SchedulingTests/MsBuildProcessBuilderTests.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/SchedulingTests/MsBuildProcessBuilderTests.cs
@@ -166,8 +166,11 @@ namespace Test.BuildXL.FrontEnd.MsBuild
         [Fact]
         public void EnvironmentIsHonored()
         {
+            var one = new DiscriminatingUnion<string, UnitValue>();
+            one.SetValue("1");
+
             var project = CreateProjectWithPredictions("A.proj");
-            var testProj = Start(new MsBuildResolverSettings { Environment = new Dictionary<string, string> { ["Test"] = "1" } })
+            var testProj = Start(new MsBuildResolverSettings { Environment = new Dictionary<string, DiscriminatingUnion<string, UnitValue>> { ["Test"] = one } })
                 .Add(project)
                 .ScheduleAll()
                 .AssertSuccess()
@@ -184,7 +187,7 @@ namespace Test.BuildXL.FrontEnd.MsBuild
             Environment.SetEnvironmentVariable(envVar, "1");
 
             var project = CreateProjectWithPredictions("A.proj");
-            var testProj = Start(new MsBuildResolverSettings { Environment = new Dictionary<string, string>() })
+            var testProj = Start(new MsBuildResolverSettings { Environment = new Dictionary<string, DiscriminatingUnion<string, UnitValue>>() })
                 .Add(project)
                 .ScheduleAll()
                 .AssertSuccess()

--- a/Public/Src/FrontEnd/UnitTests/Script.Ast/Util/ConfigurationConverterTests.cs
+++ b/Public/Src/FrontEnd/UnitTests/Script.Ast/Util/ConfigurationConverterTests.cs
@@ -295,8 +295,8 @@ namespace Test.DScript.Util
             var msBuildResolver = resolver as MsBuildResolverSettings;
             XAssert.IsNotNull(msBuildResolver);
 
-            XAssert.AreEqual("hi", msBuildResolver.Environment["1"]);
-            XAssert.AreEqual("bye", msBuildResolver.Environment["2"]);
+            XAssert.AreEqual("hi", msBuildResolver.Environment["1"].GetValue());
+            XAssert.AreEqual("bye", msBuildResolver.Environment["2"].GetValue());
         }
 
         /// <summary>

--- a/Public/Src/Utilities/Configuration/Resolvers/Mutable/MsBuildResolverSettings.cs
+++ b/Public/Src/Utilities/Configuration/Resolvers/Mutable/MsBuildResolverSettings.cs
@@ -81,7 +81,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
         public IReadOnlyList<string> InitialTargets { get; set; }
 
         /// <inheritdoc/>
-        public IReadOnlyDictionary<string, string> Environment { get; set; }
+        public IReadOnlyDictionary<string, DiscriminatingUnion<string, UnitValue>> Environment { get; set; }
 
         /// <inheritdoc/>
         public IReadOnlyDictionary<string, string> GlobalProperties { get; set; }

--- a/Public/Src/Utilities/Configuration/UnionType.cs
+++ b/Public/Src/Utilities/Configuration/UnionType.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace BuildXL.Utilities.Configuration
+{
+    /// <summary>
+    /// Represents a discriminating union type from TypeScript (the usual T1 | T2 | ... | Tn construct)
+    /// </summary>
+    /// <remarks>
+    /// Useful for declaring C# backed-values that map to a union. Works together with the configuration converter.
+    /// </remarks>
+    public abstract class DiscriminatingUnion
+    {
+        private HashSet<Type> m_allowedTypes;
+        private object m_value;
+
+        /// <nodoc/>
+        public DiscriminatingUnion(params Type[] types)
+        {
+            m_allowedTypes = new HashSet<Type>(types);
+        }
+
+        /// <nodoc/>
+        public bool TrySetValue(object o)
+        {
+            if (m_allowedTypes.Contains(o.GetType()))
+            {
+                m_value = o;
+                return true;
+            }
+            return false;
+        }
+
+        /// <nodoc/>
+        public object GetValue()
+        {
+            return m_value;
+        }
+    }
+
+    /// <summary>
+    /// A specialization of <see cref="DiscriminatingUnion"/> for the case of two disjuncts
+    /// </summary>
+    public sealed class DiscriminatingUnion<T, Q> : DiscriminatingUnion
+    {
+        /// <nodoc/>
+        public DiscriminatingUnion() : base(typeof(T), typeof(Q))
+        { }
+
+        /// <nodoc/>
+        public DiscriminatingUnion(T value) : base(typeof(T), typeof(Q))
+        {
+            TrySetValue(value);
+        }
+
+        /// <nodoc/>
+        public DiscriminatingUnion(Q value) : base(typeof(T), typeof(Q))
+        {
+            TrySetValue(value);
+        }
+
+        /// <nodoc/>
+        public void SetValue(T value)
+        {
+            TrySetValue(value);
+        }
+
+        /// <nodoc/>
+        public void SetValue(Q value)
+        {
+            TrySetValue(value);
+        }
+    }
+}

--- a/Public/Src/Utilities/Utilities/BuildParameters.cs
+++ b/Public/Src/Utilities/Utilities/BuildParameters.cs
@@ -181,7 +181,7 @@ namespace BuildXL.Utilities
             ///     Any duplicates found in <paramref name="parameters"/> are reported only if they
             ///     have different values.
             /// </remarks>
-            public IBuildParameters PopulateFromDictionary(IReadOnlyDictionary<string, string> parameters)
+            public IBuildParameters PopulateFromDictionary(IEnumerable<KeyValuePair<string, string>> parameters)
             {
                 Contract.Ensures(Contract.Result<IBuildParameters>() != null);
 
@@ -215,7 +215,7 @@ namespace BuildXL.Utilities
                 return result;
             });
 
-            private IBuildParameters Create(IReadOnlyDictionary<string, string> value)
+            private IBuildParameters Create(IEnumerable<KeyValuePair<string, string>> value)
             {
                 Contract.Ensures(Contract.Result<IBuildParameters>() != null);
 

--- a/Public/Src/Utilities/Utilities/UnitValue.cs
+++ b/Public/Src/Utilities/Utilities/UnitValue.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace BuildXL.Utilities
+{
+    /// <summary>
+    /// The type that allows only one value
+    /// </summary>
+    public readonly struct UnitValue
+    {
+        /// <nodoc/>
+        public static readonly UnitValue Unit = default(UnitValue);
+    }
+}


### PR DESCRIPTION
- Expose a new primitive type 'unit' in DScript
- Enhance the MSBuild resolver environment to take either string values for env variable values, or 'unit' representing a passthrough

E.g.:

```
environment: Map.empty<string, (PassthroughEnvironmentVariable | string)>()
                      .add("Path", Environment.getStringValue("PATH"))
                      .add("USERPROFILE", Unit.unit())

```