### PR TITLE
Enable additional DScript interpreter test for macOS

### DIFF
--- a/Public/Src/Deployment/Tests.Osx/test_runner.sh
+++ b/Public/Src/Deployment/Tests.Osx/test_runner.sh
@@ -14,6 +14,9 @@ chmod +x "$bxlSh"
 find "$MY_DIR/TestProj/tests" -name "*.TestProcess" -exec chmod +x {} \;
 find "$MY_DIR/TestProj/tests" -name "*CoreDump*" -exec chmod +x {} \;
 
+# Allow for up to 4mb of thread stack size
+export COMPlus_DefaultStackSize=400000
+
 # run the build
 # Temporarily disable this until we have the new macOS based CI
 # /kextMeasureProcessCpuTimes

--- a/Public/Src/Deployment/Tests.Osx/test_runner.sh
+++ b/Public/Src/Deployment/Tests.Osx/test_runner.sh
@@ -14,9 +14,6 @@ chmod +x "$bxlSh"
 find "$MY_DIR/TestProj/tests" -name "*.TestProcess" -exec chmod +x {} \;
 find "$MY_DIR/TestProj/tests" -name "*CoreDump*" -exec chmod +x {} \;
 
-# Allow for up to 4mb of thread stack size
-export COMPlus_DefaultStackSize=400000
-
 # run the build
 # Temporarily disable this until we have the new macOS based CI
 # /kextMeasureProcessCpuTimes

--- a/Public/Src/FrontEnd/UnitTests/Script.Interpretation/InterpretBinaryExpressions.cs
+++ b/Public/Src/FrontEnd/UnitTests/Script.Interpretation/InterpretBinaryExpressions.cs
@@ -116,7 +116,7 @@ export const r = ""other.."" + p`myfile.txt`;
             Assert.True(((string)result).EndsWith("/myfile.txt`"));
         }
 
-        [FactIfSupported(requiresWindowsBasedOperatingSystem: true)]
+        [Fact]
         public void SuperLongBinaryExpressionShouldNotLeadToStackoverflow()
         {
             // This sample led to stack overflow when NodeWalker was recursive

--- a/Public/Src/FrontEnd/UnitTests/Script.Interpretation/InterpretBinaryExpressions.cs
+++ b/Public/Src/FrontEnd/UnitTests/Script.Interpretation/InterpretBinaryExpressions.cs
@@ -116,6 +116,10 @@ export const r = ""other.."" + p`myfile.txt`;
             Assert.True(((string)result).EndsWith("/myfile.txt`"));
         }
 
+        /*
+         * On macOS the default stack size is 512kb and this test fails if the stack size limit is not adjusted prior to CoreCLR init
+         * (e.g. if running the thest within a debugger / IDE). Our bxl wrapper shell scripts currently set COMPlus_DefaultStackSize to fix this.
+         */
         [Fact]
         public void SuperLongBinaryExpressionShouldNotLeadToStackoverflow()
         {

--- a/Public/Src/Sandbox/MacOs/scripts/bxl.sh
+++ b/Public/Src/Sandbox/MacOs/scripts/bxl.sh
@@ -23,6 +23,9 @@ declare arg_loadKext=""
 
 declare g_bxlCmdArgs=()
 
+# Allow for up to 1MB of thread stack size
+export COMPlus_DefaultStackSize=100000
+
 # Clears and then populates the 'g_bxlArgs' array with arguments to be passed to 'bxl'.
 # The arguments are decided based on sensible defaults as well as the current values of the 'arg_*' variables.
 function setBxlCmdArgs {

--- a/Public/Src/Utilities/Native/BuildXL.Native.dsc
+++ b/Public/Src/Utilities/Native/BuildXL.Native.dsc
@@ -45,7 +45,7 @@ namespace Native {
             Configuration.dll,
         ],
         runtimeContent: [
-            ...addIfLazy(MacServices.Deployment.macBinaryUsage !== "none"  && qualifier.targetRuntime === "osx-x64", () => [
+            ...addIfLazy(MacServices.Deployment.macBinaryUsage !== "none" && qualifier.targetRuntime === "osx-x64", () => [
                 MacServices.Deployment.sandboxMonitor,
                 MacServices.Deployment.ariaLibrary,
                 MacServices.Deployment.interopLibrary


### PR DESCRIPTION
Enable SuperLongBinaryExpressionShouldNotLeadToStackoverflow test for macOS now that we know the culprit of stack overflows. On macOS all threads besides the main thread have "only" 512 Kilobytes of stack size (see https://developer.apple.com/library/archive/qa/qa1419/_index.html). `COMPlus_DefaultStackSize` helps here.