### PR TITLE
QTest pips are being counted twice in PipCounters

### DIFF
--- a/Public/Sdk/SelfHost/BuildXL/Tools/QTest/Tool.QTestRunner.dsc
+++ b/Public/Sdk/SelfHost/BuildXL/Tools/QTest/Tool.QTestRunner.dsc
@@ -83,7 +83,7 @@ function validateArguments(args: QTestArguments): void {
 export function runQTest(args: QTestArguments): Result {
     args = Object.merge<QTestArguments>(defaultArgs, args);
     validateArguments(args);
-    let tags = Object.merge<string[]>(args.tags, defaultArgs.tags);
+
     let logDir = args.qTestLogs || Context.getNewOutputDirectory("qtestlogs");
     let consolePath = p`${logDir}/qtest.stdout`;
     let qtestRunTempDirectory = Context.getTempDirectory("qtestRunTemp");
@@ -191,7 +191,7 @@ export function runQTest(args: QTestArguments): Result {
 
     let result = Transformer.execute({
         tool: args.qTestTool ? args.qTestTool : qTestTool,
-        tags: tags,
+        tags: args.tags,
         description: args.description,
         arguments: commandLineArgs,
         consoleOutput: consolePath,
@@ -238,7 +238,7 @@ export function runQTest(args: QTestArguments): Result {
 
         Transformer.execute({
             tool: args.qTestTool ? args.qTestTool : qTestTool,
-            tags: tags,
+            tags: args.tags,
             description: "QTest Coverage Upload",
             arguments: commandLineArgsForUploadPip,
             consoleOutput: coverageConsolePath,


### PR DESCRIPTION
Default tags array was merged twice adding duplicate telemetry tags.
This resulted in QTest pips being counted twice in all counters.