### PR TITLE
Fix flaky test ConsumerProducersCanOnlyReadFromProducersInSharedOpaqueWithSameRoot

### DIFF
--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SharedOpaqueDirectoryTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SharedOpaqueDirectoryTests.cs
@@ -310,7 +310,7 @@ namespace IntegrationTest.BuildXL.Scheduler
             var pipB = CreateAndScheduleSharedOpaqueProducer(
                 sharedOpaqueDir,
                 fileToProduceStatically: FileArtifact.Invalid,
-                sourceFileToRead: CreateSourceFile(),
+                sourceFileToRead: dummyOutputA,
                 Operation.WriteFile(outputArtifactB),
                 Operation.ReadFile(outputArtifactA, doNotInfer: true));
 


### PR DESCRIPTION
Order pips to avoid a race