### PR TITLE
Speed up loggen by adding a 'lite' version

### DIFF
--- a/Public/Src/App/Bxl/Bxl.dsc
+++ b/Public/Src/App/Bxl/Bxl.dsc
@@ -10,6 +10,7 @@ namespace Main {
     export const exe = BuildXLSdk.executable({
         assemblyName: "bxl",
         generateLogs: true,
+        generateLogsLite: false,
         assemblyInfo: {
             fileVersion: Branding.Managed.fileVersion,
         },

--- a/Public/Src/Engine/Cache/BuildXL.Cache.dsc
+++ b/Public/Src/Engine/Cache/BuildXL.Cache.dsc
@@ -14,6 +14,7 @@ namespace Cache {
     export const dll = BuildXLSdk.library({
         assemblyName: "BuildXL.Engine.Cache",
         generateLogs: true,
+        generateLogsLite: false,
         sources: [
             ...globR(d`.`, "*.cs"),
             openBondCacheDescriptorOutput.csharpResult.typesFile,

--- a/Public/Src/Engine/Dll/BuildXL.Engine.dsc
+++ b/Public/Src/Engine/Dll/BuildXL.Engine.dsc
@@ -16,6 +16,7 @@ namespace Engine {
     export const dll = BuildXLSdk.library({
         assemblyName: "BuildXL.Engine",
         generateLogs: true,
+        generateLogsLite: false,
         sources: [
             ...globR(d`.`, "*.cs"),
             ...addIfLazy(useMicrosoftInternalBond, () => [

--- a/Public/Src/Engine/Scheduler/BuildXL.Scheduler.dsc
+++ b/Public/Src/Engine/Scheduler/BuildXL.Scheduler.dsc
@@ -8,6 +8,7 @@ namespace Scheduler {
     export const dll = BuildXLSdk.library({
         assemblyName: "BuildXL.Scheduler",
         generateLogs: true,
+        generateLogsLite: false,
         sources: globR(d`.`, "*.cs"),
         references: [
             ...addIf(BuildXLSdk.isFullFramework,

--- a/Public/Src/FrontEnd/Script/BuildXL.FrontEnd.Script.dsc
+++ b/Public/Src/FrontEnd/Script/BuildXL.FrontEnd.Script.dsc
@@ -10,6 +10,7 @@ namespace Script {
         rootNamespace: "BuildXL.FrontEnd.Script",
         sources: globR(d`.`, "*.cs"),
         generateLogs: true,
+        generateLogsLite: false,
         // After switching to C# 7 features, the style cop fails on the legit cases.
         references: [
             ...addIfLazy(BuildXLSdk.isFullFramework, () => [

--- a/Public/Src/Tools/SandboxExec/SandboxExec.dsc
+++ b/Public/Src/Tools/SandboxExec/SandboxExec.dsc
@@ -11,9 +11,9 @@ namespace SandboxExec {
 
     @@public
     export const exe = BuildXLSdk.executable({
+        assemblyName: "SandboxExec",
         generateLogs: true,
         allowUnsafeBlocks: true,
-        assemblyName: "SandboxExec",
         sources: globR(d`.`, "*.cs"),
         references: [
             importFrom("BuildXL.Utilities").dll,

--- a/Public/Src/Tools/SandboxedProcessExecutor/SandboxedProcessExecutor.dsc
+++ b/Public/Src/Tools/SandboxedProcessExecutor/SandboxedProcessExecutor.dsc
@@ -11,10 +11,10 @@ namespace SandboxedProcessExecutor {
 
     @@public
     export const exe = BuildXLSdk.executable({
-        generateLogs: true,
-        allowUnsafeBlocks: true,
         assemblyName: "SandboxedProcessExecutor",
         rootNamespace: "BuildXL.SandboxedProcessExecutor",
+        generateLogs: true,
+        allowUnsafeBlocks: true,
         sources: globR(d`.`, "*.cs"),
         references: [
             importFrom("BuildXL.Utilities").dll,

--- a/Public/Src/Utilities/Instrumentation/LogGen/Parser.cs
+++ b/Public/Src/Utilities/Instrumentation/LogGen/Parser.cs
@@ -51,7 +51,9 @@ namespace BuildXL.LogGen
             // First create a compilation to act upon values and run codegen
             var syntaxTrees = new ConcurrentBag<SyntaxTree>();
 
-            CSharpParseOptions opts = new CSharpParseOptions(preprocessorSymbols: m_configuration.PreprocessorDefines.ToArray());
+            CSharpParseOptions opts = new CSharpParseOptions(
+                preprocessorSymbols: m_configuration.PreprocessorDefines.ToArray(),
+                languageVersion: LanguageVersion.Latest);
 
             Parallel.ForEach(
                 m_configuration.SourceFiles.Distinct(StringComparer.OrdinalIgnoreCase),
@@ -84,7 +86,11 @@ namespace BuildXL.LogGen
                 "temp",
                 syntaxTrees,
                 metadataFileReferences,
-                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+                new CSharpCompilationOptions(
+                    OutputKind.DynamicallyLinkedLibrary,
+                    deterministic: true
+                )
+            );
 
             // Hold on to all of the errors. Most are probably ok but some may be relating to event definitions and
             // should cause errors
@@ -98,6 +104,7 @@ namespace BuildXL.LogGen
 
                 if (d.Severity == DiagnosticSeverity.Error)
                 {
+                    Console.WriteLine(d.ToString());
                     errorsByFile.Add(d.Location.SourceTree.FilePath, d);
                 }
             }

--- a/Public/Src/Utilities/Instrumentation/Tracing/BuildXL.Tracing.dsc
+++ b/Public/Src/Utilities/Instrumentation/Tracing/BuildXL.Tracing.dsc
@@ -7,6 +7,7 @@ namespace Tracing {
     export const dll = BuildXLSdk.library({
         assemblyName: "BuildXL.Tracing",
         generateLogs: true,
+        generateLogsLite: false,
         sources: [
             ...globR(d`.`, "*.cs"),
             importFrom("BuildXL.Tracing.AriaTenantToken").Contents.all.getFile(r`AriaTenantToken.cs`),


### PR DESCRIPTION
When we use the 'lite' version this does two things:
a) Reduces the C# files that loggenerator has to parse to only files under the `Tracing` folder
b) Reduces the C# references to a fixed small set just needed by just log generation. This will get most loggens out of the critical path of our selfhost.