### PR TITLE
Report violations under shared opaques for writes in existing files

### DIFF
--- a/Public/Src/Engine/Processes/FileAccessPolicy.cs
+++ b/Public/Src/Engine/Processes/FileAccessPolicy.cs
@@ -85,12 +85,11 @@ namespace BuildXL.Processes
         /// Override writes allowed by policy based on file existence checks. 
         /// </summary>
         /// <remarks>
-        /// Override writes allowed by policy based on file existence checks. 
-        /// Used mainly in the context of shared opaques, where the whole cone under the opaque root is write-allowed by policy (except known inputs).
+        /// Used entirely in the context of shared opaques, where the whole cone under the opaque root is write-allowed by policy (except known inputs).
         /// This policy makes sure that writes on undeclared inputs that fall under the write-allowed cone are flagged as DFAs.
         /// The way to dermine undeclared inputs is based on file existence: if a pip tries to write into a file - allowed by policy - but
-        /// that was not created by the pip (i.e. the file was there before the first write), then it is a write on an undeclared input
-        /// Observe detours never blocks in this case, denying the access is surfaced as a DFA after the write happened.
+        /// that was not created by the pip (i.e. the file was there before the first write attempted by this pip), then it is a write on an undeclared input
+        /// Observe that sandboxing never blocks in this case, denying the access is surfaced as a DFA after the write happened.
         /// </remarks>
         OverrideAllowWriteForExistingFiles = 0x400,
 

--- a/Public/Src/Engine/Processes/FileAccessPolicy.cs
+++ b/Public/Src/Engine/Processes/FileAccessPolicy.cs
@@ -82,6 +82,19 @@ namespace BuildXL.Processes
         AllowRealInputTimestamps = 0x200,
 
         /// <summary>
+        /// Override writes allowed by policy based on file existence checks. 
+        /// </summary>
+        /// <remarks>
+        /// Override writes allowed by policy based on file existence checks. 
+        /// Used mainly in the context of shared opaques, where the whole cone under the opaque root is write-allowed by policy (except known inputs).
+        /// This policy makes sure that writes on undeclared inputs that fall under the write-allowed cone are flagged as DFAs.
+        /// The way to dermine undeclared inputs is based on file existence: if a pip tries to write into a file - allowed by policy - but
+        /// that was not created by the pip (i.e. the file was there before the first write), then it is a write on an undeclared input
+        /// Observe detours never blocks in this case, denying the access is surfaced as a DFA after the write happened.
+        /// </remarks>
+        OverrideAllowWriteForExistingFiles = 0x400,
+
+        /// <summary>
         /// If set, then we will report attempts to access files under this scope, whether they exist or not (combination of <see cref="ReportAccessIfExistent"/>
         /// and <see cref="ReportAccessIfNonexistent"/>).
         /// </summary>

--- a/Public/Src/Engine/Processes/FileAccessStatusMethod.cs
+++ b/Public/Src/Engine/Processes/FileAccessStatusMethod.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace BuildXL.Processes
+{
+    /// <summary>
+    /// The method that was used for determining the file access status
+    /// </summary>
+    public enum FileAccessStatusMethod : byte
+    {
+        /// <summary>
+        /// File access was determined based on manifest information
+        /// </summary>
+        PolicyBased = 0,
+
+        /// <summary>
+        /// File access was determined by querying the file system
+        /// </summary>
+        /// <remarks>
+        /// Only used when <see cref="FileAccessPolicy.OverrideAllowWriteForExistingFiles"/> is on
+        /// </remarks>
+        FileExistenceBased = 1,
+    }
+}

--- a/Public/Src/Engine/Processes/ReportedFileAccess.cs
+++ b/Public/Src/Engine/Processes/ReportedFileAccess.cs
@@ -96,6 +96,11 @@ namespace BuildXL.Processes
         /// </summary>
         public readonly FileAccessStatus Status;
 
+        /// <summary>
+        /// What method was used for determining the <see cref="FileAccessStatus"/>
+        /// </summary>
+        public readonly FileAccessStatusMethod Method;
+
         // The following fields are a byte-wide and should be kept
         // together at the end of the structure to minimize padding.
 
@@ -138,7 +143,8 @@ namespace BuildXL.Processes
             FlagsAndAttributes flagsAndAttributes,
             AbsolutePath manifestPath,
             string path,
-            string enumeratePatttern)
+            string enumeratePatttern,
+            FileAccessStatusMethod fileAccessStatusMethod = FileAccessStatusMethod.PolicyBased)
         {
             Contract.Requires(process != null);
             Operation = operation;
@@ -155,6 +161,7 @@ namespace BuildXL.Processes
             ManifestPath = manifestPath;
             Path = path;
             EnumeratePattern = enumeratePatttern;
+            Method = fileAccessStatusMethod;
         }
 
         /// <summary>
@@ -192,7 +199,8 @@ namespace BuildXL.Processes
                    ShareMode == other.ShareMode &&
                    CreationDisposition == other.CreationDisposition &&
                    FlagsAndAttributes == other.FlagsAndAttributes &&
-                   string.Equals(EnumeratePattern, other.EnumeratePattern, StringComparison.OrdinalIgnoreCase);
+                   string.Equals(EnumeratePattern, other.EnumeratePattern, StringComparison.OrdinalIgnoreCase) &&
+                   Method == other.Method;
         }
 
         /// <summary>
@@ -660,6 +668,7 @@ namespace BuildXL.Processes
 
             writer.WriteNullableString(Path);
             writer.WriteNullableString(EnumeratePattern);
+            writer.Write((byte)Method);
         }
 
         /// <nodoc />
@@ -685,7 +694,8 @@ namespace BuildXL.Processes
                 flagsAndAttributes: (FlagsAndAttributes)reader.ReadUInt32(),
                 manifestPath: readPath != null ? readPath(reader) : reader.ReadAbsolutePath(),
                 path: reader.ReadNullableString(),
-                enumeratePatttern: reader.ReadNullableString());
+                enumeratePatttern: reader.ReadNullableString(),
+                fileAccessStatusMethod: (FileAccessStatusMethod)reader.ReadByte());
         }
 
         /// <inherit />

--- a/Public/Src/Engine/Processes/ReportedFileOperation.cs
+++ b/Public/Src/Engine/Processes/ReportedFileOperation.cs
@@ -173,6 +173,13 @@ namespace BuildXL.Processes
         ChangedReadWriteToReadAccess,
 
         /// <summary>
+        /// This is a quazy operation. We issue this only when <see cref="FileAccessPolicy.OverrideAllowWriteForExistingFiles"/> is set, representing
+        /// that an allow for write check was performed for a given path for the first time (in the scope of a process, another process in the same process 
+        /// tree may also report this for the same path)
+        /// </summary>
+        FirstAllowWriteCheckInProcess,
+
+        /// <summary>
         /// Access of reparse point target.
         /// </summary>
         ReparsePointTarget,

--- a/Public/Src/Engine/Processes/ReportedFileOperation.cs
+++ b/Public/Src/Engine/Processes/ReportedFileOperation.cs
@@ -166,14 +166,14 @@ namespace BuildXL.Processes
         ZwOpenFile,
 
         /// <summary>
-        /// This is a quazy operation. We issue this
+        /// This is a quasi operation. We issue this
         /// report when Detours is changing file open
         /// request with Read/Write access to Read access only.
         /// </summary>
         ChangedReadWriteToReadAccess,
 
         /// <summary>
-        /// This is a quazy operation. We issue this only when <see cref="FileAccessPolicy.OverrideAllowWriteForExistingFiles"/> is set, representing
+        /// This is a quasi operation. The sandbox issues this only when <see cref="FileAccessPolicy.OverrideAllowWriteForExistingFiles"/> is set, representing
         /// that an allow for write check was performed for a given path for the first time (in the scope of a process, another process in the same process 
         /// tree may also report this for the same path)
         /// </summary>

--- a/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
@@ -1802,7 +1802,7 @@ namespace BuildXL.Processes
                             // For shared opaques and if allowed undeclared source reads is enabled, make sure that any file used as an undeclared input under the 
                             // shared opaque gets deny write access. Observe that with exclusive opaques they are wiped out before the pip runs, so it is moot to check for inputs
                             // TODO: considering configuring this policy for all shared opaques, and not only when AllowedUndeclaredSourceReads is set. The case of a write on an undeclared
-                            // input is more likely to happen when undeclared sources are allowed, but also possible otherwide. For now, this is just a conservative way to try this feature
+                            // input is more likely to happen when undeclared sources are allowed, but also possible otherwise. For now, this is just a conservative way to try this feature
                             // out for a subset of our scenarios.
                             (m_pip.AllowUndeclaredSourceReads && directory.IsSharedOpaque ? FileAccessPolicy.OverrideAllowWriteForExistingFiles : FileAccessPolicy.Deny);
 

--- a/Public/Src/Engine/Processes/SandboxedProcessReports.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessReports.cs
@@ -658,7 +658,7 @@ namespace BuildXL.Processes
                 // is reported for a given path, and ignore subsequent reports.
                 // Races are ignored: a race means two child processes are racing to create or delete the same file
                 // - something that is not a good build behavior anyway - and the outcome will be that we will 
-                // non -deterministically deny the access
+                // non-deterministically deny the access
                 if (path != null && !m_overrideAllowedWritePaths.ContainsKey(path))
                 {
                     // We should override write allowed accesses for this path if the status of the special operation was 'denied'
@@ -668,7 +668,7 @@ namespace BuildXL.Processes
                 return true;
             }
 
-            FileAccessStatusMethod method;
+            FileAccessStatusMethod method = FileAccessStatusMethod.PolicyBased;
 
             // If we are processing an allowed write, but this should be overridden based on file existence, 
             // we change the status here
@@ -680,10 +680,6 @@ namespace BuildXL.Processes
             {
                 status = FileAccessStatus.Denied;
                 method = FileAccessStatusMethod.FileExistenceBased;
-            }
-            else
-            {
-                method = FileAccessStatusMethod.PolicyBased;
             }
 
             var reportedAccess =

--- a/Public/Src/Engine/Processes/SandboxedProcessReports.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessReports.cs
@@ -35,6 +35,7 @@ namespace BuildXL.Processes
         private readonly ConcurrentDictionary<uint, ReportedProcess> m_processesExits = new ConcurrentDictionary<uint, ReportedProcess>();
 
         private readonly Dictionary<string, string> m_pathCache = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, bool> m_overrideAllowedWritePaths = new Dictionary<string, bool>();
         private readonly IDetoursEventListener m_detoursEventListener;
 
         public readonly List<ReportedProcess> Processes = new List<ReportedProcess>();
@@ -647,6 +648,44 @@ namespace BuildXL.Processes
                 }
             }
 
+            if (operation == ReportedFileOperation.FirstAllowWriteCheckInProcess)
+            {
+                // This operation represents that a given path was checked for write access for the first time
+                // within the scope of a process. The status of the operation represents whether that access should
+                // have been allowed/denied, based on the existence of the file.
+                // However, we need to determine whether to deny the access based on the first time the path was
+                // checked for writes across the whole process tree. This means checking the first time this operation 
+                // is reported for a given path, and ignore subsequent reports.
+                // Races are ignored: a race means two child processes are racing to create or delete the same file
+                // - something that is not a good build behavior anyway - and the outcome will be that we will 
+                // non -deterministically deny the access
+                if (path != null && !m_overrideAllowedWritePaths.ContainsKey(path))
+                {
+                    // We should override write allowed accesses for this path if the status of the special operation was 'denied'
+                    m_overrideAllowedWritePaths[path] = (status == FileAccessStatus.Denied);
+                }
+
+                return true;
+            }
+
+            FileAccessStatusMethod method;
+
+            // If we are processing an allowed write, but this should be overridden based on file existence, 
+            // we change the status here
+            if (path != null &&
+                (requestedAccess & RequestedAccess.Write) != 0 &&
+                status == FileAccessStatus.Allowed &&
+                m_overrideAllowedWritePaths.TryGetValue(path, out bool shouldOverrideAllowedAccess) &&
+                shouldOverrideAllowedAccess)
+            {
+                status = FileAccessStatus.Denied;
+                method = FileAccessStatusMethod.FileExistenceBased;
+            }
+            else
+            {
+                method = FileAccessStatusMethod.PolicyBased;
+            }
+
             var reportedAccess =
                 new ReportedFileAccess(
                     operation,
@@ -662,7 +701,8 @@ namespace BuildXL.Processes
                     flagsAndAttributes,
                     manifestPath,
                     path,
-                    enumeratePattern);
+                    enumeratePattern,
+                    method);
 
             HandleReportedAccess(reportedAccess);
             return true;
@@ -848,6 +888,7 @@ namespace BuildXL.Processes
                     { "CreateSymbolicLink_Source", ReportedFileOperation.CreateSymbolicLinkSource },
                     { "ReparsePointTarget", ReportedFileOperation.ReparsePointTarget },
                     { "ChangedReadWriteToReadAccess", ReportedFileOperation.ChangedReadWriteToReadAccess },
+                    { "FirstAllowWriteCheckInProcess", ReportedFileOperation.FirstAllowWriteCheckInProcess },
                     { "MoveFileWithProgress_Source", ReportedFileOperation.MoveFileWithProgressSource },
                     { "MoveFileWithProgress_Dest", ReportedFileOperation.MoveFileWithProgressDest },
                     { "MultipleOperations", ReportedFileOperation.MultipleOperations },

--- a/Public/Src/Engine/Scheduler/Tracing/Log.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/Log.cs
@@ -2071,7 +2071,7 @@ namespace BuildXL.Scheduler.Tracing
             EventTask = (int)Tasks.Scheduler,
             Message =
                 PipDependencyAnalysisPrefix +
-                "Allowed undeclared access on an output file: This pip accesses path '{4}', but '{5}' writes into it. " +
+                "Undeclared access on an output file: This pip accesses path '{4}', but '{5}' writes into it. " +
                 "Even though the undeclared access is allowed, it should only happen on a source file.")]
         public abstract void DependencyViolationWriteInUndeclaredSourceRead(
             LoggingContext context,
@@ -2081,6 +2081,24 @@ namespace BuildXL.Scheduler.Tracing
             string pipWorkingDirectory,
             string path,
             string producingPipDescription);
+
+        [GeneratedEvent(
+            (int)LogEventId.DependencyViolationWriteOnExistingFile,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Verbose,
+            Keywords = (int)Keywords.UserMessage | (int)Keywords.DependencyAnalysis,
+            EventTask = (int)Tasks.Scheduler,
+            Message =
+                PipDependencyAnalysisPrefix +
+                "This pip writes to path '{4}', but the file was not created by this pip. This means the " +
+                "pip is attempting to rewrite a file without an explicit rewrite declaration. This may introduce non-deterministic behaviors in the build.")]
+        public abstract void DependencyViolationWriteOnExistingFile(
+            LoggingContext context,
+            long pipSemiStableHash,
+            string pipDescription,
+            string pipSpecPath,
+            string pipWorkingDirectory,
+            string path);
 
         [GeneratedEvent(
             (int)LogEventId.DependencyViolationWriteOnAbsentPathProbe,

--- a/Public/Src/Engine/Scheduler/Tracing/LogEventId.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/LogEventId.cs
@@ -117,6 +117,7 @@ namespace BuildXL.Scheduler.Tracing
         FingerprintStoreGarbageCollectCanceled = 5024,
 
         DependencyViolationWriteInUndeclaredSourceRead = 5025,
+        DependencyViolationWriteOnExistingFile = 5047,
         DependencyViolationWriteOnAbsentPathProbe = 5026,
         DependencyViolationAbsentPathProbeInsideUndeclaredOpaqueDirectory = 5027,
         RocksDbException = 5028,

--- a/Public/Src/Engine/UnitTests/Processes.Detours/SandboxedProcessPipExecutorTest.cs
+++ b/Public/Src/Engine/UnitTests/Processes.Detours/SandboxedProcessPipExecutorTest.cs
@@ -1033,6 +1033,125 @@ namespace Test.BuildXL.Processes.Detours
             }
         }
 
+        /// <summary>
+        /// Blocking accesses under shared opaques based on file existence is a Windows-only feature for now.
+        /// </summary>
+        [TheoryIfSupported(requiresWindowsBasedOperatingSystem: true)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ProcessFileAccessesBlockedBasedOnFileExistenceUnderSharedOpaques(bool pipCreatesFile)
+        {
+            var context = BuildXLContext.CreateInstanceForTesting();
+            var symbolTable = context.SymbolTable;
+
+            using (var tempFiles = new TempFileStorage(canGetFileNames: true, rootPath: TemporaryDirectory))
+            {
+                string executable = CmdHelper.CmdX64;
+                FileArtifact executableFileArtifact = FileArtifact.CreateSourceFile(AbsolutePath.Create(context.PathTable, executable));
+
+                string workingDirectory = tempFiles.GetUniqueDirectory();
+                var sharedOpaqueRoot = Path.Combine(workingDirectory, "sharedOpaque");
+
+                AbsolutePath workingDirectoryAbsolutePath = AbsolutePath.Create(context.PathTable, sharedOpaqueRoot);
+
+                // Create a shared opaque.
+                var sharedOpaque = new DirectoryArtifact(AbsolutePath.Create(context.PathTable, sharedOpaqueRoot), 1, isSharedOpaque: true);
+
+                // The shared opaque input contains input/in.txt
+                var inputUndersharedOpaqueRoot = Path.Combine(sharedOpaqueRoot, "input", "in.txt");
+                Directory.CreateDirectory(sharedOpaqueRoot);
+                Directory.CreateDirectory(Path.Combine(sharedOpaqueRoot, "input"));
+
+                // If the test is configured so the pip does not create the file, we create it before the pip runs
+                if (!pipCreatesFile)
+                {
+                    File.WriteAllText(inputUndersharedOpaqueRoot, "Foo");
+                }
+
+                var arguments = new PipDataBuilder(context.PathTable.StringTable);
+                arguments.Add("/d");
+                arguments.Add("/c");
+                using (arguments.StartFragment(PipDataFragmentEscaping.CRuntimeArgumentRules, " "))
+                {
+                    // Writes into 'input/in.txt' (under the shared opaque input) twice
+                    arguments.Add("echo");
+                    arguments.Add("foo");
+                    arguments.Add(">");
+                    arguments.Add(@"input\in.txt");
+                    arguments.Add("&&");
+                    arguments.Add("echo");
+                    arguments.Add("bar");
+                    arguments.Add(">");
+                    arguments.Add(@"input\in.txt");
+                }
+
+                var pip = new Process(
+                    executableFileArtifact,
+                    workingDirectoryAbsolutePath,
+                    arguments.ToPipData(" ", PipDataFragmentEscaping.NoEscaping),
+                    FileArtifact.Invalid,
+                    PipData.Invalid,
+                    ReadOnlyArray<EnvironmentVariable>.Empty,
+                    FileArtifact.Invalid,
+                    FileArtifact.Invalid,
+                    FileArtifact.Invalid,
+                    tempFiles.GetUniqueDirectory(context.PathTable),
+                    null,
+                    null,
+                    ReadOnlyArray<FileArtifact>.FromWithoutCopy(executableFileArtifact),
+                    ReadOnlyArray<FileArtifactWithAttributes>.Empty,
+                    ReadOnlyArray<DirectoryArtifact>.Empty, 
+                    ReadOnlyArray<DirectoryArtifact>.FromWithoutCopy(new DirectoryArtifact[] { sharedOpaque }),
+                    ReadOnlyArray<PipId>.Empty,
+                    ReadOnlyArray<AbsolutePath>.From(CmdHelper.GetCmdDependencies(context.PathTable)),
+                    ReadOnlyArray<AbsolutePath>.From(CmdHelper.GetCmdDependencyScopes(context.PathTable)),
+                    ReadOnlyArray<StringId>.Empty,
+                    ReadOnlyArray<int>.Empty,
+                    ReadOnlyArray<ProcessSemaphoreInfo>.Empty,
+                    new PipProvenance(
+                        0,
+                        ModuleId.Invalid,
+                        StringId.Invalid,
+                        FullSymbol.Invalid.Combine(context.SymbolTable, SymbolAtom.CreateUnchecked(context.StringTable, "SharedOpaqueAccesses")),
+                        LocationData.Invalid,
+                        QualifierId.Unqualified,
+                        PipData.Invalid),
+                    toolDescription: StringId.Invalid,
+                    additionalTempDirectories: ReadOnlyArray<AbsolutePath>.Empty,
+                    // Write on existing files are for now blocked only when allow undeclared source reads are on
+                    options: Process.Options.AllowUndeclaredSourceReads);
+
+                SandboxedProcessPipExecutionResult result = await RunProcess(
+                    context,
+                    new SandboxConfiguration {
+                        FileAccessIgnoreCodeCoverage = true,
+                        FailUnexpectedFileAccesses = false,
+                        UnsafeSandboxConfiguration = new UnsafeSandboxConfiguration { IgnoreUndeclaredAccessesUnderSharedOpaques = false },
+                        LogObservedFileAccesses = true},
+                    pip,
+                    fileAccessWhitelist: null,
+                    new Dictionary<string, string>(),
+                    SemanticPathExpander.Default,
+                    new TestDirectoryArtifactContext(
+                            SealDirectoryKind.SharedOpaque,
+                            new FileArtifact[] { }));
+
+                XAssert.AreEqual(SandboxedProcessPipExecutionStatus.Succeeded, result.Status);
+
+                if (!pipCreatesFile)
+                {
+                    // There should be two denied accesses, both based on file existence
+                    var deniedAccessesBasedOnExistence = result.AllReportedFileAccesses.Where(a => a.Status == FileAccessStatus.Denied && a.Method == FileAccessStatusMethod.FileExistenceBased);
+                    XAssert.AreEqual(2, deniedAccessesBasedOnExistence.Count());
+                }
+                else
+                {
+                    // No violations when the pip is the one creating the file
+                    XAssert.AreEqual(null, result.UnexpectedFileAccesses.FileAccessViolationsNotWhitelisted);
+                }
+            }
+        }
+
         [Fact]
         public async Task ProcessTooLargeCommandLine()
         {

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/AllowedUndeclaredReadsTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/AllowedUndeclaredReadsTests.cs
@@ -1,25 +1,22 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Diagnostics.ContractsLight;
 using System.IO;
 using System.Linq;
 using BuildXL.Native.IO;
+using BuildXL.Pips;
 using BuildXL.Pips.Operations;
 using BuildXL.Utilities;
-using BuildXL.Utilities.Tracing;
-using JetBrains.Annotations;
+using BuildXL.Utilities.Configuration;
+using BuildXL.Utilities.Configuration.Mutable;
 using Test.BuildXL.Executables.TestProcess;
 using Test.BuildXL.Scheduler;
+using Test.BuildXL.TestUtilities.Xunit;
 using Xunit;
 using Xunit.Abstractions;
 using LogEventId = BuildXL.Scheduler.Tracing.LogEventId;
 using Process = BuildXL.Pips.Operations.Process;
-using BuildXL.Pips;
-using BuildXL.Utilities.Configuration;
 
 namespace IntegrationTest.BuildXL.Scheduler
 {
@@ -38,6 +35,9 @@ namespace IntegrationTest.BuildXL.Scheduler
 
         public AllowedUndeclaredReadsTests(ITestOutputHelper output) : base(output)
         {
+            // TODO: remove when the default changes
+            ((UnsafeSandboxConfiguration)(Configuration.Sandbox.UnsafeSandboxConfiguration)).IgnoreUndeclaredAccessesUnderSharedOpaques = false;
+
             SharedOpaqueDirectoryRoot = Path.Combine(ObjectRoot, "sharedOpaqueDirectory");
             OutOfMountRoot = Path.Combine(TemporaryDirectory, "outOfMount");
             Directory.CreateDirectory(OutOfMountRoot);
@@ -381,6 +381,66 @@ namespace IntegrationTest.BuildXL.Scheduler
             // We should get the violation anyway
             RunScheduler().AssertFailure();
             AssertErrorEventLogged(LogEventId.DependencyViolationWriteInUndeclaredSourceRead);
+        }
+
+        /// <summary>
+        /// TODO: blocking writes on existing undeclared inputs is not implemented on Mac yet
+        /// </summary>
+        [FactIfSupported(requiresWindowsBasedOperatingSystem: true)]
+        public void WritingUndeclaredInputsUnderSharedOpaquesAreBlocked()
+        {
+            // Create an undeclared source file under the cone of a shared opaque
+            var source = CreateSourceFile(SharedOpaqueDirectoryRoot);
+
+            // Run a pip that writes into the source file
+            var pipBuilder = CreatePipBuilder(new Operation[] { Operation.WriteFile(source, doNotInfer: true) });
+            pipBuilder.AddOutputDirectory(DirectoryArtifact.CreateWithZeroPartialSealId(AbsolutePath.Create(Context.PathTable, SharedOpaqueDirectoryRoot)), SealDirectoryKind.SharedOpaque);
+            pipBuilder.Options |= Process.Options.AllowUndeclaredSourceReads;
+
+            var result = SchedulePipBuilder(pipBuilder);
+
+            RunScheduler().AssertFailure();
+            IgnoreWarnings();
+            AssertErrorEventLogged(LogEventId.DependencyViolationWriteOnExistingFile);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void WritingToExistentFileProducedBySamePipIsAllowed(bool varyPathCasing)
+        {
+            // Run a pip that writes into a file twice: the second time, the file will exist. However, this should be allowed.
+            // This test complements WritingUndeclaredInputsUnderSharedOpaquesAreBlocked, since the check cannot be made purely based on file existence,
+            // but should also consider when the first write happened
+            var outputFile = CreateOutputFileArtifact(SharedOpaqueDirectoryRoot);
+            var pipBuilder = CreatePipBuilder(new Operation[] {
+                Operation.WriteFile(outputFile, doNotInfer: true),
+                Operation.WriteFile(outputFile, doNotInfer: true, changePathToAllUpperCase: varyPathCasing),
+            });
+            pipBuilder.AddOutputDirectory(DirectoryArtifact.CreateWithZeroPartialSealId(AbsolutePath.Create(Context.PathTable, SharedOpaqueDirectoryRoot)), SealDirectoryKind.SharedOpaque);
+            pipBuilder.Options |= Process.Options.AllowUndeclaredSourceReads;
+
+            var result = SchedulePipBuilder(pipBuilder);
+
+            RunScheduler().AssertSuccess();
+        }
+
+        [Fact]
+        public void WritingToExistentFileProducedBySamePipIsAllowedInChildProcess()
+        {
+            // Run a pip that writes into a file twice, but the second time it happens on a child process.
+            var outputFile = CreateOutputFileArtifact(SharedOpaqueDirectoryRoot);
+            var pipBuilder = CreatePipBuilder(new Operation[] {
+                Operation.WriteFile(outputFile, doNotInfer: true),
+                Operation.Spawn(Context.PathTable, waitToFinish: true, Operation.WriteFile(outputFile, doNotInfer: true)),
+            });
+
+            pipBuilder.AddOutputDirectory(DirectoryArtifact.CreateWithZeroPartialSealId(AbsolutePath.Create(Context.PathTable, SharedOpaqueDirectoryRoot)), SealDirectoryKind.SharedOpaque);
+            pipBuilder.Options |= Process.Options.AllowUndeclaredSourceReads;
+
+            var result = SchedulePipBuilder(pipBuilder);
+
+            RunScheduler().AssertSuccess();
         }
 
         private ProcessWithOutputs ScheduleProcessWithUndeclaredReads(

--- a/Public/Src/Sandbox/Windows/DetoursServices/DataTypes.h
+++ b/Public/Src/Sandbox/Windows/DetoursServices/DataTypes.h
@@ -128,6 +128,13 @@ enum FileAccessPolicy
     // this flag is specified
     FileAccessPolicy_AllowRealInputTimestamps = 0x200,
 
+    // Override writes allowed by policy based on file existence checks. 
+    // Used mainly in the context of shared opaques, where the whole cone under the opaque root is write-allowed by policy (except known inputs).
+    // This policy makes sure that writes on undeclared inputs that fall under the write-allowed cone are flagged as DFAs.
+    // The way to dermine undeclared inputs is based on file existence: if a pip tries to write into a file - allowed by policy - but
+    // that was not created by the pip (i.e. the file was there before the first write), then it is a write on an undeclared input
+    FileAccessPolicy_OverrideAllowWriteForExistingFiles = 0x400,
+
     // If set, then we will report all attempts to access files under this scope (whether existent or not).
     // BuildXL uses this information to discover dynamic dependencies, such as #include-ed files.
     FileAccessPolicy_ReportAccess = FileAccessPolicy_ReportAccessIfNonExistent | FileAccessPolicy_ReportAccessIfExistent,

--- a/Public/Src/Sandbox/Windows/DetoursServices/DataTypes.h
+++ b/Public/Src/Sandbox/Windows/DetoursServices/DataTypes.h
@@ -131,7 +131,7 @@ enum FileAccessPolicy
     // Override writes allowed by policy based on file existence checks. 
     // Used mainly in the context of shared opaques, where the whole cone under the opaque root is write-allowed by policy (except known inputs).
     // This policy makes sure that writes on undeclared inputs that fall under the write-allowed cone are flagged as DFAs.
-    // The way to dermine undeclared inputs is based on file existence: if a pip tries to write into a file - allowed by policy - but
+    // The way to determine undeclared inputs is based on file existence: if a pip tries to write into a file - allowed by policy - but
     // that was not created by the pip (i.e. the file was there before the first write), then it is a write on an undeclared input
     FileAccessPolicy_OverrideAllowWriteForExistingFiles = 0x400,
 

--- a/Public/Src/Sandbox/Windows/DetoursServices/DetoursHelpers.cpp
+++ b/Public/Src/Sandbox/Windows/DetoursServices/DetoursHelpers.cpp
@@ -1025,3 +1025,11 @@ bool EnumerateDirectory(
 
     return true;
 }
+
+bool ExistsAsFile(const wchar_t* path)
+{
+    DWORD dwAttrib = Real_GetFileAttributesW(path);
+
+    return (dwAttrib != INVALID_FILE_ATTRIBUTES &&
+        !(dwAttrib & FILE_ATTRIBUTE_DIRECTORY));
+}

--- a/Public/Src/Sandbox/Windows/DetoursServices/DetoursHelpers.cpp
+++ b/Public/Src/Sandbox/Windows/DetoursServices/DetoursHelpers.cpp
@@ -1026,9 +1026,9 @@ bool EnumerateDirectory(
     return true;
 }
 
-bool ExistsAsFile(const wchar_t* path)
+bool ExistsAsFile(_In_ PCWSTR path)
 {
-    DWORD dwAttrib = Real_GetFileAttributesW(path);
+    DWORD dwAttrib = GetFileAttributesW(path);
 
     return (dwAttrib != INVALID_FILE_ATTRIBUTES &&
         !(dwAttrib & FILE_ATTRIBUTE_DIRECTORY));

--- a/Public/Src/Sandbox/Windows/DetoursServices/DetoursHelpers.h
+++ b/Public/Src/Sandbox/Windows/DetoursServices/DetoursHelpers.h
@@ -122,7 +122,7 @@ bool EnumerateDirectory(
     bool treatReparsePointAsFile,
     _Inout_ std::vector<std::pair<std::wstring, DWORD>>& filesAndDirectories);
 
-bool ExistsAsFile(const wchar_t* path);
+bool ExistsAsFile(_In_ PCWSTR path);
 
 class ReportData
 {

--- a/Public/Src/Sandbox/Windows/DetoursServices/DetoursHelpers.h
+++ b/Public/Src/Sandbox/Windows/DetoursServices/DetoursHelpers.h
@@ -122,6 +122,8 @@ bool EnumerateDirectory(
     bool treatReparsePointAsFile,
     _Inout_ std::vector<std::pair<std::wstring, DWORD>>& filesAndDirectories);
 
+bool ExistsAsFile(const wchar_t* path);
+
 class ReportData
 {
 private:

--- a/Public/Src/Sandbox/Windows/DetoursServices/DetoursServices.cpp
+++ b/Public/Src/Sandbox/Windows/DetoursServices/DetoursServices.cpp
@@ -30,6 +30,7 @@
 #include "DetouredProcessInjector.h"
 #include "SendReport.h"
 #include <Psapi.h>
+#include "FilesCheckedForAccess.h"
 
 #define BUILDXL_DETOURS_CREATE_PROCESS_RETRY_COUNT 5
 #define BUILDXL_DETOURS_MS_TO_SLEEP 10
@@ -1075,6 +1076,7 @@ static bool DllProcessAttach()
     g_invariantLocale = _wcreate_locale(LC_CTYPE, L"");
     InitProcessKind();
     InitializeHandleOverlay();
+    InitializeFilesCheckedForWriteAccesses();
 
 #define ATTACH(Name) \
     Real_##Name = ::Name; \

--- a/Public/Src/Sandbox/Windows/DetoursServices/DetoursServices.dsc
+++ b/Public/Src/Sandbox/Windows/DetoursServices/DetoursServices.dsc
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import * as Native from "Sdk.Native";
+import {Transformer} from "Sdk.Transformers";
 
 namespace Core {
     export declare const qualifier: BuildXLSdk.PlatformDependentQualifier;
@@ -36,6 +37,7 @@ namespace Core {
         f`DetouredProcessInjector.h`,
         f`UniqueHandle.h`,
         f`SubstituteProcessExecution.h`,
+        f`FilesCheckedForAccess.h`,
     ];
 
     export const pathToDeviceMapLib: PathAtom = a`${qualifier.platform.replace("x", qualifier.configuration)}`;
@@ -126,6 +128,7 @@ namespace Core {
                 f`DeviceMap.cpp`,
                 f`DetouredProcessInjector.cpp`,
                 f`SubstituteProcessExecution.cpp`,
+                f`FilesCheckedForAccess.cpp`,
             ],
 
             exports: [

--- a/Public/Src/Sandbox/Windows/DetoursServices/FilesCheckedForAccess.cpp
+++ b/Public/Src/Sandbox/Windows/DetoursServices/FilesCheckedForAccess.cpp
@@ -4,11 +4,6 @@
 #include "FilesCheckedForAccess.h"
 #include "string.h"
 
-FilesCheckedForAccess FilesCheckedForAccess::Create()
-{
-    return FilesCheckedForAccess();
-}
-
 FilesCheckedForAccess::FilesCheckedForAccess()
 {
     InitializeCriticalSection(&m_lock);

--- a/Public/Src/Sandbox/Windows/DetoursServices/FilesCheckedForAccess.cpp
+++ b/Public/Src/Sandbox/Windows/DetoursServices/FilesCheckedForAccess.cpp
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "FilesCheckedForAccess.h"
+#include "string.h"
+
+FilesCheckedForAccess FilesCheckedForAccess::Create()
+{
+    return FilesCheckedForAccess();
+}
+
+FilesCheckedForAccess::FilesCheckedForAccess()
+{
+    InitializeCriticalSection(&m_lock);
+}
+
+bool FilesCheckedForAccess::TryRegisterPath(const CanonicalizedPath& path) {
+    std::pair<std::unordered_set<std::wstring>::iterator, bool> result;
+    
+    EnterCriticalSection(&m_lock);
+    result = m_pathSet.insert(path.GetPathString());
+    LeaveCriticalSection(&m_lock);
+
+    return result.second;
+}
+
+bool FilesCheckedForAccess::IsRegistered(const CanonicalizedPath& path) {
+    std::unordered_set<std::wstring>::iterator result;
+    
+    EnterCriticalSection(&m_lock);
+    result = m_pathSet.find(path.GetPathString());
+    LeaveCriticalSection(&m_lock);
+
+    return (result != m_pathSet.end());
+}
+
+FilesCheckedForAccess* g_filesCheckedForAccess = NULL;
+
+void InitializeFilesCheckedForWriteAccesses() {
+    assert(g_filesCheckedForAccess == NULL);
+    g_filesCheckedForAccess = new FilesCheckedForAccess();
+}
+
+FilesCheckedForAccess* GetGlobalFilesCheckedForAccesses() {
+    assert(g_filesCheckedForAccess != NULL);
+    return g_filesCheckedForAccess;
+}

--- a/Public/Src/Sandbox/Windows/DetoursServices/FilesCheckedForAccess.h
+++ b/Public/Src/Sandbox/Windows/DetoursServices/FilesCheckedForAccess.h
@@ -36,7 +36,6 @@ struct CaseInsensitiveStringHasher {
 class FilesCheckedForAccess {
 public:
     FilesCheckedForAccess();
-    static FilesCheckedForAccess Create();
     // Tries to register that a given path was checked for access
     // Returns whether the path was not registered before
     bool TryRegisterPath(const CanonicalizedPath& path);

--- a/Public/Src/Sandbox/Windows/DetoursServices/FilesCheckedForAccess.h
+++ b/Public/Src/Sandbox/Windows/DetoursServices/FilesCheckedForAccess.h
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include "CanonicalizedPath.h"
+#include <unordered_set>
+#include <cwctype>
+#include <algorithm>
+
+// Case-insensitive equality for wstrings
+struct CaseInsensitiveStringComparer : public std::binary_function<std::wstring, std::wstring, bool> {
+    bool operator()(const std::wstring &lhs, const std::wstring &rhs) const {
+        if (lhs.length() == rhs.length()) {
+            return std::equal(rhs.begin(), rhs.end(), lhs.begin(), 
+                [](const wchar_t a, const wchar_t b) { return towlower(a) == towlower(b); });
+        }
+        else {
+            return false;
+        }
+    }
+};
+
+// Case-insensitive hasher for wstrings
+struct CaseInsensitiveStringHasher {
+    size_t operator()(const std::wstring & str) const {
+        std::wstring lowerstr(str);
+        std::transform(lowerstr.begin(), lowerstr.end(), lowerstr.begin(), std::towlower);
+
+        return std::hash<std::wstring>()(lowerstr);
+    }
+};
+
+// Keeps a set of case-insensitive paths that were checked for access 
+// All operations are thread-safe
+class FilesCheckedForAccess {
+public:
+    FilesCheckedForAccess();
+    static FilesCheckedForAccess Create();
+    // Tries to register that a given path was checked for access
+    // Returns whether the path was not registered before
+    bool TryRegisterPath(const CanonicalizedPath& path);
+    
+    // Returns whether the given path is registered.
+    bool IsRegistered(const CanonicalizedPath& path);
+
+private:
+    std::unordered_set<std::wstring, CaseInsensitiveStringHasher, CaseInsensitiveStringComparer> m_pathSet;
+    CRITICAL_SECTION m_lock;
+};
+
+// Sets up structures for recording write access checks.
+void InitializeFilesCheckedForWriteAccesses();
+
+// Returns a pointer to the global instance of FilesCheckedForWriteAccess
+// Assumes InitializeFilesCheckedForWriteAccesses() has been called
+FilesCheckedForAccess* GetGlobalFilesCheckedForAccesses();

--- a/Public/Src/Sandbox/Windows/DetoursServices/PolicyResult.cpp
+++ b/Public/Src/Sandbox/Windows/DetoursServices/PolicyResult.cpp
@@ -104,6 +104,7 @@ void PolicyResult::ReportIndeterminatePolicyAndSetLastError(FileOperationContext
         -1);
 }
 
+#if !(MAC_OS_SANDBOX) && !(MAC_OS_LIBRARY)
 bool PolicyResult::AllowWrite() const {
 
     bool isWriteAllowedByPolicy = (m_policy & FileAccessPolicy_AllowWrite) != 0;
@@ -148,3 +149,4 @@ bool PolicyResult::AllowWrite() const {
 
     return isWriteAllowedByPolicy;
 }
+#endif

--- a/Public/Src/Sandbox/Windows/DetoursServices/PolicyResult.cpp
+++ b/Public/Src/Sandbox/Windows/DetoursServices/PolicyResult.cpp
@@ -4,6 +4,7 @@
 #include "PolicyResult.h"
 #include "DetoursHelpers.h"
 #include "SendReport.h"
+#include "FilesCheckedForAccess.h"
 
 bool PolicyResult::Initialize(PCPathChar path)
 {
@@ -101,4 +102,52 @@ void PolicyResult::ReportIndeterminatePolicyAndSetLastError(FileOperationContext
         fakeAccessCheck,
         ERROR_SUCCESS,
         -1);
+}
+
+bool PolicyResult::AllowWrite() const {
+
+    bool isWriteAllowedByPolicy = (m_policy & FileAccessPolicy_AllowWrite) != 0;
+
+    // Send a special message to managed code if the policy to override allowed writes based on file existence is set
+    // and the write is allowed by policy (for the latter, if the write is denied, there is nothing to override)
+    if (OverrideAllowWriteForExistingFiles() && isWriteAllowedByPolicy) {
+        
+        // Let's check if this path was already checked for allow writes in this process. Observe this structure lifespan is the same 
+        // as the current process so other child processes won't share it. 
+        // But for the current process it will avoid probing the file system over and over for the same path.
+        FilesCheckedForAccess* filesCheckedForWriteAccess = GetGlobalFilesCheckedForAccesses();
+        
+        if (filesCheckedForWriteAccess->TryRegisterPath(m_canonicalizedPath)) {
+            DWORD error = GetLastError();
+
+            // Our ultimate goal is to understand if the path represents a file that was there before the pip started (and therefore blocked for writes).
+            // The existence of the file on disk before the first time the file is written will tell us that. But the problem is that knowing when is the first
+            // time is not trivial: it involves sharing information across child processes.
+            // So what we do is just to emit a special report line with the information of whether the access should be allowed or not, based on existence, from
+            // the perspective of the running process. These special report lines are then processed outside of detours to determine the real first write attempt
+            // Observe this implies that in this case we never block accesses on detours based on file existence, but generate a DFA on managed code
+            bool fileExists = ExistsAsFile(m_canonicalizedPath.GetPathString());
+
+            AccessCheckResult accessCheck = AccessCheckResult(RequestedAccess::Read, ResultAction::Allow, ReportLevel::Ignore);
+            FileOperationContext operationContext(
+                L"FirstAllowWriteCheckInProcess",
+                GENERIC_WRITE,
+                FILE_SHARE_WRITE,
+                OPEN_ALWAYS,
+                FILE_ATTRIBUTE_NORMAL,
+                this->GetCanonicalizedPath().GetPathString());
+
+            ReportFileAccess(
+                operationContext,
+                fileExists? FileAccessStatus_Denied : FileAccessStatus_Allowed,
+                *this,
+                AccessCheckResult(RequestedAccess::None, ResultAction::Deny, ReportLevel::Report),
+                0,
+                -1);
+
+            SetLastError(error);
+        }
+    }
+
+    return isWriteAllowedByPolicy;
 }

--- a/Public/Src/Sandbox/Windows/DetoursServices/PolicyResult.h
+++ b/Public/Src/Sandbox/Windows/DetoursServices/PolicyResult.h
@@ -158,10 +158,11 @@ public:
     CanonicalizedPathType const& GetCanonicalizedPath() const { return m_canonicalizedPath; }
     bool AllowRead() const { return (m_policy & FileAccessPolicy_AllowRead) != 0; }
     bool AllowReadIfNonexistent() const { return (m_policy & FileAccessPolicy_AllowReadIfNonExistent) != 0; }
-    bool AllowWrite() const { return (m_policy & FileAccessPolicy_AllowWrite) != 0; }
+    bool AllowWrite() const;
     bool AllowSymlinkCreation() const { return (m_policy & FileAccessPolicy_AllowSymlinkCreation) != 0; }
     bool AllowCreateDirectory() const { return (m_policy & FileAccessPolicy_AllowCreateDirectory) != 0; }
 	bool AllowRealInputTimestamps() const { return (m_policy & FileAccessPolicy_AllowRealInputTimestamps) != 0; }
+    bool OverrideAllowWriteForExistingFiles() const { return (m_policy & FileAccessPolicy_OverrideAllowWriteForExistingFiles) != 0; }
     bool ReportUsnAfterOpen() const { return (m_policy & FileAccessPolicy_ReportUsnAfterOpen) != 0; }
     bool ReportDirectoryEnumeration() const { return (m_policy & FileAccessPolicy_ReportDirectoryEnumerationAccess) != 0; }
     bool IndicateUntracked() const { return ((m_policy & FileAccessPolicy_AllowAll) == FileAccessPolicy_AllowAll) && ((m_policy & FileAccessPolicy_ReportAccess) == 0); }
@@ -183,7 +184,7 @@ public:
     bool ShouldOverrideTimestamps(AccessCheckResult const& accessCheck) const {
         return (accessCheck.ResultAction == ResultAction::Allow || accessCheck.ResultAction == ResultAction::Warn) && !AllowRealInputTimestamps();
     }
-
+    
 private:
     /// Performs common work when checking for writable access
     AccessCheckResult CreateAccessCheckResult(ResultAction result, ReportLevel reportLevel) const;

--- a/Public/Src/Sandbox/Windows/DetoursServices/PolicyResult.h
+++ b/Public/Src/Sandbox/Windows/DetoursServices/PolicyResult.h
@@ -158,7 +158,11 @@ public:
     CanonicalizedPathType const& GetCanonicalizedPath() const { return m_canonicalizedPath; }
     bool AllowRead() const { return (m_policy & FileAccessPolicy_AllowRead) != 0; }
     bool AllowReadIfNonexistent() const { return (m_policy & FileAccessPolicy_AllowReadIfNonExistent) != 0; }
+#if !(MAC_OS_SANDBOX) && !(MAC_OS_LIBRARY)
     bool AllowWrite() const;
+#else
+    bool AllowWrite() const { return (m_policy & FileAccessPolicy_AllowWrite) != 0; }
+#endif
     bool AllowSymlinkCreation() const { return (m_policy & FileAccessPolicy_AllowSymlinkCreation) != 0; }
     bool AllowCreateDirectory() const { return (m_policy & FileAccessPolicy_AllowCreateDirectory) != 0; }
 	bool AllowRealInputTimestamps() const { return (m_policy & FileAccessPolicy_AllowRealInputTimestamps) != 0; }

--- a/Public/Src/Utilities/UnitTests/Executables/TestProcess/Operation.cs
+++ b/Public/Src/Utilities/UnitTests/Executables/TestProcess/Operation.cs
@@ -26,6 +26,7 @@ namespace Test.BuildXL.Executables.TestProcess
         private const int ERROR_ALREADY_EXISTS = 183;
         private const string StdErrMoniker = "stderr";
         private const string WaitToFinishMoniker = "wait";
+        private const string AllUppercasePath = "allUpper";
 
         /// <summary>
         /// Returns an <code>IEnumerable</code> containing <paramref name="operation"/>
@@ -280,6 +281,7 @@ namespace Test.BuildXL.Executables.TestProcess
         ///   - search pattern for directory enumerations in <see cref="Type.EnumerateDir"/>
         ///   - whether to wait for the spawned process to finish in <see cref="Type.Spawn"/>
         ///   - whether to use stdout or stderr in <see cref="Type.Echo"/>
+        ///   - whether to use an all uppercase path in <see cref="Type.WriteFile"/> (for testing casing awareness)
         /// </summary>
         public string AdditionalArgs { get; private set; }
 
@@ -288,7 +290,15 @@ namespace Test.BuildXL.Executables.TestProcess
         /// </summary>
         public int RetriesOnWrite { get; }
 
-        private Operation(Type type, FileOrDirectoryArtifact? path = null, string content = null, FileOrDirectoryArtifact? linkPath = null, SymbolicLinkFlag? symLinkFlag = null, bool? doNotInfer = null, string additionalArgs = null, int retriesOnWrite = 5)
+        private Operation(
+            Type type, 
+            FileOrDirectoryArtifact? path = null, 
+            string content = null, 
+            FileOrDirectoryArtifact? linkPath = null, 
+            SymbolicLinkFlag? symLinkFlag = null, 
+            bool? doNotInfer = null, 
+            string additionalArgs = null, 
+            int retriesOnWrite = 5)
         {
             Contract.Requires(content == null || !content.Contains(Environment.NewLine));
 
@@ -463,11 +473,11 @@ namespace Test.BuildXL.Executables.TestProcess
         /// Creates a write file operation that appends. The file is created if it does not exist.
         /// Writes random content to file at path if no content is specified.
         /// </summary>
-        public static Operation WriteFile(FileArtifact path, string content = null, bool doNotInfer = false)
+        public static Operation WriteFile(FileArtifact path, string content = null, bool doNotInfer = false, bool changePathToAllUpperCase = false)
         {
             return content == Environment.NewLine
-                ? new Operation(Type.AppendNewLine, path, doNotInfer: doNotInfer)
-                : new Operation(Type.WriteFile, path, content, doNotInfer: doNotInfer);
+                ? new Operation(Type.AppendNewLine, path, doNotInfer: doNotInfer, additionalArgs: changePathToAllUpperCase? Operation.AllUppercasePath : null)
+                : new Operation(Type.WriteFile, path, content, doNotInfer: doNotInfer, additionalArgs: changePathToAllUpperCase ? Operation.AllUppercasePath : null);
         }
 
         /// <summary>
@@ -787,6 +797,11 @@ namespace Test.BuildXL.Executables.TestProcess
         {
             try
             {
+                if (AdditionalArgs == AllUppercasePath)
+                {
+                    file = file.ToUpperInvariant();
+                }
+
                 File.AppendAllText(file, content);
             }
             catch (UnauthorizedAccessException)


### PR DESCRIPTION
Shared opaques define a cone where writes are always allowed. The only exception are known dependencies, where those specific paths are blocked. However, this doesn't prevent writes on files that were not created by the writing pip and exist before the pip started. 
This PR addresses that problem by identifying the first write to a file that happens in the context of a pip, and determining whether the file being written existed before the first write happened. 
This new type of violations are only produced under a specific policy flag - for now set only for shared opaques and when undeclared source read mode is on (effectively, only for MSBuild and Ninja). We can consider extending this policy to all shared opaques in general.
For now this is a Windows-specific feature. We can think about adding this for Mac as well.