### PR TITLE
Outputs order handling

### DIFF
--- a/Public/Src/Engine/Cache/Fingerprints/PipCacheDescriptor.bond
+++ b/Public/Src/Engine/Cache/Fingerprints/PipCacheDescriptor.bond
@@ -40,6 +40,12 @@ struct RelativePathFileMaterializationInfo
     2: BondFileMaterializationInfo Info;
 }
 
+struct AbsolutePathFileMaterializationInfo
+{
+    1: string AbsolutePath;
+    2: BondFileMaterializationInfo Info;
+}
+
 /// <summary>
 /// TODO: Remove along with PipCacheDescriptor (V1)
 /// </summary>
@@ -250,7 +256,7 @@ struct PipCacheDescriptorV2Metadata : PipFingerprintEntryData
     /// Hashes of the outputs
     /// The ordering must match with outputs defined in the pip
     /// </summary>
-    11: vector<BondFileMaterializationInfo> StaticOutputHashes;
+    11: vector<AbsolutePathFileMaterializationInfo> StaticOutputHashes;
 
     /// <summary>
     /// Dynamic outputs (<relative path, hash>) per opaque directory.

--- a/Public/Src/Engine/Cache/Fingerprints/PipCacheDescriptorV2Metadata.cs
+++ b/Public/Src/Engine/Cache/Fingerprints/PipCacheDescriptorV2Metadata.cs
@@ -27,7 +27,7 @@ namespace BuildXL.Engine.Cache.Fingerprints
         /// <nodoc />
         public IEnumerable<BondContentHash> ListRelatedContent()
         {
-            return StaticOutputHashes.Select(info => info.Hash);
+            return StaticOutputHashes.Select(info => info.Info.Hash);
         }
 
         /// <nodoc />

--- a/Public/Src/Engine/Scheduler/Fingerprints/PipFingerprinter.cs
+++ b/Public/Src/Engine/Scheduler/Fingerprints/PipFingerprinter.cs
@@ -254,11 +254,11 @@ namespace BuildXL.Scheduler.Fingerprints
             AddFileOutput(fingerprinter, "StandardError", process.StandardError);
             AddFileOutput(fingerprinter, "StandardOutput", process.StandardOutput);
 
-            fingerprinter.AddOrderIndependentCollection<FileArtifact, ReadOnlyArray<FileArtifact>>("Dependencies", process.Dependencies, (fp, f) => AddFileDependency(fp, f), m_expandedPathFileArtifactComparer);            
-            fingerprinter.AddOrderIndependentCollection<DirectoryArtifact, ReadOnlyArray<DirectoryArtifact>>("DirectoryDependencies", process.DirectoryDependencies, (fp, d) => AddDirectoryDependency(fp, d), m_directoryComparer);
+            fingerprinter.AddCollection<FileArtifact, ReadOnlyArray<FileArtifact>>("Dependencies", process.Dependencies, (fp, f) => AddFileDependency(fp, f));            
+            fingerprinter.AddCollection<DirectoryArtifact, ReadOnlyArray<DirectoryArtifact>>("DirectoryDependencies", process.DirectoryDependencies, (fp, d) => AddDirectoryDependency(fp, d));
                         
-            fingerprinter.AddOrderIndependentCollection<FileArtifactWithAttributes, ReadOnlyArray<FileArtifactWithAttributes>>("Outputs", process.FileOutputs, (fp, f) => AddFileOutput(fp, f), m_expandedPathFileArtifactWithAttributesComparer);
-            fingerprinter.AddOrderIndependentCollection<DirectoryArtifact, ReadOnlyArray<DirectoryArtifact>>("DirectoryOutputs", process.DirectoryOutputs, (h, p) => h.Add(p.Path), m_directoryComparer);
+            fingerprinter.AddCollection<FileArtifactWithAttributes, ReadOnlyArray<FileArtifactWithAttributes>>("Outputs", process.FileOutputs, (fp, f) => AddFileOutput(fp, f));
+            fingerprinter.AddCollection<DirectoryArtifact, ReadOnlyArray<DirectoryArtifact>>("DirectoryOutputs", process.DirectoryOutputs, (h, p) => h.Add(p.Path));
 
             fingerprinter.AddOrderIndependentCollection<AbsolutePath, ReadOnlyArray<AbsolutePath>>("UntrackedPaths", process.UntrackedPaths, (h, p) => h.Add(p), m_pathTable.ExpandedPathComparer);
             fingerprinter.AddOrderIndependentCollection<AbsolutePath, ReadOnlyArray<AbsolutePath>>("UntrackedScopes", process.UntrackedScopes, (h, p) => h.Add(p), m_pathTable.ExpandedPathComparer);

--- a/Public/Src/Engine/Scheduler/Fingerprints/PipFingerprinter.cs
+++ b/Public/Src/Engine/Scheduler/Fingerprints/PipFingerprinter.cs
@@ -254,11 +254,11 @@ namespace BuildXL.Scheduler.Fingerprints
             AddFileOutput(fingerprinter, "StandardError", process.StandardError);
             AddFileOutput(fingerprinter, "StandardOutput", process.StandardOutput);
 
-            fingerprinter.AddCollection<FileArtifact, ReadOnlyArray<FileArtifact>>("Dependencies", process.Dependencies, (fp, f) => AddFileDependency(fp, f));            
-            fingerprinter.AddCollection<DirectoryArtifact, ReadOnlyArray<DirectoryArtifact>>("DirectoryDependencies", process.DirectoryDependencies, (fp, d) => AddDirectoryDependency(fp, d));
-                        
-            fingerprinter.AddCollection<FileArtifactWithAttributes, ReadOnlyArray<FileArtifactWithAttributes>>("Outputs", process.FileOutputs, (fp, f) => AddFileOutput(fp, f));
-            fingerprinter.AddCollection<DirectoryArtifact, ReadOnlyArray<DirectoryArtifact>>("DirectoryOutputs", process.DirectoryOutputs, (h, p) => h.Add(p.Path));
+            fingerprinter.AddOrderIndependentCollection<FileArtifact, ReadOnlyArray<FileArtifact>>("Dependencies", process.Dependencies, (fp, f) => AddFileDependency(fp, f), m_expandedPathFileArtifactComparer);            
+            fingerprinter.AddOrderIndependentCollection<DirectoryArtifact, ReadOnlyArray<DirectoryArtifact>>("DirectoryDependencies", process.DirectoryDependencies, (fp, d) => AddDirectoryDependency(fp, d), m_directoryComparer);
+
+            fingerprinter.AddOrderIndependentCollection<FileArtifactWithAttributes, ReadOnlyArray<FileArtifactWithAttributes>>("Outputs", process.FileOutputs, (fp, f) => AddFileOutput(fp, f), m_expandedPathFileArtifactWithAttributesComparer);
+            fingerprinter.AddOrderIndependentCollection<DirectoryArtifact, ReadOnlyArray<DirectoryArtifact>>("DirectoryOutputs", process.DirectoryOutputs, (h, p) => h.Add(p.Path), m_directoryComparer);
 
             fingerprinter.AddOrderIndependentCollection<AbsolutePath, ReadOnlyArray<AbsolutePath>>("UntrackedPaths", process.UntrackedPaths, (h, p) => h.Add(p), m_pathTable.ExpandedPathComparer);
             fingerprinter.AddOrderIndependentCollection<AbsolutePath, ReadOnlyArray<AbsolutePath>>("UntrackedScopes", process.UntrackedScopes, (h, p) => h.Add(p), m_pathTable.ExpandedPathComparer);

--- a/Public/Src/Engine/Scheduler/Fingerprints/PipFingerprinter.cs
+++ b/Public/Src/Engine/Scheduler/Fingerprints/PipFingerprinter.cs
@@ -259,7 +259,7 @@ namespace BuildXL.Scheduler.Fingerprints
 
             fingerprinter.AddOrderIndependentCollection<FileArtifactWithAttributes, ReadOnlyArray<FileArtifactWithAttributes>>("Outputs", process.FileOutputs, (fp, f) => AddFileOutput(fp, f), m_expandedPathFileArtifactWithAttributesComparer);
             fingerprinter.AddOrderIndependentCollection<DirectoryArtifact, ReadOnlyArray<DirectoryArtifact>>("DirectoryOutputs", process.DirectoryOutputs, (h, p) => h.Add(p.Path), m_directoryComparer);
-
+                         
             fingerprinter.AddOrderIndependentCollection<AbsolutePath, ReadOnlyArray<AbsolutePath>>("UntrackedPaths", process.UntrackedPaths, (h, p) => h.Add(p), m_pathTable.ExpandedPathComparer);
             fingerprinter.AddOrderIndependentCollection<AbsolutePath, ReadOnlyArray<AbsolutePath>>("UntrackedScopes", process.UntrackedScopes, (h, p) => h.Add(p), m_pathTable.ExpandedPathComparer);
 

--- a/Public/Src/Engine/Scheduler/Fingerprints/PipFingerprintingVersion.cs
+++ b/Public/Src/Engine/Scheduler/Fingerprints/PipFingerprintingVersion.cs
@@ -33,7 +33,8 @@ namespace BuildXL.Scheduler.Fingerprints
         /// 57: Fixed enumeration in StoreContentForProcessAndCreateCacheEntryAsync
         /// 58: Added RequiresAdmin field into the process pip.
         /// 59: Report all accesses under shared opaque fix
+        /// 60: Save AbsolutePath in the StaticOutputHashes
         /// </remarks>
-        TwoPhaseV2 = 59,
+        TwoPhaseV2 = 60,
     }
 }

--- a/Public/Src/Engine/Scheduler/PipExecutor.cs
+++ b/Public/Src/Engine/Scheduler/PipExecutor.cs
@@ -2850,11 +2850,12 @@ namespace BuildXL.Scheduler
             List<(FileArtifact, FileMaterializationInfo)> cachedArtifactContentHashes =
                 new List<(FileArtifact, FileMaterializationInfo)>(pip.Outputs.Length);
 
-            // Outputs should be the same as what was in the metadata section.
+            Dictionary<string, FileArtifactWithAttributes> outputs = pip.Outputs.ToDictionary(o => o.Path.ToString(pathTable), o => o);
+            FileArtifactWithAttributes attributedOutput;
             for (int i = 0; i < metadata.StaticOutputHashes.Count; i++)
             {
-                FileMaterializationInfo materializationInfo = metadata.StaticOutputHashes[i].Info.ToFileMaterializationInfo(pathTable);
-                FileArtifactWithAttributes attributedOutput = pip.Outputs.Where(o => AbsolutePath.Create(pathTable, metadata.StaticOutputHashes[i].AbsolutePath) == o.Path).Single();
+                FileMaterializationInfo materializationInfo = metadata.StaticOutputHashes[i].Info.ToFileMaterializationInfo(pathTable);                
+                outputs.TryGetValue(metadata.StaticOutputHashes[i].AbsolutePath, out attributedOutput);
                 FileArtifact output = attributedOutput.ToFileArtifact();
 
                 // Following logic should be in sync with StoreContentForProcess method.

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/OutputReorderTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/OutputReorderTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.IO;
 using System.Linq;
 using BuildXL.Pips.Operations;
 using BuildXL.Scheduler.Fingerprints;
@@ -41,6 +42,9 @@ namespace IntegrationTest.BuildXL.Scheduler
             Process pipA = SchedulePipBuilder(builderA).Process;
             RunScheduler().AssertCacheMiss(pipA.PipId);
 
+            File.Delete(ArtifactToString(outputFile1));
+            File.Delete(ArtifactToString(outputFile2));
+
             ResetPipGraphBuilder();
 
             var opsB = new Operation[]
@@ -57,7 +61,5 @@ namespace IntegrationTest.BuildXL.Scheduler
             var pipB = SchedulePipBuilder(builderB).Process;
             RunScheduler().AssertCacheHit(pipB.PipId);
         }
-
-
     }
 }

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/OutputReorderTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/OutputReorderTests.cs
@@ -25,22 +25,39 @@ namespace IntegrationTest.BuildXL.Scheduler
         {
             FileArtifact outputFile1 = CreateSourceFile();
             FileArtifact outputFile2 = CreateSourceFile();
+            FileArtifact inputFile = CreateSourceFile();
 
-            var builderA = CreatePipBuilder(new Operation[]{});
-            builderA.AddOutputFile(outputFile1, FileExistence.Optional);
-            builderA.AddOutputFile(outputFile2, FileExistence.Optional);
+            var opsA = new Operation[]
+            {
+                Operation.ReadFile(inputFile),
+                Operation.WriteFile(outputFile1, doNotInfer: true),
+                Operation.WriteFile(outputFile2, doNotInfer: true),
+            };
+
+            var builderA = CreatePipBuilder(opsA);
+            builderA.AddOutputFile(outputFile1, FileExistence.Required);
+            builderA.AddOutputFile(outputFile2, FileExistence.Required);
 
             Process pipA = SchedulePipBuilder(builderA).Process;
             RunScheduler().AssertCacheMiss(pipA.PipId);
 
             ResetPipGraphBuilder();
 
-            var builderB = CreatePipBuilder(new Operation[] { });
-            builderB.AddOutputFile(outputFile2, FileExistence.Optional);
-            builderB.AddOutputFile(outputFile1, FileExistence.Optional);
+            var opsB = new Operation[]
+            {
+                Operation.ReadFile(inputFile),
+                Operation.WriteFile(outputFile1, doNotInfer: true),
+                Operation.WriteFile(outputFile2, doNotInfer: true),
+            };
+
+            var builderB = CreatePipBuilder(opsB);
+            builderB.AddOutputFile(outputFile2, FileExistence.Required);
+            builderB.AddOutputFile(outputFile1, FileExistence.Required);
 
             var pipB = SchedulePipBuilder(builderB).Process;
             RunScheduler().AssertCacheHit(pipB.PipId);
         }
+
+
     }
 }

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/OutputReorderTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/OutputReorderTests.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using BuildXL.Pips.Operations;
+using BuildXL.Scheduler.Fingerprints;
+using BuildXL.Storage;
+using BuildXL.Utilities;
+using Test.BuildXL.Executables.TestProcess;
+using Test.BuildXL.Scheduler;
+using Test.BuildXL.TestUtilities.Xunit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace IntegrationTest.BuildXL.Scheduler
+{
+    public class OutputReorderTests : SchedulerIntegrationTestBase
+    {
+        public OutputReorderTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void ReorderOutputsCacheHit()
+        {
+            FileArtifact outputFile1 = CreateSourceFile();
+            FileArtifact outputFile2 = CreateSourceFile();
+
+            var builderA = CreatePipBuilder(new Operation[]{});
+            builderA.AddOutputFile(outputFile1, FileExistence.Optional);
+            builderA.AddOutputFile(outputFile2, FileExistence.Optional);
+
+            Process pipA = SchedulePipBuilder(builderA).Process;
+            RunScheduler().AssertCacheMiss(pipA.PipId);
+
+            ResetPipGraphBuilder();
+
+            var builderB = CreatePipBuilder(new Operation[] { });
+            builderB.AddOutputFile(outputFile2, FileExistence.Optional);
+            builderB.AddOutputFile(outputFile1, FileExistence.Optional);
+
+            var pipB = SchedulePipBuilder(builderB).Process;
+            RunScheduler().AssertCacheHit(pipB.PipId);
+        }
+    }
+}

--- a/Public/Src/Engine/UnitTests/Scheduler/HistoricMetadataCacheTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/HistoricMetadataCacheTests.cs
@@ -55,6 +55,9 @@ namespace Test.BuildXL.Scheduler
                 AbsolutePath.Create(pathTable, X("/M/hgf/sf4as/83afsd"));
                 AbsolutePath.Create(pathTable, X("/Z/bd/sfas/Cache"));
 
+                var abPath1 = AbsolutePath.Create(pathTable, X("/H/aslj/sfas/p1OUT.bin"));
+                var abPath2 = AbsolutePath.Create(pathTable, X("/H/aslj/sfas/P2.txt"));
+
                 var pathSet1 = ObservedPathSetTestUtilities.CreatePathSet(
                     pathTable,
                     X("/X/a/b/c"),
@@ -64,7 +67,14 @@ namespace Test.BuildXL.Scheduler
                 PipCacheDescriptorV2Metadata metadata1 =
                     new PipCacheDescriptorV2Metadata
                     {
-                        StaticOutputHashes = new List<BondFileMaterializationInfo> { new BondFileMaterializationInfo { FileName = "p1OUT.bin" } }
+                        StaticOutputHashes = new List<AbsolutePathFileMaterializationInfo>
+                                            {
+                                                new AbsolutePathFileMaterializationInfo
+                                                {
+                                                    AbsolutePath = abPath1.GetName(pathTable).ToString(context.StringTable),
+                                                    Info = new BondFileMaterializationInfo { FileName = "p1OUT.bin" }
+                                                }
+                                            }
                     };
 
                 var storedPathSet1 = await cache.TryStorePathSetAsync(pathSet1);
@@ -87,7 +97,14 @@ namespace Test.BuildXL.Scheduler
                 PipCacheDescriptorV2Metadata metadata2 =
                     new PipCacheDescriptorV2Metadata
                     {
-                        StaticOutputHashes = new List<BondFileMaterializationInfo> { new BondFileMaterializationInfo { FileName = "P2.txt" } },
+                        StaticOutputHashes = new List<AbsolutePathFileMaterializationInfo>
+                                            {
+                                                new AbsolutePathFileMaterializationInfo
+                                                {
+                                                    AbsolutePath = abPath2.ToString(pathTable),
+                                                    Info = new BondFileMaterializationInfo { FileName = abPath2.GetName(pathTable).ToString(context.StringTable) }
+                                                }
+                                            },
                         DynamicOutputs = new List<List<RelativePathFileMaterializationInfo>>
                                          {
                                          new List<RelativePathFileMaterializationInfo>
@@ -247,7 +264,7 @@ namespace Test.BuildXL.Scheduler
             Assert.Equal(metadata1.StaticOutputHashes.Count, metadata2.StaticOutputHashes.Count);
             for (int i = 0; i < metadata1.StaticOutputHashes.Count; i++)
             {
-                Assert.Equal(metadata1.StaticOutputHashes[i].FileName, metadata2.StaticOutputHashes[i].FileName);
+                Assert.Equal(metadata1.StaticOutputHashes[i].Info.FileName, metadata2.StaticOutputHashes[i].Info.FileName);
             }
 
             Assert.Equal(metadata1.DynamicOutputs.Count, metadata2.DynamicOutputs.Count);

--- a/Public/Src/Engine/UnitTests/Scheduler/PipFingerprinterTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/PipFingerprinterTests.cs
@@ -92,7 +92,7 @@ namespace Test.BuildXL.Scheduler
                 (fingerprinter, pip) => fingerprinter.ComputeWeakFingerprint(pip));
         }
 
-        [Fact]
+        //[Fact]
         public void ProcessFingerprintingOrderIndependent()
         {
             var pathTable = m_context.PathTable;

--- a/Public/Src/Engine/UnitTests/Scheduler/PipFingerprinterTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/PipFingerprinterTests.cs
@@ -92,7 +92,7 @@ namespace Test.BuildXL.Scheduler
                 (fingerprinter, pip) => fingerprinter.ComputeWeakFingerprint(pip));
         }
 
-        //[Fact]
+        [Fact]
         public void ProcessFingerprintingOrderIndependent()
         {
             var pathTable = m_context.PathTable;

--- a/Public/Src/Utilities/Utilities/Pools.cs
+++ b/Public/Src/Utilities/Utilities/Pools.cs
@@ -78,7 +78,7 @@ namespace BuildXL.Utilities
                 map => { map.Clear(); return map; });
 
         /// <summary>
-        /// Global pool of maps from <see cref="BuildXL.Utilities.AbsolutePath"/> to many <see cref="BuildXL.Utilities.FileArtifactWithAttributes"/>.
+        /// Global pool of maps from <see cref="BuildXL.Utilities.AbsolutePath"/> to <see cref="BuildXL.Utilities.FileArtifactWithAttributes"/>.
         /// </summary>
         public static ObjectPool<Dictionary<AbsolutePath, FileArtifactWithAttributes>> AbsolutePathFileArtifactWithAttributesMap { get; } =
             new ObjectPool<Dictionary<AbsolutePath, FileArtifactWithAttributes>>(
@@ -86,7 +86,7 @@ namespace BuildXL.Utilities
                 map => { map.Clear(); return map;});
 
         /// <summary>
-        /// Global pool of maps from string to many <see cref="BuildXL.Utilities.FileArtifactWithAttributes"/>.
+        /// Global pool of maps from string to <see cref="BuildXL.Utilities.FileArtifactWithAttributes"/>.
         /// </summary>
         public static ObjectPool<Dictionary<string, FileArtifactWithAttributes>> StringFileArtifactWithAttributesMap { get; } =
             new ObjectPool<Dictionary<string, FileArtifactWithAttributes>>(

--- a/Public/Src/Utilities/Utilities/Pools.cs
+++ b/Public/Src/Utilities/Utilities/Pools.cs
@@ -86,6 +86,14 @@ namespace BuildXL.Utilities
                 map => { map.Clear(); return map;});
 
         /// <summary>
+        /// Global pool of maps from string to many <see cref="BuildXL.Utilities.FileArtifactWithAttributes"/>.
+        /// </summary>
+        public static ObjectPool<Dictionary<string, FileArtifactWithAttributes>> StringFileArtifactWithAttributesMap { get; } =
+            new ObjectPool<Dictionary<string, FileArtifactWithAttributes>>(
+                () => new Dictionary<string, FileArtifactWithAttributes>(),
+                map => { map.Clear(); return map; });
+
+        /// <summary>
         /// Global pool of StringBuilder instances.
         /// </summary>
         public static ObjectPool<StringBuilder> StringBuilderPool { get; } = new ObjectPool<StringBuilder>(
@@ -463,6 +471,18 @@ namespace BuildXL.Utilities
         public static PooledObjectWrapper<Dictionary<AbsolutePath, FileArtifactWithAttributes>> GetAbsolutePathFileArtifactWithAttributesMap()
         {
             return AbsolutePathFileArtifactWithAttributesMap.GetInstance();
+        }
+
+        /// <summary>
+        /// Gets a mapping from string to <see cref="FileArtifactWithAttributes"/> from a common object pool.
+        /// </summary>
+        /// <remarks>
+        /// You are expected to call the Dispose method on the returned PooledObjectWrapper instance
+        /// when you are done with the set. Calling Dispose returns the set to the pool.
+        /// </remarks>
+        public static PooledObjectWrapper<Dictionary<string, FileArtifactWithAttributes>> GetStringFileArtifactWithAttributesMap()
+        {
+            return StringFileArtifactWithAttributesMap.GetInstance();
         }
     }
 }


### PR DESCRIPTION
This is a proposed solution to fix the reordering issue of the dependencies and outputs.

The outputs are sorted in fingerprint computing. The original order in the spec doesn't matter. So when you change only the dependencies' or/and outputs' orders you will still get cache hit.
However, the dependencies and outputs keeps their original order in the metadata. So when the cache hit pips try to retrieve the output/dependencies contents from metadata by the new spec ordering, they will be messed up and fail the build.

In this PR I updated the PipCacheDescriptor.bond, adding the absolutepath for the StaticOutputHashes. So when we retrieve the metadata, the corresponding outputartifact is going to be associated with the absolutepath instead of index.

[AB#1537359](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1537359)