### PR TITLE
Make ImplicitPin configurable in MemoizationStoreAdapterCache

### DIFF
--- a/Public/Src/Cache/ContentStore/Interfaces/Stores/ImplicitPin.cs
+++ b/Public/Src/Cache/ContentStore/Interfaces/Stores/ImplicitPin.cs
@@ -1,11 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace BuildXL.Cache.ContentStore.Interfaces.Stores
 {
     /// <summary>
     ///     Session options for pinning behavior.
     /// </summary>
+    [Flags]
     public enum ImplicitPin
     {
         /// <summary>
@@ -14,8 +17,18 @@ namespace BuildXL.Cache.ContentStore.Interfaces.Stores
         None = 0,
 
         /// <summary>
-        ///     Implicitly pin on gets and puts.
+        ///     Implicitly pin on puts.
         /// </summary>
-        PutAndGet
+        Put = 1,
+
+        /// <summary>
+        ///     Implicitly pin on gets.
+        /// </summary>
+        Get = 2,
+
+        /// <summary>
+        ///     Implicitly pin on puts and gets.
+        /// </summary>
+        PutAndGet = 3
     }
 }

--- a/Public/Src/Cache/ContentStore/Library/Sessions/FileSystemContentSession.cs
+++ b/Public/Src/Cache/ContentStore/Library/Sessions/FileSystemContentSession.cs
@@ -40,7 +40,7 @@ namespace BuildXL.Cache.ContentStore.Sessions
             UrgencyHint urgencyHint,
             Counter retryCounter)
         {
-            return Store.PutFileAsync(operationContext, path, realizationMode, hashType, MakePinRequest());
+            return Store.PutFileAsync(operationContext, path, realizationMode, hashType, MakePinRequest(ImplicitPin.Put));
         }
 
         /// <inheritdoc />
@@ -52,7 +52,7 @@ namespace BuildXL.Cache.ContentStore.Sessions
             UrgencyHint urgencyHint,
             Counter retryCounter)
         {
-            return Store.PutFileAsync(operationContext, path, realizationMode, contentHash, MakePinRequest());
+            return Store.PutFileAsync(operationContext, path, realizationMode, contentHash, MakePinRequest(ImplicitPin.Put));
         }
 
         /// <inheritdoc />
@@ -64,7 +64,7 @@ namespace BuildXL.Cache.ContentStore.Sessions
             CancellationToken cts,
             UrgencyHint urgencyHint)
         {
-            return Store.PutTrustedFileAsync(context, path, realizationMode, contentHash, MakePinRequest());
+            return Store.PutTrustedFileAsync(context, path, realizationMode, contentHash, MakePinRequest(ImplicitPin.Put));
         }
 
         /// <inheritdoc />
@@ -75,7 +75,7 @@ namespace BuildXL.Cache.ContentStore.Sessions
             UrgencyHint urgencyHint,
             Counter retryCounter)
         {
-            return Store.PutStreamAsync(operationContext, stream, hashType, MakePinRequest());
+            return Store.PutStreamAsync(operationContext, stream, hashType, MakePinRequest(ImplicitPin.Put));
         }
 
         /// <inheritdoc />
@@ -86,19 +86,19 @@ namespace BuildXL.Cache.ContentStore.Sessions
             UrgencyHint urgencyHint,
             Counter retryCounter)
         {
-            return Store.PutStreamAsync(operationContext, stream, contentHash, MakePinRequest());
+            return Store.PutStreamAsync(operationContext, stream, contentHash, MakePinRequest(ImplicitPin.Put));
         }
 
         /// <inheritdoc />
         public Task<PutResult> PutFileAsync(Context context, AbsolutePath path, HashType hashType, FileRealizationMode realizationMode, CancellationToken cts, UrgencyHint urgencyHint, Func<Stream, Stream> wrapStream)
         {
-            return Store.PutFileAsync(context, path, hashType, realizationMode,  wrapStream, MakePinRequest());
+            return Store.PutFileAsync(context, path, hashType, realizationMode,  wrapStream, MakePinRequest(ImplicitPin.Put));
         }
 
         /// <inheritdoc />
         public Task<PutResult> PutFileAsync(Context context, AbsolutePath path, ContentHash contentHash, FileRealizationMode realizationMode, CancellationToken cts, UrgencyHint urgencyHint, Func<Stream, Stream> wrapStream)
         {
-            return Store.PutFileAsync(context, path, contentHash, realizationMode, wrapStream, MakePinRequest());
+            return Store.PutFileAsync(context, path, contentHash, realizationMode, wrapStream, MakePinRequest(ImplicitPin.Put));
         }
     }
 }

--- a/Public/Src/Cache/ContentStore/Library/Sessions/ReadOnlyFileSystemContentSession.cs
+++ b/Public/Src/Cache/ContentStore/Library/Sessions/ReadOnlyFileSystemContentSession.cs
@@ -76,7 +76,7 @@ namespace BuildXL.Cache.ContentStore.Sessions
         protected override Task<OpenStreamResult> OpenStreamCoreAsync(
             OperationContext operationContext, ContentHash contentHash, UrgencyHint urgencyHint, Counter retryCounter)
         {
-            return Store.OpenStreamAsync(operationContext, contentHash, MakePinRequest());
+            return Store.OpenStreamAsync(operationContext, contentHash, MakePinRequest(ImplicitPin.Get));
         }
 
         /// <inheritdoc />
@@ -90,7 +90,7 @@ namespace BuildXL.Cache.ContentStore.Sessions
             UrgencyHint urgencyHint,
             Counter retryCounter)
         {
-            return Store.PlaceFileAsync(operationContext, contentHash, path, accessMode, replacementMode, realizationMode, MakePinRequest());
+            return Store.PlaceFileAsync(operationContext, contentHash, path, accessMode, replacementMode, realizationMode, MakePinRequest(ImplicitPin.Put));
         }
 
         /// <inheritdoc />
@@ -114,7 +114,7 @@ namespace BuildXL.Cache.ContentStore.Sessions
             UrgencyHint urgencyHint,
             Counter retryCounter)
         {
-            return Store.PlaceFileAsync(operationContext, hashesWithPaths, accessMode, replacementMode, realizationMode, MakePinRequest());
+            return Store.PlaceFileAsync(operationContext, hashesWithPaths, accessMode, replacementMode, realizationMode, MakePinRequest(ImplicitPin.Get));
         }
 
         /// <inheritdoc />
@@ -137,11 +137,11 @@ namespace BuildXL.Cache.ContentStore.Sessions
         }
 
         /// <summary>
-        ///     Build a PinRequest based on auto-pin configuration.
+        ///     Build a PinRequest based on whether auto-pin configuration matches request.
         /// </summary>
-        protected PinRequest? MakePinRequest()
+        protected PinRequest? MakePinRequest(ImplicitPin implicitPin)
         {
-            return _implicitPin == ImplicitPin.PutAndGet ? new PinRequest(_pinContext) : (PinRequest?)null;
+            return (implicitPin & _implicitPin) != ImplicitPin.None ? new PinRequest(_pinContext) : (PinRequest?)null;
         }
     }
 }

--- a/Public/Src/Cache/ContentStore/Vsts/BlobReadOnlyContentSession.cs
+++ b/Public/Src/Cache/ContentStore/Vsts/BlobReadOnlyContentSession.cs
@@ -198,7 +198,7 @@ namespace BuildXL.Cache.ContentStore.Vsts
             string tempFile = null;
             try
             {
-                if (ImplicitPin == ImplicitPin.PutAndGet)
+                if (ImplicitPin == ImplicitPin.Get)
                 {
                     var pinResult = await PinAsync(context, contentHash, context.Token, urgencyHint).ConfigureAwait(false);
                     if (!pinResult.Succeeded)
@@ -267,7 +267,7 @@ namespace BuildXL.Cache.ContentStore.Vsts
                     return new PlaceFileResult(PlaceFileResult.ResultCode.NotPlacedAlreadyExists);
                 }
 
-                if (ImplicitPin == ImplicitPin.PutAndGet)
+                if (ImplicitPin == ImplicitPin.Get)
                 {
                     var pinResult = await PinAsync(context, contentHash, context.Token, urgencyHint).ConfigureAwait(false);
                     if (!pinResult.Succeeded)

--- a/Public/Src/Cache/ContentStore/Vsts/DedupReadOnlyContentSession.cs
+++ b/Public/Src/Cache/ContentStore/Vsts/DedupReadOnlyContentSession.cs
@@ -199,7 +199,7 @@ namespace BuildXL.Cache.ContentStore.Vsts
             string tempFile = null;
             try
             {
-                if (ImplicitPin == ImplicitPin.PutAndGet)
+                if (ImplicitPin == ImplicitPin.Get)
                 {
                     var pinResult = await PinAsync(context, contentHash, context.Token, urgencyHint).ConfigureAwait(false);
                     if (!pinResult.Succeeded)
@@ -276,7 +276,7 @@ namespace BuildXL.Cache.ContentStore.Vsts
                     return new PlaceFileResult(PlaceFileResult.ResultCode.NotPlacedAlreadyExists);
                 }
 
-                if (ImplicitPin == ImplicitPin.PutAndGet)
+                if (ImplicitPin == ImplicitPin.Get)
                 {
                     var pinResult = await PinAsync(context, contentHash, context.Token, urgencyHint).ConfigureAwait(false);
                     if (!pinResult.Succeeded)

--- a/Public/Src/Cache/MemoizationStore/Vsts/BuildCacheServiceConfiguration.cs
+++ b/Public/Src/Cache/MemoizationStore/Vsts/BuildCacheServiceConfiguration.cs
@@ -88,6 +88,11 @@ namespace BuildXL.Cache.MemoizationStore.Vsts
         public const bool DefaultUseDedupStore = false;
 
         /// <summary>
+        /// Default value indicating whether implicit pin is used.
+        /// </summary>
+        public const bool DefaultUseImplicitPin = false;
+
+        /// <summary>
         /// Default value indicating whether Unix file access mode override is enabled.
         /// </summary>
         public const bool DefaultOverrideUnixFileAccessMode = false;
@@ -221,6 +226,12 @@ namespace BuildXL.Cache.MemoizationStore.Vsts
         /// </summary>
         [DataMember]
         public bool UseDedupStore { get; set; } = DefaultUseDedupStore;
+
+        /// <summary>
+        /// Gets or sets whether an implicit pin is used.
+        /// </summary>
+        [DataMember]
+        public bool UseImplicitPin { get; set; } = DefaultUseImplicitPin;
 
         /// <summary>
         /// Gets or sets whether to override Unix file access modes.

--- a/Public/Src/Cache/MemoizationStore/Vsts/BuildCacheServiceConfiguration.cs
+++ b/Public/Src/Cache/MemoizationStore/Vsts/BuildCacheServiceConfiguration.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.Serialization;
+using BuildXL.Cache.ContentStore.Interfaces.Stores;
 using BuildXL.Cache.MemoizationStore.VstsInterfaces;
 using Newtonsoft.Json;
 
@@ -90,7 +91,7 @@ namespace BuildXL.Cache.MemoizationStore.Vsts
         /// <summary>
         /// Default value indicating whether implicit pin is used.
         /// </summary>
-        public const bool DefaultUseImplicitPin = true;
+        public const ImplicitPin DefaultImplicitPin = ImplicitPin.PutAndGet;
 
         /// <summary>
         /// Default value indicating whether Unix file access mode override is enabled.
@@ -231,7 +232,7 @@ namespace BuildXL.Cache.MemoizationStore.Vsts
         /// Gets or sets whether an implicit pin is used.
         /// </summary>
         [DataMember]
-        public bool UseImplicitPin { get; set; } = DefaultUseImplicitPin;
+        public ImplicitPin ImplicitPin { get; set; } = DefaultImplicitPin;
 
         /// <summary>
         /// Gets or sets whether to override Unix file access modes.

--- a/Public/Src/Cache/MemoizationStore/Vsts/BuildCacheServiceConfiguration.cs
+++ b/Public/Src/Cache/MemoizationStore/Vsts/BuildCacheServiceConfiguration.cs
@@ -90,7 +90,7 @@ namespace BuildXL.Cache.MemoizationStore.Vsts
         /// <summary>
         /// Default value indicating whether implicit pin is used.
         /// </summary>
-        public const bool DefaultUseImplicitPin = false;
+        public const bool DefaultUseImplicitPin = true;
 
         /// <summary>
         /// Default value indicating whether Unix file access mode override is enabled.

--- a/Public/Src/Cache/VerticalStore/BuildCacheAdapter/DistributedBuildCacheFactory.cs
+++ b/Public/Src/Cache/VerticalStore/BuildCacheAdapter/DistributedBuildCacheFactory.cs
@@ -7,6 +7,7 @@ using System.ComponentModel;
 using System.Diagnostics.ContractsLight;
 using System.Threading.Tasks;
 using BuildXL.Cache.ContentStore.Interfaces.Logging;
+using BuildXL.Cache.ContentStore.Interfaces.Stores;
 using BuildXL.Cache.ContentStore.Stores;
 using BuildXL.Cache.Interfaces;
 using BuildXL.Cache.MemoizationStore.Distributed.Metadata;
@@ -65,6 +66,7 @@ namespace BuildXL.Cache.BuildCacheAdapter
         //     "UseDedupStore":{27}
         //     "DisableContent":{28}
         //     "OverrideUnixFileAccessMode":{29}
+        //     "UseImplicitPin":{30}
         // }
         private sealed class Config : BuildCacheCacheConfig
         {
@@ -111,7 +113,8 @@ namespace BuildXL.Cache.BuildCacheAdapter
                 logger.Debug($"Distributed cache created successfully.");
 
                 var statsFilePath = new AbsolutePath(logPath.Path + ".stats");
-                var cache = new MemoizationStoreAdapterCache(cacheConfig.CacheId, distributedCache, logger, statsFilePath);
+                var implicitPin = cacheConfig.UseImplicitPin ? ImplicitPin.PutAndGet : ImplicitPin.None;
+                var cache = new MemoizationStoreAdapterCache(cacheConfig.CacheId, distributedCache, logger, statsFilePath, implicitPin: implicitPin);
 
                 logger.Diagnostic($"Initializing the cache [{cacheConfig.CacheId}]");
                 var startupResult = await cache.StartupAsync();

--- a/Public/Src/Cache/VerticalStore/BuildCacheAdapter/DistributedBuildCacheFactory.cs
+++ b/Public/Src/Cache/VerticalStore/BuildCacheAdapter/DistributedBuildCacheFactory.cs
@@ -66,7 +66,7 @@ namespace BuildXL.Cache.BuildCacheAdapter
         //     "UseDedupStore":{27}
         //     "DisableContent":{28}
         //     "OverrideUnixFileAccessMode":{29}
-        //     "UseImplicitPin":{30}
+        //     "ImplicitPin":{30}
         // }
         private sealed class Config : BuildCacheCacheConfig
         {
@@ -113,8 +113,7 @@ namespace BuildXL.Cache.BuildCacheAdapter
                 logger.Debug($"Distributed cache created successfully.");
 
                 var statsFilePath = new AbsolutePath(logPath.Path + ".stats");
-                var implicitPin = cacheConfig.UseImplicitPin ? ImplicitPin.PutAndGet : ImplicitPin.None;
-                var cache = new MemoizationStoreAdapterCache(cacheConfig.CacheId, distributedCache, logger, statsFilePath, implicitPin: implicitPin);
+                var cache = new MemoizationStoreAdapterCache(cacheConfig.CacheId, distributedCache, logger, statsFilePath, implicitPin: cacheConfig.ImplicitPin);
 
                 logger.Diagnostic($"Initializing the cache [{cacheConfig.CacheId}]");
                 var startupResult = await cache.StartupAsync();

--- a/Public/Src/Cache/VerticalStore/MemoizationStoreAdapter/MemoizationStoreAdapterCache.cs
+++ b/Public/Src/Cache/VerticalStore/MemoizationStoreAdapter/MemoizationStoreAdapterCache.cs
@@ -217,7 +217,7 @@ namespace BuildXL.Cache.MemoizationStoreAdapter
             var createSessionResult = m_cache.CreateReadOnlySession(
                 context,
                 $"{CacheId}-Anonymous",
-                ImplicitPin.PutAndGet);
+                m_implicitPin);
             if (createSessionResult.Succeeded)
             {
                 var innerCacheSession = createSessionResult.Session;

--- a/Public/Src/Cache/VerticalStore/MemoizationStoreAdapter/MemoizationStoreAdapterCache.cs
+++ b/Public/Src/Cache/VerticalStore/MemoizationStoreAdapter/MemoizationStoreAdapterCache.cs
@@ -33,6 +33,7 @@ namespace BuildXL.Cache.MemoizationStoreAdapter
         private readonly AbsolutePath m_statsFile;
         private bool m_isShutdown;
         private readonly bool m_replaceExistingOnPlaceFile;
+        private ImplicitPin m_implicitPin;
 
         /// <summary>
         /// .ctor
@@ -42,12 +43,14 @@ namespace BuildXL.Cache.MemoizationStoreAdapter
         /// <param name="logger">For logging diagnostics.</param>
         /// <param name="statsFile">A file to write stats about the cache into.</param>
         /// <param name="replaceExistingOnPlaceFile">When true, replace existing file when placing file.</param>
+        /// <param name="implicitPin">ImplicitPin to be used when creating sessions.</param>
         public MemoizationStoreAdapterCache(
             string cacheId,
             BuildXL.Cache.MemoizationStore.Interfaces.Caches.ICache innerCache,
             ILogger logger,
             AbsolutePath statsFile,
-            bool replaceExistingOnPlaceFile = false)
+            bool replaceExistingOnPlaceFile = false,
+            ImplicitPin implicitPin = ImplicitPin.PutAndGet)
         {
             Contract.Requires(cacheId != null);
             Contract.Requires(innerCache != null);
@@ -59,6 +62,7 @@ namespace BuildXL.Cache.MemoizationStoreAdapter
             m_statsFile = statsFile;
             m_fileSystem = new PassThroughFileSystem(m_logger);
             m_replaceExistingOnPlaceFile = replaceExistingOnPlaceFile;
+            m_implicitPin = implicitPin;
         }
 
         /// <summary>
@@ -157,7 +161,7 @@ namespace BuildXL.Cache.MemoizationStoreAdapter
             var createSessionResult = m_cache.CreateSession(
                 context,
                 $"{CacheId}-{sessionId}",
-                ImplicitPin.PutAndGet);
+                m_implicitPin);
             if (createSessionResult.Succeeded)
             {
                 var innerCacheSession = createSessionResult.Session;
@@ -184,7 +188,7 @@ namespace BuildXL.Cache.MemoizationStoreAdapter
             Contract.Requires(!IsReadOnly);
 
             var context = new Context(m_logger);
-            var createSessionResult = m_cache.CreateSession(context, $"{CacheId}-Anonymous", ImplicitPin.PutAndGet);
+            var createSessionResult = m_cache.CreateSession(context, $"{CacheId}-Anonymous", m_implicitPin);
             if (createSessionResult.Succeeded)
             {
                 var innerCacheSession = createSessionResult.Session;


### PR DESCRIPTION
It will be needed for DedupStore, since pinning now makes hundreds of calls to VSTS to verify the existence of each chunk of a file, so pinning before each put/place is no longer the "fail fast" route.