### PR TITLE
Nuget full framework dependency spec generator changes

### DIFF
--- a/Public/Src/FrontEnd/Core/PackageHashFile.cs
+++ b/Public/Src/FrontEnd/Core/PackageHashFile.cs
@@ -31,7 +31,7 @@ namespace BuildXL.FrontEnd.Core
         // The file format change will force specs regeneration.
         // Change the version if the nuget spec generation has changed in a backward incompatible way.
         private const string HashFileFormatVersion = "8";
-        private const string GeneratedSpecsVersion = "14";
+        private const string GeneratedSpecsVersion = "15";
 
         /// <summary>
         /// The minimal number of lines for the hash file.

--- a/Public/Src/FrontEnd/Nuget/NugetAnalyzedPackage.cs
+++ b/Public/Src/FrontEnd/Nuget/NugetAnalyzedPackage.cs
@@ -59,6 +59,11 @@ namespace BuildXL.FrontEnd.Nuget
         /// </summary>
         public MultiValueDictionary<PathAtom, NugetTargetFramework> AssemblyToTargetFramework { get; private set; }
 
+        /// <summary>
+        /// Indicates if the package contains only .NETStandard comaptible assemblies (this is false if full framework or .NETCoreApp assemblies are present)
+        /// </summary>
+        public bool IsNetStandardPackageOnly { get; private set; }
+
         /// <nodoc />
         public PackageOnDisk PackageOnDisk { get; }
 
@@ -410,6 +415,10 @@ namespace BuildXL.FrontEnd.Nuget
 
             Dependencies = dependencies;
             DependenciesPerFramework = dependenciesPerFramework;
+
+            IsNetStandardPackageOnly =
+                !TargetFrameworks.Any(tfm => NugetFrameworkMonikers.FullFrameworkVersionHistory.Contains(tfm)) &&
+                !TargetFrameworks.Any(tfm => NugetFrameworkMonikers.NetCoreAppVersionHistory.Contains(tfm));
 
             return true;
         }

--- a/Public/Src/FrontEnd/Nuget/NugetFrameworkMonikers.cs
+++ b/Public/Src/FrontEnd/Nuget/NugetFrameworkMonikers.cs
@@ -111,6 +111,12 @@ namespace BuildXL.FrontEnd.Nuget
         public readonly List<PathAtom> NetCoreVersionHistory;
 
         /// <nodoc />
+        public readonly List<PathAtom> NetCoreAppVersionHistory;
+
+        /// <nodoc />
+        public readonly List<PathAtom> NetStandardToFullFrameworkCompatibility;
+
+        /// <nodoc />
         public Dictionary<string, PathAtom> TargetFrameworkNameToMoniker { get; }
 
         /// <nodoc />
@@ -141,6 +147,8 @@ namespace BuildXL.FrontEnd.Nuget
             NetCoreApp30  = Register(stringTable, "netcoreapp3.0",  ".NETCoreApp3.0", NetCoreVersionHistory);
             NetStandard21 = Register(stringTable, "netstandard2.1", ".NETStandard2.1", NetCoreVersionHistory);
 
+            NetCoreAppVersionHistory = new List<PathAtom>() { NetCoreApp20, NetCoreApp21, NetCoreApp22, NetCoreApp30 };
+
             Net10  = Register(stringTable, "net10",  ".NETFramework1.0", FullFrameworkVersionHistory);
             Net11  = Register(stringTable, "net11",  ".NETFramework1.1", FullFrameworkVersionHistory);
             Net20  = Register(stringTable, "net20",  ".NETFramework2.0", FullFrameworkVersionHistory);
@@ -153,6 +161,8 @@ namespace BuildXL.FrontEnd.Nuget
             Net461 = Register(stringTable, "net461", ".NETFramework4.6.1", FullFrameworkVersionHistory);
             Net462 = Register(stringTable, "net462", ".NETFramework4.6.2", FullFrameworkVersionHistory);
             Net472 = Register(stringTable, "net472", ".NETFramework4.7.2", FullFrameworkVersionHistory);
+
+            NetStandardToFullFrameworkCompatibility = new List<PathAtom>() { Net461, Net462, Net472 };
         }
 
         private PathAtom Register(StringTable stringTable, string smallMoniker, string largeMoniker, List<PathAtom> versions)

--- a/Public/Src/FrontEnd/Nuget/NugetFrameworkMonikers.cs
+++ b/Public/Src/FrontEnd/Nuget/NugetFrameworkMonikers.cs
@@ -114,6 +114,9 @@ namespace BuildXL.FrontEnd.Nuget
         public Dictionary<string, PathAtom> TargetFrameworkNameToMoniker { get; }
 
         /// <nodoc />
+        public bool IsFullFrameworkMoniker(PathAtom moniker) => FullFrameworkVersionHistory.Contains(moniker);
+
+        /// <nodoc />
         public NugetFrameworkMonikers(StringTable stringTable)
         {
             LibFolderName = PathAtom.Create(stringTable, "lib");

--- a/Public/Src/FrontEnd/Nuget/NugetSpecGenerator.cs
+++ b/Public/Src/FrontEnd/Nuget/NugetSpecGenerator.cs
@@ -141,6 +141,11 @@ namespace BuildXL.FrontEnd.Nuget
                         return;
                     }
 
+                    if (analyzedPackage.IsNetStandardPackageOnly)
+                    {
+                        cases.AddRange(m_nugetFrameworkMonikers.NetStandardToFullFrameworkCompatibility.Select(m => new CaseClause(new LiteralExpression(m.ToString(m_pathTable.StringTable)))));
+                    }
+
                     cases.AddRange(monikers.Take(monikers.Count - 1).Select(m => new CaseClause(new LiteralExpression(m.ToString(m_pathTable.StringTable)))));
 
                     var compile = new List<IExpression>();
@@ -196,8 +201,8 @@ namespace BuildXL.FrontEnd.Nuget
                                     PropertyAccess("Contents", "all"),
                                     Array(compile),
                                     Array(runtime),
-                                    m_nugetFrameworkMonikers.IsFullFrameworkMoniker(monikers.Last()) 
-                                        ? Array(dependencies) 
+                                    m_nugetFrameworkMonikers.IsFullFrameworkMoniker(monikers.Last())
+                                        ? Array(dependencies)
                                         : Array(new CallExpression(new Identifier("...addIfLazy"),
                                             new BinaryExpression(
                                                 new PropertyAccessExpression("qualifier", "targetFramework"),
@@ -335,6 +340,11 @@ namespace BuildXL.FrontEnd.Nuget
         private bool TryCreateQualifier(NugetAnalyzedPackage analyzedPackage, out IStatement statement)
         {
             List<PathAtom> compatibleTfms = new List<PathAtom>();
+
+            if (analyzedPackage.IsNetStandardPackageOnly)
+            {
+                compatibleTfms.AddRange(m_nugetFrameworkMonikers.NetStandardToFullFrameworkCompatibility);
+            }
 
             FindAllCompatibleFrameworkMonikers(analyzedPackage,
                 (List<PathAtom> monikers) => compatibleTfms.AddRange(monikers),

--- a/Public/Src/FrontEnd/Nuget/NugetSpecGenerator.cs
+++ b/Public/Src/FrontEnd/Nuget/NugetSpecGenerator.cs
@@ -165,7 +165,7 @@ namespace BuildXL.FrontEnd.Nuget
                     }
 
                     // For full framework dependencies we unconditionally include all the distinct dependencies from the nuspec file,
-                    // .NETStandard dependencies are only included if the monikor and the parsed target framework match!
+                    // .NETStandard dependencies are only included if the moniker and the parsed target framework match!
                     if (m_nugetFrameworkMonikers.IsFullFrameworkMoniker(monikers.First()))
                     {
                         dependencies.AddRange(allFullFrameworkDeps.Select(dep => CreateImportFromForDependency(dep)));

--- a/Public/Src/FrontEnd/Nuget/NugetSpecGenerator.cs
+++ b/Public/Src/FrontEnd/Nuget/NugetSpecGenerator.cs
@@ -174,7 +174,7 @@ namespace BuildXL.FrontEnd.Nuget
                     {
                         if (analyzedPackage.DependenciesPerFramework.TryGetValue(monikers.First(), out IReadOnlyList<INugetPackage> dependencySpecificFrameworks))
                         {
-                            dependencies.AddRange(dependencySpecificFrameworks.Select(dep => CreateImportFromForDependency(dep)));\
+                            dependencies.AddRange(dependencySpecificFrameworks.Select(dep => CreateImportFromForDependency(dep)));
                         }
                     }
 

--- a/Public/Src/FrontEnd/Nuget/NugetSpecGenerator.cs
+++ b/Public/Src/FrontEnd/Nuget/NugetSpecGenerator.cs
@@ -155,38 +155,26 @@ namespace BuildXL.FrontEnd.Nuget
                     // Compile items
                     if (TryGetValueForFrameworkAndFallbacks(analyzedPackage.References, new NugetTargetFramework(monikers.First()), out IReadOnlyList<RelativePath> refAssemblies))
                     {
-                        foreach (var assembly in refAssemblies)
-                        {
-                            compile.Add(CreateSimpleBinary(assembly));
-                        }
+                        compile.AddRange(refAssemblies.Select(r => CreateSimpleBinary(r)));
                     }
 
                     // Runtime items
                     if (TryGetValueForFrameworkAndFallbacks(analyzedPackage.Libraries, new NugetTargetFramework(monikers.First()), out IReadOnlyList<RelativePath> libAssemblies))
                     {
-                        foreach (var assembly in libAssemblies)
-                        {
-                            runtime.Add(CreateSimpleBinary(assembly));
-                        }
+                        runtime.AddRange(libAssemblies.Select(l => CreateSimpleBinary(l)));
                     }
 
                     // For full framework dependencies we unconditionally include all the distinct dependencies from the nuspec file,
                     // .NETStandard dependencies are only included if the monikor and the parsed target framework match!
                     if (m_nugetFrameworkMonikers.IsFullFrameworkMoniker(monikers.First()))
                     {
-                        foreach (var dependencySpecificFramework in allFullFrameworkDeps)
-                        {
-                            dependencies.Add(CreateImportFromForDependency(dependencySpecificFramework));
-                        }
+                        dependencies.AddRange(allFullFrameworkDeps.Select(dep => CreateImportFromForDependency(dep)));
                     }
                     else
                     {
                         if (analyzedPackage.DependenciesPerFramework.TryGetValue(monikers.First(), out IReadOnlyList<INugetPackage> dependencySpecificFrameworks))
                         {
-                            foreach (var dependencySpecificFramework in dependencySpecificFrameworks)
-                            {
-                                dependencies.Add(CreateImportFromForDependency(dependencySpecificFramework));
-                            }
+                            dependencies.AddRange(dependencySpecificFrameworks.Select(dep => CreateImportFromForDependency(dep)));\
                         }
                     }
 


### PR DESCRIPTION
The Nuget spec file explicitly lists group dependencies for specific target frameworks. The logic so far has been to only include those dependencies (and their transitive closure) if the target framework of the qualifier evaluated matches the one specified in the nuspec files group dependency section. This is especially important for .NETCore, where continuous releases include more assemblies in the runtime folder and would collide when using all specified dependencies without looking at the target framework.

The right solution is explicitly specifying for what target framework a dependency and its transitive closure should be included using e.g. `withQualifier()`. We keep this for .NETStandard/Core going forward. For full framework builds (which we are gradually deprecating) and for the fact that package maintainers don't keep their Nuget dependencies in check to explicitly make statements about what dependencies are needed for which target framework, we now always include all dependencies at their latest version.