### PR TITLE
Don't duplicate DX0064 message for pips that don't match the error regex

### DIFF
--- a/Public/Src/App/Bxl/BuildXLApp.cs
+++ b/Public/Src/App/Bxl/BuildXLApp.cs
@@ -787,7 +787,7 @@ namespace BuildXL
                     {
                         case (int)EventId.FileMonitoringError:
                             return ExitKind.BuildFailedWithFileMonErrors;
-                        case (int)EventId.PipProcessExpectedMissingOutputs:
+                        case (int)BuildXL.Processes.Tracing.LogEventId.PipProcessExpectedMissingOutputs:
                             return ExitKind.BuildFailedWithMissingOutputErrors;
                         case (int)EventId.InvalidOutputDueToSimpleDoubleWrite:
                             return ExitKind.BuildFailedSpecificationError;

--- a/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
@@ -3458,13 +3458,6 @@ namespace BuildXL.Processes
                 {
                     return new LogErrorResult(success: false, errorWasTruncated: errorWasTruncated);
                 }
-
-                string stdOut = await TryFilterAsync(result.StandardOutput, s => true, appendNewLine: true);
-                string stdErr = await TryFilterAsync(result.StandardError, s => true, appendNewLine: true);
-                LogPipProcessError(result, exitedWithSuccessExitCode, stdErr, stdOut);
-
-                stdOutTotalLength = stdOut.Length;
-                stdErrTotalLength = stdErr.Length;
             }
 
             return new LogErrorResult(success: true, errorWasTruncated: errorWasTruncated);

--- a/Public/Src/Engine/UnitTests/Engine/DeterminismProbeTests.cs
+++ b/Public/Src/Engine/UnitTests/Engine/DeterminismProbeTests.cs
@@ -89,7 +89,7 @@ namespace Test.BuildXL.Engine
 
             FailedBuild("Build #4");
             AssertVerboseEventLogged(EventId.PipProcessMissingExpectedOutputOnCleanExit);
-            AssertErrorEventLogged(EventId.PipProcessExpectedMissingOutputs);
+            AssertErrorEventLogged(global::BuildXL.Processes.Tracing.LogEventId.PipProcessExpectedMissingOutputs);
             AssertErrorEventLogged(EventId.PipProcessError);
 
             // Verify DeterminismProbeEncounteredPipFailure was logged

--- a/Public/Src/Engine/UnitTests/Processes.Detours/SandboxedProcessPipExecutorTest.cs
+++ b/Public/Src/Engine/UnitTests/Processes.Detours/SandboxedProcessPipExecutorTest.cs
@@ -119,7 +119,7 @@ namespace Test.BuildXL.Processes.Detours
                         sandboxConfiguration,
                         pip);
 
-                    AssertErrorEventLogged(EventId.PipProcessExpectedMissingOutputs);
+                    AssertErrorEventLogged(global::BuildXL.Processes.Tracing.LogEventId.PipProcessExpectedMissingOutputs);
                     AssertErrorEventLogged(EventId.PipProcessError);
                 }
             }

--- a/Public/Src/Engine/UnitTests/Processes/Containers/ContainerSandboxExecutorIntegrationTests.cs
+++ b/Public/Src/Engine/UnitTests/Processes/Containers/ContainerSandboxExecutorIntegrationTests.cs
@@ -183,7 +183,7 @@ namespace Test.BuildXL.Processes
 
                 // The redirected output is created as a tombstone file, but the sandboxed pip executor should report it as an absent file
                 AssertErrorEventLogged(EventId.PipProcessMissingExpectedOutputOnCleanExit);
-                AssertErrorEventLogged(EventId.PipProcessExpectedMissingOutputs);
+                AssertErrorEventLogged(global::BuildXL.Processes.Tracing.LogEventId.PipProcessExpectedMissingOutputs);
             }
         }
 

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/BaselineTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/BaselineTests.cs
@@ -275,7 +275,7 @@ namespace IntegrationTest.BuildXL.Scheduler
             // Fail on missing output
             RunScheduler().AssertFailure();
             AssertVerboseEventLogged(EventId.PipProcessMissingExpectedOutputOnCleanExit);
-            AssertErrorEventLogged(EventId.PipProcessExpectedMissingOutputs);
+            AssertErrorEventLogged(global::BuildXL.Processes.Tracing.LogEventId.PipProcessExpectedMissingOutputs);
             AssertErrorEventLogged(EventId.PipProcessError);
         }
 

--- a/Public/Src/Utilities/Utilities/Tracing/EventId.cs
+++ b/Public/Src/Utilities/Utilities/Tracing/EventId.cs
@@ -431,7 +431,7 @@ namespace BuildXL.Utilities.Tracing
 
         Channel = 502,
         StorageCacheContentHitSources = 503,
-        PipProcessExpectedMissingOutputs = 504,
+        // Elsewhere = 504,
         // was PipProcessAllowedMissingOutputs = 505,
 
         // USN/Change Journal usage (FileChangeTracker)


### PR DESCRIPTION
We have been duplicate logging the DX0064 message when the error regex doesn't match anything. Also cleaned up our definition of the EventId.

Fixes [AB#1563224](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1563224)