### PR TITLE
Remove invalid assertion in FlushableCache

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/FlushableCache.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/FlushableCache.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Diagnostics.ContractsLight;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -51,9 +50,6 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                     // acquired. However, this isn't required by our code right now; although it is a simple change.
                     _cache = new ConcurrentBigMap<ShortHash, ContentLocationEntry>();
                 }
-
-                // There should be no flushes ongoing, or we wouldn't have acquired the lock.
-                Contract.Assert(_flushingCache.Count == 0);
             }
         }
 
@@ -112,8 +108,6 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
 
             using (_database.Counters[ContentLocationDatabaseCounters.CacheFlush].Start())
             {
-                Contract.Assert(_flushingCache.Count == 0);
-
                 using (_exchangeLock.AcquireWriteLock())
                 {
                     _flushingCache = _cache;

--- a/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/NuCache/ContentLocationDatabaseCacheTests.cs
+++ b/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/NuCache/ContentLocationDatabaseCacheTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BuildXL.Cache.ContentStore.Distributed.NuCache;
@@ -21,7 +22,7 @@ namespace ContentStoreTest.Distributed.ContentLocation.NuCache
     /// </summary>
     public class ContentLocationDatabaseCacheTests : TestWithOutput
     {
-        protected readonly MemoryClock _clock = new MemoryClock();
+        protected readonly MemoryClock Clock = new MemoryClock();
 
         /// <summary>
         /// Notice that a <see cref="MemoryContentLocationDatabaseConfiguration"/> is used. This is on purpose, to
@@ -35,167 +36,199 @@ namespace ContentStoreTest.Distributed.ContentLocation.NuCache
             CacheMaximumUpdatesPerFlush = -1
         };
 
-        protected readonly ContentLocationDatabase _database;
-
         public ContentLocationDatabaseCacheTests(ITestOutputHelper output)
             : base(output)
         {
-            _database = ContentLocationDatabase.Create(_clock, DefaultConfiguration, () => new MachineId[] { });
+            
         }
 
-        private async Task WithContext(Action<OperationContext> action)
+        private async Task RunTest(Action<OperationContext, ContentLocationDatabase> action) => await RunCustomTest(DefaultConfiguration, action);
+
+        private async Task RunCustomTest(ContentLocationDatabaseConfiguration configuration, Action<OperationContext, ContentLocationDatabase> action)
         {
             var tracingContext = new Context(TestGlobal.Logger);
             var operationContext = new OperationContext(tracingContext);
 
-            await _database.StartupAsync(operationContext).ShouldBeSuccess();
-            _database.SetDatabaseMode(isDatabaseWritable: true);
+            var database = ContentLocationDatabase.Create(Clock, configuration, () => new MachineId[] { });
+            await database.StartupAsync(operationContext).ShouldBeSuccess();
+            database.SetDatabaseMode(isDatabaseWritable: true);
 
-            action(operationContext);
+            action(operationContext, database);
 
-            await _database.ShutdownAsync(operationContext).ShouldBeSuccess();
+            await database.ShutdownAsync(operationContext).ShouldBeSuccess();
         }
 
         [Fact]
         public Task ReadMyWrites()
         {
-            return WithContext(context =>
+            return RunTest((context, database) =>
              {
                  var machine = new MachineId(1);
                  var hash = new ShortHash(ContentHash.Random());
 
-                 _database.LocationAdded(context, hash, machine, 200);
+                 database.LocationAdded(context, hash, machine, 200);
 
-                 _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(1);
-                 _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(0);
+                 database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(1);
+                 database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(0);
 
-                 _database.TryGetEntry(context, hash, out var entry).Should().BeTrue();
+                 database.TryGetEntry(context, hash, out var entry).Should().BeTrue();
                  entry.ContentSize.Should().Be(200);
                  entry.Locations.Count.Should().Be(1);
                  entry.Locations[machine].Should().BeTrue();
 
-                 _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(1);
-                 _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(1);
+                 database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(1);
+                 database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(1);
              });
         }
 
         [Fact]
         public Task ReadMyDeletes()
         {
-            return WithContext(context =>
+            return RunTest((context, database) =>
             {
                 var machine = new MachineId(1);
                 var hash = new ShortHash(ContentHash.Random());
 
-                _database.LocationAdded(context, hash, machine, 200);
+                database.LocationAdded(context, hash, machine, 200);
 
-                _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(1);
-                _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(0);
+                database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(1);
+                database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(0);
 
-                _database.LocationRemoved(context, hash, machine);
+                database.LocationRemoved(context, hash, machine);
 
-                _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(1);
-                _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(1);
+                database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(1);
+                database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(1);
 
-                _database.TryGetEntry(context, hash, out var entry).Should().BeFalse();
+                database.TryGetEntry(context, hash, out var entry).Should().BeFalse();
 
-                _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(1);
-                _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(2);
+                database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(1);
+                database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(2);
             });
         }
 
         [Fact]
         public Task SubsequentWrites()
         {
-            return WithContext(context =>
+            return RunTest((context, database) =>
             {
                 var machine = new MachineId(1);
                 var machine2 = new MachineId(2);
                 var hash = new ShortHash(ContentHash.Random());
 
-                _database.LocationAdded(context, hash, machine, 200);
-                _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(1);
-                _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(0);
+                database.LocationAdded(context, hash, machine, 200);
+                database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(1);
+                database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(0);
 
-                _database.LocationAdded(context, hash, machine2, 200);
-                _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(1);
-                _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(1);
+                database.LocationAdded(context, hash, machine2, 200);
+                database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(1);
+                database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(1);
 
-                _database.TryGetEntry(context, hash, out var entry).Should().BeTrue();
+                database.TryGetEntry(context, hash, out var entry).Should().BeTrue();
                 entry.ContentSize.Should().Be(200);
                 entry.Locations.Count.Should().Be(2);
                 entry.Locations[machine].Should().BeTrue();
                 entry.Locations[machine2].Should().BeTrue();
 
-                _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(1);
-                _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(2);
+                database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(1);
+                database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(2);
             });
         }
 
         [Fact]
         public Task SizeChangeOverwrites()
         {
-            return WithContext(context =>
+            return RunTest((context, database) =>
             {
                 var machine = new MachineId(1);
                 var machine2 = new MachineId(2);
                 var hash = new ShortHash(ContentHash.Random());
 
-                _database.LocationAdded(context, hash, machine, 200);
-                _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(1);
-                _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(0);
+                database.LocationAdded(context, hash, machine, 200);
+                database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(1);
+                database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(0);
 
-                _database.LocationAdded(context, hash, machine2, 400);
-                _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(1);
-                _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(1);
+                database.LocationAdded(context, hash, machine2, 400);
+                database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(1);
+                database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(1);
 
-                _database.TryGetEntry(context, hash, out var entry).Should().BeTrue();
+                database.TryGetEntry(context, hash, out var entry).Should().BeTrue();
                 entry.ContentSize.Should().Be(400);
                 entry.Locations.Count.Should().Be(2);
                 entry.Locations[machine].Should().BeTrue();
                 entry.Locations[machine2].Should().BeTrue();
 
-                _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(1);
-                _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(2);
+                database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(1);
+                database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(2);
             });
         }
 
         [Fact]
         public Task DeleteUnknownDoesNotFailOrModify()
         {
-            return WithContext(context =>
+            return RunTest((context, database) =>
             {
                 var machine = new MachineId(1);
                 var hash = new ShortHash(ContentHash.Random());
 
-                _database.LocationRemoved(context, hash, machine);
-                _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(1);
-                _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(0);
+                database.LocationRemoved(context, hash, machine);
+                database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(1);
+                database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(0);
 
-                _database.TryGetEntry(context, hash, out var entry).Should().BeFalse();
-                _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(2);
-                _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(0);
+                database.TryGetEntry(context, hash, out var entry).Should().BeFalse();
+                database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(2);
+                database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(0);
             });
         }
 
         [Fact]
         public Task FlushSyncsToStorage()
         {
-            return WithContext(context =>
+            return RunTest((context, database) =>
             {
                 var machine = new MachineId(1);
                 var hash = new ShortHash(ContentHash.Random());
 
-                _database.LocationAdded(context, hash, machine, 200);
-                _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(1);
-                _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(0);
+                database.LocationAdded(context, hash, machine, 200);
+                database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(1);
+                database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(0);
 
-                _database.ForceCacheFlush(context);
-                _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheFlushes].Value.Should().Be(1);
+                database.ForceCacheFlush(context);
+                database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheFlushes].Value.Should().Be(1);
 
-                _database.TryGetEntry(context, hash, out var entry).Should().BeTrue();
-                _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(2);
-                _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(0);
+                database.TryGetEntry(context, hash, out var entry).Should().BeTrue();
+                database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheMiss].Value.Should().Be(2);
+                database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheHit].Value.Should().Be(0);
+            });
+        }
+
+        [Fact]
+        public Task PartialFlushingWorks()
+        {
+            ContentLocationDatabaseConfiguration configuration = new MemoryContentLocationDatabaseConfiguration
+            {
+                CacheEnabled = true,
+                // These ensure no flushing happens unless explicitly directed
+                CacheFlushingMaximumInterval = Timeout.InfiniteTimeSpan,
+                CacheMaximumUpdatesPerFlush = -1,
+                FlushPreservePercentInMemory = 0.5,
+            };
+
+            return RunCustomTest(configuration, (context, database) =>
+            {
+                // Setup small test DB
+                foreach (var _ in Enumerable.Range(0, 100))
+                {
+                    database.LocationAdded(context, new ShortHash(ContentHash.Random()), new MachineId(1), 200);
+                }
+
+                database.ForceCacheFlush(context);
+                database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheFlushes].Value.Should().Be(1);
+                database.Counters[ContentLocationDatabaseCounters.NumberOfPersistedEntries].Value.Should().Be(100);
+
+                // The second flush will discard the flushing cache, and we haven't added anything in-between
+                database.ForceCacheFlush(context);
+                database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheFlushes].Value.Should().Be(2);
+                database.Counters[ContentLocationDatabaseCounters.NumberOfPersistedEntries].Value.Should().Be(100);
             });
         }
     }


### PR DESCRIPTION
When running a partial flush, the flushing cache may have leftover entries from the previous flush. This is correct behavior, but not part of the original design.

Since partial flushes were added later, and although I removed these assertions locally when using it, I forgot to add it to the original PR. Adding it here along with a test to ensure it doesn't happen again.