### PR TITLE
Make sure all accesses under shared opaques get reported

### DIFF
--- a/Public/Src/App/Bxl/Args.cs
+++ b/Public/Src/App/Bxl/Args.cs
@@ -1033,7 +1033,11 @@ namespace BuildXL
                                 }
                             },
                             isUnsafe: true),
-
+                        OptionHandlerFactory.CreateBoolOption(
+                            "unsafe_IgnoreUndeclaredAccessesUnderSharedOpaques",
+                            sign =>
+                            sandboxConfiguration.UnsafeSandboxConfigurationMutable.IgnoreUndeclaredAccessesUnderSharedOpaques = sign,
+                            isUnsafe: true),
                         // </ end unsafe options>
                          OptionHandlerFactory.CreateBoolOption(
                             "useCustomPipDescriptionOnConsole",

--- a/Public/Src/Engine/Dll/Engine.cs
+++ b/Public/Src/Engine/Dll/Engine.cs
@@ -2211,6 +2211,7 @@ namespace BuildXL.Engine
                 { "unsafe_PreserveOutputs", Logger.Log.ConfigPreserveOutputs },
                 { "unsafe_SourceFileCanBeInsideOutputDirectory", loggingContext => { } /* Special case: unsafe option we do not want logged */ },
                 { "unsafe_UnexpectedFileAccessesAreErrors", Logger.Log.ConfigUnsafeUnexpectedFileAccessesAsWarnings },
+                { "unsafe_IgnoreUndeclaredAccessesUnderSharedOpaques", Logger.Log.ConfigUnsafeIgnoreUndeclaredAccessesUnderSharedOpaques },
             };
         }
 

--- a/Public/Src/Engine/Dll/Tracing/Log.cs
+++ b/Public/Src/Engine/Dll/Tracing/Log.cs
@@ -1089,8 +1089,8 @@ namespace BuildXL.Engine.Tracing
             (ushort)EventId.ConfigUnsafeIgnoreUndeclaredAccessesUnderSharedOpaques,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Warning,
-            Keywords = (int)Events.Keywords.UserMessage,
-            EventTask = (int)Events.Tasks.Engine,
+            Keywords = (int)Keywords.UserMessage,
+            EventTask = (int)Tasks.Engine,
             Message = "/unsafe_IgnoreUndeclaredAccessesUnderSharedOpaques enabled: Undeclared accesses under shared opaques will not be reported. This is an unsafe configuration since it removes all guarantees of build correctness.")]
         public abstract void ConfigUnsafeIgnoreUndeclaredAccessesUnderSharedOpaques(LoggingContext context);
 

--- a/Public/Src/Engine/Dll/Tracing/Log.cs
+++ b/Public/Src/Engine/Dll/Tracing/Log.cs
@@ -1086,6 +1086,15 @@ namespace BuildXL.Engine.Tracing
         public abstract void ConfigUnsafeUnexpectedFileAccessesAsWarnings(LoggingContext context);
 
         [GeneratedEvent(
+            (ushort)EventId.ConfigUnsafeIgnoreUndeclaredAccessesUnderSharedOpaques,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Warning,
+            Keywords = (int)Events.Keywords.UserMessage,
+            EventTask = (int)Events.Tasks.Engine,
+            Message = "/unsafe_IgnoreUndeclaredAccessesUnderSharedOpaques enabled: Undeclared accesses under shared opaques will not be reported. This is an unsafe configuration since it removes all guarantees of build correctness.")]
+        public abstract void ConfigUnsafeIgnoreUndeclaredAccessesUnderSharedOpaques(LoggingContext context);
+
+        [GeneratedEvent(
             (ushort)EventId.ConfigUnsafeLazySymlinkCreation,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Warning,

--- a/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
@@ -2902,14 +2902,19 @@ namespace BuildXL.Processes
                             continue;
                         }
 
-                        // If the access occurred under any of the pip shared opaque outputs, and the access is not happening on any known input paths (neither dynamic nor static)
-                        // then we just skip reporting the access. Together with the above step, this means that no accesses under shared opaques that represent outputs are actually
-                        // reported as observed accesses. This matches the same behavior that occurs on static outputs.
-                        if (!allInputPathsUnderSharedOpaques.Contains(entry.Key) && IsAccessUnderASharedOpaque(firstAccess, dynamicWriteAccesses, out _))
+                        // The following two lines need to be removed in order to report file accesses for
+                        // undeclared files and sealed directories. But since this is a breaking change, we do
+                        // it under an unsafe flag.
+                        if (m_sandboxConfig.UnsafeSandboxConfiguration.IgnoreUndeclaredAccessesUnderSharedOpaques)
                         {
-                            continue;
+                            // If the access occurred under any of the pip shared opaque outputs, and the access is not happening on any known input paths (neither dynamic nor static)
+                            // then we just skip reporting the access. Together with the above step, this means that no accesses under shared opaques that represent outputs are actually
+                            // reported as observed accesses. This matches the same behavior that occurs on static outputs.
+                            if (!allInputPathsUnderSharedOpaques.Contains(entry.Key) && IsAccessUnderASharedOpaque(firstAccess, dynamicWriteAccesses, out _))
+                            {
+                                continue;
+                            }
                         }
-
                         ObservationFlags observationFlags = ObservationFlags.None;
 
                         if (isProbe)

--- a/Public/Src/Engine/Scheduler/Fingerprints/PipFingerprintingVersion.cs
+++ b/Public/Src/Engine/Scheduler/Fingerprints/PipFingerprintingVersion.cs
@@ -32,7 +32,8 @@ namespace BuildXL.Scheduler.Fingerprints
         /// 56: Added NeedsToRunInContainer, ContainerIsolationLevel and DoubleWritePolicy
         /// 57: Fixed enumeration in StoreContentForProcessAndCreateCacheEntryAsync
         /// 58: Added RequiresAdmin field into the process pip.
+        /// 59: Report all accesses under shared opaque fix
         /// </remarks>
-        TwoPhaseV2 = 58,
+        TwoPhaseV2 = 59,
     }
 }

--- a/Public/Src/Engine/UnitTests/Processes.Detours/SandboxedProcessPipExecutorTest.cs
+++ b/Public/Src/Engine/UnitTests/Processes.Detours/SandboxedProcessPipExecutorTest.cs
@@ -1027,9 +1027,8 @@ namespace Test.BuildXL.Processes.Detours
 
                 XAssert.AreEqual(SandboxedProcessPipExecutionStatus.Succeeded, result.Status);
 
-                // There should be a single reported file access: The attempt to read 'input/in.txt'. The accesses related to outputs (creating the nested output
-                // directory and writing the file) should not be reported here
-                ObservedFileAccess access = result.ObservedFileAccesses.Single();
+                // There should be a single reported file access that is not related to creating directories: The attempt to read 'input/in.txt'. The accesses related to writing the file should not be reported here.
+                ObservedFileAccess access = result.ObservedFileAccesses.Single(fa => !fa.Accesses.All(a => a.Operation == ReportedFileOperation.CreateDirectory));
                 XAssert.AreEqual(AbsolutePath.Create(context.PathTable, inputUndersharedOpaqueRoot), access.Path);
             }
         }

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SharedOpaqueDirectoryTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SharedOpaqueDirectoryTests.cs
@@ -32,7 +32,7 @@ namespace IntegrationTest.BuildXL.Scheduler
         public SharedOpaqueDirectoryTests(ITestOutputHelper output) : base(output)
         {
             // TODO: remove when the default changes
-            ((UnsafeSandboxConfiguration)(Configuration.Sandbox.UnsafeSandboxConfiguration)).IgnoreDynamicWritesOnAbsentProbes = false;
+            ((UnsafeSandboxConfiguration)(Configuration.Sandbox.UnsafeSandboxConfiguration)).IgnoreUndeclaredAccessesUnderSharedOpaques = false;
         }
 
         /// <summary>
@@ -281,6 +281,38 @@ namespace IntegrationTest.BuildXL.Scheduler
                                                    });
             builderD.AddInputDirectory(pipB.ProcessOutputs.GetOpaqueDirectory(sharedOpaqueDirPath));
             SchedulePipBuilder(builderD);
+
+            IgnoreWarnings();
+            RunScheduler().AssertFailure();
+
+            AssertVerboseEventLogged(EventId.PipProcessDisallowedFileAccess);
+            AssertErrorEventLogged(EventId.FileMonitoringError);
+        }
+
+        /// <summary>
+        /// Consumers which produce to a shared opaque can only read files in that opaque directory which were produced by its declared producers
+        /// </summary>
+        [Fact]
+        public void ConsumerProducersCanOnlyReadFromProducersInSharedOpaqueWithSameRoot()
+        {
+            var sharedOpaqueDir = Path.Combine(ObjectRoot, "sharedopaquedir");
+            AbsolutePath sharedOpaqueDirPath = AbsolutePath.Create(Context.PathTable, sharedOpaqueDir);
+
+            // PipA produces outputArtifactA in a shared opaque directory
+            FileArtifact outputArtifactA = CreateOutputFileArtifact(sharedOpaqueDir);
+            // Dummy output, just to force an order between pips and avoid races
+            FileArtifact dummyOutputA = CreateOutputFileArtifact();
+            var pipA = CreateAndScheduleSharedOpaqueProducer(sharedOpaqueDir, fileToProduceStatically: dummyOutputA, CreateSourceFile(), new KeyValuePair<FileArtifact, string>(outputArtifactA, null));
+
+            // PipB produces outputArtifactB in the same shared opaque directory root, but reads from A without
+            // declaring any dependency on it
+            FileArtifact outputArtifactB = CreateOutputFileArtifact(sharedOpaqueDir);
+            var pipB = CreateAndScheduleSharedOpaqueProducer(
+                sharedOpaqueDir,
+                fileToProduceStatically: FileArtifact.Invalid,
+                sourceFileToRead: CreateSourceFile(),
+                Operation.WriteFile(outputArtifactB),
+                Operation.ReadFile(outputArtifactA, doNotInfer: true));
 
             IgnoreWarnings();
             RunScheduler().AssertFailure();

--- a/Public/Src/FrontEnd/UnitTests/Ninja/ExecutionTests/NinjaIntegrationTests.cs
+++ b/Public/Src/FrontEnd/UnitTests/Ninja/ExecutionTests/NinjaIntegrationTests.cs
@@ -85,7 +85,7 @@ namespace Test.BuildXL.FrontEnd.Ninja
         [Fact]
         public void OrderOnlyDependenciesHonored()
         {
-            var config = BuildAndGetConfiguration(CreateProjectWithOrderOnlyDependencies("first.txt", "boo.txt", "second.txt"));
+            var config = BuildAndGetConfiguration(CreateProjectWithOrderOnlyDependencies("first.txt", "second.txt"));
             var engineResult = RunEngineWithConfig(config);
 
             Assert.True(engineResult.IsSuccess);
@@ -100,7 +100,7 @@ namespace Test.BuildXL.FrontEnd.Ninja
 
             // Make sure pips ran and did its job
             Assert.True(File.Exists(Path.Combine(SourceRoot, DefaultProjectRoot, "first.txt")));
-            Assert.True(File.Exists(Path.Combine(SourceRoot, DefaultProjectRoot, "boo.txt")));
+            Assert.True(File.Exists(Path.Combine(SourceRoot, DefaultProjectRoot, "second.txt")));
         }
 
 

--- a/Public/Src/FrontEnd/UnitTests/Ninja/Infrastructure/NinjaPipExecutionTestBase.cs
+++ b/Public/Src/FrontEnd/UnitTests/Ninja/Infrastructure/NinjaPipExecutionTestBase.cs
@@ -125,14 +125,14 @@ build all: phony {secondOutput}
             return new NinjaSpec(content, new[] { "all" });
         }
 
-        protected NinjaSpec CreateProjectWithOrderOnlyDependencies(string firstOutput, string undeclaredOutput, string secondOutput)
+        protected NinjaSpec CreateProjectWithOrderOnlyDependencies(string firstOutput, string secondOutput)
         {
             var content =
                 $@"rule ruleA
-    command = cmd /C ""echo hola > {firstOutput} && echo r > {undeclaredOutput}""
+    command = cmd /C ""echo hola > {firstOutput}""
 
 rule ruleB
-    command = cmd /C ""COPY {undeclaredOutput} $out""
+    command = cmd /C ""COPY {firstOutput} $out""
 
 build {firstOutput}: ruleA
 build {secondOutput} : ruleB || {firstOutput}

--- a/Public/Src/Utilities/Configuration/IUnsafeSandboxConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/IUnsafeSandboxConfiguration.cs
@@ -102,6 +102,14 @@ namespace BuildXL.Utilities.Configuration
         /// </remarks>
         DoubleWritePolicy? DoubleWritePolicy { get; }
 
+        /// <summary>
+        /// Undeclared accesses under a shared opaque are not reported.
+        /// </summary>
+        /// <remarks>
+        /// Temporary flag due to a bug in the sandboxed process pip executor to allow customers to snap to the fixed behavior
+        /// </remarks>
+        bool IgnoreUndeclaredAccessesUnderSharedOpaques { get; }
+
         // NOTE: if you add a property here, don't forget to update UnsafeSandboxConfigurationExtensions
 
         // NOTE: whenever unsafe options change, the fingerprint version needs to be bumped
@@ -148,6 +156,7 @@ namespace BuildXL.Utilities.Configuration
             {
                 writer.Write((byte)@this.DoubleWritePolicy.Value);
             }
+            writer.Write(@this.IgnoreUndeclaredAccessesUnderSharedOpaques);
         }
 
         /// <nodoc/>
@@ -171,6 +180,7 @@ namespace BuildXL.Utilities.Configuration
                 IgnorePreloadedDlls = reader.ReadBoolean(),
                 IgnoreDynamicWritesOnAbsentProbes = reader.ReadBoolean(),
                 DoubleWritePolicy = reader.ReadBoolean() ? (DoubleWritePolicy?)reader.ReadByte() : null,
+                IgnoreUndeclaredAccessesUnderSharedOpaques = reader.ReadBoolean(),
             };
         }
 
@@ -196,7 +206,8 @@ namespace BuildXL.Utilities.Configuration
                 // the pip in question. Because that requires pip specific details, that is determined in UnsafeOptions
                 && IsAsSafeOrSafer(lhs.IgnorePreloadedDlls, rhs.IgnorePreloadedDlls, SafeDefaults.IgnorePreloadedDlls)
                 && IsAsSafeOrSafer(lhs.IgnoreDynamicWritesOnAbsentProbes, rhs.IgnoreDynamicWritesOnAbsentProbes, SafeDefaults.IgnoreDynamicWritesOnAbsentProbes)
-                && IsAsSafeOrSafer(lhs.DoubleWritePolicy(), rhs.DoubleWritePolicy(), SafeDefaults.DoubleWritePolicy());
+                && IsAsSafeOrSafer(lhs.DoubleWritePolicy(), rhs.DoubleWritePolicy(), SafeDefaults.DoubleWritePolicy())
+                && IsAsSafeOrSafer(lhs.IgnoreUndeclaredAccessesUnderSharedOpaques, rhs.IgnoreUndeclaredAccessesUnderSharedOpaques, SafeDefaults.IgnoreUndeclaredAccessesUnderSharedOpaques);
         }
 
         private static bool IsAllowMissingOutputFileNamesSafer(IReadOnlyList<string> lhsValue, IReadOnlyList<string> rhsValue)

--- a/Public/Src/Utilities/Configuration/Mutable/UnsafeSandboxConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/UnsafeSandboxConfiguration.cs
@@ -26,6 +26,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             IgnoreGetFinalPathNameByHandle = false;
             MonitorZwCreateOpenQueryFile = true;
             IgnoreDynamicWritesOnAbsentProbes = false;
+            IgnoreUndeclaredAccessesUnderSharedOpaques = true;
             // Make sure to update SafeOptions below if necessary when new flags are added
         }
 
@@ -36,6 +37,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
         public static readonly IUnsafeSandboxConfiguration SafeOptions = new UnsafeSandboxConfiguration()
         {
             IgnorePreloadedDlls = false,
+            IgnoreUndeclaredAccessesUnderSharedOpaques = false,
         };
 
         /// <nodoc />
@@ -57,6 +59,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             IgnoreGetFinalPathNameByHandle = template.IgnoreGetFinalPathNameByHandle;
             IgnoreDynamicWritesOnAbsentProbes = template.IgnoreDynamicWritesOnAbsentProbes;
             DoubleWritePolicy = template.DoubleWritePolicy;
+            IgnoreUndeclaredAccessesUnderSharedOpaques = template.IgnoreUndeclaredAccessesUnderSharedOpaques;
         }
 
         /// <inheritdoc />
@@ -106,5 +109,8 @@ namespace BuildXL.Utilities.Configuration.Mutable
 
         /// <inheritdoc />
         public DoubleWritePolicy? DoubleWritePolicy { get; set; }
+
+        /// <inheritdoc />
+        public bool IgnoreUndeclaredAccessesUnderSharedOpaques { get; set; }
     }
 }

--- a/Public/Src/Utilities/Utilities/Tracing/EventId.cs
+++ b/Public/Src/Utilities/Utilities/Tracing/EventId.cs
@@ -568,6 +568,7 @@ namespace BuildXL.Utilities.Tracing
         ConfigUnsafeExistingDirectoryProbesAsEnumerations = 927,
         ConfigUnsafeAllowMissingOutput = 928,
         ConfigIgnoreValidateExistingFileAccessesForOutputs = 929,
+        ConfigUnsafeIgnoreUndeclaredAccessesUnderSharedOpaques = 930,
 
         // Elsewhere  = 932,
 


### PR DESCRIPTION
Not all accesses corresponding to inputs falling under the cone of a shared opaque were reported. Undeclared accesses and sealed directory accesses were skipped. This PR fixes that problem, but considering this is a breaking change, the fix takes place under an unsafe flag that is on by default.
The plan is to fix affected customers first and then swap the default (or even remove the flag)