### PR TITLE
Fix non-internal sandbox build change detection

### DIFF
--- a/Public/Src/Sandbox/MacOs/projects.dsc
+++ b/Public/Src/Sandbox/MacOs/projects.dsc
@@ -21,13 +21,23 @@ namespace Sandbox {
         derivedDataOutDir: StaticDirectory
     }
 
-    const sandboxSealDir = Transformer.sealSourceDirectory(
-        d`${Context.getMount("Sandbox").path}`,
-        Transformer.SealSourceDirectoryOption.allDirectories);
+    function sourceFileDependencies()
+    {
+        const sandboxDir = d`${Context.getMount("Sandbox").path}`;
+        const thirdPartyDir = d`../../../../third_party`;
 
-    const thirdPartySealDir = Transformer.sealSourceDirectory(
-        d`../../../../third_party`,
-        Transformer.SealSourceDirectoryOption.allDirectories);
+        const sourceSealOptions =  Transformer.SealSourceDirectoryOption.allDirectories;
+        const globPattern = "*";
+
+        return BuildXLSdk.Flags.isMicrosoftInternal ?
+            [
+                Transformer.sealSourceDirectory(sandboxDir, sourceSealOptions),
+                Transformer.sealSourceDirectory(thirdPartyDir, sourceSealOptions)
+            ] : [
+                ...Transformer.sealDirectory(sandboxDir, globR(sandboxDir, globPattern)).contents,
+                ...Transformer.sealDirectory(thirdPartyDir, globR(thirdPartyDir, globPattern)).contents
+            ];
+    }
 
     export function build(args: Args): Result {
         const conf = args.configuration || qualifier.configuration;
@@ -45,10 +55,10 @@ namespace Sandbox {
             ],
             dependencies: [
                 ...(args.dependencies || []),
-                sandboxSealDir,
-                thirdPartySealDir
+                ...sourceFileDependencies()
             ]
         });
+
         return {
             outFiles: outFilePaths.map(result.getOutputFile),
             derivedDataOutDir: result.getOutputDirectory(outDir)

--- a/Public/Src/Sandbox/MacOs/projects.dsc
+++ b/Public/Src/Sandbox/MacOs/projects.dsc
@@ -21,7 +21,7 @@ namespace Sandbox {
         derivedDataOutDir: StaticDirectory
     }
 
-    function sourceFileDependencies()
+    const sourceFileDependencies = (() =>
     {
         const sandboxDir = d`${Context.getMount("Sandbox").path}`;
         const thirdPartyDir = d`../../../../third_party`;
@@ -37,7 +37,7 @@ namespace Sandbox {
                 ...Transformer.sealDirectory(sandboxDir, globR(sandboxDir, globPattern)).contents,
                 ...Transformer.sealDirectory(thirdPartyDir, globR(thirdPartyDir, globPattern)).contents
             ];
-    }
+    })();
 
     export function build(args: Args): Result {
         const conf = args.configuration || qualifier.configuration;
@@ -55,7 +55,7 @@ namespace Sandbox {
             ],
             dependencies: [
                 ...(args.dependencies || []),
-                ...sourceFileDependencies()
+                ...sourceFileDependencies
             ]
         });
 


### PR DESCRIPTION
Fix source file dependencies for sandbox build phase to correctly build code changes when the sandbox is not running during the bxl execution (non-internal builds). Previously, source file changes would not trigger rebuild.