### PR TITLE
Increase copy delay for "bad" sources

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
@@ -175,7 +175,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
 
                     if (badContentLocations.Count == hashInfo.Locations.Count)
                     {
-                        // Double delay because all locations are bad. This allows the machines more time to recover, especially if they are overwhelmed by requests.
+                        // Reduce delay by a randomized amount because all locations are "bad", suggesting that the server(s) is/are throttling due to incoming traffic. Copies tend to be quick, so retrying sooner may be helpful.
                         waitDelay += TimeSpan.FromTicks((long)(waitDelay.Ticks * ThreadSafeRandom.Generator.NextDouble()));
                         extendedForBadLocations = true;
                     }

--- a/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
@@ -129,7 +129,6 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
 
             try
             {
-                Random r = new Random();
                 PutResult putResult = null;
                 var badContentLocations = new HashSet<MachineLocation>();
                 var missingContentLocations = new HashSet<MachineLocation>();
@@ -177,7 +176,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
                     if (badContentLocations.Count == hashInfo.Locations.Count)
                     {
                         // Double delay because all locations are bad. This allows the machines more time to recover, especially if they are overwhelmed by requests.
-                        waitDelay += TimeSpan.FromTicks((long)(waitDelay.Ticks * r.NextDouble()));
+                        waitDelay += TimeSpan.FromTicks((long)(waitDelay.Ticks * ThreadSafeRandom.Generator.NextDouble()));
                         extendedForBadLocations = true;
                     }
 


### PR DESCRIPTION
In some cases, multiple CASaaS instances can overwhelm a single FsServer with too many requests for content (>2000 active requests). In this case, the FsServer client will catch an FsServerException and return a CopyFileResult with a result of SourcePathError. If all locations have this issue (which should only be common in the case where a single machine has new content which is needed by all non-master machines), then we can avoid an immediate retry and give the source machine a chance to work through its backlog. This also adds some randomness to the delay in an attempt to spread out the requests.