### PR TITLE
Add ContentLocationDabase's in-memory cache configuration options

### DIFF
--- a/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
@@ -309,6 +309,24 @@ namespace BuildXL.Cache.Host.Configuration
         [DataMember]
         public int? ContentLocationDatabaseEntryTimeToLiveMinutes { get; set; }
 
+        [DataMember]
+        public bool? ContentLocationDatabaseCacheEnabled { get; set; }
+
+        [DataMember]
+        public int? ContentLocationDatabaseFlushDegreeOfParallelism { get; set; }
+
+        [DataMember]
+        public bool? ContentLocationDatabaseFlushSingleTransaction { get; set; }
+
+        [DataMember]
+        public double? ContentLocationDatabaseFlushPreservePercentInMemory { get; set; }
+
+        [DataMember]
+        public int? ContentLocationDatabaseCacheMaximumUpdatesPerFlush { get; set; }
+
+        [DataMember]
+        public TimeSpan? ContentLocationDatabaseCacheFlushingMaximumInterval { get; set; }
+
         // Key Vault Settings
         [DataMember]
         public string KeyVaultSettingsString { get; set; }

--- a/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
@@ -87,35 +87,12 @@ namespace BuildXL.Cache.Host.Service.Internal
                     dbConfig.LocalDatabaseGarbageCollectionInterval = TimeSpan.FromMinutes(_distributedSettings.ContentLocationDatabaseGcIntervalMinutes.Value);
                 }
 
-                if (_distributedSettings.ContentLocationDatabaseCacheEnabled.HasValue)
-                {
-                    dbConfig.CacheEnabled = _distributedSettings.ContentLocationDatabaseCacheEnabled.Value;
-                }
-
-                if (_distributedSettings.ContentLocationDatabaseFlushDegreeOfParallelism.HasValue)
-                {
-                    dbConfig.FlushDegreeOfParallelism = _distributedSettings.ContentLocationDatabaseFlushDegreeOfParallelism.Value;
-                }
-
-                if (_distributedSettings.ContentLocationDatabaseFlushSingleTransaction.HasValue)
-                {
-                    dbConfig.FlushSingleTransaction = _distributedSettings.ContentLocationDatabaseFlushSingleTransaction.Value;
-                }
-
-                if (_distributedSettings.ContentLocationDatabaseFlushPreservePercentInMemory.HasValue)
-                {
-                    dbConfig.FlushPreservePercentInMemory = _distributedSettings.ContentLocationDatabaseFlushPreservePercentInMemory.Value;
-                }
-
-                if (_distributedSettings.ContentLocationDatabaseCacheMaximumUpdatesPerFlush.HasValue)
-                {
-                    dbConfig.CacheMaximumUpdatesPerFlush = _distributedSettings.ContentLocationDatabaseCacheMaximumUpdatesPerFlush.Value;
-                }
-
-                if (_distributedSettings.ContentLocationDatabaseCacheFlushingMaximumInterval.HasValue)
-                {
-                    dbConfig.CacheFlushingMaximumInterval = _distributedSettings.ContentLocationDatabaseCacheFlushingMaximumInterval.Value;
-                }
+                ApplyIfNotNull(_distributedSettings.ContentLocationDatabaseCacheEnabled, v => dbConfig.CacheEnabled = v);
+                ApplyIfNotNull(_distributedSettings.ContentLocationDatabaseFlushDegreeOfParallelism, v => dbConfig.FlushDegreeOfParallelism = v);
+                ApplyIfNotNull(_distributedSettings.ContentLocationDatabaseFlushSingleTransaction, v => dbConfig.FlushSingleTransaction = v);
+                ApplyIfNotNull(_distributedSettings.ContentLocationDatabaseFlushPreservePercentInMemory, v => dbConfig.FlushPreservePercentInMemory = v);
+                ApplyIfNotNull(_distributedSettings.ContentLocationDatabaseCacheMaximumUpdatesPerFlush, v => dbConfig.CacheMaximumUpdatesPerFlush = v);
+                ApplyIfNotNull(_distributedSettings.ContentLocationDatabaseCacheFlushingMaximumInterval, v => dbConfig.CacheFlushingMaximumInterval = v);
 
                 ApplySecretSettingsForLlsAsync(redisContentLocationStoreConfiguration, localCacheRoot).GetAwaiter().GetResult();
             }

--- a/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
@@ -87,6 +87,36 @@ namespace BuildXL.Cache.Host.Service.Internal
                     dbConfig.LocalDatabaseGarbageCollectionInterval = TimeSpan.FromMinutes(_distributedSettings.ContentLocationDatabaseGcIntervalMinutes.Value);
                 }
 
+                if (_distributedSettings.ContentLocationDatabaseCacheEnabled.HasValue)
+                {
+                    dbConfig.CacheEnabled = _distributedSettings.ContentLocationDatabaseCacheEnabled.Value;
+                }
+
+                if (_distributedSettings.ContentLocationDatabaseFlushDegreeOfParallelism.HasValue)
+                {
+                    dbConfig.FlushDegreeOfParallelism = _distributedSettings.ContentLocationDatabaseFlushDegreeOfParallelism.Value;
+                }
+
+                if (_distributedSettings.ContentLocationDatabaseFlushSingleTransaction.HasValue)
+                {
+                    dbConfig.FlushSingleTransaction = _distributedSettings.ContentLocationDatabaseFlushSingleTransaction.Value;
+                }
+
+                if (_distributedSettings.ContentLocationDatabaseFlushPreservePercentInMemory.HasValue)
+                {
+                    dbConfig.FlushPreservePercentInMemory = _distributedSettings.ContentLocationDatabaseFlushPreservePercentInMemory.Value;
+                }
+
+                if (_distributedSettings.ContentLocationDatabaseCacheMaximumUpdatesPerFlush.HasValue)
+                {
+                    dbConfig.CacheMaximumUpdatesPerFlush = _distributedSettings.ContentLocationDatabaseCacheMaximumUpdatesPerFlush.Value;
+                }
+
+                if (_distributedSettings.ContentLocationDatabaseCacheFlushingMaximumInterval.HasValue)
+                {
+                    dbConfig.CacheFlushingMaximumInterval = _distributedSettings.ContentLocationDatabaseCacheFlushingMaximumInterval.Value;
+                }
+
                 ApplySecretSettingsForLlsAsync(redisContentLocationStoreConfiguration, localCacheRoot).GetAwaiter().GetResult();
             }
 


### PR DESCRIPTION
Adds ContentLocationDatabase's in-memory cache configuration options to CloudBuild's layer so we can actually deploy