### PR TITLE
Handle long paths in directory creation in BuildXL's cache layer

### DIFF
--- a/Public/Src/Cache/VerticalStore/BasicFilesystem/BasicFilesystemCache.cs
+++ b/Public/Src/Cache/VerticalStore/BasicFilesystem/BasicFilesystemCache.cs
@@ -19,6 +19,7 @@ using BuildXL.Cache.Interfaces;
 using BuildXL.Storage;
 using BuildXL.Utilities;
 using Newtonsoft.Json;
+using BuildXL.Native.IO;
 #if FEATURE_MICROSOFT_DIAGNOSTICS_TRACING
 using Microsoft.Diagnostics.Tracing;
 #else
@@ -234,17 +235,17 @@ namespace BuildXL.Cache.BasicFilesystem
                 // Obviously, the directories either need to be created
                 // if they are not there but this will fail if we are
                 // read-only and they are not there.  (We want that)
-                Directory.CreateDirectory(m_cacheRoot);
-                Directory.CreateDirectory(m_sessionRoot);
+                FileUtilities.CreateDirectory(m_cacheRoot);
+                FileUtilities.CreateDirectory(m_sessionRoot);
 
                 foreach (string casRoot in m_casShardRoots.Distinct())
                 {
-                    Directory.CreateDirectory(casRoot);
+                    FileUtilities.CreateDirectory(casRoot);
                 }
 
                 foreach (string wfpRoot in m_weakFingerprintShardRoots.Distinct())
                 {
-                    Directory.CreateDirectory(wfpRoot);
+                    FileUtilities.CreateDirectory(wfpRoot);
                 }
 
                 try
@@ -642,7 +643,7 @@ namespace BuildXL.Cache.BasicFilesystem
                     // Note that this can fail due to high-load-races so...
                     try
                     {
-                        Directory.CreateDirectory(Path.GetDirectoryName(path));
+                        FileUtilities.CreateDirectory(Path.GetDirectoryName(path));
                     }
 #pragma warning disable ERP022 // TODO: This should really handle specific errors
                     catch
@@ -851,7 +852,7 @@ namespace BuildXL.Cache.BasicFilesystem
                 // Make sure the CAS shared directory exists - if this fails, we fail to
                 // add to the CAS
                 string directory = Path.GetDirectoryName(path);
-                Directory.CreateDirectory(directory);
+                FileUtilities.CreateDirectory(directory);
 
                 // This name is a unique name for a given attempt at a CAS entry.
                 // We depend on uniqueness here to allow multiple uploads at the

--- a/Public/Src/Cache/VerticalStore/BasicFilesystem/BasicFilesystemCacheSession.cs
+++ b/Public/Src/Cache/VerticalStore/BasicFilesystem/BasicFilesystemCacheSession.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using BuildXL.Cache.ContentStore.Interfaces.Results;
 using BuildXL.Cache.ImplementationSupport;
 using BuildXL.Cache.Interfaces;
+using BuildXL.Native.IO;
 using BuildXL.Storage;
 using BuildXL.Utilities;
 
@@ -471,7 +472,7 @@ namespace BuildXL.Cache.BasicFilesystem
 
                     try
                     {
-                        Directory.CreateDirectory(Path.GetDirectoryName(filename));
+                        FileUtilities.CreateDirectory(Path.GetDirectoryName(filename));
                         await m_cache.CopyFromCasAsync(hash, filename);
                         counter.FileSize(new FileInfo(filename).Length);
                     }

--- a/Public/Src/Cache/VerticalStore/InMemory/MemCacheSession.cs
+++ b/Public/Src/Cache/VerticalStore/InMemory/MemCacheSession.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Threading.Tasks;
 using BuildXL.Cache.ContentStore.Hashing;
 using BuildXL.Cache.Interfaces;
+using BuildXL.Native.IO;
 using BuildXL.Storage;
 using BuildXL.Utilities;
 
@@ -284,7 +285,7 @@ namespace BuildXL.Cache.InMemory
 
             try
             {
-                Directory.CreateDirectory(Path.GetDirectoryName(filename));
+                FileUtilities.CreateDirectory(Path.GetDirectoryName(filename));
                 using (FileStream fs = new FileStream(filename, FileMode.CreateNew, FileAccess.Write))
                 {
                     await casStream.Result.CopyToAsync(fs);

--- a/Public/Src/Cache/VerticalStore/VerticalAggregator/BuildXL.Cache.VerticalAggregator.dsc
+++ b/Public/Src/Cache/VerticalStore/VerticalAggregator/BuildXL.Cache.VerticalAggregator.dsc
@@ -15,6 +15,7 @@ namespace VerticalAggregator {
             ImplementationSupport.dll,
             Interfaces.dll,
             importFrom("BuildXL.Utilities").dll,
+            importFrom("BuildXL.Utilities").Native.dll,
         ],
         internalsVisibleTo: [
             "bxlcacheanalyzer",

--- a/Public/Src/Cache/VerticalStore/VerticalAggregator/VerticalCacheAggregatorSession.cs
+++ b/Public/Src/Cache/VerticalStore/VerticalAggregator/VerticalCacheAggregatorSession.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Threading.Tasks;
 using BuildXL.Cache.ImplementationSupport;
 using BuildXL.Cache.Interfaces;
+using BuildXL.Native.IO;
 using BuildXL.Utilities;
 
 // ReSharper disable InconsistentNaming
@@ -1217,7 +1218,7 @@ namespace BuildXL.Cache.VerticalAggregator
                         // TODO: Remove this once the remote properly handles the directory's nonexistence
                         // NOTE: There are unit tests that validate this behavior but the VSTS cache does not
                         //       seem to run these tests.  Unclear why it does not run the normal ICache test suite
-                        Directory.CreateDirectory(Path.GetDirectoryName(filename));
+                        FileUtilities.CreateDirectory(Path.GetDirectoryName(filename));
 
                         // This is for the potential inconssistent hash recovery operation
                         bool secondTry = false;

--- a/Public/Src/Engine/Cache/Artifacts/InMemoryArtifactContentCache.cs
+++ b/Public/Src/Engine/Cache/Artifacts/InMemoryArtifactContentCache.cs
@@ -245,7 +245,7 @@ namespace BuildXL.Engine.Cache.Artifacts
                                 ExceptionUtilities.HandleRecoverableIOException(
                                     () =>
                                     {
-                                        Directory.CreateDirectory(Path.GetDirectoryName(expandedPath));
+                                        FileUtilities.CreateDirectory(Path.GetDirectoryName(expandedPath));
                                         File.WriteAllBytes(expandedPath, entry.Content);
                                     },
                                     ex => { throw new BuildXLException("Failed to materialize content (content found, but couldn't write it)", ex); });

--- a/Public/Src/Utilities/Native/IO/Windows/FileSystem.Win.cs
+++ b/Public/Src/Utilities/Native/IO/Windows/FileSystem.Win.cs
@@ -1747,7 +1747,7 @@ namespace BuildXL.Native.IO.Windows
 
             int rootLength = GetRootLength(directoryPath);
 
-            if (Directory.Exists(directoryPath))
+            if (Directory.Exists(ToLongPathIfExceedMaxPath(directoryPath)))
             {
                 // Short cut if directory exists
                 return;
@@ -1768,7 +1768,7 @@ namespace BuildXL.Native.IO.Windows
                 while (i >= rootLength && !parentPathExists)
                 {
                     string dir = directoryPath.Substring(0, i + 1);
-                    if (!Directory.Exists(dir))
+                    if (!Directory.Exists(ToLongPathIfExceedMaxPath(dir)))
                     {
                         stackDirs.Push(dir);
                     }


### PR DESCRIPTION
BuildXL's cache layer calls `Directory.CreateDirectory` to create directory without handling long paths. Fortunately, BuildXL's has `FileUtilitites.CreateDirectory` that, for most part, handles long paths. 

This change switch `Directory.CreateDirectory` to `FileUtilities.CreateDirectory`, as well as, fix directory existence check in `FileUtilities.CreateDirectory`.