### PR TITLE
Enable the MSBuildResolver to work under dotnet core

### DIFF
--- a/Public/Sdk/Public/Managed/Frameworks/helpers.dsc
+++ b/Public/Sdk/Public/Managed/Frameworks/helpers.dsc
@@ -4,7 +4,8 @@ namespace Helpers
 {
     export declare const qualifier : {};
 
-    function getToolTemplate() : Transformer.ExecuteArgumentsComposible {
+    @@public
+    export function getDotNetToolTemplate() : Transformer.ExecuteArgumentsComposible {
         const host = Context.getCurrentHost();
 
         Contract.assert(host.cpuArchitecture === "x64", "The current DotNetCore Runtime package only has x64 version of Node. Ensure this runs on a 64-bit OS -or- update PowerShell.Core package to have other architectures embedded and fix this logic");
@@ -40,7 +41,7 @@ namespace Helpers
         };
     }
 
-    const toolTemplate = getToolTemplate();
+    const toolTemplate = getDotNetToolTemplate();
 
     @@public
     export function wrapInDotNetExeForCurrentOs(args: Transformer.ExecuteArguments) : Transformer.ExecuteArguments {

--- a/Public/Sdk/Public/Managed/Shared/types.dsc
+++ b/Public/Sdk/Public/Managed/Shared/types.dsc
@@ -129,12 +129,12 @@ export interface LinkResource {
 }
 
 @@public
-export function isBinary(item: Reference) : item is Binary {
+export function isBinary(item: any) : item is Binary {
     return item["binary"] !== undefined;
 }
 
 @@public
-export function isAssembly(item: Reference) : item is Assembly {
+export function isAssembly(item: any) : item is Assembly {
     return item["name"] !== undefined &&
            (item["compile"] !== undefined || item["runtime"] !== undefined) &&
            item["contents"] === undefined; // Exclude nuget packages

--- a/Public/Sdk/Public/Managed/Testing/XUnit/xunitframework.dsc
+++ b/Public/Sdk/Public/Managed/Testing/XUnit/xunitframework.dsc
@@ -47,6 +47,7 @@ const xunitNetStandardRuntimeConfigFiles: File[] = Managed.RuntimeConfigFiles.cr
     "xunit.console",
     Managed.Factory.createBinary(xunitNetCoreConsolePackage, r`/lib/netcoreapp2.0/xunit.console.dll`),
     xunitReferences,
+    undefined, // runtimeContentToSkip
     undefined, // appconfig
     true);
 
@@ -62,6 +63,7 @@ function additionalRuntimeContent(args: Managed.TestArguments) : Deployment.Depl
                 "xunit.console",
                 Managed.Factory.createBinary(xunitNetCoreConsolePackage, r`/lib/netcoreapp2.0/xunit.console.dll`),
                 xunitReferences,
+                args.runtimeContentToSkip, 
                 undefined, // appConfig
                 true)),
         xunitConsolePackage.getFile(r`/tools/netcoreapp2.0/xunit.runner.utility.netcoreapp10.dll`),

--- a/Public/Sdk/Public/Managed/managedSdk.dsc
+++ b/Public/Sdk/Public/Managed/managedSdk.dsc
@@ -209,7 +209,7 @@ export function assembly(args: Arguments, targetType: Csc.TargetType) : Result {
 
     if (targetType === "exe")
     {
-        runtimeConfigFiles = RuntimeConfigFiles.createFiles(framework, name, runtimeBinary, references, appConfig);
+        runtimeConfigFiles = RuntimeConfigFiles.createFiles(framework, name, runtimeBinary, references, args.runtimeContentToSkip, appConfig);
         if (framework.applicationDeploymentStyle === "selfContained")
         {
             const frameworkRuntimeFiles = framework.runtimeContentProvider(qualifier.targetRuntime);

--- a/Public/Sdk/Public/Managed/runtimeConfigFiles.dsc
+++ b/Public/Sdk/Public/Managed/runtimeConfigFiles.dsc
@@ -5,6 +5,7 @@ import {Transformer} from "Sdk.Transformers";
 
 import * as Json from "Sdk.Json";
 import * as Shared from "Sdk.Managed.Shared";
+import * as Deployment from "Sdk.Deployment";
 
 namespace RuntimeConfigFiles {
 
@@ -18,6 +19,7 @@ namespace RuntimeConfigFiles {
         assemblyName: string, 
         runtimeBinary: Shared.Binary,
         references: Shared.Reference[], 
+        runtimeContentToSkip: Deployment.DeployableItem[], 
         appConfig: File, 
         testRunnerDeployment?: boolean
         ) : File[] {
@@ -44,7 +46,7 @@ namespace RuntimeConfigFiles {
                 }
 
                 return [
-                    createDependenciesJson(framework, assemblyName, runtimeBinary, references, testRunnerDeployment),
+                    createDependenciesJson(framework, assemblyName, runtimeBinary, references, runtimeContentToSkip, testRunnerDeployment),
                     createRuntimeConfigJson(framework, assemblyName, runtimeConfigFolder, testRunnerDeployment),
                 ];
             case "none":
@@ -68,12 +70,13 @@ namespace RuntimeConfigFiles {
         assemblyName: string,
         runtimeBinary: Shared.Binary,
         references: Shared.Reference[], 
+        runtimeContentToSkip: Deployment.DeployableItem[], 
         testRunnerDeployment?: boolean
         ): File {
 
         const specFileOutput = Context.getNewOutputDirectory("DotNetSpecFiles");
 
-        const runtimeReferences = Helpers.computeTransitiveReferenceClosure(framework, references, false);
+        const runtimeReferences = Helpers.computeTransitiveReferenceClosure(framework, references, runtimeContentToSkip, false);
 
         const dependencySpecExtension = `${assemblyName}.deps.json`;
         const dependencySpecPath = p`${specFileOutput}/${dependencySpecExtension}`;

--- a/Public/Sdk/Public/Prelude/Prelude.Configuration.Resolvers.dsc
+++ b/Public/Sdk/Public/Prelude/Prelude.Configuration.Resolvers.dsc
@@ -136,12 +136,28 @@ interface MsBuildResolver extends ResolverBase, UntrackingSettings {
     runInContainer?: boolean;
 
     /**
-     * Collection of directories to search for the required MsBuild assemblies and MsBuild.exe (a.k.a. MSBuild toolset).
+     * Collection of directories to search for the required MsBuild assemblies and MsBuild.exe/MSBuild.dll (a.k.a. MSBuild toolset).
      * If not specified, locations in %PATH% are used.
      * Locations are traversed in specification order.
     */
     msBuildSearchLocations?: Directory[];
 
+    /**
+     * Whether to use the full framework or dotnet core version of MSBuild. Selected runtime is used both for build evaluation and execution.
+     * Default is full framework.
+     * Observe that using the full framework version means that msbuild.exe is expected to be found in msbuildSearchLocations 
+     * (or PATH if not specified). If using the dotnet core version, the same logic applies but to msbuild.dll
+     */
+    msBuildRuntime?: "FullFramework" | "DotNetCore";
+
+    /**
+     * Collection of directories to search for dotnet.exe, when DotNetCore is specified as the msBuildRuntime. If not 
+     * specified, locations in %PATH% are used.
+     * Locations are traversed in specification order.
+     * It has no effect if the specified MSBuild runtime is full framework.
+     */
+    dotNetSearchLocations?: Directory[];
+    
     /**
      * Optional file paths for the projects or solutions that should be used to start parsing. These are relative
      * paths with respect to the root traversal.

--- a/Public/Sdk/SelfHost/Libraries/Dotnet-Runtime-External/DotNet-Runtime.linux-x64.dsc
+++ b/Public/Sdk/SelfHost/Libraries/Dotnet-Runtime-External/DotNet-Runtime.linux-x64.dsc
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import {Transformer} from "Sdk.Transformers";
+import {createPublicDotNetRuntime} from "DotNet-Runtime.Common";
+
+const v3 = <StaticDirectory>importFrom("DotNet-Runtime.linux-x64.3.0.0-preview5").extracted;
+const v2 = <StaticDirectory>importFrom("DotNet-Runtime.linux-x64.2.2.2").extracted;
+
+@@public
+export const extracted = createPublicDotNetRuntime(v3, v2);

--- a/Public/Sdk/SelfHost/Libraries/Dotnet-Runtime-External/DotNet-Runtime.osx-x64.dsc
+++ b/Public/Sdk/SelfHost/Libraries/Dotnet-Runtime-External/DotNet-Runtime.osx-x64.dsc
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import {Transformer} from "Sdk.Transformers";
+import {createPublicDotNetRuntime} from "DotNet-Runtime.Common";
+
+const v3 = <StaticDirectory>importFrom("DotNet-Runtime.osx-x64.3.0.0-preview5").extracted;
+const v2 = <StaticDirectory>importFrom("DotNet-Runtime.osx-x64.2.2.2").extracted;
+
+@@public
+export const extracted = createPublicDotNetRuntime(v3, v2);

--- a/Public/Sdk/SelfHost/Libraries/Dotnet-Runtime-External/DotNet-Runtime.win-x64.dsc
+++ b/Public/Sdk/SelfHost/Libraries/Dotnet-Runtime-External/DotNet-Runtime.win-x64.dsc
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import {Transformer} from "Sdk.Transformers";
+import {createPublicDotNetRuntime} from "DotNet-Runtime.Common";
+
+const v3 = <StaticDirectory>importFrom("DotNet-Runtime.win-x64.3.0.0-preview5").extracted;
+const v2 = <StaticDirectory>importFrom("DotNet-Runtime.win-x64.2.2.2").extracted;
+
+@@public
+export const extracted = createPublicDotNetRuntime(v3, v2);

--- a/Public/Sdk/SelfHost/Libraries/Dotnet-Runtime-External/common.dsc
+++ b/Public/Sdk/SelfHost/Libraries/Dotnet-Runtime-External/common.dsc
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import {Transformer} from "Sdk.Transformers";
+
+@@public
+export function createPublicDotNetRuntime(v3Runtime : StaticDirectory, v2Runtime: StaticDirectory) : StaticDirectory {
+    const netCoreAppV2 = v2Runtime.contents.filter(file => file.path.isWithin(d`${v2Runtime.root}/shared`));
+
+    // We create a package that has dotnet executable and related SDK, plus the V2 SDK
+    const dotNetRuntimeRoot = Context.getNewOutputDirectory("DotNet-Runtime");
+    
+    const sealDirectory = Transformer.sealDirectory(
+        dotNetRuntimeRoot, 
+        [
+            ...v3Runtime.contents.map(file => Transformer.copyFile(file, file.path.relocate(v3Runtime.root, dotNetRuntimeRoot))), 
+            ...netCoreAppV2.map(file => Transformer.copyFile(file, file.path.relocate(v2Runtime.root, dotNetRuntimeRoot)))
+        ]
+    );
+
+    return sealDirectory;
+}

--- a/Public/Sdk/SelfHost/Libraries/Dotnet-Runtime-External/module.config.dsc
+++ b/Public/Sdk/SelfHost/Libraries/Dotnet-Runtime-External/module.config.dsc
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// These are the external versions of the architecture-specific DotNet-Runtime packages.
+// They are created from the 3.0.0-preview5 version, plus the 2.2 NetCore.App SDK, which is deployed side-by-side
+// The latter is required for MSBuild tests
+
+module({
+    name: "DotNet-Runtime.win-x64", 
+    nameResolutionSemantics: NameResolutionSemantics.implicitProjectReferences,
+    projects: [f`DotNet-Runtime.win-x64.dsc`]
+});
+
+module({
+    name: "DotNet-Runtime.osx-x64", 
+    nameResolutionSemantics: NameResolutionSemantics.implicitProjectReferences,
+    projects: [f`DotNet-Runtime.osx-x64.dsc`]
+});
+
+module({
+    name: "DotNet-Runtime.linux-x64", 
+    nameResolutionSemantics: NameResolutionSemantics.implicitProjectReferences,
+    projects: [f`DotNet-Runtime.linux-x64.dsc`]
+});
+
+module({
+    name: "DotNet-Runtime.Common", 
+    nameResolutionSemantics: NameResolutionSemantics.implicitProjectReferences,
+    projects: [f`common.dsc`]
+});

--- a/Public/Sdk/SelfHost/Libraries/MSBuild/msbuild.dsc
+++ b/Public/Sdk/SelfHost/Libraries/MSBuild/msbuild.dsc
@@ -34,8 +34,7 @@ export const msbuildRuntimeContent = [
 
 function getFrameworkFolder() { 
     return BuildXLSdk.isDotNetCoreBuild ? "dotnetcore" : qualifier.targetFramework;
-}
-    
+}  
 
 @@public
 export const deployment = [

--- a/Public/Sdk/SelfHost/Libraries/MSBuild/msbuild.dsc
+++ b/Public/Sdk/SelfHost/Libraries/MSBuild/msbuild.dsc
@@ -21,7 +21,7 @@ export const msbuildRuntimeContent = [
     importFrom("System.Numerics.Vectors").pkg,
     importFrom("Microsoft.Build.Runtime").pkg,
     ...BuildXLSdk.isDotNetCoreBuild ? [
-        importFrom("CodePagesForMSBuild").withQualifier({targetFramework: "netstandard2.0"}).pkg,
+        importFrom("System.Text.Encoding.CodePages").withQualifier({targetFramework: "netstandard2.0"}).pkg,
         importFrom("Microsoft.Build.Tasks.Core").withQualifier({targetFramework: "netstandard2.0"}).pkg,
         importFrom("Microsoft.Build.Runtime").Contents.all.getFile(r`contentFiles/any/netcoreapp2.1/MSBuild.dll`),
         importFrom("Microsoft.Build.Runtime").Contents.all.getFile(r`contentFiles/any/netcoreapp2.1/MSBuild.runtimeconfig.json`),

--- a/Public/Sdk/SelfHost/Libraries/MSBuild/msbuild.dsc
+++ b/Public/Sdk/SelfHost/Libraries/MSBuild/msbuild.dsc
@@ -21,6 +21,7 @@ export const msbuildRuntimeContent = [
     importFrom("System.Numerics.Vectors").pkg,
     importFrom("Microsoft.Build.Runtime").pkg,
     ...BuildXLSdk.isDotNetCoreBuild ? [
+        importFrom("Microsoft.NETCore.App.210").pkg,
         importFrom("System.Text.Encoding.CodePages").withQualifier({targetFramework: "netstandard2.0"}).pkg,
         importFrom("Microsoft.Build.Tasks.Core").withQualifier({targetFramework: "netstandard2.0"}).pkg,
         importFrom("Microsoft.Build.Runtime").Contents.all.getFile(r`contentFiles/any/netcoreapp2.1/MSBuild.dll`),

--- a/Public/Sdk/SelfHost/Libraries/MSBuild/msbuild.dsc
+++ b/Public/Sdk/SelfHost/Libraries/MSBuild/msbuild.dsc
@@ -33,9 +33,10 @@ export const msbuildRuntimeContent = [
 ];
 
 function getFrameworkFolder() { 
-    return qualifier.targetFramework === "net472" ? a`net472` : a`dotnetcore`; 
+    return BuildXLSdk.isDotNetCoreBuild ? "dotnetcore" : qualifier.targetFramework;
 }
     
+
 @@public
 export const deployment = [
     {

--- a/Public/Sdk/SelfHost/Libraries/MSBuild/msbuild.dsc
+++ b/Public/Sdk/SelfHost/Libraries/MSBuild/msbuild.dsc
@@ -17,7 +17,7 @@ export const msbuildReferences: Managed.ManagedNugetPackage[] = [
 /** Runtime content for tests */
 @@public
 export const msbuildRuntimeContent = [
-    importFrom("System.Threading.Tasks.Dataflow").pkg,
+    BuildXLSdk.isDotNetCoreBuild ? importFrom("System.Threading.Tasks.Dataflow").pkg : importFrom("DataflowForMSBuild").pkg,
     importFrom("System.Numerics.Vectors").pkg,
     importFrom("Microsoft.Build.Runtime").pkg,
     ...BuildXLSdk.isDotNetCoreBuild ? [

--- a/Public/Sdk/SelfHost/MacOS/coreRT.dsc
+++ b/Public/Sdk/SelfHost/MacOS/coreRT.dsc
@@ -17,7 +17,7 @@ export namespace CoreRT {
     @@public
     export function compileToNative(asm: Shared.Assembly): NativeExecutableResult {
         /** Compile to native object file */
-        const referencesClosure = Managed.Helpers.computeTransitiveClosure(asm.references, /*compile*/ false);
+        const referencesClosure = Managed.Helpers.computeTransitiveClosure(asm.references, asm.runtimeContentToSkip, /*compile*/ false);
         const ilcResult = Ilc.compile({
             out: `${asm.name}.o`,
             inputs: [ 

--- a/Public/Src/Deployment/buildXL.dsc
+++ b/Public/Src/Deployment/buildXL.dsc
@@ -45,14 +45,7 @@ namespace BuildXL {
                                     ).exe
                                 ]
                             } ] ),
-                    {
-                        subfolder: r`MsBuildGraphBuilder`,
-                        contents: BuildXLSdk.isDotNetCoreBuild ? [] : [
-                            // If the current qualifier is full framework, this tool has to be built with 472
-                            importFrom("BuildXL.Tools").MsBuildGraphBuilder.withQualifier(
-                                Object.merge<(typeof qualifier) & {targetFramework: "net472"}>(qualifier, {targetFramework: "net472"})).exe
-                        ]
-                    },
+                    importFrom("BuildXL.Tools").MsBuildGraphBuilder.deployment,
                     {
                         subfolder: r`bvfs`,
                         contents: qualifier.targetRuntime !== "win-x64" ? [] : [

--- a/Public/Src/FrontEnd/MsBuild.Serialization/MSBuildGraphBuilderArguments.cs
+++ b/Public/Src/FrontEnd/MsBuild.Serialization/MSBuildGraphBuilderArguments.cs
@@ -59,6 +59,11 @@ namespace BuildXL.FrontEnd.MsBuild.Serialization
         /// </remarks>
         public bool AllowProjectsWithoutTargetProtocol { get; }
 
+        /// <summary>
+        /// Whether the MSBuild runtime is DotNet core (as opposed to full framework)
+        /// </summary>
+        public bool MsBuildRuntimeIsDotNetCore { get; }
+
         /// <nodoc/>
         public MSBuildGraphBuilderArguments(
             IReadOnlyCollection<string> projectsToParse,
@@ -67,7 +72,8 @@ namespace BuildXL.FrontEnd.MsBuild.Serialization
             IReadOnlyCollection<string> mSBuildSearchLocations,
             IReadOnlyCollection<string> entryPointTargets,
             IReadOnlyCollection<GlobalProperties> requestedQualifiers,
-            bool allowProjectsWithoutTargetProtocol)
+            bool allowProjectsWithoutTargetProtocol,
+            bool msBuildRuntimeIsDotNetCore)
         {
             Contract.Requires(projectsToParse?.Count > 0);
             Contract.Requires(!string.IsNullOrEmpty(outputPath));
@@ -83,6 +89,7 @@ namespace BuildXL.FrontEnd.MsBuild.Serialization
             EntryPointTargets = entryPointTargets;
             RequestedQualifiers = requestedQualifiers;
             AllowProjectsWithoutTargetProtocol = allowProjectsWithoutTargetProtocol;
+            MsBuildRuntimeIsDotNetCore = msBuildRuntimeIsDotNetCore;
         }
 
         /// <inheritdoc/>
@@ -94,7 +101,8 @@ Serialized graph path: {OutputPath}
 Global properties: {string.Join(" ", GlobalProperties.Select(kvp => $"[{kvp.Key}]={kvp.Value}"))}
 Search locations: {string.Join(" ", MSBuildSearchLocations)}
 Requested qualifiers: {string.Join(" ", RequestedQualifiers.Select(qualifier => string.Join(";", qualifier.Select(kvp => $"[{kvp.Key}]={kvp.Value}"))))}
-Allow projects without target protocol: {AllowProjectsWithoutTargetProtocol}";
+Allow projects without target protocol: {AllowProjectsWithoutTargetProtocol}
+MSBuild runtime is DotNetCore: {MsBuildRuntimeIsDotNetCore}";
         }
     }
 }

--- a/Public/Src/FrontEnd/MsBuild.Serialization/ProjectGraphWithPredictionsResult.cs
+++ b/Public/Src/FrontEnd/MsBuild.Serialization/ProjectGraphWithPredictionsResult.cs
@@ -29,39 +29,57 @@ namespace BuildXL.FrontEnd.MsBuild.Serialization
         public IReadOnlyDictionary<string, TPathType> MsBuildAssemblyPaths { get; }
         
         /// <summary>
-        /// Path to MsBuild.exe that was found
+        /// Path to MsBuild that was found
         /// </summary>
         /// <remarks>
         /// The path may not be valid if <see cref="Succeeded"/> is false.
+        /// The last component of the path could be either MSBuild.exe or MSBuild.dll, depending on the selected runtime.
         /// </remarks>
-        public TPathType PathToMsBuildExe { get; }
+        public TPathType PathToMsBuild { get; }
+
+        /// <summary>
+        /// Path to dotnet.exe, if the dotnet core version of MSBuild was specified to run
+        /// </summary>
+        /// <remarks>
+        /// This is not actually populated by the graph construction tool, but by bxl
+        /// </remarks>
+        public TPathType PathToDotNetExe { get; }
 
         /// <nodoc/>
         public bool Succeeded { get; }
 
         /// <nodoc/>
-        public static ProjectGraphWithPredictionsResult<TPathType> CreateSuccessfulGraph(ProjectGraphWithPredictions<TPathType> projectGraphWithPredictions, IReadOnlyDictionary<string, TPathType> assemblyPathsToLoad, TPathType pathToMsBuildExe)
+        public static ProjectGraphWithPredictionsResult<TPathType> CreateSuccessfulGraph(ProjectGraphWithPredictions<TPathType> projectGraphWithPredictions, IReadOnlyDictionary<string, TPathType> assemblyPathsToLoad, TPathType pathToMsBuild)
         {
             Contract.Requires(projectGraphWithPredictions != null);
             Contract.Requires(assemblyPathsToLoad != null);
-            return new ProjectGraphWithPredictionsResult<TPathType>(projectGraphWithPredictions, failure: default, msBuildAssemblyPaths: assemblyPathsToLoad, pathToMsBuildExe: pathToMsBuildExe, succeeded: true);
+            return new ProjectGraphWithPredictionsResult<TPathType>(projectGraphWithPredictions, failure: default, msBuildAssemblyPaths: assemblyPathsToLoad, pathToMsBuild: pathToMsBuild, pathToDotNetExe: default(TPathType), succeeded: true);
         }
 
         /// <nodoc/>
-        public static ProjectGraphWithPredictionsResult<TPathType> CreateFailure(GraphConstructionError failure, IReadOnlyDictionary<string, TPathType> assemblyPathsToLoad, TPathType pathToMsBuildExe)
+        public static ProjectGraphWithPredictionsResult<TPathType> CreateFailure(GraphConstructionError failure, IReadOnlyDictionary<string, TPathType> assemblyPathsToLoad, TPathType pathToMsBuild)
         {
             Contract.Requires(failure != null);
             Contract.Requires(assemblyPathsToLoad != null);
-            return new ProjectGraphWithPredictionsResult<TPathType>(default, failure, assemblyPathsToLoad, pathToMsBuildExe, succeeded: false);
+            return new ProjectGraphWithPredictionsResult<TPathType>(default, failure, assemblyPathsToLoad, pathToMsBuild, pathToDotNetExe: default(TPathType), succeeded: false);
+        }
+
+        /// <summary>
+        /// Returns a new instance of this with a specific path to dotnet.exe
+        /// </summary>
+        public ProjectGraphWithPredictionsResult<TPathType> WithPathToDotNetExe(TPathType pathToDotNetExe)
+        {
+            return new ProjectGraphWithPredictionsResult<TPathType>(Result, Failure, MsBuildAssemblyPaths, PathToMsBuild, pathToDotNetExe, Succeeded);
         }
 
         [JsonConstructor]
-        private ProjectGraphWithPredictionsResult(ProjectGraphWithPredictions<TPathType> result, GraphConstructionError failure, IReadOnlyDictionary<string, TPathType> msBuildAssemblyPaths, TPathType pathToMsBuildExe, bool succeeded)
+        private ProjectGraphWithPredictionsResult(ProjectGraphWithPredictions<TPathType> result, GraphConstructionError failure, IReadOnlyDictionary<string, TPathType> msBuildAssemblyPaths, TPathType pathToMsBuild, TPathType pathToDotNetExe, bool succeeded)
         {
             Result = result;
             Failure = failure;
             Succeeded = succeeded;
-            PathToMsBuildExe = pathToMsBuildExe;
+            PathToMsBuild = pathToMsBuild;
+            PathToDotNetExe = pathToDotNetExe;
             MsBuildAssemblyPaths = msBuildAssemblyPaths;
         }
     }

--- a/Public/Src/FrontEnd/MsBuild/MsBuildFrontEnd.cs
+++ b/Public/Src/FrontEnd/MsBuild/MsBuildFrontEnd.cs
@@ -64,11 +64,7 @@ namespace BuildXL.FrontEnd.MsBuild
                 // If this is the first time a resolver is reporting the load of MsBuild assemblies, we just store the result
                 if (m_loadedMsBuildAssemblyLocations.Count == 0)
                 {
-                    foreach(var assembly in assemblyPathsToLoad)
-                    {
-                        m_loadedMsBuildAssemblyLocations.Add(assembly);
-                    }
-                    
+                    m_loadedMsBuildAssemblyLocations.AddRange(assemblyPathsToLoad);
                     return true;
                 }
 

--- a/Public/Src/FrontEnd/MsBuild/MsBuildResolver.cs
+++ b/Public/Src/FrontEnd/MsBuild/MsBuildResolver.cs
@@ -158,7 +158,8 @@ namespace BuildXL.FrontEnd.MsBuild
                 m_host, 
                 result.ModuleDefinition, 
                 m_msBuildResolverSettings, 
-                result.MsBuildExeLocation, 
+                result.MsBuildLocation, 
+                result.DotNetExeLocation,
                 m_frontEndName, 
                 m_msBuildWorkspaceResolver.UserDefinedEnvironment, 
                 m_msBuildWorkspaceResolver.UserDefinedPassthroughVariables);

--- a/Public/Src/FrontEnd/MsBuild/PipGraphConstructor.cs
+++ b/Public/Src/FrontEnd/MsBuild/PipGraphConstructor.cs
@@ -35,7 +35,8 @@ namespace BuildXL.FrontEnd.MsBuild
             FrontEndHost frontEndHost,
             ModuleDefinition moduleDefinition,
             IMsBuildResolverSettings resolverSettings,
-            AbsolutePath pathToMsBuildExe,
+            AbsolutePath pathToMsBuild,
+            AbsolutePath pathToDotnetExe,
             string frontEndName,
             IEnumerable<KeyValuePair<string, string>> userDefinedEnvironment,
             IEnumerable<string> userDefinedPassthroughVariables)
@@ -44,14 +45,15 @@ namespace BuildXL.FrontEnd.MsBuild
             Contract.Requires(frontEndHost != null);
             Contract.Requires(moduleDefinition != null);
             Contract.Requires(resolverSettings != null);
-            Contract.Requires(pathToMsBuildExe.IsValid);
+            Contract.Requires(pathToMsBuild.IsValid);
+            Contract.Requires(!resolverSettings.ShouldRunDotNetCoreMSBuild() || pathToDotnetExe.IsValid);
             Contract.Requires(!string.IsNullOrEmpty(frontEndName));
             Contract.Requires(userDefinedEnvironment != null);
             Contract.Requires(userDefinedPassthroughVariables != null);
 
             m_context = context;
             m_frontEndHost = frontEndHost;
-            m_pipConstructor = new PipConstructor(context, frontEndHost, moduleDefinition, resolverSettings, pathToMsBuildExe, frontEndName, userDefinedEnvironment, userDefinedPassthroughVariables);
+            m_pipConstructor = new PipConstructor(context, frontEndHost, moduleDefinition, resolverSettings, pathToMsBuild, pathToDotnetExe, frontEndName, userDefinedEnvironment, userDefinedPassthroughVariables);
         }
 
         /// <summary>

--- a/Public/Src/FrontEnd/MsBuild/ProjectGraphResult.cs
+++ b/Public/Src/FrontEnd/MsBuild/ProjectGraphResult.cs
@@ -21,18 +21,22 @@ namespace BuildXL.FrontEnd.MsBuild
         public ModuleDefinition ModuleDefinition { get; }
 
         /// <nodoc/>
-        public AbsolutePath MsBuildExeLocation { get; }
+        public AbsolutePath MsBuildLocation { get; }
 
         /// <nodoc/>
-        public ProjectGraphResult(ProjectGraphWithPredictions<AbsolutePath> projectGraphWithPredictions, ModuleDefinition moduleDefinition, AbsolutePath msBuildExeLocation)
+        public AbsolutePath DotNetExeLocation { get; }
+
+        /// <nodoc/>
+        public ProjectGraphResult(ProjectGraphWithPredictions<AbsolutePath> projectGraphWithPredictions, ModuleDefinition moduleDefinition, AbsolutePath msBuildLocation, AbsolutePath dotnetExeLocation)
         {
             Contract.Requires(projectGraphWithPredictions != null);
             Contract.Requires(moduleDefinition != null);
-            Contract.Requires(msBuildExeLocation.IsValid);
+            Contract.Requires(msBuildLocation.IsValid);
 
             ProjectGraph = projectGraphWithPredictions;
             ModuleDefinition = moduleDefinition;
-            MsBuildExeLocation = msBuildExeLocation;
+            MsBuildLocation = msBuildLocation;
+            DotNetExeLocation = dotnetExeLocation;
         }
     }
 }

--- a/Public/Src/FrontEnd/MsBuild/Tracing/Log.cs
+++ b/Public/Src/FrontEnd/MsBuild/Tracing/Log.cs
@@ -69,9 +69,9 @@ namespace BuildXL.FrontEnd.MsBuild.Tracing
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Error,
             EventTask = (ushort)Tasks.Parser,
-            Message = EventConstants.LabeledProvenancePrefix + "Build parameter 'PATH' is not specified, and no explicit locations were defined in the resolver settings via 'MsBuildAssemblyLocations'.",
+            Message = EventConstants.LabeledProvenancePrefix + "Build parameter 'PATH' is not specified, and no explicit locations were defined in the resolver settings via '{specifiedVia}'.",
             Keywords = (int)(Keywords.UserMessage | Keywords.Diagnostics))]
-        public abstract void NoSearchLocationsSpecified(LoggingContext context, Location location);
+        public abstract void NoSearchLocationsSpecified(LoggingContext context, Location location, string specifiedVia);
 
         [GeneratedEvent(
             (ushort)LogEventId.CannotParseBuildParameterPath,

--- a/Public/Src/FrontEnd/UnitTests/Libs/Prelude.Configuration.Resolvers.ts
+++ b/Public/Src/FrontEnd/UnitTests/Libs/Prelude.Configuration.Resolvers.ts
@@ -122,6 +122,21 @@ interface MsBuildResolver {
     */
     msBuildSearchLocations?: Directory[];
 
+	 /**
+     * Whether to use the full framework or dotnet core version of MSBuild. Selected runtime is used both for build evaluation and execution.
+     * Default is full framework.
+     * Observe that using the full framework version means that msbuild.exe is expected to be found in msbuildSearchLocations 
+     * (or PATH if not specified). If using the dotnet core version, the same logic applies but to msbuild.dll
+     */
+    msBuildRuntime?: "FullFramework" | "DotNetCore";
+
+    /**
+     * Collection of directories to search for dotnet.exe, when DotNetCore is specified as the msBuildRuntime. If not 
+     * specified, locations in %PATH% are used.
+     * Locations are traversed in specification order.
+     */
+    dotNetSearchLocations?: Directory[];
+	
     /**
      * Targets to execute on the entry point project.
      * If not provided, the default targets are used.

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/ExecutionTests/MsBuildDotNetRuntimeTests.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/ExecutionTests/MsBuildDotNetRuntimeTests.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using BuildXL.Utilities.Configuration.Mutable;
+using BuildXL.Engine.Tracing;
+using BuildXL.Pips.Operations;
+using BuildXL.Scheduler.Graph;
+using Test.BuildXL.EngineTestUtilities;
+using Xunit;
+using Xunit.Abstractions;
+using System;
+using BuildXL.Utilities;
+using BuildXL.Utilities.Configuration;
+
+namespace Test.BuildXL.FrontEnd.MsBuild
+{
+    /// <summary>
+    /// Uses an MSBuild resolver to schedule and execute pips based on MSBuild.
+    /// </summary>
+    /// <remarks>
+    /// These tests actually execute pips, and are therefore expensive
+    /// </remarks>
+    public class MsBuildDotNetRuntimeTests : MsBuildPipExecutionTestBase
+    {
+        public MsBuildDotNetRuntimeTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        [Theory]
+        [InlineData("DotNetCore")]
+        [InlineData("FullFramework")]
+        public void RuntimeSelectionIsEffective(string msBuildRuntime)
+        {
+            const string TestProj1 = "test1.csproj";
+            var pathToTestProj1 = R("public", "dir1", TestProj1);
+            
+            const string Dirs = "dirs.proj";
+            var config = (CommandLineConfiguration)Build(
+                        msBuildRuntime: msBuildRuntime, 
+                        dotnetSearchLocations: $"[d`{TestDeploymentDir}/{RelativePathToDotnetExe}`]")
+                    .AddSpec(Dirs, CreateDirsProject(pathToTestProj1))
+                    .AddSpec(pathToTestProj1, CreateEmptyProject())
+                    .PersistSpecsAndGetConfiguration();
+
+            config.Sandbox.FileSystemMode = FileSystemMode.RealAndMinimalPipGraph;
+
+            var engineResult = RunEngineWithConfig(config);
+            Assert.True(engineResult.IsSuccess);
+
+            var pipGraph = engineResult.EngineState.PipGraph;
+
+            var processPips = pipGraph.RetrievePipsOfType(PipType.Process).ToList();
+            var testProj1 = (Process)processPips.Find(pip => pip.Provenance.OutputValueSymbol.ToString(engineResult.EngineState.SymbolTable).Contains(TestProj1));
+            Assert.True(testProj1 != null);
+
+            if (msBuildRuntime == "DotNetCore")
+            {
+                // The main executable has to be dotnet.exe (or dotnet in the mac/unix case)
+                Assert.Contains("DOTNET", testProj1.Executable.Path.ToString(PathTable).ToUpperInvariant());
+            }
+            else
+            {
+                // The main executable has to be msbuild.exe
+                Assert.Contains("MSBUILD.EXE", testProj1.Executable.Path.ToString(PathTable).ToUpperInvariant());
+            }
+        }
+    }
+}

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/ExecutionTests/MsBuildIntegrationTests.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/ExecutionTests/MsBuildIntegrationTests.cs
@@ -136,7 +136,9 @@ namespace Test.BuildXL.FrontEnd.MsBuild
                             runInContainer: false, 
                             environment: environment, 
                             globalProperties: null,
-                            filenameEntryPoint: pathToTestProj1)
+                            filenameEntryPoint: pathToTestProj1,
+                            msBuildRuntime: null,
+                            dotnetSearchLocations: null)
                     .AddSpec(pathToTestProj1, CreateWriteFileTestProject("MyFile"))
                     .PersistSpecsAndGetConfiguration();
 

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/Infrastructure/MsBuildPipSchedulingTestBase.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/Infrastructure/MsBuildPipSchedulingTestBase.cs
@@ -40,6 +40,19 @@ namespace Test.BuildXL.FrontEnd.MsBuild.Infrastructure
 
         protected AbsolutePath TestPath { get; }
 
+        // Keep the paths below in sync with Public\Src\FrontEnd\UnitTests\MsBuild\Test.BuildXL.FrontEnd.MsBuild.dsc
+        private AbsolutePath FullframeworkMSBuild => AbsolutePath.Create(PathTable, TestDeploymentDir)
+            .Combine(PathTable, "msbuild")
+            .Combine(PathTable, "net472")
+            .Combine(PathTable, "MSBuild.exe");
+        private AbsolutePath DotnetCoreMSBuild => AbsolutePath.Create(PathTable, TestDeploymentDir)
+            .Combine(PathTable, "msbuild")
+            .Combine(PathTable, "dotnetcore")
+            .Combine(PathTable, "MSBuild.dll");
+        private AbsolutePath DotnetExe => AbsolutePath.Create(PathTable, TestDeploymentDir)
+            .Combine(PathTable, "dotnet")
+            .Combine(PathTable, OperatingSystemHelper.IsUnixOS ? "dotnet" : "dotnet.exe");
+
         /// <nodoc/>
         public MsBuildPipSchedulingTestBase(ITestOutputHelper output, bool usePassThroughFileSystem = false) : base(output, usePassThroughFileSystem)
         {
@@ -134,7 +147,8 @@ namespace Test.BuildXL.FrontEnd.MsBuild.Infrastructure
                     controller,
                     m_testModule,
                     resolverSettings,
-                    AbsolutePath.Create(PathTable, TestDeploymentDir).Combine(PathTable, "MSBuild.exe"),
+                    resolverSettings.ShouldRunDotNetCoreMSBuild()? DotnetCoreMSBuild : FullframeworkMSBuild,
+                    resolverSettings.ShouldRunDotNetCoreMSBuild()? DotnetExe : AbsolutePath.Invalid,
                     nameof(MsBuildFrontEnd),
                     trackedEnv,
                     passthroughVars);

--- a/Public/Src/Tools/Tool.MsBuildGraphBuilder/IMsBuildAssemblyLoader.cs
+++ b/Public/Src/Tools/Tool.MsBuildGraphBuilder/IMsBuildAssemblyLoader.cs
@@ -19,6 +19,11 @@ namespace MsBuildGraphBuilderTool
         /// <param name="searchLocations">A collection of full paths to directories, representing search locations on disk</param>
         /// <param name="failureReason">On failure, the reason for why the assemblies were not found</param>
         /// <param name="locatedAssemblyPaths">A dictionary from assembly names to paths to the required assemblies that were found. May not be complete if the invocation failed.</param>
-        bool TryLoadMsBuildAssemblies(IEnumerable<string> searchLocations, GraphBuilderReporter reporter, out string failureReason, out IReadOnlyDictionary<string, string> locatedAssemblyPaths, out string locatedMsBuildExePath);
+        bool TryLoadMsBuildAssemblies(
+            IEnumerable<string> searchLocations, 
+            GraphBuilderReporter reporter, 
+            out string failureReason, 
+            out IReadOnlyDictionary<string, string> locatedAssemblyPaths, 
+            out string locatedMsBuildExePath);
     }
 }

--- a/Public/Src/Tools/Tool.MsBuildGraphBuilder/MsBuildAssemblyLoader.cs
+++ b/Public/Src/Tools/Tool.MsBuildGraphBuilder/MsBuildAssemblyLoader.cs
@@ -50,7 +50,7 @@ namespace MsBuildGraphBuilderTool
 
         public MsBuildAssemblyLoader(bool msBuildRuntimeIsDotNetCore)
         {
-            m_msbuild = msBuildRuntimeIsDotNetCore ? "MsBuild.dll" : "MsBuild.exe";
+            m_msbuild = msBuildRuntimeIsDotNetCore ? "MSBuild.dll" : "MSBuild.exe";
 
             m_assemblyNamesToLoad = new[]
             {

--- a/Public/Src/Tools/Tool.MsBuildGraphBuilder/MsBuildAssemblyLoader.cs
+++ b/Public/Src/Tools/Tool.MsBuildGraphBuilder/MsBuildAssemblyLoader.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using Microsoft.Build.Tasks;
 
 namespace MsBuildGraphBuilderTool
 {
@@ -31,12 +32,29 @@ namespace MsBuildGraphBuilderTool
         private const string SystemCollectionsImmutable = "System.Collections.Immutable.dll";
         private const string SystemThreadingDataflow = "System.Threading.Tasks.Dataflow.dll";
 
-        // MsBuild.exe is not a required to be loaded but is required to be found
-        private const string MsBuildExe = "MsBuild.exe";
+        // MsBuild is not a required to be loaded but is required to be found
+        // Under DotNetCore there is not an msbuild.exe but a msbuild.dll
+        private string m_msbuild;
 
-        private static readonly string[] s_assemblyNamesToLoad = new[]
+        private readonly string[] m_assemblyNamesToLoad;
+
+        /// <summary>
+        /// The expected public token for each required assembly
+        /// </summary>
+        private readonly Dictionary<string, string> m_assemblyPublicTokens;
+
+        private static ResolveEventHandler s_msBuildHandler;
+
+        // Assembly resolution is multi-threaded
+        private readonly ConcurrentDictionary<string, Assembly> m_loadedAssemblies;
+
+        public MsBuildAssemblyLoader(bool msBuildRuntimeIsDotNetCore)
+        {
+            m_msbuild = msBuildRuntimeIsDotNetCore ? "MsBuild.dll" : "MsBuild.exe";
+
+            m_assemblyNamesToLoad = new[]
             {
-                MsBuildExe,
+                m_msbuild,
                 MicrosoftBuild,
                 MicrosoftBuildFramework,
                 MicrosoftBuildUtilities,
@@ -44,35 +62,26 @@ namespace MsBuildGraphBuilderTool
                 SystemThreadingDataflow
             };
 
-        /// <summary>
-        /// The expected public token for each required assembly
-        /// </summary>
-        private static readonly Dictionary<string, string> s_assemblyPublicTokens = new Dictionary<string, string>
-        {
-            [MsBuildExe] = MSBuildPublicKeyToken,
-            [MicrosoftBuild] = MSBuildPublicKeyToken,
-            [MicrosoftBuildFramework] = MSBuildPublicKeyToken,
-            [MicrosoftBuildUtilities] = MSBuildPublicKeyToken,
-            [SystemCollectionsImmutable] = DotNetPublicToken,
-            [SystemThreadingDataflow] = DotNetPublicToken,
-        };
+            m_assemblyPublicTokens = new Dictionary<string, string>
+            {
+                [m_msbuild] = MSBuildPublicKeyToken,
+                [MicrosoftBuild] = MSBuildPublicKeyToken,
+                [MicrosoftBuildFramework] = MSBuildPublicKeyToken,
+                [MicrosoftBuildUtilities] = MSBuildPublicKeyToken,
+                [SystemCollectionsImmutable] = DotNetPublicToken,
+                [SystemThreadingDataflow] = DotNetPublicToken,
+            };
 
-        private static ResolveEventHandler s_msBuildHandler;
-
-        // Assembly resolution is multi-threaded
-        private readonly ConcurrentDictionary<string, Assembly> m_loadedAssemblies = new ConcurrentDictionary<string, Assembly>(5, s_assemblyNamesToLoad.Length, StringComparer.OrdinalIgnoreCase);
-
-        private static readonly Lazy<MsBuildAssemblyLoader> s_singleton = new Lazy<MsBuildAssemblyLoader>(() => new MsBuildAssemblyLoader());
-
-        private MsBuildAssemblyLoader()
-        {
+            m_loadedAssemblies = new ConcurrentDictionary<string, Assembly>(5, m_assemblyNamesToLoad.Length, StringComparer.OrdinalIgnoreCase);
         }
 
-        /// <nodoc/>
-        public static MsBuildAssemblyLoader Instance => s_singleton.Value;
-
         /// <inheritdoc/>
-        public bool TryLoadMsBuildAssemblies(IEnumerable<string> searchLocations, GraphBuilderReporter reporter, out string failureReason, out IReadOnlyDictionary<string, string> locatedAssemblyPaths, out string locatedMsBuildExePath)
+        public bool TryLoadMsBuildAssemblies(
+            IEnumerable<string> searchLocations, 
+            GraphBuilderReporter reporter, 
+            out string failureReason, 
+            out IReadOnlyDictionary<string, string> locatedAssemblyPaths, 
+            out string locatedMsBuildExePath)
         {
             // We want to make sure the provided locations actually contain all the needed assemblies
             if (!TryGetAssemblyLocations(searchLocations, reporter, out locatedAssemblyPaths, out IReadOnlyDictionary<string, string> missingAssemblyNames, out locatedMsBuildExePath))
@@ -104,7 +113,7 @@ namespace MsBuildGraphBuilderTool
 
                     // Automatically un-register the handler once all supported assemblies have been loaded.
                     // No need to synchronize threads here, if the handler was already removed, nothing bad happens
-                    if (m_loadedAssemblies.Count == s_assemblyNamesToLoad.Length)
+                    if (m_loadedAssemblies.Count == m_assemblyNamesToLoad.Length)
                     {
                         AppDomain.CurrentDomain.AssemblyResolve -= s_msBuildHandler;
                     }
@@ -128,10 +137,10 @@ namespace MsBuildGraphBuilderTool
             out IReadOnlyDictionary</* assembly name */ string, /* not found reason */ string> missingAssemblies, 
             out string locatedMsBuildExePath)
         {
-            var foundAssemblies = new Dictionary<string, string>(s_assemblyNamesToLoad.Length, StringComparer.OrdinalIgnoreCase);
-            var notFoundAssemblies = new Dictionary<string, string>(s_assemblyNamesToLoad.Length, StringComparer.OrdinalIgnoreCase);
+            var foundAssemblies = new Dictionary<string, string>(m_assemblyNamesToLoad.Length, StringComparer.OrdinalIgnoreCase);
+            var notFoundAssemblies = new Dictionary<string, string>(m_assemblyNamesToLoad.Length, StringComparer.OrdinalIgnoreCase);
 
-            var assembliesToFind = new HashSet<string>(s_assemblyNamesToLoad, StringComparer.OrdinalIgnoreCase);
+            var assembliesToFind = new HashSet<string>(m_assemblyNamesToLoad, StringComparer.OrdinalIgnoreCase);
             locatedMsBuildExePath = string.Empty;
 
             foreach (var location in locations)
@@ -142,7 +151,7 @@ namespace MsBuildGraphBuilderTool
                 try
                 {
                     var dlls = Directory.EnumerateFiles(location, "*.dll", SearchOption.TopDirectoryOnly);
-                    var msBuildExe = Directory.EnumerateFiles(location, MsBuildExe, SearchOption.TopDirectoryOnly);
+                    var msBuildExe = Directory.EnumerateFiles(location, m_msbuild, SearchOption.TopDirectoryOnly);
 
                     foreach (string fullPath in dlls.Union(msBuildExe))
                     {
@@ -158,7 +167,7 @@ namespace MsBuildGraphBuilderTool
 
                                 // If the file found is msbuild.exe, we update the associated location but don't store the path
                                 // in foundAssemblies, since this is not an assembly we really want to load
-                                if (file.Equals(MsBuildExe, StringComparison.OrdinalIgnoreCase))
+                                if (file.Equals(m_msbuild, StringComparison.OrdinalIgnoreCase))
                                 {
                                     locatedMsBuildExePath = fullPath;
                                 }
@@ -222,7 +231,7 @@ namespace MsBuildGraphBuilderTool
             return assembliesToFind.Count == 0;
         }
 
-        private static bool IsMsBuildAssembly(AssemblyName assemblyName, string fullPathToAssembly, out string notFoundReason)
+        private bool IsMsBuildAssembly(AssemblyName assemblyName, string fullPathToAssembly, out string notFoundReason)
         {
             if (string.Equals($"{assemblyName.Name}.dll", MicrosoftBuild, StringComparison.OrdinalIgnoreCase))
             {
@@ -258,7 +267,7 @@ namespace MsBuildGraphBuilderTool
                 sb.Append($"{b:x2}");
             }
 
-            if (s_assemblyPublicTokens.TryGetValue(assemblyName.Name, out string publicToken) && !sb.ToString().Equals(publicToken, StringComparison.OrdinalIgnoreCase))
+            if (m_assemblyPublicTokens.TryGetValue(assemblyName.Name, out string publicToken) && !sb.ToString().Equals(publicToken, StringComparison.OrdinalIgnoreCase))
             {
                 notFoundReason = $"The assembly under '{fullPathToAssembly}' is expected to contain public token '{publicToken}' but '{sb}' was found.";
                 return false;

--- a/Public/Src/Tools/Tool.MsBuildGraphBuilder/MsBuildGraphBuilder.cs
+++ b/Public/Src/Tools/Tool.MsBuildGraphBuilder/MsBuildGraphBuilder.cs
@@ -54,7 +54,7 @@ namespace MsBuildGraphBuilderTool
             // The output file is used as a unique name to identify the pipe
             using (var reporter = new GraphBuilderReporter(Path.GetFileName(arguments.OutputPath)))
             {
-                DoBuildGraphAndSerialize(MsBuildAssemblyLoader.Instance, reporter, arguments);
+                DoBuildGraphAndSerialize(new MsBuildAssemblyLoader(arguments.MsBuildRuntimeIsDotNetCore), reporter, arguments);
             }
         }
 

--- a/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildAssemblyLoaderTests.cs
+++ b/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildAssemblyLoaderTests.cs
@@ -5,12 +5,13 @@ using System;
 using System.Linq;
 using MsBuildGraphBuilderTool;
 using Test.BuildXL.TestUtilities.Xunit;
+using Test.ProjectGraphBuilder.Utilities;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Test.ProjectGraphBuilder
 {
-    public class MsBuildAssemblyLoaderTests : XunitBuildXLTest
+    public class MsBuildAssemblyLoaderTests : GraphBuilderToolTestBase
     {
         public MsBuildAssemblyLoaderTests(ITestOutputHelper output): base(output)
         {
@@ -21,8 +22,7 @@ namespace Test.ProjectGraphBuilder
         {
             using (var reporter = new GraphBuilderReporter(Guid.NewGuid().ToString()))
             {
-                var assemblyLoader = MsBuildAssemblyLoader.Instance;
-                var succeed = assemblyLoader.TryLoadMsBuildAssemblies(
+                var succeed = AssemblyLoader.TryLoadMsBuildAssemblies(
                     // The test deployment dir should have all assemblies needed by the loader
                     new [] {TestDeploymentDir},
                     reporter,
@@ -44,8 +44,7 @@ namespace Test.ProjectGraphBuilder
         {
             using (var reporter = new GraphBuilderReporter(Guid.NewGuid().ToString()))
             {
-                var assemblyLoader = MsBuildAssemblyLoader.Instance;
-                var succeed = assemblyLoader.TryLoadMsBuildAssemblies(
+                var succeed = AssemblyLoader.TryLoadMsBuildAssemblies(
                     // An empty location should result in not finding any of the required assemblies
                     new string[] {},
                     reporter,

--- a/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphConstructionTests.cs
+++ b/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphConstructionTests.cs
@@ -14,7 +14,7 @@ using Xunit.Abstractions;
 
 namespace Test.ProjectGraphBuilder
 {
-    public class MsBuildGraphConstructionTests : TemporaryStorageTestBase
+    public class MsBuildGraphConstructionTests : GraphBuilderToolTestBase
     {
         private readonly MsBuildProjectBuilder m_builder;
 
@@ -233,14 +233,13 @@ namespace Test.ProjectGraphBuilder
         {
             string outputFile = Path.Combine(TemporaryDirectory, Guid.NewGuid().ToString());
 
-            var arguments = new MSBuildGraphBuilderArguments(
-                    projectEntryPoints,
-                    outputFile,
-                    globalProperties: GlobalProperties.Empty,
-                    mSBuildSearchLocations: new[] {TestDeploymentDir},
-                    entryPointTargets: new string[0],
-                    requestedQualifiers: new GlobalProperties[] { GlobalProperties.Empty },
-                    allowProjectsWithoutTargetProtocol: true);
+            var arguments = GetStandardBuilderArguments(
+                projectEntryPoints,
+                outputFile,
+                GlobalProperties.Empty,
+                new string[0],
+                new GlobalProperties[] { GlobalProperties.Empty },
+                allowProjectsWithoutTargetProtocol: true);
 
             return BuildGraphAndDeserialize(arguments);
 
@@ -249,14 +248,14 @@ namespace Test.ProjectGraphBuilder
         private MSBuildGraphBuilderArguments CreateBuilderArguments(string entryPointPath, GlobalProperties[] requestedQualifiers = null, GlobalProperties globalProperties = null, bool allowProjectsWithoutTargetProtocol = true)
         {
             string outputFile = Path.Combine(TemporaryDirectory, Guid.NewGuid().ToString());
-            var arguments = new MSBuildGraphBuilderArguments(
+            var arguments = GetStandardBuilderArguments(
                     new string[] { entryPointPath },
                     outputFile,
                     globalProperties: globalProperties ?? GlobalProperties.Empty,
-                    mSBuildSearchLocations: new[] { TestDeploymentDir },
                     entryPointTargets: new string[0],
                     requestedQualifiers: requestedQualifiers ?? new GlobalProperties[] { GlobalProperties.Empty },
                     allowProjectsWithoutTargetProtocol: allowProjectsWithoutTargetProtocol);
+
             return arguments;
         }
     }

--- a/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphDecorationTests.cs
+++ b/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphDecorationTests.cs
@@ -16,7 +16,7 @@ namespace Test.ProjectGraphBuilder
     /// <summary>
     /// Tests related to the decorations associated to the project graph (e.g. failures, location of assemblies, etc.)
     /// </summary>
-    public class MsBuildGraphDecorationTests : TemporaryStorageTestBase
+    public class MsBuildGraphDecorationTests : GraphBuilderToolTestBase
     {
         public MsBuildGraphDecorationTests(ITestOutputHelper output): base(output)
         {
@@ -56,13 +56,13 @@ namespace Test.ProjectGraphBuilder
             // We expect the result to succeed
             Assert.True(projectGraphWithPredictionsResult.Succeeded);
             // The locations for MSBuild.exe and its assemblies should be properly set
-            Assert.Contains(TestDeploymentDir, projectGraphWithPredictionsResult.PathToMsBuildExe);
+            Assert.Contains(TestDeploymentDir, projectGraphWithPredictionsResult.PathToMsBuild);
             Assert.All(projectGraphWithPredictionsResult.MsBuildAssemblyPaths.Values, assemblyPath => assemblyPath.Contains(TestDeploymentDir));
         }
 
         private ProjectGraphWithPredictionsResult<string> BuildGraphAndDeserialize(string projectEntryPointContent = null)
         {
-            return BuildGraphAndDeserialize(MsBuildAssemblyLoader.Instance, projectEntryPointContent);
+            return BuildGraphAndDeserialize(AssemblyLoader, projectEntryPointContent);
         }
 
         private ProjectGraphWithPredictionsResult<string> BuildGraphAndDeserialize(IMsBuildAssemblyLoader assemblyLoader, string projectEntryPointContent = null)
@@ -77,11 +77,10 @@ namespace Test.ProjectGraphBuilder
 
             using (var reporter = new GraphBuilderReporter(Guid.NewGuid().ToString()))
             {
-                var arguments = new MSBuildGraphBuilderArguments(
+                var arguments = GetStandardBuilderArguments(
                     new[] { entryPoint },
                     outputFile,
                     globalProperties: GlobalProperties.Empty,
-                    mSBuildSearchLocations: new string[] {TestDeploymentDir},
                     entryPointTargets: new string[0],
                     requestedQualifiers: new GlobalProperties[] { GlobalProperties.Empty},
                     allowProjectsWithoutTargetProtocol: false);

--- a/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphProgressTests.cs
+++ b/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphProgressTests.cs
@@ -8,14 +8,13 @@ using System.Text;
 using System.Threading.Tasks;
 using BuildXL.FrontEnd.MsBuild.Serialization;
 using MsBuildGraphBuilderTool;
-using Test.BuildXL.TestUtilities.Xunit;
 using Test.ProjectGraphBuilder.Utilities;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Test.ProjectGraphBuilder
 {
-    public class MsBuildGraphProgressTests : TemporaryStorageTestBase
+    public class MsBuildGraphProgressTests : GraphBuilderToolTestBase
     {
         private readonly string m_entryPoint;
 
@@ -69,16 +68,15 @@ namespace Test.ProjectGraphBuilder
         private bool BuildAndReport(GraphBuilderReporter reporter, out string failure)
         {
             string outputFile = Path.Combine(TemporaryDirectory, Guid.NewGuid().ToString());
-            var arguments = new MSBuildGraphBuilderArguments(
+            var arguments = GetStandardBuilderArguments(
                 new[] { m_entryPoint },
                 outputFile,
                 globalProperties: GlobalProperties.Empty,
-                mSBuildSearchLocations: new[] {TestDeploymentDir},
                 entryPointTargets: new string[0],
                 requestedQualifiers: new GlobalProperties[] { GlobalProperties.Empty },
                 allowProjectsWithoutTargetProtocol: false);
 
-            MsBuildGraphBuilder.BuildGraphAndSerializeForTesting(MsBuildAssemblyLoader.Instance, reporter, arguments);
+            MsBuildGraphBuilder.BuildGraphAndSerializeForTesting(AssemblyLoader, reporter, arguments);
             var result = SimpleDeserializer.Instance.DeserializeGraph(outputFile);
 
             failure = string.Empty;
@@ -117,6 +115,5 @@ namespace Test.ProjectGraphBuilder
                     }
                 );
         }
-
     }
 }

--- a/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphProjectPredictionTests.cs
+++ b/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildGraphProjectPredictionTests.cs
@@ -19,7 +19,7 @@ namespace Test.ProjectGraphBuilder
     /// <summary>
     /// Makes sure that project predictions are plumbed through and serialized into the project graph. The actual predictions are not tested here.
     /// </summary>
-    public class MsBuildGraphProjectPredictionTests : TemporaryStorageTestBase
+    public class MsBuildGraphProjectPredictionTests : GraphBuilderToolTestBase
     {
         public MsBuildGraphProjectPredictionTests(ITestOutputHelper output): base(output)
         {
@@ -44,11 +44,10 @@ namespace Test.ProjectGraphBuilder
 ");
 
             MsBuildGraphBuilder.BuildGraphAndSerialize(
-                new MSBuildGraphBuilderArguments(
+                GetStandardBuilderArguments(
                     new[] { entryPoint },
                     outputFile,
                     globalProperties: GlobalProperties.Empty,
-                    mSBuildSearchLocations: new[] { TestDeploymentDir },
                     entryPointTargets: new string[0],
                     requestedQualifiers: new GlobalProperties[] { GlobalProperties.Empty },
                     allowProjectsWithoutTargetProtocol: false));
@@ -72,17 +71,16 @@ namespace Test.ProjectGraphBuilder
 
             using (var reporter = new GraphBuilderReporter(Guid.NewGuid().ToString()))
             {
-                var arguments = new MSBuildGraphBuilderArguments(
+                var arguments = GetStandardBuilderArguments(
                     new[] { entryPoint },
                     outputFile,
                     globalProperties: GlobalProperties.Empty,
-                    mSBuildSearchLocations: new[] { TestDeploymentDir },
                     entryPointTargets: new string[0],
                     requestedQualifiers: new GlobalProperties[] { GlobalProperties.Empty },
                     allowProjectsWithoutTargetProtocol: false);
 
                 MsBuildGraphBuilder.BuildGraphAndSerializeForTesting(
-                    MsBuildAssemblyLoader.Instance,
+                    AssemblyLoader,
                     reporter,
                     arguments,
                     new IProjectPredictor[] { new ThrowOnPredictionPredictor() });

--- a/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildPredictionCollectorTests.cs
+++ b/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildPredictionCollectorTests.cs
@@ -68,7 +68,7 @@ namespace Test.ProjectGraphBuilder
             var predictionFailures = new ConcurrentQueue<(string predictorName, string failure)>();
             var collector = new MsBuildPredictionCollector(inputFilePredictions, outputFolderPredictions, predictionFailures);
 
-            collector.AddInputFile("!@#$%^&*()", TemporaryDirectory, "Mock");
+            collector.AddInputFile("!@#$%^&*()\0", TemporaryDirectory, "Mock");
 
             Assert.Equal(0, inputFilePredictions.Count);
 
@@ -76,7 +76,7 @@ namespace Test.ProjectGraphBuilder
 
             Assert.Equal(1, predictionFailures.Count);
             Assert.Equal("Mock", predictionFailures.Single().predictorName);
-            Assert.Contains("!@#$%^&*()", predictionFailures.Single().failure);
+            Assert.Contains("!@#$%^&*()\0", predictionFailures.Single().failure);
         }
 
         [Fact]
@@ -160,7 +160,7 @@ namespace Test.ProjectGraphBuilder
             var predictionFailures = new ConcurrentQueue<(string predictorName, string failure)>();
             var collector = new MsBuildPredictionCollector(inputFilePredictions, outputFolderPredictions, predictionFailures);
 
-            collector.AddInputDirectory("!@#$%^&*()", TemporaryDirectory, "Mock");
+            collector.AddInputDirectory("!@#$%^&*()\0", TemporaryDirectory, "Mock");
 
             Assert.Equal(0, inputFilePredictions.Count);
 
@@ -168,7 +168,7 @@ namespace Test.ProjectGraphBuilder
 
             Assert.Equal(1, predictionFailures.Count);
             Assert.Equal("Mock", predictionFailures.Single().predictorName);
-            Assert.Contains("!@#$%^&*()", predictionFailures.Single().failure);
+            Assert.Contains("!@#$%^&*()\0", predictionFailures.Single().failure);
         }
 
         [Fact]
@@ -222,7 +222,7 @@ namespace Test.ProjectGraphBuilder
             var predictionFailures = new ConcurrentQueue<(string predictorName, string failure)>();
             var collector = new MsBuildPredictionCollector(inputFilePredictions, outputFolderPredictions, predictionFailures);
 
-            collector.AddOutputFile("!@#$%^&*()", TemporaryDirectory, "Mock");
+            collector.AddOutputFile("!@#$%^&*()\0", TemporaryDirectory, "Mock");
 
             Assert.Equal(0, inputFilePredictions.Count);
 
@@ -230,7 +230,7 @@ namespace Test.ProjectGraphBuilder
 
             Assert.Equal(1, predictionFailures.Count);
             Assert.Equal("Mock", predictionFailures.Single().predictorName);
-            Assert.Contains("!@#$%^&*()", predictionFailures.Single().failure);
+            Assert.Contains("!@#$%^&*()\0", predictionFailures.Single().failure);
         }
 
         [Fact]
@@ -282,7 +282,7 @@ namespace Test.ProjectGraphBuilder
             var predictionFailures = new ConcurrentQueue<(string predictorName, string failure)>();
             var collector = new MsBuildPredictionCollector(inputFilePredictions, outputFolderPredictions, predictionFailures);
 
-            collector.AddOutputDirectory("!@#$%^&*()", TemporaryDirectory, "Mock");
+            collector.AddOutputDirectory("!@#$%^&*()\0", TemporaryDirectory, "Mock");
 
             Assert.Equal(0, inputFilePredictions.Count);
 

--- a/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/Test.Tool.MsBuildGraphBuilder.dsc
+++ b/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/Test.Tool.MsBuildGraphBuilder.dsc
@@ -24,5 +24,8 @@ namespace Test.Tool.MsBuildGraphBuilder {
             ...MSBuild.msbuildRuntimeContent,
             ...MSBuild.msbuildReferences,
         ],
+        runtimeContentToSkip: [
+            importFrom("System.Threading.Tasks.Dataflow").pkg
+        ]
     });
 }

--- a/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/Test.Tool.MsBuildGraphBuilder.dsc
+++ b/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/Test.Tool.MsBuildGraphBuilder.dsc
@@ -6,20 +6,15 @@ import * as MSBuild from "Sdk.Selfhost.MSBuild";
 
 namespace Test.Tool.MsBuildGraphBuilder {
 
-    export declare const qualifier: MSBuild.MSBuildQualifier;
-
-    // If the current qualifier is full framework, this tool has to be built with 472
-    const msBuildGraphBuilderReference : Managed.Assembly =
-        importFrom("BuildXL.Tools").MsBuildGraphBuilder.withQualifier(to472(qualifier)).exe;
+    export declare const qualifier: BuildXLSdk.DefaultQualifier;
 
     @@public
     export const dll = BuildXLSdk.test({
         assemblyName: "Test.Tool.ProjectGraphBuilder",
         sources: globR(d`.`, "*.cs"),
-        // TODO: QTest
         testFramework: importFrom("Sdk.Managed.Testing.XUnit").framework,
         references:[
-            msBuildGraphBuilderReference,
+            importFrom("BuildXL.Tools").MsBuildGraphBuilder.exe,
             importFrom("Microsoft.Build.Prediction").pkg,
             importFrom("Newtonsoft.Json").pkg,
             importFrom("BuildXL.FrontEnd").MsBuild.Serialization.dll,
@@ -29,12 +24,5 @@ namespace Test.Tool.MsBuildGraphBuilder {
             ...MSBuild.msbuildRuntimeContent,
             ...MSBuild.msbuildReferences,
         ],
-        runtimeContentToSkip : [
-            importFrom("System.Threading.Tasks.Dataflow").pkg
-        ]
     });
-
-    function to472(aQualifier: (typeof qualifier)) : (typeof qualifier) & {targetFramework: "net472"} {
-        return Object.merge<(typeof qualifier) & {targetFramework: "net472"}>(aQualifier, {targetFramework: "net472"});
-    }
 }

--- a/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/Utilities/GraphBuilderToolTestBase.cs
+++ b/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/Utilities/GraphBuilderToolTestBase.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using BuildXL.FrontEnd.MsBuild.Serialization;
+using MsBuildGraphBuilderTool;
+using Test.BuildXL.TestUtilities.Xunit;
+using Xunit.Abstractions;
+
+namespace Test.ProjectGraphBuilder.Utilities
+{
+    public abstract class GraphBuilderToolTestBase : TemporaryStorageTestBase
+    {
+        /// <nodoc/>
+        public GraphBuilderToolTestBase(ITestOutputHelper output) : base(output) {}
+
+#if FEATURE_CORECLR
+        /// <nodoc/>
+        protected bool RunningUnderDotNetCore => true;
+#else
+        /// <nodoc/>
+        protected bool RunningUnderDotNetCore => false;
+#endif
+        /// <nodoc/>
+        protected MsBuildAssemblyLoader AssemblyLoader => new MsBuildAssemblyLoader(RunningUnderDotNetCore);
+
+        /// <nodoc/>
+        protected MSBuildGraphBuilderArguments GetStandardBuilderArguments(
+            IReadOnlyCollection<string> projectsToParse,
+            string outputFile,
+            GlobalProperties globalProperties,
+            IReadOnlyCollection<string> entryPointTargets,
+            IReadOnlyCollection<GlobalProperties> requestedQualifiers,
+            bool allowProjectsWithoutTargetProtocol)
+        {
+            return new MSBuildGraphBuilderArguments(
+                    projectsToParse,
+                    outputFile,
+                    globalProperties,
+                    mSBuildSearchLocations: new[] {TestDeploymentDir},
+                    entryPointTargets,
+                    requestedQualifiers,
+                    allowProjectsWithoutTargetProtocol,
+                    RunningUnderDotNetCore);
+        }
+    }
+}

--- a/Public/Src/Utilities/Configuration/Resolvers/IMsBuildResolverSettings.cs
+++ b/Public/Src/Utilities/Configuration/Resolvers/IMsBuildResolverSettings.cs
@@ -57,6 +57,26 @@ namespace BuildXL.Utilities.Configuration
         IReadOnlyList<DirectoryArtifact> MsBuildSearchLocations { get; }
 
         /// <summary>
+        /// Whether to use the full framework or dotnet core version of MSBuild. 
+        /// </summary>
+        /// <remarks>
+        /// Selected runtime is used both for build evaluation and execution.
+        /// Default is full framework.
+        /// Observe that using the full framework version means that msbuild.exe is expected to be found in msbuildSearchLocations
+        /// (or PATH if not specified). If using the dotnet core version, the same logic applies but to msbuild.dll
+        /// </remarks>
+        string MsBuildRuntime { get; }
+
+        /// <summary>
+        /// Collection of directories to search for dotnet.exe, when DotNetCore is specified as the msBuildRuntime. 
+        /// </summary>
+        /// <remarks>
+        /// If not specified, locations in %PATH% are used.
+        /// Locations are traversed in specification order.
+        /// </remarks>
+        IReadOnlyList<DirectoryArtifact> DotNetSearchLocations { get; }
+
+        /// <summary>
         /// Optional file paths for the projects or solutions that should be used to start parsing. These are relative 
         /// paths with respect to the root traversal.
         /// </summary>
@@ -193,5 +213,14 @@ namespace BuildXL.Utilities.Configuration
             trackedEnv = trackedList;
             passthroughEnv = passthroughList;
         }
+
+        /// <summary>
+        /// Whether MSBuildRuntime is DotNetCore.
+        /// </summary>
+        /// <remarks>
+        /// Keep in sync with Public\Sdk\Public\Prelude\Prelude.Configuration.Resolvers.dsc
+        /// If not specified, the default is full framework, so this function returns false in that case.
+        /// </remarks>
+        public static bool ShouldRunDotNetCoreMSBuild(this IMsBuildResolverSettings msBuildResolverSettings) => msBuildResolverSettings.MsBuildRuntime == "DotNetCore";
     }
 }

--- a/Public/Src/Utilities/Configuration/Resolvers/Mutable/MsBuildResolverSettings.cs
+++ b/Public/Src/Utilities/Configuration/Resolvers/Mutable/MsBuildResolverSettings.cs
@@ -45,6 +45,8 @@ namespace BuildXL.Utilities.Configuration.Mutable
             UseLegacyProjectIsolation = resolverSettings.UseLegacyProjectIsolation;
             DoubleWritePolicy = resolverSettings.DoubleWritePolicy;
             AllowProjectsToNotSpecifyTargetProtocol = resolverSettings.AllowProjectsToNotSpecifyTargetProtocol;
+            MsBuildRuntime = resolverSettings.MsBuildRuntime;
+            DotNetSearchLocations = resolverSettings.DotNetSearchLocations;
         }
 
         /// <inheritdoc/>
@@ -109,5 +111,11 @@ namespace BuildXL.Utilities.Configuration.Mutable
 
         /// <inheritdoc/>
         public bool? AllowProjectsToNotSpecifyTargetProtocol { get; set; }
+
+        /// <inheritdoc/>
+        public string MsBuildRuntime { get; set; }
+
+        /// <inheritdoc/>
+        public IReadOnlyList<DirectoryArtifact> DotNetSearchLocations { get; set; }
     }
 }

--- a/config.dsc
+++ b/config.dsc
@@ -369,7 +369,6 @@ config({
                 { id: "System.Security.Principal.Windows", version: "4.6.0-preview5.19224.8" },
                 { id: "System.Security.SecureString", version: "4.3.0" },
                 { id: "System.Text.Encoding", version: "4.3.0" },
-                { id: "System.Text.Encoding.CodePages", version: "4.3.0" },
                 { id: "System.Text.Encoding.Extensions", version: "4.3.0" },
                 { id: "System.Text.RegularExpressions", version: "4.3.0" },
                 { id: "System.Threading", version: "4.3.0" },
@@ -442,7 +441,7 @@ config({
                 // Extra dependencies to make MSBuild work
                 { id: "Microsoft.VisualStudio.Setup.Configuration.Interop", version: "1.16.30"},
                 { id: "System.CodeDom", version: "4.4.0"},
-                { id: "System.Text.Encoding.CodePages", version: "4.5.1", alias: "CodePagesForMSBuild" },
+                { id: "System.Text.Encoding.CodePages", version: "4.5.1", dependentPackageIdsToSkip: ["System.Runtime.CompilerServices.Unsafe"]},
 
                 // Used for MSBuild input/output prediction
                 { id: "Microsoft.Build.Prediction", version: "0.3.0" },

--- a/config.dsc
+++ b/config.dsc
@@ -127,7 +127,6 @@ config({
                 { id: "System.Data.SQLite.Linq", version: "1.0.102.0" },
                 { id: "System.Reflection.Metadata", version: "1.6.0" },
                 { id: "System.Threading.Tasks.Dataflow", version: "4.9.0" },
-                { id: "System.Threading.Tasks.Dataflow", version: "4.5.24", alias: "DataflowForMSBuildRuntime"},
 
                 // Nuget
                 { id: "NuGet.Commandline", version: "4.7.1" },
@@ -443,6 +442,7 @@ config({
                 // Extra dependencies to make MSBuild work
                 { id: "Microsoft.VisualStudio.Setup.Configuration.Interop", version: "1.16.30"},
                 { id: "System.CodeDom", version: "4.4.0"},
+                { id: "System.Text.Encoding.CodePages", version: "4.5.1", alias: "CodePagesForMSBuild" },
 
                 // Used for MSBuild input/output prediction
                 { id: "Microsoft.Build.Prediction", version: "0.3.0" },

--- a/config.dsc
+++ b/config.dsc
@@ -443,6 +443,7 @@ config({
                 { id: "System.CodeDom", version: "4.4.0"},
                 { id: "System.Text.Encoding.CodePages", version: "4.5.1", dependentPackageIdsToSkip: ["System.Runtime.CompilerServices.Unsafe"]},
                 { id: "System.Threading.Tasks.Dataflow", version: "4.5.24", alias: "DataflowForMSBuild" },
+                { id: "Microsoft.NETCore.App", version: "2.1.0", alias: "Microsoft.NETCore.App.210" },
 
                 // Used for MSBuild input/output prediction
                 { id: "Microsoft.Build.Prediction", version: "0.3.0" },

--- a/config.dsc
+++ b/config.dsc
@@ -442,6 +442,7 @@ config({
                 { id: "Microsoft.VisualStudio.Setup.Configuration.Interop", version: "1.16.30"},
                 { id: "System.CodeDom", version: "4.4.0"},
                 { id: "System.Text.Encoding.CodePages", version: "4.5.1", dependentPackageIdsToSkip: ["System.Runtime.CompilerServices.Unsafe"]},
+                { id: "System.Threading.Tasks.Dataflow", version: "4.5.24", alias: "DataflowForMSBuild" },
 
                 // Used for MSBuild input/output prediction
                 { id: "Microsoft.Build.Prediction", version: "0.3.0" },

--- a/config.dsc
+++ b/config.dsc
@@ -483,6 +483,10 @@ config({
         importFile(f`config.microsoftInternal.dsc`).resolver,
 
         {
+            kind: "SourceResolver",
+            modules: [f`Public\Sdk\SelfHost\Libraries\Dotnet-Runtime-External\module.config.dsc`],
+        },
+        {
             kind: "Download",
             downloads: [
                 // PowerShell.Core
@@ -507,24 +511,42 @@ config({
 
                 // DotNet Core Runtime
                 {
-                    moduleName: "DotNet-Runtime.win-x64",
+                    moduleName: "DotNet-Runtime.win-x64.3.0.0-preview5",
                     url: "https://download.visualstudio.microsoft.com/download/pr/9459ede1-e223-40c7-a4c5-2409e789121a/46d4eb6067bda9f412a472f7286ffd94/dotnet-runtime-3.0.0-preview5-27626-15-win-x64.zip",
                     hash: "VSO0:6DBFE7BC9FA24D33A46A3A0732164BD5A4F5984E8FCE091D305FA635CD876AA700",
                     archiveType: "zip",
                 },
                 {
-                    moduleName: "DotNet-Runtime.osx-x64",
+                    moduleName: "DotNet-Runtime.osx-x64.3.0.0-preview5",
                     url: "https://download.visualstudio.microsoft.com/download/pr/85024962-5dee-4f64-ab29-a903f3749f85/6178bfacc58f4d9a596b5e3facc767ab/dotnet-runtime-3.0.0-preview5-27626-15-osx-x64.tar.gz",
                     hash: "VSO0:C6AB5808D30BFF857263BC467FE8D818F35486763F673F79CA5A758727CEF3A900",
                     archiveType: "tgz",
                 },
                 {
-                    moduleName: "DotNet-Runtime.linux-x64",
+                    moduleName: "DotNet-Runtime.linux-x64.3.0.0-preview5",
                     url: "https://download.visualstudio.microsoft.com/download/pr/f15ad9ab-7bd2-4ff5-87b6-b1a08f062ea2/6fdd314c16c17ba22934cd0ac6b4d343/dotnet-runtime-3.0.0-preview5-27626-15-linux-x64.tar.gz",
-                    hash: "VSO0:C6AB5808D30BFF857263BC467FE8D818F35486763F673F79CA5A758727CEF3A900",
+                    hash: "VSO0:00F83B929904F647BD8FB22361052BB347A1E5FA9A3A32A67EE1569DE443D92700",
                     archiveType: "tgz",
                 },
-
+                // The following are needed for dotnet core MSBuild test deployments
+                {
+                    moduleName: "DotNet-Runtime.win-x64.2.2.2",
+                    url: "https://download.visualstudio.microsoft.com/download/pr/b10d0a68-b720-48ae-bab8-4ac39bd1b5d3/f32b8b41dff5c1488c2b915a007fc4a6/dotnet-runtime-2.2.2-win-x64.zip",
+                    hash: "VSO0:6BBAE77F9BA0231C90ABD9EA720FF886E8613CE8EF29D8B657AF201E2982829600",
+                    archiveType: "zip",
+                },
+                {
+                    moduleName: "DotNet-Runtime.osx-x64.2.2.2",
+                    url: "https://download.visualstudio.microsoft.com/download/pr/d1f0dfb3-b6bd-42ae-895f-f149bf1d90ca/9b1fb91a9692fc31d6fc83e97caba4cd/dotnet-runtime-2.2.2-osx-x64.tar.gz",
+                    hash: "VSO0:88B2B6E8CEF711E108FDE529E781F555516634CD442B3503B712D22947F0788700",
+                    archiveType: "tgz",
+                },
+                {
+                    moduleName: "DotNet-Runtime.linux-x64.2.2.2",
+                    url: "https://download.visualstudio.microsoft.com/download/pr/97b97652-4f74-4866-b708-2e9b41064459/7c722daf1a80a89aa8c3dec9103c24fc/dotnet-runtime-2.2.2-linux-x64.tar.gz",
+                    hash: "VSO0:6E5172671364C65B06C9940468A62BAF70EE27392CB2CA8B2C8BFE058CCD088300",
+                    archiveType: "tgz",
+                },
                 // NodeJs
                 {
                     moduleName: "NodeJs.win-x64",


### PR DESCRIPTION
Enable the MSBuild resolver to work under dotnet core, and add the option to run MSBuild full framework vs dotnet core.
The same runtime is used for MSBuild at graph construction and execution time. If dotnetcore is specified, the location of particular dotnet.exe to use is required.