### PR TITLE
Substitute process shim NRE fix and logging

### DIFF
--- a/Public/Src/Engine/Processes/SandboxedProcessInfo.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessInfo.cs
@@ -226,7 +226,7 @@ namespace BuildXL.Processes
         public IBuildParameters EnvironmentVariables { get; set; }
 
         /// <summary>
-        /// Environment variables (can be null)
+        /// Root drive remappings (can be null)
         /// </summary>
         public IReadOnlyDictionary<string, string> RootMappings { get; set; }
 

--- a/Public/Src/Pips/Dll/Builders/ProcessBuilder.cs
+++ b/Public/Src/Pips/Dll/Builders/ProcessBuilder.cs
@@ -447,7 +447,6 @@ namespace BuildXL.Pips.Builders
             m_environmentVariables[key] = PipData.Invalid;
         }
 
-
         /// <summary>
         /// Set GlobalUnsafePassthroughEnvironmentVariables for each pip.
         /// The passthrough environment varibles will not be computed in pip fingerprint.

--- a/Public/Src/Sandbox/Windows/DetoursServices/DetouredFunctions.cpp
+++ b/Public/Src/Sandbox/Windows/DetoursServices/DetouredFunctions.cpp
@@ -1794,6 +1794,7 @@ BOOL WINAPI Detoured_CreateProcessW(
 {
     bool injectedShim = false;
     BOOL ret = MaybeInjectSubstituteProcessShim(
+        lpApplicationName,
         lpCommandLine,
         lpProcessAttributes,
         lpThreadAttributes,
@@ -1806,6 +1807,7 @@ BOOL WINAPI Detoured_CreateProcessW(
         injectedShim);
     if (injectedShim)
     {
+        Dbg(L"Injected shim for lpCommandLine='%s', returning 0x%08X from CreateProcessW", lpCommandLine, ret);
         return ret;
     }
 

--- a/Public/Src/Sandbox/Windows/DetoursServices/SubstituteProcessExecution.cpp
+++ b/Public/Src/Sandbox/Windows/DetoursServices/SubstituteProcessExecution.cpp
@@ -260,7 +260,7 @@ BOOL WINAPI MaybeInjectSubstituteProcessShim(
         wstring command;
         wstring commandArgs;
         FindApplicationNameFromCommandLine(cmdLine, command, commandArgs);
-        Dbg(L"Shim: Found command='%s', args='%s' from lpApplicationName='%s', lpCommandLine='%s'", command.c_str(), commandArgs.c_str(), lpCommandLine);
+        Dbg(L"Shim: Found command='%s', args='%s' from lpApplicationName='%s', lpCommandLine='%s'", command.c_str(), commandArgs.c_str(), lpApplicationName, lpCommandLine);
 
         if (ShouldSubstituteShim(command, commandArgs.c_str()))
         {

--- a/Public/Src/Sandbox/Windows/DetoursServices/SubstituteProcessExecution.cpp
+++ b/Public/Src/Sandbox/Windows/DetoursServices/SubstituteProcessExecution.cpp
@@ -238,6 +238,7 @@ static bool ShouldSubstituteShim(const wstring &command, const wchar_t *commandA
 }
 
 BOOL WINAPI MaybeInjectSubstituteProcessShim(
+    _In_opt_    LPCWSTR               lpApplicationName,
     _In_opt_    LPCWSTR               lpCommandLine,
     _In_opt_    LPSECURITY_ATTRIBUTES lpProcessAttributes,
     _In_opt_    LPSECURITY_ATTRIBUTES lpThreadAttributes,
@@ -251,12 +252,15 @@ BOOL WINAPI MaybeInjectSubstituteProcessShim(
 {
     if (g_substituteProcessExecutionShimPath != nullptr)
     {
-        // lpCommandLine contains the command, possibly with quotes containing spaces,
-        // as the first whitespace-delimited token. We can ignore lpApplicationName
-        // and just always parse that command line. 
+        // when lpCommandLine is null we just use lpApplicationName as the command line to parse.
+        // When lpCommandLine is not null, it contains the command, possibly with quotes containing spaces,
+        // as the first whitespace-delimited token; we can ignore lpApplicationName in this case.
+        Dbg(L"Shim: Finding command and args from lpApplicationName='%s', lpCommandLine='%s'", lpApplicationName, lpCommandLine);
+        LPCWSTR cmdLine = lpCommandLine == nullptr ? lpApplicationName : lpCommandLine;
         wstring command;
         wstring commandArgs;
-        FindApplicationNameFromCommandLine(lpCommandLine, command, commandArgs);
+        FindApplicationNameFromCommandLine(cmdLine, command, commandArgs);
+        Dbg(L"Shim: Found command='%s', args='%s' from lpApplicationName='%s', lpCommandLine='%s'", command.c_str(), commandArgs.c_str(), lpCommandLine);
 
         if (ShouldSubstituteShim(command, commandArgs.c_str()))
         {

--- a/Public/Src/Sandbox/Windows/DetoursServices/SubstituteProcessExecution.cpp
+++ b/Public/Src/Sandbox/Windows/DetoursServices/SubstituteProcessExecution.cpp
@@ -250,9 +250,9 @@ BOOL WINAPI MaybeInjectSubstituteProcessShim(
     _Out_       LPPROCESS_INFORMATION lpProcessInformation,
     _Out_       bool&                 injectedShim)
 {
-    if (g_substituteProcessExecutionShimPath != nullptr)
+    if (g_substituteProcessExecutionShimPath != nullptr && (lpCommandLine != nullptr || lpApplicationName != nullptr))
     {
-        // when lpCommandLine is null we just use lpApplicationName as the command line to parse.
+        // When lpCommandLine is null we just use lpApplicationName as the command line to parse.
         // When lpCommandLine is not null, it contains the command, possibly with quotes containing spaces,
         // as the first whitespace-delimited token; we can ignore lpApplicationName in this case.
         Dbg(L"Shim: Finding command and args from lpApplicationName='%s', lpCommandLine='%s'", lpApplicationName, lpCommandLine);

--- a/Public/Src/Sandbox/Windows/DetoursServices/SubstituteProcessExecution.h
+++ b/Public/Src/Sandbox/Windows/DetoursServices/SubstituteProcessExecution.h
@@ -7,6 +7,7 @@
 /// if this child process matches requirements. Returns true in injectedShim if the
 /// substitution was performed and the caller should avoid running the real child process.
 BOOL WINAPI MaybeInjectSubstituteProcessShim(
+    _In_opt_    LPCWSTR               lpApplicationName,
     _In_opt_    LPCWSTR               lpCommandLine,
     _In_opt_    LPSECURITY_ATTRIBUTES lpProcessAttributes,
     _In_opt_    LPSECURITY_ATTRIBUTES lpThreadAttributes,


### PR DESCRIPTION
Fix issue with null lpCommandLine (use lpApplicationName instead), and add debug tracing