### PR TITLE
Check path validity when adding directory ancestor to manifest

### DIFF
--- a/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
@@ -1925,7 +1925,7 @@ namespace BuildXL.Processes
             // Rationale: probes may be performed on those directories (directory probes don't need declarations)
             // so they need to be faked as well
             var currentPath = path.GetParent(m_pathTable);
-            while (!allInputPathsUnderSharedOpaques.Contains(currentPath) && currentPath.IsWithin(m_pathTable, sharedOpaqueRoot))
+            while (currentPath.IsValid && !allInputPathsUnderSharedOpaques.Contains(currentPath) && currentPath.IsWithin(m_pathTable, sharedOpaqueRoot))
             {
                 // We want to set a policy for the directory without affecting the scope for the underlying artifacts
                 m_fileAccessManifest.AddPath(


### PR DESCRIPTION
Contract exception occurs when adding directory ancestor to manifest.

Suppose that the shared opaque root is `B:\` (due to subst), and the path in question is `B:\file.txt`. Because `B:\` is within `B:\` when calling `AbsolutePath.IsWithin`, the parent traversal continues and ends up in an invalid path.

[AB#1554783](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1554783)