### PR TITLE
Allow users to specify the source from which a qtest target is built.

### DIFF
--- a/Public/Sdk/SelfHost/BuildXL/Tools/QTest/Tool.QTestRunner.dsc
+++ b/Public/Sdk/SelfHost/BuildXL/Tools/QTest/Tool.QTestRunner.dsc
@@ -336,7 +336,7 @@ export interface QTestArguments extends Transformer.RunnerArguments {
     /** Specifies the environment variables to forward to qtest */
     qTestEnvironmentVariables?: Transformer.EnvironmentVariable[];
     /** Specify the path relative to enlistment root of the sources from which the test target is built */
-    testSourceDir?: string;
+    testSourceDir?: RelativePath;
 }
 /**
  * Test results from a vstest.console.exe run

--- a/Public/Sdk/SelfHost/BuildXL/Tools/QTest/Tool.QTestRunner.dsc
+++ b/Public/Sdk/SelfHost/BuildXL/Tools/QTest/Tool.QTestRunner.dsc
@@ -172,7 +172,7 @@ export function runQTest(args: QTestArguments): Result {
         Cmd.option("--qTestAdditionalOptions ", args.qTestAdditionalOptions, args.qTestAdditionalOptions ? true : false),
         Cmd.option("--qTestContextInfo ", qTestContextInfoPath),
         Cmd.option("--qTestBuildType ", args.qTestBuildType || "unset"),
-        Cmd.option("--testSourceDir", args.testSourceDir)
+        Cmd.option("--testSourceDir ", args.testSourceDir)
     ];          
 
     let unsafeOptions = {

--- a/Public/Sdk/SelfHost/BuildXL/Tools/QTest/Tool.QTestRunner.dsc
+++ b/Public/Sdk/SelfHost/BuildXL/Tools/QTest/Tool.QTestRunner.dsc
@@ -171,7 +171,8 @@ export function runQTest(args: QTestArguments): Result {
         Cmd.flag("--qTestIgnoreQTestSkip", args.qTestIgnoreQTestSkip),
         Cmd.option("--qTestAdditionalOptions ", args.qTestAdditionalOptions, args.qTestAdditionalOptions ? true : false),
         Cmd.option("--qTestContextInfo ", qTestContextInfoPath),
-        Cmd.option("--qTestBuildType ", args.qTestBuildType || "unset")
+        Cmd.option("--qTestBuildType ", args.qTestBuildType || "unset"),
+        Cmd.option("--testSourceDir", args.testSourceDir)
     ];          
 
     let unsafeOptions = {
@@ -334,6 +335,8 @@ export interface QTestArguments extends Transformer.RunnerArguments {
     qTestBuildType?: string;
     /** Specifies the environment variables to forward to qtest */
     qTestEnvironmentVariables?: Transformer.EnvironmentVariable[];
+    /** Specify the path relative to enlistment root of the sources from which the test target is built */
+    testSourceDir?: string;
 }
 /**
  * Test results from a vstest.console.exe run

--- a/config.microsoftInternal.dsc
+++ b/config.microsoftInternal.dsc
@@ -18,7 +18,7 @@ export const pkgs = isMicrosoftInternal ? [
     { id: "runtime.osx-x64.BuildXL", version: "1.94.99" },
     { id: "Aria.Cpp.SDK.osx-x64", version: "8.5.4" },
 
-    { id: "CB.QTest", version: "19.6.12.220934" },
+    { id: "CB.QTest", version: "19.6.15.644" },
     { id: "CloudBuild.VmCommandProxy", version: "19.6.9.150831" },
 
     { id: "BuildXL.Tracing.AriaTenantToken", version: "1.0.0" },


### PR DESCRIPTION
This is essential for the correct operation of qtest's flaky test detection and reporting.