### PR TITLE
Reduce DScript AST conversion parallelism

### DIFF
--- a/Public/Src/FrontEnd/Script/RuntimeModel/AstConversionConfiguration.cs
+++ b/Public/Src/FrontEnd/Script/RuntimeModel/AstConversionConfiguration.cs
@@ -23,8 +23,7 @@ namespace BuildXL.FrontEnd.Script.RuntimeModel.AstBridge
             PolicyRules = policyRules ?? CollectionUtilities.EmptyArray<string>();
             UnsafeOptions = UnsafeConversionConfiguration.GetConfigurationFromEnvironmentVariables();
 
-            // In DScript V2 AST converter itself does not convert nodes in parallel.
-            DegreeOfParalellism = useLegacyOfficeLogic ? degreeOfParallelism : 1;
+            DegreeOfParalellism = 1;
             DisableLanguagePolicies = disableLanguagePolicies;
         }
 

--- a/Public/Src/FrontEnd/Script/RuntimeModel/AstConversionConfiguration.cs
+++ b/Public/Src/FrontEnd/Script/RuntimeModel/AstConversionConfiguration.cs
@@ -16,9 +16,7 @@ namespace BuildXL.FrontEnd.Script.RuntimeModel.AstBridge
         /// <nodoc/>
         public AstConversionConfiguration(
             [CanBeNull]IEnumerable<string> policyRules,
-            int degreeOfParallelism,
-            bool disableLanguagePolicies,
-            bool useLegacyOfficeLogic)
+            bool disableLanguagePolicies)
         {
             PolicyRules = policyRules ?? CollectionUtilities.EmptyArray<string>();
             UnsafeOptions = UnsafeConversionConfiguration.GetConfigurationFromEnvironmentVariables();
@@ -32,9 +30,7 @@ namespace BuildXL.FrontEnd.Script.RuntimeModel.AstBridge
         {
             return new AstConversionConfiguration(
                 policyRules: configuration.EnabledPolicyRules,
-                degreeOfParallelism: configuration.MaxFrontEndConcurrency(),
-                disableLanguagePolicies: configuration.DisableLanguagePolicyAnalysis(),
-                useLegacyOfficeLogic: configuration.UseLegacyOfficeLogic())
+                disableLanguagePolicies: configuration.DisableLanguagePolicyAnalysis())
             {
                 PreserveFullNameSymbols = configuration.PreserveFullNames(),
             };
@@ -47,9 +43,7 @@ namespace BuildXL.FrontEnd.Script.RuntimeModel.AstBridge
         {
             return new AstConversionConfiguration(
                 policyRules: configuration.EnabledPolicyRules,
-                degreeOfParallelism: configuration.MaxFrontEndConcurrency(),
-                disableLanguagePolicies: configuration.DisableLanguagePolicyAnalysis(),
-                useLegacyOfficeLogic: configuration.UseLegacyOfficeLogic())
+                disableLanguagePolicies: configuration.DisableLanguagePolicyAnalysis())
             {
                 PreserveFullNameSymbols = configuration.PreserveFullNames(),
             };

--- a/Public/Src/FrontEnd/UnitTests/Core/DsTest.cs
+++ b/Public/Src/FrontEnd/UnitTests/Core/DsTest.cs
@@ -1167,9 +1167,7 @@ namespace Test.BuildXL.FrontEnd.Core
         {
             var conversionConfiguration = new AstConversionConfiguration(
                 policyRules: customRules ?? new string[] { },
-                degreeOfParallelism: 1,
-                disableLanguagePolicies: configuration.DisableLanguagePolicyAnalysis(),
-                useLegacyOfficeLogic: false)
+                disableLanguagePolicies: configuration.DisableLanguagePolicyAnalysis())
             {
                 PreserveFullNameSymbols = true,
             };

--- a/Public/Src/IDE/Debugger/ExpressionEvaluator.cs
+++ b/Public/Src/IDE/Debugger/ExpressionEvaluator.cs
@@ -37,9 +37,7 @@ namespace BuildXL.FrontEnd.Script.Debugger
 
             var configuration = new AstConversionConfiguration(
                 policyRules: Enumerable.Empty<string>(),
-                degreeOfParallelism: 1,
-                disableLanguagePolicies: false,
-                useLegacyOfficeLogic: false);
+                disableLanguagePolicies: false);
 
             s_parser = new RuntimeModelFactory(
                 m_logger,


### PR DESCRIPTION
@smera tells me that this extra layer of parallelism was a vestige of the past that was pinned in non-DScript V2 due to lack of testing for the new default. The AST conversion is already parallelized at another layer in V2 and legacy modes.

Based on testing in CloudBuild (thanks @norahuang) it's apparent that this setting is what's causing the occasional degenerate graph construction times for some very large builds. In local smaller scale builds there is definitely less variance without the extra layer of parallelism. In aggregate the duration is about the same. I think it makes sense to make this change for sake of dramatically improving the degenerate cases of the large CB builds.