### PR TITLE
Fix unix time and risk coefficient for distributed eviction

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
@@ -1077,33 +1077,36 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                 () =>
                 {
                     var effectiveLastAccessTimes = new List<ContentHashWithLastAccessTimeAndReplicaCount>();
+                    double logInverseMachineRisk = -Math.Log(_configuration.MachineRisk);
 
                     foreach (var contentHash in contentHashes)
                     {
-                        DateTime? effectiveLastAccessTime = null;
+                        DateTime lastAccessTime = contentHash.LastAccessTime;
                         int replicaCount = 1;
+                        DateTime? effectiveLastAccessTime = null;
+
                         if (TryGetContentLocations(context, contentHash.Hash, out var entry))
                         {
+                            // Use the latest last access time between LLS and local last access time
+                            DateTime distributedLastAccessTime = entry.LastAccessTimeUtc.ToDateTime();
+                            lastAccessTime = distributedLastAccessTime > lastAccessTime ? distributedLastAccessTime : lastAccessTime;
+
                             // TODO[LLS]: Maybe some machines should be primary replicas for the content and not prioritize deletion (bug 1365340)
                             // just because there are many replicas
+
+                            replicaCount = entry.Locations.Count;
 
                             // Incorporate both replica count and size into an evictability metric.
                             // It's better to eliminate big content (more bytes freed per eviction) and it's better to eliminate content with more replicas (less chance
                             // of all replicas being inaccessible).
                             // A simple model with exponential decay of likelihood-to-use and a fixed probability of each replica being inaccessible shows that the metric
-                            //   evictability = age + (time decay parameter) * (number of replicas + log(size of content))
+                            //   evictability = age + (time decay parameter) * (-log(risk of content unavailability) * (number of replicas) + log(size of content))
                             // minimizes the increase in the probability of (content wanted && all replicas inaccessible) / per bytes freed.
                             // Since this metric is just the age plus a computed quantity, it can be intrepreted as an "effective age".
                             // (One dev wanted no penalty until we reach a threshold number of replicas. We don't have a model justification for this but I'm content to oblige.)
-                            TimeSpan totalReplicaPenalty = TimeSpan.FromMinutes(_configuration.ReplicaPenaltyInMinutes * (Math.Max(0, entry.Locations.Count - 3) + Math.Log(Math.Max(1, entry.ContentSize))));
-                            
-                            replicaCount = entry.Locations.Count;
+                            TimeSpan totalReplicaPenalty = TimeSpan.FromMinutes(_configuration.ContentLifetime.TotalMinutes * (Math.Max(0, replicaCount - 3) * logInverseMachineRisk + Math.Log(Math.Max(1, entry.ContentSize))));
+                            effectiveLastAccessTime = lastAccessTime - totalReplicaPenalty;
 
-                            // Use the latest last access time between LLS and local last access time
-                            var lastAccessTime = entry.LastAccessTimeUtc > contentHash.LastAccessTime
-                                ? entry.LastAccessTimeUtc
-                                : contentHash.LastAccessTime;
-                            effectiveLastAccessTime = lastAccessTime.ToDateTime() - totalReplicaPenalty;
                             Counters[ContentLocationStoreCounters.EffectiveLastAccessTimeLookupHit].Increment();
                         }
                         else
@@ -1111,7 +1114,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                             Counters[ContentLocationStoreCounters.EffectiveLastAccessTimeLookupMiss].Increment();
                         }
 
-                        effectiveLastAccessTimes.Add(new ContentHashWithLastAccessTimeAndReplicaCount(contentHash.Hash, contentHash.LastAccessTime, replicaCount, effectiveLastAccessTime: effectiveLastAccessTime ?? contentHash.LastAccessTime));
+                        effectiveLastAccessTimes.Add(new ContentHashWithLastAccessTimeAndReplicaCount(contentHash.Hash, lastAccessTime, replicaCount, effectiveLastAccessTime: effectiveLastAccessTime ?? lastAccessTime));
                     }
 
                     return Result.Success<IReadOnlyList<ContentHashWithLastAccessTimeAndReplicaCount>>(effectiveLastAccessTimes);

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStoreConfiguration.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStoreConfiguration.cs
@@ -115,9 +115,16 @@ namespace BuildXL.Cache.ContentStore.Distributed
         public MachineReputationTrackerConfiguration ReputationTrackerConfiguration { get; set; } = new MachineReputationTrackerConfiguration();
 
         /// <summary>
-        /// Amount of time added per additional replica to effective last access time computed for distributed eviction.
+        /// Estimated decay time for content re-use.
         /// </summary>
-        public int ReplicaPenaltyInMinutes { get; set; } = 10;
+        /// <remarks><para>This is used in the opitmal distributed eviction algorithm.</para></remarks>
+        public TimeSpan ContentLifetime { get; set; } = TimeSpan.FromDays(0.5);
+
+        /// <summary>
+        /// Estimated chance of a content not being available on a machine in the distributed pool.
+        /// </summary>
+        /// <remarks><para>This is used in the opitmal distributed eviction algorithm.</para></remarks>
+        public double MachineRisk { get; set; } = 0.1;
 
         /// <summary>
         /// The minimum age of content before it is eagerly touched.

--- a/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/LocalLocationStoreDistributedContentTests.cs
+++ b/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/LocalLocationStoreDistributedContentTests.cs
@@ -1974,7 +1974,7 @@ namespace ContentStoreTest.Distributed.Sessions
                 MachineExpiry = TimeSpan.FromMinutes(10),
                 EnableReconciliation = _enableReconciliation,
                 InlinePostInitialization = true,
-                ReplicaPenaltyInMinutes = ReplicaCreditInMinutes,
+                ContentLifetime = TimeSpan.FromMinutes(ReplicaCreditInMinutes),
 
                 // Set recompute time to zero to force recomputation on every heartbeat
                 RecomputeInactiveMachinesExpiry = TimeSpan.Zero,

--- a/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
@@ -68,7 +68,8 @@ namespace BuildXL.Cache.Host.Service.Internal
                 MaxBlobSize = _distributedSettings.MaxBlobSize
             };
 
-            ApplyIfNotNull(_distributedSettings.ReplicaCreditInMinutes, v => redisContentLocationStoreConfiguration.ReplicaPenaltyInMinutes = v);
+            ApplyIfNotNull(_distributedSettings.ReplicaCreditInMinutes, v => redisContentLocationStoreConfiguration.ContentLifetime = TimeSpan.FromMinutes(v));
+            ApplyIfNotNull(_distributedSettings.MachineRisk, v => redisContentLocationStoreConfiguration.MachineRisk = v);
             ApplyIfNotNull(_distributedSettings.LocationEntryExpiryMinutes, v => redisContentLocationStoreConfiguration.LocationEntryExpiry = TimeSpan.FromMinutes(v));
             ApplyIfNotNull(_distributedSettings.MachineExpiryMinutes, v => redisContentLocationStoreConfiguration.MachineExpiry = TimeSpan.FromMinutes(v));
 


### PR DESCRIPTION
In previous effective age computation:

- we did a computation that mixed UnixTime and DateTime
- we were missing the -log(machineRisk) coefficient of replica count

Fixing these also required piping the machine risk down into the distributed evictability computation layer.