### PR TITLE
 Pass a CSV mapping when uploading logs to Kusto

### DIFF
--- a/Public/Src/Cache/ContentStore/App/Application.cs
+++ b/Public/Src/Cache/ContentStore/App/Application.cs
@@ -418,7 +418,7 @@ namespace BuildXL.Cache.ContentStore.App
                 database: KustoDatabase,
                 table: KustoTable,
                 csvMapping: csvMapping,
-                deleteFilesOnSuccess: false,
+                deleteFilesOnSuccess: true,
                 checkForIngestionErrors: true,
                 log: _consoleLog
                 );

--- a/Public/Src/Cache/ContentStore/App/Application.cs
+++ b/Public/Src/Cache/ContentStore/App/Application.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.ContractsLight;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BuildXL.Cache.ContentStore.Exceptions;
@@ -27,6 +28,7 @@ using BuildXL.Cache.ContentStore.Tracing;
 using BuildXL.Cache.Host.Configuration;
 using BuildXL.Cache.Host.Service;
 using CLAP;
+using Kusto.Data.Common;
 
 // ReSharper disable UnusedMember.Global
 namespace BuildXL.Cache.ContentStore.App
@@ -63,27 +65,32 @@ namespace BuildXL.Cache.ContentStore.App
         private const string KustoTable = "CloudBuildLogEvent";
 
         /// <summary>
-        ///     The Kusto schema of the target table (<see cref="KustoTable"/>).
-        ///
-        ///     The schema for the target table can be automatically exported from the Kusto Explorer.
+        ///     CSV file schema to be produced by <see cref="CsvFileLog"/>.
         /// </summary>
-        private const string KustoTableSchema = "env_ver:string, env_name:string, env_time:datetime, env_epoch:string, env_seqNum:long, env_popSample:real, env_iKey:string, env_flags:long, env_cv:string, env_os:string, env_osVer:string, env_appId:string, env_appVer:string, env_cloud_ver:string, env_cloud_name:string, env_cloud_role:string, env_cloud_roleVer:string, env_cloud_roleInstance:string, env_cloud_environment:string, env_cloud_location:string, env_cloud_deploymentUnit:string, Stamp:string, Ring:string, BuildId:string, CorrelationId:string, ParentCorrelationId:string, Exception:string, Message:string, LogLevel:long, LogLevelFriendly:string, LoggingType:string, LoggingMethod:string, LoggingLineNumber:long, PreciseTimeStamp:datetime, LocalPreciseTimeStamp:datetime, ThreadId:long, ThreadPrincipal:string, Cluster:string, Environment:string, MachineFunction:string, Machine:string, Service:string, ServiceVersion:string, SourceNamespace:string, SourceMoniker:string, SourceVersion:string, ProcessId:long, BuildQueue:string";
-
-        /// <summary>
-        ///     CSV file schema to be passed to <see cref="CsvFileLog"/>.
-        ///     This schema is automatically generated from <see cref="KustoTableSchema"/>
-        /// </summary>
-        private static readonly CsvFileLog.ColumnKind[] KustoTableCsvSchema = CsvFileLog.ParseTableSchema(KustoTableSchema);      
+        private static readonly CsvFileLog.ColumnKind[] KustoTableCsvSchema = new CsvFileLog.ColumnKind[]
+        {
+            CsvFileLog.ColumnKind.BuildId,
+            CsvFileLog.ColumnKind.Machine,
+            CsvFileLog.ColumnKind.PreciseTimeStamp,
+            CsvFileLog.ColumnKind.LocalPreciseTimeStamp,
+            CsvFileLog.ColumnKind.ThreadId,
+            CsvFileLog.ColumnKind.ProcessId,
+            CsvFileLog.ColumnKind.LogLevel,
+            CsvFileLog.ColumnKind.LogLevelFriendly,
+            CsvFileLog.ColumnKind.Message,
+            CsvFileLog.ColumnKind.env_os,
+            CsvFileLog.ColumnKind.env_osVer,
+        };
 
         private readonly CancellationToken _cancellationToken;
         private readonly IAbsFileSystem _fileSystem;
         private readonly ConsoleLog _consoleLog;
         private readonly Logger _logger;
         private readonly Tracer _tracer;
-        private readonly KustoUploader _kustoUploader;
         private bool _waitForDebugger;
         private FileLog _fileLog;
         private CsvFileLog _csvFileLog;
+        private KustoUploader _kustoUploader;
         private Severity _fileLogSeverity = Severity.Diagnostic;
         private bool _logAutoFlush;
         private string _logDirectoryPath;
@@ -107,19 +114,6 @@ namespace BuildXL.Cache.ContentStore.App
             _logger = new Logger(true, _consoleLog);
             _fileSystem = new PassThroughFileSystem(_logger);
             _tracer = new Tracer(nameof(Application));
-
-            var kustoConnectionString = Environment.GetEnvironmentVariable(KustoConnectionStringEnvVarName);
-            _kustoUploader = string.IsNullOrWhiteSpace(kustoConnectionString)
-                ? null
-                : new KustoUploader
-                    (
-                    kustoConnectionString,
-                    database: KustoDatabase,
-                    table: KustoTable,
-                    deleteFilesOnSuccess: true,
-                    checkForIngestionErrors: true,
-                    log: _consoleLog
-                    );
         }
 
         /// <inheritdoc />
@@ -391,7 +385,8 @@ namespace BuildXL.Cache.ContentStore.App
                 return;
             }
 
-            if (_kustoUploader == null)
+            var kustoConnectionString = Environment.GetEnvironmentVariable(KustoConnectionStringEnvVarName);
+            if (string.IsNullOrWhiteSpace(kustoConnectionString))
             {
                 _logger.Warning
                     (
@@ -406,8 +401,33 @@ namespace BuildXL.Cache.ContentStore.App
                 logFilePath: logFilePath + TmpCsvLogFileExt,
                 serviceName: ServiceName,
                 schema: KustoTableCsvSchema,
+                renderConstColums: false,
                 severity: _fileLogSeverity,
                 maxFileSize: _csvLogMaxFileSize
+                );
+
+            var indexedColumns = _csvFileLog.FileSchema
+                .Select((col, idx) => new CsvColumnMapping
+                    {
+                    ColumnName = col.ToString(),
+                    Ordinal = idx
+                    });
+            var constColumns = _csvFileLog.ConstSchema
+                .Select(col => new CsvColumnMapping
+                    {
+                    ColumnName = col.ToString(),
+                    ConstValue = _csvFileLog.RenderConstColumn(col)
+                });
+
+            _kustoUploader = new KustoUploader
+                (
+                kustoConnectionString,
+                database: KustoDatabase,
+                table: KustoTable,
+                csvMapping: indexedColumns.Concat(constColumns),
+                deleteFilesOnSuccess: true,
+                checkForIngestionErrors: true,
+                log: _consoleLog
                 );
 
             // Every time a log file written to disk and closed, we rename it and upload it to Kusto.

--- a/Public/Src/Cache/ContentStore/App/KustoUploader.cs
+++ b/Public/Src/Cache/ContentStore/App/KustoUploader.cs
@@ -2,11 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks.Dataflow;
 using BuildXL.Cache.ContentStore.Interfaces.Logging;
 using BuildXL.Cache.ContentStore.Logging;
+using Kusto.Data.Common;
 using Kusto.Ingest;
 
 namespace BuildXL.Cache.ContentStore.App
@@ -47,6 +49,7 @@ namespace BuildXL.Cache.ContentStore.App
         /// <param name="connectionString">Kusto connection string.</param>
         /// <param name="database">Database into which to ingest.</param>
         /// <param name="table">Table into which to ingest.</param>
+        /// <param name="csvMapping">Csv mapping that applies to all CSV files to be uploaded via <see cref="UploadSingleCsvFile"/></param>
         /// <param name="deleteFilesOnSuccess">Whether to delete files upon successful upload.</param>
         /// <param name="checkForIngestionErrors">
         ///     Whether to check for ingestion errors before disposing this object.
@@ -59,6 +62,7 @@ namespace BuildXL.Cache.ContentStore.App
             string connectionString,
             string database,
             string table,
+            IEnumerable<CsvColumnMapping> csvMapping,
             bool deleteFilesOnSuccess,
             bool checkForIngestionErrors,
             ILog log = null
@@ -71,8 +75,9 @@ namespace BuildXL.Cache.ContentStore.App
             _hasUploadErrors = false;
             _ingestionProperties = new KustoQueuedIngestionProperties(database, table)
             {
-                ReportLevel = IngestionReportLevel.FailuresOnly,
-                ReportMethod = IngestionReportMethod.Queue
+                CSVMapping   = csvMapping,
+                ReportLevel  = IngestionReportLevel.FailuresOnly,
+                ReportMethod = IngestionReportMethod.Queue,
             };
             _block = new ActionBlock<FileDescription>
                 (

--- a/Public/Src/Cache/ContentStore/App/KustoUploader.cs
+++ b/Public/Src/Cache/ContentStore/App/KustoUploader.cs
@@ -160,7 +160,7 @@ namespace BuildXL.Cache.ContentStore.App
             }
 
             var start = DateTime.UtcNow;
-            var ingestionFailures = _client.PeekTopIngestionFailures().GetAwaiter().GetResult().ToList();
+            var ingestionFailures = _client.GetAndDiscardTopIngestionFailures().GetAwaiter().GetResult().ToList();
             var duration = DateTime.UtcNow.Subtract(start);
             Always("Checking for ingestion failures took {0} ms", duration.TotalMilliseconds);
 

--- a/Public/Src/Cache/ContentStore/Library/Logging/CsvFileLog.cs
+++ b/Public/Src/Cache/ContentStore/Library/Logging/CsvFileLog.cs
@@ -165,8 +165,8 @@ namespace BuildXL.Cache.ContentStore.Logging
         /// <param name="logFilePath">Full path to log file</param>
         /// <param name="schema">CSV schema as a list of columns. Each element in the list denotes a column to be rendered at that position.</param>
         /// <param name="renderConstColums">
-        ///     When true, const columns (<see cref="IsConstValueColumn"/>) from <paramref name="schema"/> are not
-        ///     rendered to the log file (those columns become available through the <see ref="ConstSchema"/> property.
+        ///     When false, const columns (<see cref="IsConstValueColumn"/>) from <paramref name="schema"/> are not
+        ///     rendered to log file (those columns become available through the <see ref="ConstSchema"/> property.
         /// </param>
         /// <param name="severity">Minimum severity to log</param>
         /// <param name="maxFileSize">Maximum size of the log file.</param>

--- a/Public/Src/Cache/ContentStore/Library/Logging/CsvFileLog.cs
+++ b/Public/Src/Cache/ContentStore/Library/Logging/CsvFileLog.cs
@@ -43,11 +43,6 @@ namespace BuildXL.Cache.ContentStore.Logging
             PreciseTimeStamp,
 
             /// <summary>
-            ///     Timestamp of the message in local time.
-            /// </summary>
-            LocalPreciseTimeStamp,
-
-            /// <summary>
             ///     The id of the thread logging the message
             /// </summary>
             ThreadId,
@@ -106,8 +101,9 @@ namespace BuildXL.Cache.ContentStore.Logging
         public IReadOnlyList<ColumnKind> FileSchema { get; }
 
         /// <summary>
-        ///     Additional const-valued columns that are conceptually part of the schema but are not rendered
-        ///     to the output CSV file (e.g., to save time/space) and hence are not included in <see cref="FileSchema"/>.
+        ///     Additional columns that are conceptually part of the schema but are not rendered to the
+        ///     output CSV file because their values remain constant throughout the execution of this log. 
+        ///     These columns are not included in <see cref="FileSchema"/>.
         /// </summary>
         public IReadOnlyList<ColumnKind> ConstSchema { get; }
 
@@ -270,8 +266,6 @@ namespace BuildXL.Cache.ContentStore.Logging
             {
                 case ColumnKind.PreciseTimeStamp:
                     return FormatTimeStamp(dateTime.ToUniversalTime());
-                case ColumnKind.LocalPreciseTimeStamp:
-                    return FormatTimeStamp(dateTime.ToLocalTime());
                 case ColumnKind.ThreadId:
                     return threadId.ToString();
                 case ColumnKind.ProcessId:

--- a/Public/Src/Cache/ContentStore/Library/Logging/CsvFileLog.cs
+++ b/Public/Src/Cache/ContentStore/Library/Logging/CsvFileLog.cs
@@ -153,7 +153,7 @@ namespace BuildXL.Cache.ContentStore.Logging
         ///     Whether the value of <paramref name="col"/> is constant over time.
         ///
         ///     For example, <code>true</code> is returned for columns <see cref="ColumnKind.Empty"/>,
-        ///     <see cref="ColumnKind.BuildId"/>, <see cref="ColumnKind.Machine"/> etc. because their values
+        ///     <see cref="ColumnKind.BuildId"/>, <see cref="ColumnKind.Machine"/> etc., because their values
         ///     don't change during a single execution of the program; in contrast, columns like
         ///     <see cref="ColumnKind.Message"/>, <see cref="ColumnKind.PreciseTimeStamp"/> are not constant.
         /// </summary>
@@ -165,7 +165,8 @@ namespace BuildXL.Cache.ContentStore.Logging
         /// <param name="logFilePath">Full path to log file</param>
         /// <param name="schema">CSV schema as a list of columns. Each element in the list denotes a column to be rendered at that position.</param>
         /// <param name="renderConstColums">
-        ///     When true, const columns (<see cref="IsConstValueColumn"/>) from <paramref name="schema"/> are not rendered to the log file.
+        ///     When true, const columns (<see cref="IsConstValueColumn"/>) from <paramref name="schema"/> are not
+        ///     rendered to the log file (those columns become available through the <see ref="ConstSchema"/> property.
         /// </param>
         /// <param name="severity">Minimum severity to log</param>
         /// <param name="maxFileSize">Maximum size of the log file.</param>

--- a/Public/Src/Cache/ContentStore/Library/Logging/CsvFileLog.cs
+++ b/Public/Src/Cache/ContentStore/Library/Logging/CsvFileLog.cs
@@ -200,8 +200,8 @@ namespace BuildXL.Cache.ContentStore.Logging
             {
                 [ColumnKind.Empty] = string.Empty,
                 [ColumnKind.BuildId] = BuildId.ToString(),
-                [ColumnKind.Machine] = CsvEscape(Environment.MachineName),
-                [ColumnKind.Service] = CsvEscape(serviceName ?? string.Empty),
+                [ColumnKind.Machine] = Environment.MachineName,
+                [ColumnKind.Service] = serviceName ?? string.Empty,
                 [ColumnKind.env_os]    = Environment.OSVersion.Platform.ToString(),
                 [ColumnKind.env_osVer] = Environment.OSVersion.Version.ToString()
             };
@@ -249,9 +249,7 @@ namespace BuildXL.Cache.ContentStore.Logging
                     line.Append(",");
                 }
 
-                line.Append('"');
-                line.Append(RenderColumn(col, dateTime, threadId, severity, message));
-                line.Append('"');
+                line.Append(CsvEscape(RenderColumn(col, dateTime, threadId, severity, message)));
             }
         }
 
@@ -276,7 +274,7 @@ namespace BuildXL.Cache.ContentStore.Logging
                 case ColumnKind.LogLevelFriendly:
                     return severity.ToString();
                 case ColumnKind.Message:
-                    return CsvEscape(message);
+                    return message;
                 default:
                     throw Contract.AssertFailure("Unknown column type: " + col);
             }
@@ -299,7 +297,7 @@ namespace BuildXL.Cache.ContentStore.Logging
 
         private string CsvEscape(string str)
         {
-            return str.Replace("\"", "\"\"");
+            return '"' + str.Replace("\"", "\"\"") + '"';
         }
     }
 }

--- a/Public/Src/Cache/ContentStore/Test/Logging/CsvFileLogTests.cs
+++ b/Public/Src/Cache/ContentStore/Test/Logging/CsvFileLogTests.cs
@@ -193,7 +193,7 @@ namespace ContentStoreTest.Logging
                 renderConstColums: false);
             csvLog.IsConstValueColumn(constCol).Should().BeTrue();
             csvLog.IsConstValueColumn(dynCol).Should().BeFalse();
-            
+
             csvLog.FileSchema.Should().BeEquivalentTo(TranslateSchema(expectedFileSchema));
             csvLog.ConstSchema.Should().BeEquivalentTo(TranslateSchema(expectedConstSchema));
 

--- a/Public/Src/Cache/ContentStore/Test/Logging/CsvFileLogTests.cs
+++ b/Public/Src/Cache/ContentStore/Test/Logging/CsvFileLogTests.cs
@@ -176,6 +176,49 @@ namespace ContentStoreTest.Logging
             }
         }
 
+        [Theory]
+        [InlineData("D", "D", "")]
+        [InlineData("C", "", "C")]
+        [InlineData("D,C", "D", "C")]
+        [InlineData("D,C,D", "D,D", "C")]
+        [InlineData("C,D,C", "D", "C,C")]
+        public void TestDontRenderConstColumns(string schema, string expectedFileSchema, string expectedConstSchema)
+        {
+            var constCol = CsvFileLog.ColumnKind.BuildId;
+            var dynCol = CsvFileLog.ColumnKind.Message;
+
+            var csvLog = new CsvFileLog(
+                GetRandomLogFile(),
+                schema: TranslateSchema(schema),
+                renderConstColums: false);
+            csvLog.IsConstValueColumn(constCol).Should().BeTrue();
+            csvLog.IsConstValueColumn(dynCol).Should().BeFalse();
+            
+            csvLog.FileSchema.Should().BeEquivalentTo(TranslateSchema(expectedFileSchema));
+            csvLog.ConstSchema.Should().BeEquivalentTo(TranslateSchema(expectedConstSchema));
+
+            CsvFileLog.ColumnKind[] TranslateSchema(string s)
+            {
+                return s
+                    .Split(',')
+                    .Select(c => c.Trim())
+                    .Where(c => !string.IsNullOrEmpty(c))
+                    .Select(TranslateCol)
+                    .ToArray();
+            }
+
+            CsvFileLog.ColumnKind TranslateCol(string c)
+            {
+                Assert.True(c == "D" || c == "C", $"Column specified must be either 'C' or 'D', but is '{c}'");
+                return c == "D" ? dynCol : constCol;
+            }
+        }
+
+        private static string GetRandomLogFile()
+        {
+            return Path.Combine(Path.GetTempPath(), GetRandomFileName());
+        }
+
         private string RenderMessage(CsvFileLog log, string message)
         {
             var sb = new StringBuilder();


### PR DESCRIPTION
Instead of uploading just a CSV file and relying on the order CSV file columns to match the order of columns in the Kusto table, specify a csv mapping explicitly, so that the order of columns in the CSV file doesn't matter.