### PR TITLE
Read next file chunk while waiting for GRPC response

### DIFF
--- a/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcClientBase.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcClientBase.cs
@@ -69,7 +69,7 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
             Scenario = scenario;
 
             GrpcEnvironment.InitializeIfNeeded();
-            Channel = new Channel(GrpcEnvironment.Localhost, (int)grpcPort, ChannelCredentials.Insecure);
+            Channel = new Channel(GrpcEnvironment.Localhost, (int)grpcPort, ChannelCredentials.Insecure, GrpcEnvironment.DefaultConfiguration);
             _clientCapabilities = clientCapabilities;
             _heartbeatInterval = heartbeatInterval ?? TimeSpan.FromMinutes(DefaultHeartbeatIntervalMinutes);
         }

--- a/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcContentServer.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcContentServer.cs
@@ -293,8 +293,6 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
             Debug.Assert(!(responseStream is null));
 
             int chunkSize = 0;
-            async Task<int> ReadNextChunk() { chunkSize = await reader.ReadAsync(buffer, 0, buffer.Length, ct); return chunkSize; }
-
             long chunks = 0L;
             long bytes = 0L;
 
@@ -318,6 +316,8 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
             }
 
             return (chunks, bytes);
+
+            async Task<int> ReadNextChunk() { chunkSize = await reader.ReadAsync(buffer, 0, buffer.Length, ct); return chunkSize; }
         }
 
         private async Task<(long Chunks, long Bytes)> StreamContentWithCompressionAsync(Stream reader, byte[] buffer, IServerStreamWriter<CopyFileResponse> responseStream, CancellationToken ct = default(CancellationToken))

--- a/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcContentServer.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcContentServer.cs
@@ -292,23 +292,29 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
             Debug.Assert(!(reader is null));
             Debug.Assert(!(responseStream is null));
 
+            int chunkSize = 0;
+            async Task<int> ReadNextChunk() { chunkSize = await reader.ReadAsync(buffer, 0, buffer.Length, ct); return chunkSize; }
+
             long chunks = 0L;
             long bytes = 0L;
+
+            // Pre-fill buffer with the file's first chunk
+            await ReadNextChunk();
+
             while (true)
             {
                 ct.ThrowIfCancellationRequested();
 
-                int chunkSize = await reader.ReadAsync(buffer, 0, buffer.Length, ct).ConfigureAwait(false);
                 if (chunkSize == 0) { break; }
 
                 ByteString content = ByteString.CopyFrom(buffer, 0, chunkSize);
                 CopyFileResponse response = new CopyFileResponse() { Content = content, Index = chunks };
-                await responseStream.WriteAsync(response).ConfigureAwait(false);
 
                 bytes += chunkSize;
                 chunks++;
 
-                Console.WriteLine(chunks);
+                // Read the next chunk while waiting for the response
+                await Task.WhenAll(ReadNextChunk(), responseStream.WriteAsync(response));
             }
 
             return (chunks, bytes);

--- a/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcCopyClient.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcCopyClient.cs
@@ -42,7 +42,7 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
         internal GrpcCopyClient(GrpcCopyClientKey key)
         {
             GrpcEnvironment.InitializeIfNeeded();
-            _channel = new Channel(key.Host, key.GrpcPort, ChannelCredentials.Insecure);
+            _channel = new Channel(key.Host, key.GrpcPort, ChannelCredentials.Insecure, GrpcEnvironment.DefaultConfiguration);
             _client = new ContentServer.ContentServerClient(_channel);
             Key = key;
         }

--- a/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcEnvironment.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcEnvironment.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.Threading;
+using Grpc.Core;
 
 namespace BuildXL.Cache.ContentStore.Service.Grpc
 {
@@ -21,6 +23,11 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
         public const string Localhost = "localhost";
 
         private static int _isInitialized;
+
+        /// <summary>
+        /// Allow sent and received message to have (essentially) unbounded length. This does not cause GRPC to send larger packets, but it does allow larger packets to exist.
+        /// </summary>
+        public static readonly List<ChannelOption> DefaultConfiguration = new List<ChannelOption>() { new ChannelOption(ChannelOptions.MaxSendMessageLength, int.MaxValue), new ChannelOption(ChannelOptions.MaxReceiveMessageLength, int.MaxValue) };
 
         /// <summary>
         /// Initialize the GRPC environment if not yet initialized.

--- a/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcRepairClient.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcRepairClient.cs
@@ -27,7 +27,7 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
         public GrpcRepairClient(uint grpcPort)
         {
             GrpcEnvironment.InitializeIfNeeded();
-            _channel = new Channel(GrpcEnvironment.Localhost, (int)grpcPort, ChannelCredentials.Insecure);
+            _channel = new Channel(GrpcEnvironment.Localhost, (int)grpcPort, ChannelCredentials.Insecure, GrpcEnvironment.DefaultConfiguration);
             _client = new ContentServer.ContentServerClient(_channel);
         }
 

--- a/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcServerFactory.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcServerFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.Diagnostics.ContractsLight;
 using System.Net;
 using Grpc.Core;
@@ -18,7 +19,7 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
             Contract.Requires(service != null);
 
             GrpcEnvironment.InitializeIfNeeded();
-            return new Server
+            return new Server(GrpcEnvironment.DefaultConfiguration)
             {
                 Services = { service },
                 Ports = { new ServerPort(IPAddress.Any.ToString(), grpcPort, ServerCredentials.Insecure) },
@@ -33,7 +34,7 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
             Contract.Requires(services.Length != 0);
 
             GrpcEnvironment.InitializeIfNeeded();
-            var server = new Server
+            var server = new Server(GrpcEnvironment.DefaultConfiguration)
             {
                 Ports = { new ServerPort(IPAddress.Any.ToString(), grpcPort, ServerCredentials.Insecure) },
                 // need a higher number here to avoid throttling: 7000 worked for initial experiments.

--- a/Public/Src/Cache/ContentStore/Library/Service/LocalContentServerBase.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/LocalContentServerBase.cs
@@ -249,7 +249,7 @@ namespace BuildXL.Cache.ContentStore.Service
         {
             Contract.Requires(definitions.Length != 0);
             GrpcEnvironment.InitializeIfNeeded();
-            _grpcServer = new Server
+            _grpcServer = new Server(GrpcEnvironment.DefaultConfiguration)
                           {
                               Ports = { new ServerPort(IPAddress.Any.ToString(), grpcPort, ServerCredentials.Insecure) },
 

--- a/Public/Src/Cache/DistributedCache.Host/Configuration/LocalCasSettings.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Configuration/LocalCasSettings.cs
@@ -37,7 +37,8 @@ namespace BuildXL.Cache.Host.Configuration
             string scenarioName = null,
             uint grpcPort = 0,
             string grpcPortFileName = null,
-            bool supportsProactiveReplication = true)
+            bool supportsProactiveReplication = true,
+            int? bufferSizeForGrpcCopies = null)
         {
             CasClientSettings = new LocalCasClientSettings(useCasService, cacheName, connectionsPerSession, retryIntervalSecondsOnFailServiceCalls, retryCountOnFailServiceCalls);
 
@@ -47,7 +48,8 @@ namespace BuildXL.Cache.Host.Configuration
                 maxPipeListeners: maxPipeListeners,
                 scenarioName: scenarioName,
                 grpcPort: grpcPort,
-                grpcPortFileName: grpcPortFileName);
+                grpcPortFileName: grpcPortFileName,
+                bufferSizeForGrpcCopies: bufferSizeForGrpcCopies);
 
             AddNamedCache(cacheName, new NamedCacheSettings(
                 cacheRootPath, cacheSizeQuotaString, supportsSensitiveSessions, supportsProactiveReplication, requiredCapabilites: null));


### PR DESCRIPTION
GRPC's streaming protocol works as follows:
* Server sends request
* Client receives request, sends ACK
* Server waits to send next request until ACK is received

We can take advantage of this waiting time. Currently, we do nothing but wait. With this change, we read the next chunk of the file we are copying while waiting for the client's ACK.

In local tests with 0ms RTT, this showed a 20% copy time reduction in large files with small buffers. The returns were negligible for large buffers (where we spend more time copying than waiting) and small files (where we only send one request). In a lab with non-zero RTT, I would expect to see gains in these areas.