### PR TITLE
QTest: Add Recycle Bin to untracked directories

### DIFF
--- a/Public/Sdk/SelfHost/BuildXL/Tools/QTest/Tool.QTestRunner.dsc
+++ b/Public/Sdk/SelfHost/BuildXL/Tools/QTest/Tool.QTestRunner.dsc
@@ -182,6 +182,8 @@ export function runQTest(args: QTestArguments): Result {
         untrackedScopes: [
             d`d:/data`,
             d`d:/app`,
+            // Untracking Recyclebin here to primarily unblock user scenarios that
+            // deal with soft-delete and restoration of files from recycle bin.
             d`${sandboxDir.pathRoot}/$Recycle.Bin`,
             ...addIf(Environment.hasVariable("QAUTHMATERIALROOT"), Environment.getDirectoryValue("QAUTHMATERIALROOT")),
         ]

--- a/Public/Sdk/SelfHost/BuildXL/Tools/QTest/Tool.QTestRunner.dsc
+++ b/Public/Sdk/SelfHost/BuildXL/Tools/QTest/Tool.QTestRunner.dsc
@@ -182,6 +182,7 @@ export function runQTest(args: QTestArguments): Result {
         untrackedScopes: [
             d`d:/data`,
             d`d:/app`,
+            d`${sandboxDir.pathRoot}/$Recycle.Bin`,
             ...addIf(Environment.hasVariable("QAUTHMATERIALROOT"), Environment.getDirectoryValue("QAUTHMATERIALROOT")),
         ]
     };


### PR DESCRIPTION
https://dev.azure.com/mseng/1ES/_workitems/edit/1552522

Files from Recycle bin cause failure due to disallowed file access.
Added Recycle bin from the drive of the sandbox to untracked directories.
