### PR TITLE
Fix allocation issues in ConcurrentBigMap

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabase.cs
@@ -478,7 +478,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         internal abstract void Persist(OperationContext context, ShortHash hash, ContentLocationEntry entry);
 
         /// <nodoc />
-        internal virtual void PersistBatch(OperationContext context, IEnumerable<KeyValuePair<ShortHash, ContentLocationEntry>> pairs)
+        internal virtual void PersistBatch(OperationContext context, IEnumerable<ConcurrentBigMapEntry<ShortHash, ContentLocationEntry>> pairs)
         {
             foreach (var pair in pairs)
             {

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/FlushableCache.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/FlushableCache.cs
@@ -125,7 +125,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                 }
                 else
                 {
-                    var actionBlock = new ActionBlockSlim<KeyValuePair<ShortHash, ContentLocationEntry>>(_configuration.FlushDegreeOfParallelism, kv =>
+                    var actionBlock = new ActionBlockSlim<ConcurrentBigMapEntry<ShortHash, ContentLocationEntry>>(_configuration.FlushDegreeOfParallelism, kv =>
                     {
                         // Do not lock on GetLock here, as it will cause a deadlock with
                         // SetMachineExistenceAndUpdateDatabase. It is correct not do take any locks as well, because

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/RocksDbContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/RocksDbContentLocationDatabase.cs
@@ -19,6 +19,7 @@ using BuildXL.Engine.Cache;
 using BuildXL.Engine.Cache.KeyValueStores;
 using BuildXL.Native.IO;
 using BuildXL.Utilities;
+using BuildXL.Utilities.Collections;
 using BuildXL.Utilities.Tasks;
 using BuildXL.Utilities.Threading;
 using AbsolutePath = BuildXL.Cache.ContentStore.Interfaces.FileSystem.AbsolutePath;
@@ -456,12 +457,12 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         }
 
         /// <inheritdoc />
-        internal override void PersistBatch(OperationContext context, IEnumerable<KeyValuePair<ShortHash, ContentLocationEntry>> pairs)
+        internal override void PersistBatch(OperationContext context, IEnumerable<ConcurrentBigMapEntry<ShortHash, ContentLocationEntry>> pairs)
         {
             _keyValueStore.Use((store, state) => PersistBatchHelper(store, state.pairs, state.db), (pairs, db: this)).ThrowOnError();
         }
 
-        private static Unit PersistBatchHelper(IBuildXLKeyValueStore store, IEnumerable<KeyValuePair<ShortHash, ContentLocationEntry>> pairs, RocksDbContentLocationDatabase db)
+        private static Unit PersistBatchHelper(IBuildXLKeyValueStore store, IEnumerable<ConcurrentBigMapEntry<ShortHash, ContentLocationEntry>> pairs, RocksDbContentLocationDatabase db)
         {
             store.ApplyBatch(
                 pairs.Select(pair => db.GetKey(pair.Key)),

--- a/Public/Src/Engine/Scheduler/Artifacts/FileContentManager.cs
+++ b/Public/Src/Engine/Scheduler/Artifacts/FileContentManager.cs
@@ -3363,7 +3363,7 @@ namespace BuildXL.Scheduler.Artifacts
                 FileArtifactContentHashesIndex = fileArtifactContentHashesIndex;
             }
 
-            private KeyValuePair<FileArtifact, FileMaterializationInfo> GetEntry(FileContentManager manager)
+            private ConcurrentBigMapEntry<FileArtifact, FileMaterializationInfo> GetEntry(FileContentManager manager)
             {
                 Contract.Assert(FileArtifactContentHashesIndex >= 0);
                 return manager

--- a/Public/Src/Engine/Scheduler/Artifacts/SymlinkDefinitions.cs
+++ b/Public/Src/Engine/Scheduler/Artifacts/SymlinkDefinitions.cs
@@ -123,7 +123,7 @@ namespace BuildXL.Scheduler.Artifacts
 
                 var pathMap = ConcurrentBigMap<AbsolutePath, AbsolutePath>.Deserialize(
                     reader,
-                    () => new KeyValuePair<AbsolutePath, AbsolutePath>(
+                    () => new ConcurrentBigMapEntry<AbsolutePath, AbsolutePath>(
                         key: reader.ReadAbsolutePath(),
                         value: reader.ReadAbsolutePath()));
 

--- a/Public/Src/Engine/Scheduler/Graph/PipGraph.cs
+++ b/Public/Src/Engine/Scheduler/Graph/PipGraph.cs
@@ -924,7 +924,7 @@ namespace BuildXL.Scheduler.Graph
         /// <summary>
         /// Gets all pip static fingerprints.
         /// </summary>
-        public IEnumerable<KeyValuePair<PipId, ContentFingerprint>> AllPipStaticFingerprints => PipStaticFingerprints.PipStaticFingerprints;
+        public IEnumerable<ConcurrentBigMapEntry<PipId, ContentFingerprint>> AllPipStaticFingerprints => PipStaticFingerprints.PipStaticFingerprints;
 
         /// <summary>
         /// Checks if artifact must remain writable.

--- a/Public/Src/Engine/Scheduler/Graph/PipGraphStaticFingerprints.cs
+++ b/Public/Src/Engine/Scheduler/Graph/PipGraphStaticFingerprints.cs
@@ -29,7 +29,7 @@ namespace BuildXL.Scheduler.Graph
         /// <summary>
         /// Gets all pip static fingerprints.
         /// </summary>
-        public IEnumerable<KeyValuePair<PipId, ContentFingerprint>> PipStaticFingerprints => m_pipsToStaticFingerprints;
+        public IEnumerable<ConcurrentBigMapEntry<PipId, ContentFingerprint>> PipStaticFingerprints => m_pipsToStaticFingerprints;
 
         /// <summary>
         /// Creates an instance of <see cref="PipGraphStaticFingerprints"/>.
@@ -133,11 +133,11 @@ namespace BuildXL.Scheduler.Graph
 
             var staticFingerprintsToPips = ConcurrentBigMap<ContentFingerprint, PipId>.Deserialize(
                 reader,
-                () => new System.Collections.Generic.KeyValuePair<ContentFingerprint, PipId>(new ContentFingerprint(reader), PipId.Deserialize(reader)));
+                () => new ConcurrentBigMapEntry<ContentFingerprint, PipId>(new ContentFingerprint(reader), PipId.Deserialize(reader)));
 
             var pipsToStaticFingerprints = ConcurrentBigMap<PipId, ContentFingerprint>.Deserialize(
                 reader,
-                () => new System.Collections.Generic.KeyValuePair<PipId, ContentFingerprint>(PipId.Deserialize(reader), new ContentFingerprint(reader)));
+                () => new ConcurrentBigMapEntry<PipId, ContentFingerprint>(PipId.Deserialize(reader), new ContentFingerprint(reader)));
 
             return new PipGraphStaticFingerprints(staticFingerprintsToPips, pipsToStaticFingerprints);
         }

--- a/Public/Src/Engine/Scheduler/IncrementalScheduling/GraphAgnosticIncrementalSchedulingState.cs
+++ b/Public/Src/Engine/Scheduler/IncrementalScheduling/GraphAgnosticIncrementalSchedulingState.cs
@@ -1370,13 +1370,13 @@ namespace BuildXL.Scheduler.IncrementalScheduling
                         pipProducers = PipProducers.Deserialize(reader);
                         cleanPips = ConcurrentBigMap<PipStableId, PipGraphSequenceNumber>.Deserialize(
                             reader,
-                            () => new KeyValuePair<PipStableId, PipGraphSequenceNumber>(reader.ReadPipStableId(), PipGraphSequenceNumber.Deserialize(reader)));
+                            () => new ConcurrentBigMapEntry<PipStableId, PipGraphSequenceNumber>(reader.ReadPipStableId(), PipGraphSequenceNumber.Deserialize(reader)));
                         materializedPips = ConcurrentBigSet<PipStableId>.Deserialize(
                             reader,
                             () => reader.ReadPipStableId());
                         cleanSourceFiles = ConcurrentBigMap<AbsolutePath, PipGraphSequenceNumber>.Deserialize(
                             reader,
-                            () => new KeyValuePair<AbsolutePath, PipGraphSequenceNumber>(reader.ReadAbsolutePath(), PipGraphSequenceNumber.Deserialize(reader)));
+                            () => new ConcurrentBigMapEntry<AbsolutePath, PipGraphSequenceNumber>(reader.ReadAbsolutePath(), PipGraphSequenceNumber.Deserialize(reader)));
                         dynamicallyObservedFiles = IncrementalSchedulingPathMapping<PipStableId>.Deserialize(reader, r => r.ReadPipStableId());
                         dynamicallyObservedEnumerations = IncrementalSchedulingPathMapping<PipStableId>.Deserialize(reader, r => r.ReadPipStableId());
                         pipOrigins = PipOrigins.Deserialize(reader);

--- a/Public/Src/Engine/Scheduler/IncrementalScheduling/IncrementalSchedulingPathMapping.cs
+++ b/Public/Src/Engine/Scheduler/IncrementalScheduling/IncrementalSchedulingPathMapping.cs
@@ -189,7 +189,7 @@ namespace BuildXL.Scheduler.IncrementalScheduling
                         values.Add(value);
                     }
 
-                    return new KeyValuePair<AbsolutePath, HashSet<T>>(path, values);
+                    return new ConcurrentBigMapEntry<AbsolutePath, HashSet<T>>(path, values);
                 });
 
             return new IncrementalSchedulingPathMapping<T>(pathToValue, valueToPathApproximation);

--- a/Public/Src/Engine/Scheduler/IncrementalScheduling/PipOrigins.cs
+++ b/Public/Src/Engine/Scheduler/IncrementalScheduling/PipOrigins.cs
@@ -145,7 +145,7 @@ namespace BuildXL.Scheduler.IncrementalScheduling
                 reader,
                 () =>
                 {
-                    var kvp = new KeyValuePair<ContentFingerprint, (long semiStableHash, int pipGraphIndex)>(
+                    var kvp = new ConcurrentBigMapEntry<ContentFingerprint, (long semiStableHash, int pipGraphIndex)>(
                         reader.ReadContentFingerprint(buffer),
                         (reader.ReadInt64(), reader.ReadInt32()));
                     return kvp;

--- a/Public/Src/Engine/Scheduler/IncrementalScheduling/PipProducers.cs
+++ b/Public/Src/Engine/Scheduler/IncrementalScheduling/PipProducers.cs
@@ -138,7 +138,7 @@ namespace BuildXL.Scheduler.IncrementalScheduling
                             return existingSet;
                         });
 
-                    return new KeyValuePair<AbsolutePath, PipStableId>(path, producer);
+                    return new ConcurrentBigMapEntry<AbsolutePath, PipStableId>(path, producer);
                 });
 
             return new PipProducers(pipProducers, producedPaths);

--- a/Public/Src/Engine/Scheduler/Performance/PipRuntimeTimeTable.cs
+++ b/Public/Src/Engine/Scheduler/Performance/PipRuntimeTimeTable.cs
@@ -153,7 +153,7 @@ namespace BuildXL.Scheduler
                     using (BuildXLWriter writer = new BuildXLWriter(debug: false, stream: stream, leaveOpen: true, logStats: false))
                     {
                         writer.Write(m_runtimeData.Count);
-                        foreach (KeyValuePair<long, PipHistoricPerfData> kvp in m_runtimeData)
+                        foreach (var kvp in m_runtimeData)
                         {
                             writer.Write(kvp.Key);
                             kvp.Value.Serialize(writer);

--- a/Public/Src/Engine/Scheduler/SealedDirectoryTable.cs
+++ b/Public/Src/Engine/Scheduler/SealedDirectoryTable.cs
@@ -99,9 +99,9 @@ namespace BuildXL.Scheduler
             return TryFindSealDirectoryEntryContainingFileArtifact(pipTable, artifact).Value.PipId;
         }
 
-        private KeyValuePair<DirectoryArtifact, Node> TryFindSealDirectoryEntryContainingFileArtifact(PipTable pipTable, FileArtifact artifact)
+        private ConcurrentBigMapEntry<DirectoryArtifact, Node> TryFindSealDirectoryEntryContainingFileArtifact(PipTable pipTable, FileArtifact artifact)
         {
-            KeyValuePair<DirectoryArtifact, Node> smallestMatchingSeal = default(KeyValuePair<DirectoryArtifact, Node>);
+            ConcurrentBigMapEntry<DirectoryArtifact, Node> smallestMatchingSeal = default(ConcurrentBigMapEntry<DirectoryArtifact, Node>);
             int smallestMatchingSealSize = int.MaxValue;
             int next = GetHeadNodeIndex(artifact);
             while (next >= 0)
@@ -302,7 +302,7 @@ namespace BuildXL.Scheduler
         /// <summary>
         /// Handles updating the seal info for a path
         /// </summary>
-        private readonly struct UpdateSealItem : IPendingSetItem<KeyValuePair<HierarchicalNameId, SealInfo>>
+        private readonly struct UpdateSealItem : IPendingSetItem<ConcurrentBigMapEntry<HierarchicalNameId, SealInfo>>
         {
             private readonly SealedDirectoryTable m_owner;
             private readonly SealDirectory m_seal;
@@ -315,7 +315,7 @@ namespace BuildXL.Scheduler
 
             public int HashCode => m_seal.DirectoryRoot.Value.GetHashCode();
 
-            public bool Equals(KeyValuePair<HierarchicalNameId, SealInfo> other)
+            public bool Equals(ConcurrentBigMapEntry<HierarchicalNameId, SealInfo> other)
             {
                 return m_seal.DirectoryRoot.Value == other.Key;
             }
@@ -324,7 +324,7 @@ namespace BuildXL.Scheduler
             /// Adds a new head node for the sealed directory at path and
             /// updates flags for path in hierarchical name table
             /// </summary>
-            public KeyValuePair<HierarchicalNameId, SealInfo> CreateOrUpdateItem(KeyValuePair<HierarchicalNameId, SealInfo> oldItem, bool hasOldItem, out bool remove)
+            public ConcurrentBigMapEntry<HierarchicalNameId, SealInfo> CreateOrUpdateItem(ConcurrentBigMapEntry<HierarchicalNameId, SealInfo> oldItem, bool hasOldItem, out bool remove)
             {
                 remove = false;
                 int backingIndex;
@@ -350,7 +350,7 @@ namespace BuildXL.Scheduler
                 }
 
                 // We can safely update the head node here because we are in the write lock for this key
-                return new KeyValuePair<HierarchicalNameId, SealInfo>(
+                return new ConcurrentBigMapEntry<HierarchicalNameId, SealInfo>(
                     m_seal.DirectoryRoot.Value,
                     new SealInfo(fullSealIndex: fullSealIndex, headIndex: backingIndex));
             }

--- a/Public/Src/Utilities/Collections/ConcurrentBigMapEntry.cs
+++ b/Public/Src/Utilities/Collections/ConcurrentBigMapEntry.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace BuildXL.Utilities.Collections
+{
+    /// <summary>
+    /// This is a key value pair for the concurrent big map.
+    /// </summary>
+    /// <remarks>
+    /// We can't use the built-in KeyValuePair because it does not implement GetHashCode and Equals.
+    /// Using KeyValue would result in a lot more memory traffic when using the ConcurrentBigMap due to
+    /// allocations made by boxing key/values when they are added to some internal members of ConcurrentBigMap
+    /// </remarks>
+    public readonly struct ConcurrentBigMapEntry<TKey, TValue> : IEquatable<ConcurrentBigMapEntry<TKey, TValue>>
+    {
+        /// <nodoc />
+        public ConcurrentBigMapEntry(TKey key, TValue value)
+        {
+            Key = key;
+            Value = value;
+        }
+
+        /// <nodoc />
+        public TKey Key { get; }
+
+        /// <nodoc />
+        public TValue Value { get; }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            return StructUtilities.Equals(this, obj);
+        }
+
+        /// <inheritdoc />
+        public bool Equals(ConcurrentBigMapEntry<TKey, TValue> other)
+        {
+            return EqualityComparer<TKey>.Default.Equals(Key, other.Key) &&
+                EqualityComparer<TValue>.Default.Equals(Value, other.Value);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return (Key, Value).GetHashCode();
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            // Use the original KeyValuePair pair tostring for convenience.
+            return new KeyValuePair<TKey, TValue>(Key, Value).ToString();
+        }
+    }
+}


### PR DESCRIPTION
ConcurrentBigmap was using KeyValuePair in collections causing lots of unneeded boxing when adding
items to the maps. This change uses a proper struct that can safely and performently be used as entries
in hash based collections.