### PR TITLE
Fix 'BuildXL.Cache.Tools' package

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/BuildXL.Cache.ContentStore.Distributed.dsc
+++ b/Public/Src/Cache/ContentStore/Distributed/BuildXL.Cache.ContentStore.Distributed.dsc
@@ -10,7 +10,7 @@ namespace Distributed {
         (qualifier.targetFramework === 'net472' || qualifier.targetFramework === 'net451') ? importFrom("Microsoft.Azure.EventHubs").withQualifier({targetFramework: 'net461'}).pkg : importFrom("Microsoft.Azure.EventHubs").pkg,
         // Microsoft.Azure.EventHubs removes 'System.Diagnostics.DiagnosticSource' as the dependency to avoid deployment issue for .netstandard2.0, but this dependency
         // is required for non-.net core builds.
-        ...((qualifier.targetFramework === 'net472' || qualifier.targetFramework === 'net451')
+        ...((qualifier.targetFramework === 'net472' || qualifier.targetFramework === 'net451' || qualifier.targetFramework === 'net461')
             ? [ importFrom("System.Diagnostics.DiagnosticSource").pkg, importFrom("Microsoft.IdentityModel.Tokens").pkg,importFrom("Microsoft.IdentityModel.Logging").pkg ] 
             : []),
 


### PR DESCRIPTION
A previous fix added required dependencies to 'BuildXL.net472' nuget package. This change adds them to 'BuildXL.Cache.Tools' package.