### PR TITLE
Allow absolute path and frontend to accept paths beyond root drive

### DIFF
--- a/Public/Src/FrontEnd/Script/RuntimeModel/AstBridge/LiteralConverter.cs
+++ b/Public/Src/FrontEnd/Script/RuntimeModel/AstBridge/LiteralConverter.cs
@@ -227,13 +227,16 @@ namespace BuildXL.FrontEnd.Script.RuntimeModel.AstBridge
         {
             // parent folder count is a number of ../ expression in the original path literal
             var folder = currentFolder;
+            // If we go beyond the root directory, stay at the root directory. Ie C:/AAA/BBB/../../../../.. should be C:/
+            var tempFolder = currentFolder;
             for (int i = 0; i < parentFolderCount; i++)
             {
-                folder = folder.GetParent(Context.PathTable);
-                if (!folder.IsValid)
+                tempFolder = tempFolder.GetParent(Context.PathTable);
+                if (!tempFolder.IsValid)
                 {
                     break;
                 }
+                folder = tempFolder;
             }
 
             if (!folder.IsValid)

--- a/Public/Src/FrontEnd/Script/RuntimeModel/AstBridge/LiteralConverter.cs
+++ b/Public/Src/FrontEnd/Script/RuntimeModel/AstBridge/LiteralConverter.cs
@@ -226,22 +226,23 @@ namespace BuildXL.FrontEnd.Script.RuntimeModel.AstBridge
         private AbsolutePath ComputeAbsolutePath(AbsolutePath currentFolder, RelativePath relativePath, int parentFolderCount)
         {
             // parent folder count is a number of ../ expression in the original path literal
+            if (!currentFolder.IsValid)
+            {
+                return AbsolutePath.Invalid;
+            }
+
             var folder = currentFolder;
-            // If we go beyond the root directory, stay at the root directory. Ie C:/AAA/BBB/../../../../.. should be C:/
-            var tempFolder = currentFolder;
+
             for (int i = 0; i < parentFolderCount; i++)
             {
-                tempFolder = tempFolder.GetParent(Context.PathTable);
+                var tempFolder = folder.GetParent(Context.PathTable);
+                // If we go beyond the root directory (tempFolder will be invalid), stay at the root directory. 
+                // Ie. C:/AAA/BBB/../../../../.. should be C:/
                 if (!tempFolder.IsValid)
                 {
                     break;
                 }
                 folder = tempFolder;
-            }
-
-            if (!folder.IsValid)
-            {
-                return AbsolutePath.Invalid;
             }
 
             return folder.Combine(Context.PathTable, relativePath);

--- a/Public/Src/Utilities/UnitTests/Utilities/AbsolutePathTests.cs
+++ b/Public/Src/Utilities/UnitTests/Utilities/AbsolutePathTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Security.Cryptography;
 using BuildXL.Utilities;
 using Test.BuildXL.TestUtilities.Xunit;
 using Xunit.Abstractions;
@@ -33,12 +34,14 @@ namespace Test.BuildXL.Utilities
             AbsolutePath p;
             XAssert.IsTrue(AbsolutePath.TryCreate(pt, @"C:\AAA\CCC", out p));
             XAssert.AreEqual(@"C:\AAA\CCC", p.ToString(pt));
+            XAssert.IsTrue(AbsolutePath.TryCreate(pt, @"C:\..", out p));
+            XAssert.AreEqual(@"C:\", p.ToString(pt));
+            XAssert.IsTrue(AbsolutePath.TryCreate(pt, @"C:\..\..\..\..", out p));
+            XAssert.AreEqual(@"C:\", p.ToString(pt));
 
             XAssert.IsFalse(AbsolutePath.TryCreate(pt, @"C\::AAA", out p));
             XAssert.IsFalse(AbsolutePath.TryCreate(pt, @"AAA:", out p));
             XAssert.IsFalse(AbsolutePath.TryCreate(pt, @":AAA", out p));
-            XAssert.IsFalse(AbsolutePath.TryCreate(pt, @"C:\..", out p));
-            XAssert.IsFalse(AbsolutePath.TryCreate(pt, @"C:\..\..", out p));
             XAssert.IsFalse(AbsolutePath.TryCreate(pt, @"..", out p));
             XAssert.IsFalse(AbsolutePath.TryCreate(pt, @".", out p));
             XAssert.IsFalse(AbsolutePath.TryCreate(pt, @"C:\:", out p));
@@ -94,7 +97,7 @@ namespace Test.BuildXL.Utilities
 
         [FactIfSupported(requiresWindowsBasedOperatingSystem: true)]
         public void TryCreateWithDeviceOrNtPrefix()
-        {
+        {            
             var pt = new PathTable();
             AbsolutePath p;
             XAssert.IsTrue(AbsolutePath.TryCreate(pt, @"\\?\C:\AAA\CCC", out p));

--- a/Public/Src/Utilities/UnitTests/Utilities/AbsolutePathTests.cs
+++ b/Public/Src/Utilities/UnitTests/Utilities/AbsolutePathTests.cs
@@ -38,6 +38,11 @@ namespace Test.BuildXL.Utilities
             XAssert.AreEqual(@"C:\", p.ToString(pt));
             XAssert.IsTrue(AbsolutePath.TryCreate(pt, @"C:\..\..\..\..", out p));
             XAssert.AreEqual(@"C:\", p.ToString(pt));
+            XAssert.IsTrue(AbsolutePath.TryCreate(pt, @"C:\a\..\b.txt", out p));
+            XAssert.AreEqual(@"C:\b.txt", p.ToString(pt));
+            XAssert.IsTrue(AbsolutePath.TryCreate(pt, @"C:\a\..\..\..\..\b.txt", out p));
+            XAssert.AreEqual(@"C:\b.txt", p.ToString(pt));
+
 
             XAssert.IsFalse(AbsolutePath.TryCreate(pt, @"C\::AAA", out p));
             XAssert.IsFalse(AbsolutePath.TryCreate(pt, @"AAA:", out p));

--- a/Public/Src/Utilities/UnitTests/Utilities/AbsolutePathTestsUnix.cs
+++ b/Public/Src/Utilities/UnitTests/Utilities/AbsolutePathTestsUnix.cs
@@ -41,6 +41,11 @@ namespace Test.BuildXL.Utilities
             XAssert.AreEqual(@"/", p.ToString(pt));
             XAssert.IsTrue(AbsolutePath.TryCreate(pt, @"/usr/etc/aaa/../../../../../../", out p));
             XAssert.AreEqual(@"/", p.ToString(pt));
+            XAssert.IsTrue(AbsolutePath.TryCreate(pt, @"/usr/a/../b.txt", out p));
+            XAssert.AreEqual(@"/usr/b.txt", p.ToString(pt));
+            XAssert.IsTrue(AbsolutePath.TryCreate(pt, @"/usr/a/../../../../b.txt", out p));
+            XAssert.AreEqual(@"/b.txt", p.ToString(pt));
+
             XAssert.IsFalse(AbsolutePath.TryCreate(pt, @"..", out p));
             XAssert.IsFalse(AbsolutePath.TryCreate(pt, @".", out p));
             XAssert.IsFalse(AbsolutePath.TryCreate(pt, @"\", out p));

--- a/Public/Src/Utilities/UnitTests/Utilities/AbsolutePathTestsUnix.cs
+++ b/Public/Src/Utilities/UnitTests/Utilities/AbsolutePathTestsUnix.cs
@@ -34,8 +34,13 @@ namespace Test.BuildXL.Utilities
             XAssert.IsTrue(AbsolutePath.TryCreate(pt, @"/usr/local", out p));
             XAssert.AreEqual(@"/usr/local", p.ToString(pt));
 
-            XAssert.IsFalse(AbsolutePath.TryCreate(pt, @"/..", out p));
-            XAssert.IsFalse(AbsolutePath.TryCreate(pt, @"/../..", out p));
+
+            XAssert.IsTrue(AbsolutePath.TryCreate(pt, @"/..", out p));
+            XAssert.AreEqual(@"/", p.ToString(pt));
+            XAssert.IsTrue(AbsolutePath.TryCreate(pt, @"/../..", out p));
+            XAssert.AreEqual(@"/", p.ToString(pt));
+            XAssert.IsTrue(AbsolutePath.TryCreate(pt, @"/usr/etc/aaa/../../../../../../", out p));
+            XAssert.AreEqual(@"/", p.ToString(pt));
             XAssert.IsFalse(AbsolutePath.TryCreate(pt, @"..", out p));
             XAssert.IsFalse(AbsolutePath.TryCreate(pt, @".", out p));
             XAssert.IsFalse(AbsolutePath.TryCreate(pt, @"\", out p));

--- a/Public/Src/Utilities/UnitTests/Utilities/RelativePathTests.cs
+++ b/Public/Src/Utilities/UnitTests/Utilities/RelativePathTests.cs
@@ -40,10 +40,10 @@ namespace Test.BuildXL.Utilities
             XAssert.IsTrue(RelativePath.TryCreate(st, @"AAA\CCC", out p));
             XAssert.AreEqual(@"AAA\CCC", p.ToString(st));
 
-            XAssert.IsFalse(RelativePath.TryCreate(st, @"..", out p));
             XAssert.IsFalse(RelativePath.TryCreate(st, @"C\:AAA", out p));
             XAssert.IsFalse(RelativePath.TryCreate(st, @"AAA:", out p));
             XAssert.IsFalse(RelativePath.TryCreate(st, @":AAA", out p));
+            XAssert.IsFalse(RelativePath.TryCreate(st, @"..", out p));
 
             p = RelativePath.Create(st, ".");
             XAssert.AreEqual(string.Empty, p.ToString(st));

--- a/Public/Src/Utilities/UnitTests/Utilities/RelativePathTests.cs
+++ b/Public/Src/Utilities/UnitTests/Utilities/RelativePathTests.cs
@@ -40,10 +40,10 @@ namespace Test.BuildXL.Utilities
             XAssert.IsTrue(RelativePath.TryCreate(st, @"AAA\CCC", out p));
             XAssert.AreEqual(@"AAA\CCC", p.ToString(st));
 
+            XAssert.IsFalse(RelativePath.TryCreate(st, @"..", out p));
             XAssert.IsFalse(RelativePath.TryCreate(st, @"C\:AAA", out p));
             XAssert.IsFalse(RelativePath.TryCreate(st, @"AAA:", out p));
             XAssert.IsFalse(RelativePath.TryCreate(st, @":AAA", out p));
-            XAssert.IsFalse(RelativePath.TryCreate(st, @"..", out p));
 
             p = RelativePath.Create(st, ".");
             XAssert.AreEqual(string.Empty, p.ToString(st));

--- a/Public/Src/Utilities/Utilities/AbsolutePath.cs
+++ b/Public/Src/Utilities/Utilities/AbsolutePath.cs
@@ -190,12 +190,12 @@ namespace BuildXL.Utilities
             {
                 // Here we handle classic absolute paths like C:\foo.txt, or a prefixed one like \\?\C:\foo.txt after \\?\ has been skipped (skipped > 0)
                 // N.B. We intentionally do not allow C:dir. That actually means C: + (current working directory on C:) + dir, which is in fact an exotic *relative* path.
-                RelativePath.ParseResult parseResult = RelativePath.TryCreate(
+                RelativePath.ParseResult parseResult = RelativePath.TryCreateInternal(
                     table.StringTable,
                     CharSpan.Skip(absolutePath, OperatingSystemHelper.IsUnixOS ? prefixLength : 3),
                     out RelativePath relPath,
                     out characterWithError,
-                    fromAbsolutePath: true);
+                    allowDotDotOutOfScope: true);
                 if (parseResult == RelativePath.ParseResult.Success)
                 {
                     components = new StringId[1 + relPath.Components.Length];
@@ -223,7 +223,7 @@ namespace BuildXL.Utilities
             if (pathType == AbsolutePathType.UNC)
             {
                 // here we handle UNC paths like \\srv\share\foo.txt
-                RelativePath.ParseResult parseResult = RelativePath.TryCreate(table.StringTable, CharSpan.Skip(absolutePath, 2), out RelativePath relPath, out characterWithError, fromAbsolutePath: true);
+                RelativePath.ParseResult parseResult = RelativePath.TryCreateInternal(table.StringTable, CharSpan.Skip(absolutePath, 2), out RelativePath relPath, out characterWithError, allowDotDotOutOfScope: true);
                 if (parseResult == RelativePath.ParseResult.Success)
                 {
                     if (relPath.IsEmpty)
@@ -454,7 +454,7 @@ namespace BuildXL.Utilities
             }
             else
             {
-                RelativePath.ParseResult parseRes = RelativePath.TryCreate(table.StringTable, relativeOrAbsolutePath, out RelativePath relPath, out _);
+                RelativePath.ParseResult parseRes = RelativePath.TryCreateInternal(table.StringTable, relativeOrAbsolutePath, out RelativePath relPath, out _);
                 Contract.Assert(parseRes == RelativePath.ParseResult.Success);
 
                 return AddPathComponents(table, this, relPath.Components);

--- a/Public/Src/Utilities/Utilities/AbsolutePath.cs
+++ b/Public/Src/Utilities/Utilities/AbsolutePath.cs
@@ -194,7 +194,8 @@ namespace BuildXL.Utilities
                     table.StringTable,
                     CharSpan.Skip(absolutePath, OperatingSystemHelper.IsUnixOS ? prefixLength : 3),
                     out RelativePath relPath,
-                    out characterWithError);
+                    out characterWithError,
+                    isAbsolute: true);
                 if (parseResult == RelativePath.ParseResult.Success)
                 {
                     components = new StringId[1 + relPath.Components.Length];
@@ -222,7 +223,7 @@ namespace BuildXL.Utilities
             if (pathType == AbsolutePathType.UNC)
             {
                 // here we handle UNC paths like \\srv\share\foo.txt
-                RelativePath.ParseResult parseResult = RelativePath.TryCreate(table.StringTable, CharSpan.Skip(absolutePath, 2), out RelativePath relPath, out characterWithError);
+                RelativePath.ParseResult parseResult = RelativePath.TryCreate(table.StringTable, CharSpan.Skip(absolutePath, 2), out RelativePath relPath, out characterWithError, isAbsolute: true);
                 if (parseResult == RelativePath.ParseResult.Success)
                 {
                     if (relPath.IsEmpty)

--- a/Public/Src/Utilities/Utilities/AbsolutePath.cs
+++ b/Public/Src/Utilities/Utilities/AbsolutePath.cs
@@ -195,7 +195,7 @@ namespace BuildXL.Utilities
                     CharSpan.Skip(absolutePath, OperatingSystemHelper.IsUnixOS ? prefixLength : 3),
                     out RelativePath relPath,
                     out characterWithError,
-                    isAbsolute: true);
+                    fromAbsolutePath: true);
                 if (parseResult == RelativePath.ParseResult.Success)
                 {
                     components = new StringId[1 + relPath.Components.Length];
@@ -223,7 +223,7 @@ namespace BuildXL.Utilities
             if (pathType == AbsolutePathType.UNC)
             {
                 // here we handle UNC paths like \\srv\share\foo.txt
-                RelativePath.ParseResult parseResult = RelativePath.TryCreate(table.StringTable, CharSpan.Skip(absolutePath, 2), out RelativePath relPath, out characterWithError, isAbsolute: true);
+                RelativePath.ParseResult parseResult = RelativePath.TryCreate(table.StringTable, CharSpan.Skip(absolutePath, 2), out RelativePath relPath, out characterWithError, fromAbsolutePath: true);
                 if (parseResult == RelativePath.ParseResult.Success)
                 {
                     if (relPath.IsEmpty)

--- a/Public/Src/Utilities/Utilities/RelativePath.cs
+++ b/Public/Src/Utilities/Utilities/RelativePath.cs
@@ -95,8 +95,13 @@ namespace BuildXL.Utilities
         /// <summary>
         /// Try to create a RelativePath from a string.
         /// </summary>
+        /// <param name="table">StringTable instance</param>
+        /// <param name="relativePath">Relative path to pass in</param>
+        /// <param name="result">Output relative path after parsing</param>
+        /// <param name="characterWithError">Output the character that had the error</param>
+        /// <param name="fromAbsolutePath">Boolean if this function was called from AbsolutePath.cs. Defaults to false</param>
         /// <returns>Return the parser result indicating success, or what was wrong with the parsing.</returns>
-        public static ParseResult TryCreate<T>(StringTable table, T relativePath, out RelativePath result, out int characterWithError, bool isAbsolute = false)
+        public static ParseResult TryCreate<T>(StringTable table, T relativePath, out RelativePath result, out int characterWithError, bool fromAbsolutePath = false)
             where T : struct, ICharSpan<T>
         {
             Contract.Requires(table != null);
@@ -169,7 +174,7 @@ namespace BuildXL.Utilities
                                 || (relativePath[index + 2] == '/'))
                             {
                                 // component is a sole .. so try to go up
-                                if (components.Count == 0 && !isAbsolute)
+                                if (components.Count == 0 && !fromAbsolutePath)
                                 {
                                     characterWithError = index;
                                     result = Invalid;

--- a/Public/Src/Utilities/Utilities/RelativePath.cs
+++ b/Public/Src/Utilities/Utilities/RelativePath.cs
@@ -96,7 +96,7 @@ namespace BuildXL.Utilities
         /// Try to create a RelativePath from a string.
         /// </summary>
         /// <returns>Return the parser result indicating success, or what was wrong with the parsing.</returns>
-        public static ParseResult TryCreate<T>(StringTable table, T relativePath, out RelativePath result, out int characterWithError)
+        public static ParseResult TryCreate<T>(StringTable table, T relativePath, out RelativePath result, out int characterWithError, bool isAbsolute = false)
             where T : struct, ICharSpan<T>
         {
             Contract.Requires(table != null);
@@ -169,14 +169,17 @@ namespace BuildXL.Utilities
                                 || (relativePath[index + 2] == '/'))
                             {
                                 // component is a sole .. so try to go up
-                                if (components.Count == 0)
+                                if (components.Count == 0 && !isAbsolute)
                                 {
                                     characterWithError = index;
                                     result = Invalid;
                                     return ParseResult.FailureDueToDotDotOutOfScope;
                                 }
 
-                                components.RemoveAt(components.Count - 1);
+                                if (components.Count != 0)
+                                {
+                                    components.RemoveAt(components.Count - 1);
+                                }
 
                                 index += 3;
                                 start = index;

--- a/Public/Src/Utilities/Utilities/RelativePath.cs
+++ b/Public/Src/Utilities/Utilities/RelativePath.cs
@@ -95,11 +95,7 @@ namespace BuildXL.Utilities
         /// <summary>
         /// Try to create a RelativePath from a string.
         /// </summary>
-        /// <param name="table">StringTable instance</param>
-        /// <param name="relativePath">Relative path to pass in</param>
-        /// <param name="result">Output relative path after parsing</param>
-        /// <param name="characterWithError">Output the character that had the error</param>
-        /// <param name="fromAbsolutePath">Boolean if this function was called from AbsolutePath.cs. Defaults to false</param>
+        /// <param name="fromAbsolutePath">Whether this function was called from AbsolutePath.</param>
         /// <returns>Return the parser result indicating success, or what was wrong with the parsing.</returns>
         public static ParseResult TryCreate<T>(StringTable table, T relativePath, out RelativePath result, out int characterWithError, bool fromAbsolutePath = false)
             where T : struct, ICharSpan<T>


### PR DESCRIPTION
[AB#1557991](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1557991) 

Allow the absolute paths for windows/unix to go past the root (ie C:/aaa/bbb/../../../../ should resolve to C:/). This is particularly useful for any Domino auto-generated paths during the build phase. 

Furthermore, if the frontend passes in any paths that go beyond the root, we no longer throw a path invalid error, and merely return the root directory. 