### PR TITLE
Don't delete contents of preserved opaque directories on cache replay

### DIFF
--- a/Public/Src/Engine/Scheduler/Artifacts/FileContentManager.cs
+++ b/Public/Src/Engine/Scheduler/Artifacts/FileContentManager.cs
@@ -1579,9 +1579,12 @@ namespace BuildXL.Scheduler.Artifacts
 
                     if (sealDirectoryKind == SealDirectoryKind.Opaque)
                     {
-                        // Dynamic directories must be deleted before materializing files
-                        // We don't want this to happen for shared dynamic ones
-                        AddDirectoryDeletion(state, artifact.DirectoryArtifact);
+                        if (Configuration.Sandbox.UnsafeSandboxConfiguration.PreserveOutputs != PreserveOutputsMode.Enabled || !PipArtifacts.IsPreservedOutputByPip(state.PipInfo.UnderlyingPip, directory.Path, Context.PathTable))
+                        {
+                            // Dynamic directories must be deleted before materializing files
+                            // We don't want this to happen for shared dynamic ones
+                            AddDirectoryDeletion(state, artifact.DirectoryArtifact);
+                        }
 
                         // For dynamic directories we need to specify the value of
                         // allow read only since the host will not know about the


### PR DESCRIPTION
This updates the opaque directory cache replay logic to not nuke the directory before replay if the directory is preserved and running in preserve outputs mode. The goal here is to enable gradle pips to be incremental again