### PR TITLE
Fix errors getting into custom logs

### DIFF
--- a/Public/Src/App/Bxl/Args.cs
+++ b/Public/Src/App/Bxl/Args.cs
@@ -5,7 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.ContractsLight;
+#if FEATURE_MICROSOFT_DIAGNOSTICS_TRACING
+using Microsoft.Diagnostics.Tracing;
+#else
 using System.Diagnostics.Tracing;
+#endif
 using System.Globalization;
 using System.Linq;
 using BuildXL.Cache.ContentStore.Hashing;

--- a/Public/Src/App/Bxl/Args.cs
+++ b/Public/Src/App/Bxl/Args.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.ContractsLight;
+using System.Diagnostics.Tracing;
 using System.Globalization;
 using System.Linq;
 using BuildXL.Cache.ContentStore.Hashing;
@@ -280,7 +281,7 @@ namespace BuildXL
                             sign => engineConfiguration.Converge = sign),
                         OptionHandlerFactory.CreateOption(
                             "customLog",
-                            opt => ParseKeyValueOption(opt, pathTable, loggingConfiguration.CustomLog)),
+                            opt => ParseCustomLogOption(opt, pathTable, loggingConfiguration.CustomLog)),
                         OptionHandlerFactory.CreateBoolOption(
                             "debuggerBreakOnExit",
                             opt => frontEndConfiguration.DebuggerBreakOnExit = opt),
@@ -1458,25 +1459,26 @@ namespace BuildXL
             map[keyValuePair.Key] = CommandLineUtilities.GetFullPath(keyValuePair.Value, opt, pathTable);
         }
 
-        private static void ParseKeyValueOption(
+        private static void ParseCustomLogOption(
             CommandLineUtilities.Option opt,
             PathTable pathTable,
-            Dictionary<AbsolutePath, IReadOnlyList<int>> map)
+            Dictionary<AbsolutePath, (IReadOnlyList<int>, EventLevel?)> map)
         {
             Contract.Requires(map != null);
 
             var keyValuePair = CommandLineUtilities.ParseKeyValuePair(opt);
 
             var key = CommandLineUtilities.GetFullPath(keyValuePair.Key, opt, pathTable);
-            if (!map.TryGetValue(key, out IReadOnlyList<int> values))
+
+            if (!map.TryGetValue(key, out (IReadOnlyList<int> eventIds, EventLevel? _) value))
             {
-                values = new List<int>(0);
+                value.eventIds = new List<int>();
             }
 
-            var newValues = new List<int>(values);
+            var newValues = new List<int>(value.eventIds);
             ParseInt32ListOption(keyValuePair.Value, opt.Name, newValues);
 
-            map[key] = newValues;
+            map[key] = (newValues, null);
         }
 
         /// <summary>

--- a/Public/Src/App/Bxl/BuildXLApp.cs
+++ b/Public/Src/App/Bxl/BuildXLApp.cs
@@ -242,14 +242,15 @@ namespace BuildXL
         {
             mutableConfig.Logging.CustomLog.Add(
                 mutableConfig.Logging.CacheMissLog,
-                new[]
+                (new[]
                 {
                     (int)EventId.CacheMissAnalysis,
                     (int)EventId.MissingKeyWhenSavingFingerprintStore,
                     (int)EventId.FingerprintStoreSavingFailed,
                     (int)EventId.FingerprintStoreToCompareTrace,
                     (int)EventId.SuccessLoadFingerprintStoreToCompare
-                });
+                },
+                null));
         }
 
         private static void ConfigureDistributionLogging(PathTable pathTable, BuildXL.Utilities.Configuration.Mutable.CommandLineConfiguration mutableConfig)
@@ -257,7 +258,7 @@ namespace BuildXL
             if (mutableConfig.Distribution.BuildRole != DistributedBuildRoles.None)
             {
                 mutableConfig.Logging.CustomLog.Add(
-                    mutableConfig.Logging.RpcLog, DistributionHelpers.DistributionAllMessages.ToArray());
+                    mutableConfig.Logging.RpcLog, (DistributionHelpers.DistributionAllMessages.ToArray(), null));
             }
         }
 
@@ -275,10 +276,11 @@ namespace BuildXL
 
                 // NOTE: We rely on explicit exclusion of pip output messages in CloudBuild rather than turning them off by default.
                 mutableConfig.Logging.CustomLog.Add(
-                    mutableConfig.Logging.PipOutputLog, new[] { (int)EventId.PipProcessOutput });
+                    mutableConfig.Logging.PipOutputLog, (new[] { (int)EventId.PipProcessOutput }, null));
 
                 mutableConfig.Logging.CustomLog.Add(
-                    mutableConfig.Logging.DevLog, new[]
+                    mutableConfig.Logging.DevLog,
+                    (new[]
                     {
                         // Add useful low volume-messages for dev diagnostics here
                         (int)EventId.DominoInvocation,
@@ -336,7 +338,9 @@ namespace BuildXL
                         (int)Engine.Tracing.LogEventId.DeserializedFile,
                         (int)EventId.PipQueueConcurrency,
                         (int)Engine.Tracing.LogEventId.GrpcSettings
-                    });
+                    },
+                    // all errors should be included in a dev log
+                    EventLevel.Error));
 
                 // Distribution related messages are disabled in default text log and routed to special log file
                 mutableConfig.Logging.NoLog.AddRange(DistributionHelpers.DistributionInfoMessages);
@@ -1477,7 +1481,7 @@ namespace BuildXL
                     });
             }
 
-            private void ConfigureAdditionalFileLoggers(IReadOnlyDictionary<AbsolutePath, IReadOnlyList<int>> additionalLoggers)
+            private void ConfigureAdditionalFileLoggers(IReadOnlyDictionary<AbsolutePath, (IReadOnlyList<int> eventIds, EventLevel? nonMaskableLevel)> additionalLoggers)
             {
                 foreach (var additionalLogger in additionalLoggers)
                 {
@@ -1485,7 +1489,7 @@ namespace BuildXL
                         additionalLogger.Key,
                         (writer) =>
                         {
-                            var eventMask = new EventMask(enabledEvents: additionalLogger.Value, disabledEvents: null, nonMaskableLevel: EventLevel.Error);
+                            var eventMask = new EventMask(enabledEvents: additionalLogger.Value.eventIds, disabledEvents: null, nonMaskableLevel: additionalLogger.Value.nonMaskableLevel);
                             return new TextWriterEventListener(
                                 Events.Log,
                                 writer,

--- a/Public/Src/Utilities/Configuration/ILoggingConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/ILoggingConfiguration.cs
@@ -118,7 +118,7 @@ namespace BuildXL.Utilities.Configuration
         /// Creates a custom log file for a specific set of event IDs. Event list should be comma separated integers excluding the DX prefix.
         /// </summary>
         [NotNull]
-        IReadOnlyDictionary<AbsolutePath, IReadOnlyList<int>> CustomLog { get; }
+        IReadOnlyDictionary<AbsolutePath, (IReadOnlyList<int>, System.Diagnostics.Tracing.EventLevel?)> CustomLog { get; }
 
         /// <summary>
         /// Specifies the ETW log kind for custom logs by path. Normal text log kind is 'default'.

--- a/Public/Src/Utilities/Configuration/ILoggingConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/ILoggingConfiguration.cs
@@ -2,7 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+#if FEATURE_MICROSOFT_DIAGNOSTICS_TRACING
+using Microsoft.Diagnostics.Tracing;
+#else
+using System.Diagnostics.Tracing;
+#endif
 using JetBrains.Annotations;
+
 
 namespace BuildXL.Utilities.Configuration
 {
@@ -118,7 +124,7 @@ namespace BuildXL.Utilities.Configuration
         /// Creates a custom log file for a specific set of event IDs. Event list should be comma separated integers excluding the DX prefix.
         /// </summary>
         [NotNull]
-        IReadOnlyDictionary<AbsolutePath, (IReadOnlyList<int>, System.Diagnostics.Tracing.EventLevel?)> CustomLog { get; }
+        IReadOnlyDictionary<AbsolutePath, (IReadOnlyList<int>, EventLevel?)> CustomLog { get; }
 
         /// <summary>
         /// Specifies the ETW log kind for custom logs by path. Normal text log kind is 'default'.

--- a/Public/Src/Utilities/Configuration/ILoggingConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/ILoggingConfiguration.cs
@@ -122,6 +122,8 @@ namespace BuildXL.Utilities.Configuration
 
         /// <summary>
         /// Creates a custom log file for a specific set of event IDs. Event list should be comma separated integers excluding the DX prefix.
+        /// EventLevel specifies the non-skippable events. All events of this of higher event level will be included in the log
+        /// regardless whether they are specified in the event list. Defaults to null (i.e., log will include only the specified events)
         /// </summary>
         [NotNull]
         IReadOnlyDictionary<AbsolutePath, (IReadOnlyList<int>, EventLevel?)> CustomLog { get; }

--- a/Public/Src/Utilities/Configuration/Mutable/LoggingConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/LoggingConfiguration.cs
@@ -4,6 +4,11 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.ContractsLight;
+#if FEATURE_MICROSOFT_DIAGNOSTICS_TRACING
+using Microsoft.Diagnostics.Tracing;
+#else
+using System.Diagnostics.Tracing;
+#endif
 
 namespace BuildXL.Utilities.Configuration.Mutable
 {
@@ -13,7 +18,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
         /// <nodoc />
         public LoggingConfiguration()
         {
-            CustomLog = new Dictionary<AbsolutePath, (IReadOnlyList<int>, System.Diagnostics.Tracing.EventLevel?)>();
+            CustomLog = new Dictionary<AbsolutePath, (IReadOnlyList<int>, EventLevel?)>();
             CustomLogEtwKinds = new Dictionary<AbsolutePath, string>();
             NoLog = new List<int>();
             NoExecutionLog = new List<int>();
@@ -69,7 +74,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             HistoricMetadataCacheLogDirectory = pathRemapper.Remap(template.HistoricMetadataCacheLogDirectory);
             EngineCacheLogDirectory = pathRemapper.Remap(template.EngineCacheLogDirectory);
             EngineCacheCorruptFilesLogDirectory = pathRemapper.Remap(template.EngineCacheCorruptFilesLogDirectory);
-            CustomLog = new Dictionary<AbsolutePath, (IReadOnlyList<int>, System.Diagnostics.Tracing.EventLevel?)>();
+            CustomLog = new Dictionary<AbsolutePath, (IReadOnlyList<int>, EventLevel?)>();
             foreach (var kv in template.CustomLog)
             {
                 CustomLog.Add(pathRemapper.Remap(kv.Key), kv.Value);
@@ -184,10 +189,10 @@ namespace BuildXL.Utilities.Configuration.Mutable
 
         /// <nodoc />
         [SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
-        public Dictionary<AbsolutePath, (IReadOnlyList<int>, System.Diagnostics.Tracing.EventLevel?)> CustomLog { get; set; }
+        public Dictionary<AbsolutePath, (IReadOnlyList<int>, EventLevel?)> CustomLog { get; set; }
 
         /// <inheritdoc />
-        IReadOnlyDictionary<AbsolutePath, (IReadOnlyList<int>, System.Diagnostics.Tracing.EventLevel?)> ILoggingConfiguration.CustomLog => CustomLog;
+        IReadOnlyDictionary<AbsolutePath, (IReadOnlyList<int>, EventLevel?)> ILoggingConfiguration.CustomLog => CustomLog;
 
         /// <nodoc />
         [SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]

--- a/Public/Src/Utilities/Configuration/Mutable/LoggingConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/LoggingConfiguration.cs
@@ -13,7 +13,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
         /// <nodoc />
         public LoggingConfiguration()
         {
-            CustomLog = new Dictionary<AbsolutePath, IReadOnlyList<int>>();
+            CustomLog = new Dictionary<AbsolutePath, (IReadOnlyList<int>, System.Diagnostics.Tracing.EventLevel?)>();
             CustomLogEtwKinds = new Dictionary<AbsolutePath, string>();
             NoLog = new List<int>();
             NoExecutionLog = new List<int>();
@@ -69,7 +69,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             HistoricMetadataCacheLogDirectory = pathRemapper.Remap(template.HistoricMetadataCacheLogDirectory);
             EngineCacheLogDirectory = pathRemapper.Remap(template.EngineCacheLogDirectory);
             EngineCacheCorruptFilesLogDirectory = pathRemapper.Remap(template.EngineCacheCorruptFilesLogDirectory);
-            CustomLog = new Dictionary<AbsolutePath, IReadOnlyList<int>>();
+            CustomLog = new Dictionary<AbsolutePath, (IReadOnlyList<int>, System.Diagnostics.Tracing.EventLevel?)>();
             foreach (var kv in template.CustomLog)
             {
                 CustomLog.Add(pathRemapper.Remap(kv.Key), kv.Value);
@@ -184,10 +184,10 @@ namespace BuildXL.Utilities.Configuration.Mutable
 
         /// <nodoc />
         [SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
-        public Dictionary<AbsolutePath, IReadOnlyList<int>> CustomLog { get; set; }
+        public Dictionary<AbsolutePath, (IReadOnlyList<int>, System.Diagnostics.Tracing.EventLevel?)> CustomLog { get; set; }
 
         /// <inheritdoc />
-        IReadOnlyDictionary<AbsolutePath, IReadOnlyList<int>> ILoggingConfiguration.CustomLog => CustomLog;
+        IReadOnlyDictionary<AbsolutePath, (IReadOnlyList<int>, System.Diagnostics.Tracing.EventLevel?)> ILoggingConfiguration.CustomLog => CustomLog;
 
         /// <nodoc />
         [SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]

--- a/Public/Src/Utilities/UnitTests/Configuration/ConstructorTests.cs
+++ b/Public/Src/Utilities/UnitTests/Configuration/ConstructorTests.cs
@@ -220,6 +220,18 @@ namespace Test.BuildXL.Utilities
                         CreateInstance(context, type.GenericTypeArguments[1], booleanDefault));
                     return newDictionary;
                 }
+
+                if (generic == typeof(ValueTuple<,>))
+                {
+                    var newTuple = Activator.CreateInstance(type);
+
+                    // In ValueTuple classes, the first 7 values are accessible via Item1-Item7 fields.
+                    // The tuple field names (named tuples) aren't part of runtime representation.
+                    type.GetField("Item1").SetValue(newTuple, CreateInstance(context, type.GenericTypeArguments[0], booleanDefault));
+                    type.GetField("Item2").SetValue(newTuple, CreateInstance(context, type.GenericTypeArguments[1], booleanDefault));
+
+                    return newTuple;
+                }
             }
 
             if (type.GetTypeInfo().IsInterface)
@@ -408,7 +420,7 @@ namespace Test.BuildXL.Utilities
 
                     XAssert.IsTrue(
                         (expectedList == null) == (actualList == null),
-                        "One of the lists is null, the other isnt for objPath: {0}",
+                        "One of the lists is null, the other isn't for objPath: {0}",
                         objPath);
                     if (expectedList != null)
                     {
@@ -437,7 +449,7 @@ namespace Test.BuildXL.Utilities
 
                     XAssert.IsTrue(
                         (expectedDictionary == null) == (actualDictionary == null),
-                        $"One of the dictionaries is null, the other isnt for objPath: {objPath}");
+                        $"One of the dictionaries is null, the other isn't for objPath: {objPath}");
                     if (expectedDictionary != null)
                     {
                         XAssert.AreEqual(

--- a/Public/Src/Utilities/Utilities/Tracing/EventMask.cs
+++ b/Public/Src/Utilities/Utilities/Tracing/EventMask.cs
@@ -35,7 +35,7 @@ namespace BuildXL.Utilities.Tracing
         /// numeric level) will not be masked</param>
         /// <param name="enabledEvents">events to be enabled</param>
         /// <param name="disabledEvents">events to be disabled</param>
-        public EventMask(IEnumerable<int> enabledEvents, IEnumerable<int> disabledEvents, EventLevel nonMaskableLevel)
+        public EventMask(IEnumerable<int> enabledEvents, IEnumerable<int> disabledEvents, EventLevel? nonMaskableLevel)
             : this(enabledEvents, disabledEvents)
         {
             Contract.Requires(


### PR DESCRIPTION
This PR changes the behavior of /customlog flag. Now only the event specifically listed will be included in the custom log (previously such logs also included all Error level events).

This PR does not change dev.log, i.e., it stil includes all error level events.

[AB#1558752](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1558752)