### PR TITLE
Make sure passthrough variables reach both graph creation and process execution for MSBuild resolver

### DIFF
--- a/Public/Src/FrontEnd/MsBuild/PipGraphConstructor.cs
+++ b/Public/Src/FrontEnd/MsBuild/PipGraphConstructor.cs
@@ -37,8 +37,8 @@ namespace BuildXL.FrontEnd.MsBuild
             IMsBuildResolverSettings resolverSettings,
             AbsolutePath pathToMsBuildExe,
             string frontEndName,
-            [CanBeNull] IEnumerable<KeyValuePair<string, string>> userDefinedEnvironment,
-            [CanBeNull] IEnumerable<string> userDefinedPassthroughVariables)
+            IEnumerable<KeyValuePair<string, string>> userDefinedEnvironment,
+            IEnumerable<string> userDefinedPassthroughVariables)
         {
             Contract.Requires(context != null);
             Contract.Requires(frontEndHost != null);
@@ -46,6 +46,8 @@ namespace BuildXL.FrontEnd.MsBuild
             Contract.Requires(resolverSettings != null);
             Contract.Requires(pathToMsBuildExe.IsValid);
             Contract.Requires(!string.IsNullOrEmpty(frontEndName));
+            Contract.Requires(userDefinedEnvironment != null);
+            Contract.Requires(userDefinedPassthroughVariables != null);
 
             m_context = context;
             m_frontEndHost = frontEndHost;

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/ExecutionTests/MsBuildGraphConstructionTests.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/ExecutionTests/MsBuildGraphConstructionTests.cs
@@ -42,6 +42,17 @@ namespace Test.BuildXL.FrontEnd.MsBuild
         }
 
         [Fact]
+        public void PassthroughEnvironmentIsUsedDuringConstruction()
+        {
+            // We expect the resulting process to contain an output directory matching the content of OutputPath
+            Environment.SetEnvironmentVariable("OutputPath", @"Z:\\foo");
+            var env = new Dictionary<string, DiscriminatingUnion<string, UnitValue>> { ["OutputPath"] = new DiscriminatingUnion<string, UnitValue>(UnitValue.Unit)};
+
+            var process = CreateDummyProjectWithEnvironment(env);
+            Assert.True(process.DirectoryOutputs.Any(dir => dir.Path == AbsolutePath.Create(PathTable, @"Z:\foo")));
+        }
+
+        [Fact]
         public void EnvironmentBlocksExposingTheProcessEnvironment()
         {
             // Even though the output path is set in the environment, since we are passing an empty dictionary for the environment, it
@@ -58,7 +69,7 @@ namespace Test.BuildXL.FrontEnd.MsBuild
             // Null environment should expose the environment
             Environment.SetEnvironmentVariable("OutputPath", @"Z:\\foo");
 
-            var process = CreateDummyProjectWithEnvironment(environment: null);
+            var process = CreateDummyProjectWithEnvironment(environment: (Dictionary<string, string>) null);
             Assert.True(process.DirectoryOutputs.Any(dir => dir.Path == AbsolutePath.Create(PathTable, @"Z:\foo")));
         }
 
@@ -208,7 +219,12 @@ namespace Test.BuildXL.FrontEnd.MsBuild
                 fullEnvironment = environment.ToDictionary(kvp => kvp.Key, kvp => new DiscriminatingUnion<string, UnitValue>(kvp.Value));
             }
 
-            var config = BuildWithEnvironment(environment: fullEnvironment)
+            return CreateDummyProjectWithEnvironment(fullEnvironment);
+        }
+
+        private Process CreateDummyProjectWithEnvironment(Dictionary<string, DiscriminatingUnion<string, UnitValue>> environment)
+        {
+            var config = BuildWithEnvironment(environment: environment)
                     .AddSpec(R("TestProject.proj"), CreateHelloWorldProject())
                     .PersistSpecsAndGetConfiguration();
 

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/Infrastructure/MsBuildPipSchedulingTestBase.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/Infrastructure/MsBuildPipSchedulingTestBase.cs
@@ -123,7 +123,7 @@ namespace Test.BuildXL.FrontEnd.MsBuild.Infrastructure
 
             using (var controller = CreateFrontEndHost(GetDefaultCommandLine(), frontEndFactory, workspaceFactory, moduleRegistry, AbsolutePath.Invalid, out _, out _, requestedQualifiers))
             {
-                resolverSettings.TryComputeEnvironment(out var trackedEnv, out var passthroughVars);
+                resolverSettings.ComputeEnvironment(out var trackedEnv, out var passthroughVars);
 
                 var pipConstructor = new PipConstructor(
                     FrontEndContext,

--- a/Public/Src/Utilities/Configuration/BuildXL.Utilities.Configuration.dsc
+++ b/Public/Src/Utilities/Configuration/BuildXL.Utilities.Configuration.dsc
@@ -17,6 +17,7 @@ namespace Configuration {
         references: [
             $.dll,
             Interop.dll,
+            $.Collections.dll,
         ],
     });
 }


### PR DESCRIPTION
Bug fix to make sure passthrough variables are also included in graph construction and process execution. Some minor clean up as well.