### PR TITLE
Count all replicas toward effective age

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
@@ -1103,8 +1103,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                             //   evictability = age + (time decay parameter) * (-log(risk of content unavailability) * (number of replicas) + log(size of content))
                             // minimizes the increase in the probability of (content wanted && all replicas inaccessible) / per bytes freed.
                             // Since this metric is just the age plus a computed quantity, it can be intrepreted as an "effective age".
-                            // (One dev wanted no penalty until we reach a threshold number of replicas. We don't have a model justification for this but I'm content to oblige.)
-                            TimeSpan totalReplicaPenalty = TimeSpan.FromMinutes(_configuration.ContentLifetime.TotalMinutes * (Math.Max(0, replicaCount - 3) * logInverseMachineRisk + Math.Log(Math.Max(1, entry.ContentSize))));
+                            TimeSpan totalReplicaPenalty = TimeSpan.FromMinutes(_configuration.ContentLifetime.TotalMinutes * (Math.Max(1, replicaCount) * logInverseMachineRisk + Math.Log(Math.Max(1, entry.ContentSize))));
                             effectiveLastAccessTime = lastAccessTime - totalReplicaPenalty;
 
                             Counters[ContentLocationStoreCounters.EffectiveLastAccessTimeLookupHit].Increment();


### PR DESCRIPTION
Previous code didn't start adding effective age until replica count exceeded 3. The idea was to not make eviction more likely with only a small replica count. But this is wrong, because it makes evicting with just one replica left just as attractive as evicting with three. But these a quite different circumstances, and we should be much more inclined to evict with three than with one. Without the -3, all every additional replica count contributes some toward evict-ablity, and higher counts are still ordered as we want.

