### PR TITLE
QTest: Enable Retrying QTest Pip for Internal Errrors

### DIFF
--- a/Public/Sdk/SelfHost/BuildXL/Tools/QTest/Tool.QTestRunner.dsc
+++ b/Public/Sdk/SelfHost/BuildXL/Tools/QTest/Tool.QTestRunner.dsc
@@ -214,7 +214,8 @@ export function runQTest(args: QTestArguments): Result {
             ) : []),
             ...(args.qTestRuntimeDependencies || []),
         ],
-        unsafe: unsafeOptions
+        unsafe: unsafeOptions,
+        retryExitCodes: [2]
     });
 
     const qTestLogsDir: StaticDirectory = result.getOutputDirectory(logDir);
@@ -244,7 +245,8 @@ export function runQTest(args: QTestArguments): Result {
             workingDirectory: qtestCodeCovUploadTempDirectory,
             disableCacheLookup: true,
             privilegeLevel: args.privilegeLevel,
-            unsafe: unsafeOptions
+            unsafe: unsafeOptions,
+            retryExitCodes: [2]
         });
     }
 


### PR DESCRIPTION
When a QTest PIP is run currently if there are internal failures because of which QTest fails, the results show that build failed due to failing tests. However the tests themselves are not at fault.
In case of such internal failures, this change allows the QTest PIP to be retried.