### PR TITLE
Add basic IMemoizationSession constructs for CaChaaS

### DIFF
--- a/Public/Src/Cache/ContentStore/BuildXL.Cache.ContentStore.dsc
+++ b/Public/Src/Cache/ContentStore/BuildXL.Cache.ContentStore.dsc
@@ -4,6 +4,7 @@
 
 import * as BuildXLSdk from "Sdk.BuildXL";
 import * as Deployment from "Sdk.Deployment";
+import * as MemoizationStore from "BuildXL.Cache.MemoizationStore";
 
 export declare const qualifier : BuildXLSdk.DefaultQualifierWithNet451;
 

--- a/Public/Src/Cache/ContentStore/Distributed/BuildXL.Cache.ContentStore.Distributed.dsc
+++ b/Public/Src/Cache/ContentStore/Distributed/BuildXL.Cache.ContentStore.Distributed.dsc
@@ -35,6 +35,7 @@ namespace Distributed {
             Hashing.dll,
             Interfaces.dll,
             Library.dll,
+            importFrom("BuildXL.Cache.MemoizationStore").Interfaces.dll,
             ...addIf(BuildXLSdk.isFullFramework,
                 NetFx.System.IO.dll,
                 NetFx.System.IO.Compression.dll,

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabaseCounters.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabaseCounters.cs
@@ -102,5 +102,13 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
 
         /// <nodoc />
         TotalNumberOfCompletedCacheFlushes,
+
+        /// <nodoc />
+        [CounterType(CounterType.Stopwatch)]
+        AddOrGetContentHashList,
+
+        /// <nodoc />
+        [CounterType(CounterType.Stopwatch)]
+        GetContentHashList,
     }
 }

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/InMemory/MemoryContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/InMemory/MemoryContentLocationDatabase.cs
@@ -52,17 +52,31 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache.InMemory
         }
 
         /// <inheritdoc />
-        public override GetContentHashListResult GetContentHashList(OperationContext context, StrongFingerprint strongFingerprint) => null;
+        public override GetContentHashListResult GetContentHashList(OperationContext context, StrongFingerprint strongFingerprint)
+        {
+            throw new NotImplementedException();
+        }
 
         /// <inheritdoc />
         public override AddOrGetContentHashListResult AddOrGetContentHashList(
             OperationContext context,
             StrongFingerprint strongFingerprint,
-            ContentHashListWithDeterminism contentHashListWithDeterminism) =>
-            null;
+            ContentHashListWithDeterminism contentHashListWithDeterminism)
+        {
+            throw new NotImplementedException();
+        }
 
         /// <inheritdoc />
-        public override IReadOnlyCollection<GetSelectorResult> GetSelectors(OperationContext context, Fingerprint weakFingerprint) => null;
+        public override IReadOnlyCollection<GetSelectorResult> GetSelectors(OperationContext context, Fingerprint weakFingerprint)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<StructResult<StrongFingerprint>> EnumerateStrongFingerprints(OperationContext context)
+        {
+            throw new NotImplementedException();
+        }
 
         /// <inheritdoc />
         protected override IEnumerable<ShortHash> EnumerateSortedKeysFromStorage(CancellationToken token)

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/InMemory/MemoryContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/InMemory/MemoryContentLocationDatabase.cs
@@ -11,6 +11,8 @@ using BuildXL.Cache.ContentStore.Interfaces.FileSystem;
 using BuildXL.Cache.ContentStore.Interfaces.Results;
 using BuildXL.Cache.ContentStore.Interfaces.Time;
 using BuildXL.Cache.ContentStore.Tracing.Internal;
+using BuildXL.Cache.MemoizationStore.Interfaces.Results;
+using BuildXL.Cache.MemoizationStore.Interfaces.Sessions;
 
 namespace BuildXL.Cache.ContentStore.Distributed.NuCache.InMemory
 {
@@ -50,6 +52,19 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache.InMemory
         }
 
         /// <inheritdoc />
+        public override GetContentHashListResult GetContentHashList(OperationContext context, StrongFingerprint strongFingerprint) => null;
+
+        /// <inheritdoc />
+        public override AddOrGetContentHashListResult AddOrGetContentHashList(
+            OperationContext context,
+            StrongFingerprint strongFingerprint,
+            ContentHashListWithDeterminism contentHashListWithDeterminism) =>
+            null;
+
+        /// <inheritdoc />
+        public override IReadOnlyCollection<GetSelectorResult> GetSelectors(OperationContext context, Fingerprint weakFingerprint) => null;
+
+        /// <inheritdoc />
         protected override IEnumerable<ShortHash> EnumerateSortedKeysFromStorage(CancellationToken token)
         {
             return _map.Keys.OrderBy(h => h);
@@ -62,7 +77,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache.InMemory
         {
             foreach (var kvp in _map)
             {
-                if (filter == null || filter(Serialize(kvp.Value)))
+                if (filter == null || filter(SerializeContentLocationEntry(kvp.Value)))
                 {
                     yield return (kvp.Key, kvp.Value);
                 }

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/RocksDbContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/RocksDbContentLocationDatabase.cs
@@ -557,7 +557,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                         return new GetContentHashListResult(status.Failure.CreateException());
                     }
 
-                    if (result == null)
+                    if (result is null)
                     {
                         return new GetContentHashListResult(EmptyContentHashList(CacheDeterminism.None));
                     }
@@ -595,13 +595,13 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                                 var oldDeterminism = oldContentHashListWithDeterminism.ContentHashListWithDeterminism.Determinism;
 
                                 // Make sure we're not mixing SinglePhaseNonDeterminism records
-                                if (oldContentHashList != null &&
+                                if (!(oldContentHashList is null) &&
                                             oldDeterminism.IsSinglePhaseNonDeterministic != determinism.IsSinglePhaseNonDeterministic)
                                 {
                                     return AddOrGetContentHashListResult.SinglePhaseMixingError;
                                 }
 
-                                if (oldContentHashList == null || oldDeterminism.ShouldBeReplacedWith(determinism) ||
+                                if (oldContentHashList is null || oldDeterminism.ShouldBeReplacedWith(determinism) ||
                                             !IsContentAvailable(context, oldContentHashList))
                                 {
                                     // Replace if incoming has better determinism or some content for the existing
@@ -621,12 +621,12 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                                     });
 
                                     // our add lost - need to retry.
-                                    if (contentHashListResult.ContentHashListWithDeterminism.ContentHashList != null)
+                                    if (!(contentHashListResult.ContentHashListWithDeterminism.ContentHashList is null))
                                     {
                                         continue;
                                     }
 
-                                    if (contentHashListResult.ContentHashListWithDeterminism.ContentHashList == null)
+                                    if (contentHashListResult.ContentHashListWithDeterminism.ContentHashList is null)
                                     {
                                         return contentHashListResult;
                                     }
@@ -634,7 +634,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
 
                                 // If we didn't accept the new value because it is the same as before, just with a not
                                 // necessarily better determinism, then let the user know.
-                                if (oldContentHashList != null && oldContentHashList.Equals(contentHashList))
+                                if (!(oldContentHashList is null) && oldContentHashList.Equals(contentHashList))
                                 {
                                     return new AddOrGetContentHashListResult(EmptyContentHashList(oldDeterminism));
                                 }

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/RocksDbContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/RocksDbContentLocationDatabase.cs
@@ -15,10 +15,13 @@ using BuildXL.Cache.ContentStore.Interfaces.Time;
 using BuildXL.Cache.ContentStore.Interfaces.Tracing;
 using BuildXL.Cache.ContentStore.Interfaces.Utils;
 using BuildXL.Cache.ContentStore.Tracing.Internal;
+using BuildXL.Cache.MemoizationStore.Interfaces.Results;
+using BuildXL.Cache.MemoizationStore.Interfaces.Sessions;
 using BuildXL.Engine.Cache;
 using BuildXL.Engine.Cache.KeyValueStores;
 using BuildXL.Native.IO;
 using BuildXL.Utilities;
+using BuildXL.Utilities.Collections;
 using BuildXL.Utilities.Tasks;
 using BuildXL.Utilities.Threading;
 using AbsolutePath = BuildXL.Cache.ContentStore.Interfaces.FileSystem.AbsolutePath;
@@ -36,7 +39,9 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         private const string ActiveStoreSlotFileName = "activeSlot.txt";
         private StoreSlot _activeSlot = StoreSlot.Slot1;
         private string _storeLocation;
-        private readonly string _activeSlotFilePath;
+        private readonly string _activeSlotFilePath;        
+
+        private static readonly byte[] EmptyBytes = CollectionUtilities.EmptyArray<byte>();
 
         private enum StoreSlot
         {
@@ -44,9 +49,26 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             Slot2
         }
 
+        /// <summary>
+        /// There's multiple column families in this usage of RocksDB.
+        ///
+        /// The default column family is used to store a <see cref="ContentHash"/> to <see cref="ContentLocationEntry"/> mapping, which has been
+        /// the usage since this started.
+        ///
+        /// All others are documented below.
+        /// </summary>
         private enum Columns
         {
-            ClusterState
+            ClusterState,
+            /// <summary>
+            /// Stores mapping from <see cref="StrongFingerprint"/> to a <see cref="ContentHashList"/>. This allows us
+            /// to look up via a <see cref="Fingerprint"/>, or a <see cref="StrongFingerprint"/>. The only reason we
+            /// can look up by <see cref="Fingerprint"/> is that it is stored as a prefix to the
+            /// <see cref="StrongFingerprint"/>.
+            ///
+            /// This serves all of CaChaaS' needs for storage, modulo garbage collection.
+            /// </summary>
+            CaChaaS
         }
 
         private enum ClusterStateKeys
@@ -97,7 +119,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                 Tracer.Info(context, $"Creating rocksdb store at '{storeLocation}'.");
 
                 var possibleStore = KeyValueStoreAccessor.Open(storeLocation,
-                    additionalColumns: new[] { nameof(ClusterState) });
+                    additionalColumns: new[] { nameof(ClusterState), "CaChaaS" });
                 if (possibleStore.Succeeded)
                 {
                     var oldKeyValueStore = _keyValueStore;
@@ -326,7 +348,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                                     keyBuffer.Add(DeserializeKey(key));
                                     startValue = key;
 
-                                    if (keyBuffer.Count == KeysChunkSize )
+                                    if (keyBuffer.Count == KeysChunkSize)
                                     {
                                         cts.Cancel();
                                     }
@@ -338,7 +360,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                         }
 
                     }).ThrowOnError();
-                
+
                 if (keyBuffer.Count == 0)
                 {
                     break;
@@ -362,7 +384,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             while (!token.IsCancellationRequested)
             {
                 keyBuffer.Clear();
-                
+
                 _keyValueStore.Use(
                     store =>
                     {
@@ -388,7 +410,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                                     byte[] value = null;
                                     if (filter != null && filter(value = iterator.Value()))
                                     {
-                                        keyBuffer.Add((DeserializeKey(key ?? iterator.Key()), Deserialize(value)));
+                                        keyBuffer.Add((DeserializeKey(key ?? iterator.Key()), DeserializeContentLocationEntry(value)));
                                     }
 
                                     if (keyBuffer.Count == KeysChunkSize)
@@ -436,7 +458,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             ContentLocationEntry result = null;
             if (store.TryGetValue(db.GetKey(hash), out var data))
             {
-                result = db.Deserialize(data);
+                result = db.DeserializeContentLocationEntry(data);
             }
 
             return result;
@@ -465,7 +487,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         {
             store.ApplyBatch(
                 pairs.Select(pair => db.GetKey(pair.Key)),
-                pairs.Select(pair => pair.Value != null ? db.Serialize(pair.Value) : null));
+                pairs.Select(pair => pair.Value != null ? db.SerializeContentLocationEntry(pair.Value) : null));
             return Unit.Void;
         }
 
@@ -478,7 +500,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         // NOTE: This should remain static to avoid allocations in Store
         private static Unit SaveToDbHelper(ShortHash hash, ContentLocationEntry entry, IBuildXLKeyValueStore store, RocksDbContentLocationDatabase db)
         {
-            var value = db.Serialize(entry);
+            var value = db.SerializeContentLocationEntry(entry);
             store.Put(db.GetKey(hash), value);
 
             return Unit.Void;
@@ -506,6 +528,162 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         {
             return hash.ToByteArray();
         }
+
+        #region Memoization
+        // TODO(jubayard): garbage collection / removal in general
+
+        /// <inheritdoc />
+        public override GetContentHashListResult GetContentHashList(OperationContext context, StrongFingerprint strongFingerprint)
+        {
+            var key = GetCaChaaSKey(strongFingerprint);
+            ContentHashListWithDeterminism? result = null;
+            var status = _keyValueStore.Use(
+                store =>
+                {
+                    if (store.TryGetValue(key, out var data, nameof(Columns.CaChaaS)))
+                    {
+                        result = DeserializeContentHashList(data);
+                        // TODO(jubayard): since we are inside the ContentLocationDatabase, we can validate that all
+                        // hashes exist. Moreover, we can prune content.
+                    }
+                });
+
+            if (!status.Succeeded)
+            {
+                return new GetContentHashListResult(status.Failure.CreateException());
+            }
+            
+            return new GetContentHashListResult(result ?? default);
+        }
+        
+        /// <inheritdoc />
+        public override AddOrGetContentHashListResult AddOrGetContentHashList(OperationContext context, StrongFingerprint strongFingerprint, ContentHashListWithDeterminism contentHashListWithDeterminism)
+        {
+            var key = GetCaChaaSKey(strongFingerprint);
+
+            Possible<AddOrGetContentHashListResult> status = _keyValueStore.Use(
+                store =>
+                {
+                    int maxAttempts = 5;
+                    while (maxAttempts-- >= 0)
+                    {
+                        // TODO(jubayard): RocksDB supports transactional semantics that would make this logic better
+                        var contentHashList = contentHashListWithDeterminism.ContentHashList;
+                        var determinism = contentHashListWithDeterminism.Determinism;
+
+                        // Load old value
+                        var oldContentHashListWithDeterminism = GetContentHashList(context, strongFingerprint);
+                        var oldContentHashList = oldContentHashListWithDeterminism.ContentHashListWithDeterminism.ContentHashList;
+                        var oldDeterminism = oldContentHashListWithDeterminism.ContentHashListWithDeterminism.Determinism;
+
+                        // Make sure we're not mixing SinglePhaseNonDeterminism records
+                        if (oldContentHashList != null &&
+                            oldDeterminism.IsSinglePhaseNonDeterministic != determinism.IsSinglePhaseNonDeterministic)
+                        {
+                            return AddOrGetContentHashListResult.SinglePhaseMixingError;
+                        }
+                        
+                        // Replace if incoming has better determinism or some content for the existing entry is missing.
+                        if (oldContentHashList == null || oldDeterminism.ShouldBeReplacedWith(determinism) ||
+                            !IsContentAvailable(context, oldContentHashList))
+                        {
+                            // TODO(jubayard): SQLite impl runs this with exclusive access to the DB to avoid data races. We have no way to do this here.
+                            store.Put(key, SerializeContentHashList(contentHashListWithDeterminism), nameof(Columns.CaChaaS));
+
+                            // Accept the value
+                            return new AddOrGetContentHashListResult(new ContentHashListWithDeterminism(null, determinism));
+                        }
+
+                        // If we didn't accept the new value because it is the same as before, just with a not
+                        // necessarily better determinism, then let the user know.
+                        if (oldContentHashList.Equals(contentHashList))
+                        {
+                            return new AddOrGetContentHashListResult(new ContentHashListWithDeterminism(null, oldDeterminism));
+                        }
+
+                        // If we didn't accept a deterministic tool's data, then we're in an inconsistent state
+                        if (determinism.IsDeterministicTool)
+                        {
+                            return new AddOrGetContentHashListResult(
+                                AddOrGetContentHashListResult.ResultCode.InvalidToolDeterminismError,
+                                oldContentHashListWithDeterminism.ContentHashListWithDeterminism);
+                        }
+
+                        // If we did not accept the given value, return the value in the cache
+                        return new AddOrGetContentHashListResult(oldContentHashListWithDeterminism);
+                    }
+
+                    return new AddOrGetContentHashListResult("Hit too many races attempting to add content hash list into the cache");
+                });
+
+            // Success for this status here may actually be an error that's been returned
+            return status.Succeeded ? status.Result : new AddOrGetContentHashListResult(status.Failure.CreateException());
+        }
+
+        private bool IsContentAvailable(OperationContext context, ContentHashList contentHashList)
+        {
+            // TODO(jubayard): implement. Since this needs to pin stuff, we need it to happen in a higher layer.
+            return true;
+        }
+
+        private byte[] SerializeContentHashList(ContentHashListWithDeterminism value)
+        {
+            return SerializeWithPool(value, (instance, writer) => instance.Serialize(writer));
+        }
+        
+        /// <inheritdoc />
+        public override IReadOnlyCollection<GetSelectorResult> GetSelectors(OperationContext context, Fingerprint weakFingerprint)
+        {
+            var result = new List<GetSelectorResult>();
+
+            var status = _keyValueStore.Use(
+                store =>
+                {
+                    var key = SerializeWeakFingerprint(weakFingerprint);
+
+                    // This only works because the strong fingerprint serializes the weak fingerprint first. Hence,
+                    // we know that all keys here are strong fingerprints that match the weak fingerprint.
+                    foreach (var kvp in store.PrefixSearch(key, columnFamilyName: nameof(Columns.CaChaaS)))
+                    {
+                        var strongFingerprint = DeserializeStrongFingerprint(kvp.Key);
+                        result.Add(new GetSelectorResult(strongFingerprint.Selector));
+                    }
+                });
+
+            if (!status.Succeeded)
+            {
+                result.Add(new GetSelectorResult(status.Failure.CreateException()));
+            }
+
+            return result;
+        }
+
+        private byte[] SerializeWeakFingerprint(Fingerprint weakFingerprint)
+        {
+            return SerializeWithPool(weakFingerprint, (instance, writer) => instance.Serialize(writer));
+        }
+
+        private byte[] SerializeStrongFingerprint(StrongFingerprint strongFingerprint)
+        {
+            return SerializeWithPool(strongFingerprint, (instance, writer) => instance.Serialize(writer));
+        }
+        
+        private ContentHashListWithDeterminism DeserializeContentHashList(byte[] data)
+        {
+            return DeserializeWithPool(data, (reader) => new ContentHashListWithDeterminism(reader));
+        }
+
+        private byte[] GetCaChaaSKey(StrongFingerprint strongFingerprint)
+        {
+            return SerializeStrongFingerprint(strongFingerprint);
+        }
+
+        private StrongFingerprint DeserializeStrongFingerprint(byte[] bytes)
+        {
+            return DeserializeWithPool(bytes, (reader) => new StrongFingerprint(reader));
+        }
+
+        #endregion
 
         private class KeyValueStoreGuard : IDisposable
         {
@@ -543,6 +721,14 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             }
 
             public Possible<Unit> Use(Action<IBuildXLKeyValueStore> action)
+            {
+                using (_rwLock.AcquireReadLock())
+                {
+                    return _accessor.Use(action);
+                }
+            }
+
+            public Possible<TResult> Use<TResult>(Func<IBuildXLKeyValueStore, TResult> action)
             {
                 using (_rwLock.AcquireReadLock())
                 {

--- a/Public/Src/Cache/ContentStore/Distributed/Redis/RedisDatabaseFactory.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Redis/RedisDatabaseFactory.cs
@@ -71,7 +71,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Redis
         {
             if (_resetConnectionMultiplexer)
             {
-                using (await SemaphoreSlimToken.Wait(_creationSemaphore))
+                using (await SemaphoreSlimToken.WaitAsync(_creationSemaphore))
                 {
                     if (_resetConnectionMultiplexer)
                     {

--- a/Public/Src/Cache/ContentStore/DistributedTest/BuildXL.Cache.ContentStore.Distributed.Test.dsc
+++ b/Public/Src/Cache/ContentStore/DistributedTest/BuildXL.Cache.ContentStore.Distributed.Test.dsc
@@ -35,6 +35,7 @@ namespace DistributedTest {
                 InterfacesTest.dll,
                 Library.dll,
                 Test.dll,
+                importFrom("BuildXL.Cache.MemoizationStore").Interfaces.dll,
                 importFrom("BuildXL.Utilities").dll,
                 importFrom("BuildXL.Utilities").Collections.dll,
                 importFrom("BuildXL.Utilities").KeyValueStore.dll,

--- a/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/NuCache/RocksDbContentLocationDatabaseTests.cs
+++ b/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/NuCache/RocksDbContentLocationDatabaseTests.cs
@@ -270,10 +270,10 @@ namespace ContentStoreTest.Distributed.ContentLocation.NuCache
         [InlineData(DeterminismCache1, DeterminismCache2)]
         [InlineData(DeterminismCache2, DeterminismCache1)]
         [InlineData(DeterminismCache1, DeterminismTool)]
-        // TODO(jubayard): I can't tell why these are valid tests.
-        // [InlineData(DeterminismTool, DeterminismNone)]
-        // [InlineData(DeterminismTool, DeterminismCache1)]
-        // [InlineData(DeterminismCache1, DeterminismNone)]
+        // TODO(jubayard): These tests will permanently fail until this is integrated with the content store, as they rely on the content not being there when attempting to pin.
+        //[InlineData(DeterminismTool, DeterminismNone)]
+        //[InlineData(DeterminismTool, DeterminismCache1)]
+        //[InlineData(DeterminismCache1, DeterminismNone)]
         [InlineData(DeterminismNone, DeterminismNone)]
         [InlineData(DeterminismCache1, DeterminismCache1)]
         [InlineData(DeterminismTool, DeterminismTool)]

--- a/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/NuCache/RocksDbContentLocationDatabaseTests.cs
+++ b/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/NuCache/RocksDbContentLocationDatabaseTests.cs
@@ -1,0 +1,337 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BuildXL.Cache.ContentStore.Distributed.NuCache;
+using BuildXL.Cache.ContentStore.FileSystem;
+using BuildXL.Cache.ContentStore.Hashing;
+using BuildXL.Cache.ContentStore.Interfaces.FileSystem;
+using BuildXL.Cache.ContentStore.Interfaces.Logging;
+using BuildXL.Cache.ContentStore.Interfaces.Tracing;
+using BuildXL.Cache.ContentStore.InterfacesTest;
+using BuildXL.Cache.ContentStore.InterfacesTest.Results;
+using BuildXL.Cache.ContentStore.InterfacesTest.Time;
+using BuildXL.Cache.ContentStore.Tracing.Internal;
+using BuildXL.Cache.MemoizationStore.Interfaces.Results;
+using BuildXL.Cache.MemoizationStore.Interfaces.Sessions;
+using BuildXL.Utilities;
+using ContentStoreTest.Test;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ContentStoreTest.Distributed.ContentLocation.NuCache
+{
+    /// <summary>
+    /// These tests are ported from MemoizationSessionTestBase (not referenced).
+    /// 
+    /// TODO(jubayard): remove when CaChaaS is part of memoization
+    /// </summary>
+    public class RocksDbContentLocationDatabaseTests : TestWithOutput
+    {
+        protected const string Name = "name";
+        protected const int DeterminismNone = 0;
+        protected const int DeterminismCache1 = 1;
+        protected const int DeterminismCache1Expired = 2;
+        protected const int DeterminismCache2 = 3;
+        protected const int DeterminismCache2Expired = 4;
+        protected const int DeterminismTool = 5;
+        protected const int DeterminismSinglePhaseNon = 6;
+
+        protected static readonly CacheDeterminism[] Determinism =
+        {
+            CacheDeterminism.None,
+            CacheDeterminism.ViaCache(new Guid("2ABD62E7-6117-4D8B-ABB2-D3346E5AF102"), DateTime.UtcNow + TimeSpan.FromDays(7)),
+            CacheDeterminism.ViaCache(new Guid("2ABD62E7-6117-4D8B-ABB2-D3346E5AF102"), DateTime.UtcNow - TimeSpan.FromDays(7)),
+            CacheDeterminism.ViaCache(new Guid("78559E55-E0C3-4C77-A908-8AE9E6590764"), DateTime.UtcNow + TimeSpan.FromDays(7)),
+            CacheDeterminism.ViaCache(new Guid("78559E55-E0C3-4C77-A908-8AE9E6590764"), DateTime.UtcNow - TimeSpan.FromDays(7)),
+            CacheDeterminism.Tool,
+            CacheDeterminism.SinglePhaseNonDeterministic
+        };
+
+        protected readonly MemoryClock Clock = new MemoryClock();
+
+        protected readonly DisposableDirectory _workingDirectory;
+
+        protected ContentLocationDatabaseConfiguration DefaultConfiguration { get; } = null;
+
+        public RocksDbContentLocationDatabaseTests(ITestOutputHelper output)
+            : base(output)
+        {
+            // Need to use unique folder for each test instance, because more then one test may be executed simultaneously.
+            var uniqueOutputFolder = Guid.NewGuid().ToString();
+            _workingDirectory = new DisposableDirectory(new PassThroughFileSystem(TestGlobal.Logger), Path.Combine(uniqueOutputFolder, "redis"));
+
+            DefaultConfiguration = new RocksDbContentLocationDatabaseConfiguration(_workingDirectory.Path / "rocksdb");
+        }
+
+        private async Task RunTest(Action<OperationContext, ContentLocationDatabase> action) => await RunCustomTest(DefaultConfiguration, action);
+
+        private async Task RunCustomTest(ContentLocationDatabaseConfiguration configuration, Action<OperationContext, ContentLocationDatabase> action, OperationContext? overwrite = null)
+        {
+            var tracingContext = new Context(TestGlobal.Logger);
+            var operationContext = overwrite ?? new OperationContext(tracingContext);
+
+            var database = ContentLocationDatabase.Create(Clock, configuration, () => new MachineId[] { });
+            await database.StartupAsync(operationContext).ShouldBeSuccess();
+            database.SetDatabaseMode(isDatabaseWritable: true);
+
+            action(operationContext, database);
+
+            await database.ShutdownAsync(operationContext).ShouldBeSuccess();
+        }
+
+
+        [Fact]
+        public Task GetSelectorsGivesZeroTasks()
+        {
+            var weakFingerprint = Fingerprint.Random();
+
+            return RunTest((context, contentLocationDatabase) =>
+            {
+                IEnumerable<GetSelectorResult> tasks = contentLocationDatabase.GetSelectors(context, weakFingerprint).ToList();
+                Assert.Equal(0, tasks.Count());
+            });
+        }
+
+        [Fact]
+        public Task GetSelectorsGivesSelectors()
+        {
+            var weakFingerprint = Fingerprint.Random();
+            var selector1 = Selector.Random();
+            var selector2 = Selector.Random();
+            var strongFingerprint1 = new StrongFingerprint(weakFingerprint, selector1);
+            var strongFingerprint2 = new StrongFingerprint(weakFingerprint, selector2);
+            var contentHashListWithDeterminism1 = new ContentHashListWithDeterminism(ContentHashList.Random(), CacheDeterminism.None);
+            var contentHashListWithDeterminism2 = new ContentHashListWithDeterminism(ContentHashList.Random(), CacheDeterminism.None);
+
+            return RunTest((context, contentLocationDatabase) =>
+            {
+                contentLocationDatabase.AddOrGetContentHashList(
+                    context, strongFingerprint1, contentHashListWithDeterminism1).ShouldBeSuccess();
+                contentLocationDatabase.AddOrGetContentHashList(
+                    context, strongFingerprint2, contentHashListWithDeterminism2).ShouldBeSuccess();
+
+                List<GetSelectorResult> getSelectorResults = contentLocationDatabase.GetSelectors(context, weakFingerprint).ToList();
+                Assert.Equal(2, getSelectorResults.Count);
+
+                GetSelectorResult r1 = getSelectorResults[0];
+                Assert.True(r1.Succeeded);
+                Assert.True(r1.Selector == selector1 || r1.Selector == selector2);
+
+                GetSelectorResult r2 = getSelectorResults[1];
+                Assert.True(r2.Succeeded);
+                Assert.True(r2.Selector == selector1 || r2.Selector == selector2);
+            });
+        }
+
+        [Fact]
+        public Task GetNonExisting()
+        {
+            var strongFingerprint = StrongFingerprint.Random();
+
+            return RunTest((context, contentLocationDatabase) =>
+            {
+                var result = contentLocationDatabase.GetContentHashList(context, strongFingerprint);
+                Assert.Equal(new GetContentHashListResult(new ContentHashListWithDeterminism(null, CacheDeterminism.None)), result);
+            });
+        }
+
+        [Fact]
+        public Task GetExisting()
+        {
+            var strongFingerprint = StrongFingerprint.Random();
+            var contentHashListWithDeterminism = new ContentHashListWithDeterminism(ContentHashList.Random(), CacheDeterminism.None);
+
+            return RunTest((context, contentLocationDatabase) =>
+            {
+                contentLocationDatabase.AddOrGetContentHashList(
+                    context, strongFingerprint, contentHashListWithDeterminism).ShouldBeSuccess();
+
+                var result = contentLocationDatabase.GetContentHashList(context, strongFingerprint);
+                Assert.Equal(new GetContentHashListResult(contentHashListWithDeterminism), result);
+            });
+        }
+
+        [Fact]
+        public Task AddOrGetAddsNew()
+        {
+            var strongFingerprint = StrongFingerprint.Random();
+            var contentHashListWithDeterminism = new ContentHashListWithDeterminism(ContentHashList.Random(), CacheDeterminism.None);
+
+            return RunTest((context, contentLocationDatabase) =>
+            {
+                var addResult = contentLocationDatabase.AddOrGetContentHashList(
+                    context, strongFingerprint, contentHashListWithDeterminism);
+                Assert.Equal(new AddOrGetContentHashListResult(new ContentHashListWithDeterminism(null, CacheDeterminism.None)), addResult);
+
+                var getResult = contentLocationDatabase.GetContentHashList(context, strongFingerprint);
+                Assert.Equal(new GetContentHashListResult(contentHashListWithDeterminism), getResult);
+            });
+        }
+
+        [Fact]
+        public Task AddMultipleHashTypes()
+        {
+            var strongFingerprint = StrongFingerprint.Random();
+            var contentHash1 = ContentHash.Random();
+            var contentHash2 = ContentHash.Random(HashType.SHA1);
+            var contentHash3 = ContentHash.Random(HashType.MD5);
+            var contentHashList = new ContentHashList(new[] { contentHash1, contentHash2, contentHash3 });
+            var contentHashListWithDeterminism = new ContentHashListWithDeterminism(contentHashList, CacheDeterminism.None);
+
+            return RunTest((context, contentLocationDatabase) =>
+            {
+                contentLocationDatabase.AddOrGetContentHashList(
+                    context, strongFingerprint, contentHashListWithDeterminism).ShouldBeSuccess();
+
+                var result = contentLocationDatabase.GetContentHashList(context, strongFingerprint);
+                Assert.Equal(new GetContentHashListResult(contentHashListWithDeterminism), result);
+            });
+        }
+
+        [Fact]
+        public Task AddPayload()
+        {
+            var strongFingerprint = StrongFingerprint.Random();
+            var payload = new byte[] { 0, 1, 2, 3 };
+            var contentHashListWithDeterminism =
+                new ContentHashListWithDeterminism(ContentHashList.Random(payload: payload), CacheDeterminism.None);
+
+            return RunTest((context, contentLocationDatabase) =>
+            {
+                contentLocationDatabase.AddOrGetContentHashList(
+                    context, strongFingerprint, contentHashListWithDeterminism).ShouldBeSuccess();
+
+                var result = contentLocationDatabase.GetContentHashList(context, strongFingerprint);
+                Assert.Equal(new GetContentHashListResult(contentHashListWithDeterminism), result);
+                Assert.True(result.ContentHashListWithDeterminism.ContentHashList.Payload.SequenceEqual(payload));
+            });
+        }
+
+        [Fact]
+        public Task AddNullPayload()
+        {
+            var strongFingerprint = StrongFingerprint.Random();
+
+            // ReSharper disable once RedundantArgumentDefaultValue
+            var contentHashListWithDeterminism =
+                new ContentHashListWithDeterminism(ContentHashList.Random(payload: null), CacheDeterminism.None);
+
+            return RunTest((context, contentLocationDatabase) =>
+            {
+                contentLocationDatabase.AddOrGetContentHashList(
+                    context, strongFingerprint, contentHashListWithDeterminism).ShouldBeSuccess();
+
+                var result = contentLocationDatabase.GetContentHashList(context, strongFingerprint);
+                Assert.Equal(new GetContentHashListResult(contentHashListWithDeterminism), result);
+                Assert.Null(result.ContentHashListWithDeterminism.ContentHashList.Payload);
+            });
+        }
+
+        [Fact]
+        public Task AddUnexpiredDeterminism()
+        {
+            var strongFingerprint = StrongFingerprint.Random();
+            var expirationUtc = DateTime.UtcNow + TimeSpan.FromDays(7);
+            var guid = CacheDeterminism.NewCacheGuid();
+            var determinism = CacheDeterminism.ViaCache(guid, expirationUtc);
+            var contentHashListWithDeterminism = new ContentHashListWithDeterminism(ContentHashList.Random(), determinism);
+
+            return RunTest((context, contentLocationDatabase) =>
+            {
+                contentLocationDatabase.AddOrGetContentHashList(
+                    context, strongFingerprint, contentHashListWithDeterminism).ShouldBeSuccess();
+                var result = contentLocationDatabase.GetContentHashList(context, strongFingerprint);
+                Assert.Equal(guid, result.ContentHashListWithDeterminism.Determinism.EffectiveGuid);
+            });
+        }
+
+        [Fact]
+        public Task AddExpiredDeterminism()
+        {
+            var strongFingerprint = StrongFingerprint.Random();
+            var expirationUtc = DateTime.UtcNow - TimeSpan.FromDays(7);
+            var guid = CacheDeterminism.NewCacheGuid();
+            var determinism = CacheDeterminism.ViaCache(guid, expirationUtc);
+            var contentHashListWithDeterminism = new ContentHashListWithDeterminism(ContentHashList.Random(), determinism);
+
+            return RunTest((context, contentLocationDatabase) =>
+            {
+                contentLocationDatabase.AddOrGetContentHashList(
+                    context, strongFingerprint, contentHashListWithDeterminism).ShouldBeSuccess();
+                var result = contentLocationDatabase.GetContentHashList(context, strongFingerprint);
+                Assert.Equal(CacheDeterminism.None.EffectiveGuid, result.ContentHashListWithDeterminism.Determinism.EffectiveGuid);
+            });
+        }
+
+        [Theory]
+        [InlineData(DeterminismNone, DeterminismTool)]
+        [InlineData(DeterminismNone, DeterminismCache1)]
+        [InlineData(DeterminismCache1, DeterminismCache2)]
+        [InlineData(DeterminismCache2, DeterminismCache1)]
+        [InlineData(DeterminismCache1, DeterminismTool)]
+        // TODO(jubayard): I believe these are legacy and not used any more, but have yet to confirm.
+        // [InlineData(DeterminismTool, DeterminismNone)]
+        // [InlineData(DeterminismTool, DeterminismCache1)]
+        // [InlineData(DeterminismCache1, DeterminismNone)]
+        [InlineData(DeterminismNone, DeterminismNone)]
+        [InlineData(DeterminismCache1, DeterminismCache1)]
+        [InlineData(DeterminismTool, DeterminismTool)]
+        [InlineData(DeterminismSinglePhaseNon, DeterminismSinglePhaseNon)]
+        [InlineData(DeterminismTool, DeterminismTool)]
+        public Task AlwaysReplaceWhenPreviousContentMissing(int fromDeterminism, int toDeterminism)
+        {
+            var strongFingerprint = StrongFingerprint.Random();
+            var contentHashList = ContentHashList.Random();
+
+            return RunTest((context, contentLocationDatabase) =>
+            {
+                var addResult = contentLocationDatabase.AddOrGetContentHashList(
+                    context, strongFingerprint, new ContentHashListWithDeterminism(contentHashList, Determinism[fromDeterminism]));
+                Assert.Equal(Determinism[fromDeterminism].EffectiveGuid, addResult.ContentHashListWithDeterminism.Determinism.EffectiveGuid);
+
+                // What we will do here is AddOrGet() a record that we already know is
+                // there but with the determinism bit changed.
+                addResult = contentLocationDatabase.AddOrGetContentHashList(
+                    context, strongFingerprint, new ContentHashListWithDeterminism(contentHashList, Determinism[toDeterminism]))
+;
+                // We always expect the new determinism bit to take over
+                Assert.Null(addResult.ContentHashListWithDeterminism.ContentHashList);
+                Assert.Equal(Determinism[toDeterminism].EffectiveGuid, addResult.ContentHashListWithDeterminism.Determinism.EffectiveGuid);
+
+                // Validate that it was actually updated in the DB
+                var getResult = contentLocationDatabase.GetContentHashList(context, strongFingerprint);
+                Assert.Equal(Determinism[toDeterminism].EffectiveGuid, getResult.ContentHashListWithDeterminism.Determinism.EffectiveGuid);
+            });
+        }
+
+        [Theory]
+        [InlineData(DeterminismNone, DeterminismSinglePhaseNon)] // Overwriting SinglePhaseNonDeterministic with anything else is an error.
+        [InlineData(DeterminismCache1, DeterminismSinglePhaseNon)]
+        [InlineData(DeterminismTool, DeterminismSinglePhaseNon)]
+        [InlineData(DeterminismSinglePhaseNon, DeterminismNone)] // Overwriting anything else with SinglePhaseNonDeterministic is an error.
+        [InlineData(DeterminismSinglePhaseNon, DeterminismCache1)]
+        [InlineData(DeterminismSinglePhaseNon, DeterminismTool)]
+        public Task MismatchedSinglePhaseFails(int fromDeterminism, int toDeterminism)
+        {
+            var strongFingerprint = StrongFingerprint.Random();
+            var contentHashList = ContentHashList.Random();
+
+            return RunTest((context, contentLocationDatabase) =>
+            {
+                var addResult = contentLocationDatabase.AddOrGetContentHashList(
+                    context, strongFingerprint, new ContentHashListWithDeterminism(contentHashList, Determinism[fromDeterminism]));
+                Assert.Equal(Determinism[fromDeterminism].EffectiveGuid, addResult.ContentHashListWithDeterminism.Determinism.EffectiveGuid);
+
+                // What we will do here is AddOrGet() a record that we already know is
+                // there but with the determinism bit changed.
+                addResult = contentLocationDatabase.AddOrGetContentHashList(
+                    context, strongFingerprint, new ContentHashListWithDeterminism(contentHashList, Determinism[toDeterminism]));
+                Assert.Equal(AddOrGetContentHashListResult.ResultCode.SinglePhaseMixingError, addResult.Code);
+            });
+        }
+    }
+}

--- a/Public/Src/Cache/ContentStore/Interfaces/Synchronization/SemaphoreSlimExtensions.cs
+++ b/Public/Src/Cache/ContentStore/Interfaces/Synchronization/SemaphoreSlimExtensions.cs
@@ -16,7 +16,7 @@ namespace BuildXL.Cache.ContentStore.Interfaces.Synchronization.Internal
         /// </summary>
         public static Task<SemaphoreSlimToken> WaitToken(this SemaphoreSlim semaphore)
         {
-            return SemaphoreSlimToken.Wait(semaphore);
+            return SemaphoreSlimToken.WaitAsync(semaphore);
         }
     }
 }

--- a/Public/Src/Cache/ContentStore/Interfaces/Synchronization/SemaphoreSlimToken.cs
+++ b/Public/Src/Cache/ContentStore/Interfaces/Synchronization/SemaphoreSlimToken.cs
@@ -25,9 +25,20 @@ namespace BuildXL.Cache.ContentStore.Interfaces.Synchronization.Internal
         /// </summary>
         /// <param name="semaphore">The semaphore to wait on</param>
         /// <returns>A token that, when disposed, calls Release() on the SemaphoreSlim</returns>
-        public static async Task<SemaphoreSlimToken> Wait(SemaphoreSlim semaphore)
+        public static async Task<SemaphoreSlimToken> WaitAsync(SemaphoreSlim semaphore)
         {
             await semaphore.WaitAsync().ConfigureAwait(false);
+            return new SemaphoreSlimToken(semaphore);
+        }
+
+        /// <summary>
+        ///     Wait on a SemaphoreSlim and return a token that, when disposed, calls Release() on the SemaphoreSlim
+        /// </summary>
+        /// <param name="semaphore">The semaphore to wait on</param>
+        /// <returns>A token that, when disposed, calls Release() on the SemaphoreSlim</returns>
+        public static SemaphoreSlimToken Wait(SemaphoreSlim semaphore)
+        {
+            semaphore.Wait();
             return new SemaphoreSlimToken(semaphore);
         }
 

--- a/Public/Src/Cache/MemoizationStore/Interfaces/BuildXL.Cache.MemoizationStore.Interfaces.dsc
+++ b/Public/Src/Cache/MemoizationStore/Interfaces/BuildXL.Cache.MemoizationStore.Interfaces.dsc
@@ -12,6 +12,8 @@ namespace Interfaces {
             ContentStore.UtilitiesCore.dll,
             ContentStore.Hashing.dll,
             ContentStore.Interfaces.dll,
+            importFrom("BuildXL.Utilities").dll,
+            importFrom("BuildXL.Utilities").Collections.dll,
             importFrom("System.Interactive.Async").pkg,
         ],
     });

--- a/Public/Src/Cache/MemoizationStore/Interfaces/Sessions/ContentHashListWithDeterminism.cs
+++ b/Public/Src/Cache/MemoizationStore/Interfaces/Sessions/ContentHashListWithDeterminism.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics.ContractsLight;
+using System.IO;
 using BuildXL.Cache.ContentStore.Interfaces.Utils;
 
 namespace BuildXL.Cache.MemoizationStore.Interfaces.Sessions
@@ -21,6 +23,22 @@ namespace BuildXL.Cache.MemoizationStore.Interfaces.Sessions
         }
 
         /// <summary>
+        ///     Initializes a new instance of the <see cref="ContentHashListWithDeterminism"/> struct from a binary
+        ///     representation
+        /// </summary>
+        public ContentHashListWithDeterminism(BinaryReader reader)
+        {
+            Contract.Requires(reader != null);
+
+            var writeContentHashList = reader.ReadBoolean();
+            ContentHashList = writeContentHashList ? new ContentHashList(reader) : null;
+
+            var length = reader.ReadInt32();
+            var determinism = reader.ReadBytes(length);
+            Determinism = CacheDeterminism.Deserialize(determinism);
+        }
+
+        /// <summary>
         ///     Gets the content hash list member.
         /// </summary>
         public ContentHashList ContentHashList { get; }
@@ -29,6 +47,25 @@ namespace BuildXL.Cache.MemoizationStore.Interfaces.Sessions
         ///     Gets the cache determinism member.
         /// </summary>
         public CacheDeterminism Determinism { get; }
+
+        /// <summary>
+        /// Serializes an instance into a binary stream.
+        /// </summary>
+        public void Serialize(BinaryWriter writer)
+        {
+            Contract.Requires(writer != null);
+
+            var writeContentHashList = ContentHashList != null;
+            writer.Write(writeContentHashList);
+            if (writeContentHashList)
+            {
+                ContentHashList.Serialize(writer);
+            }
+
+            var determinism = Determinism.Serialize();
+            writer.Write(determinism.Length);
+            writer.Write(determinism);
+        }
 
         /// <inheritdoc />
         public bool Equals(ContentHashListWithDeterminism other)

--- a/Public/Src/Cache/MemoizationStore/Interfaces/Sessions/Fingerprint.cs
+++ b/Public/Src/Cache/MemoizationStore/Interfaces/Sessions/Fingerprint.cs
@@ -82,16 +82,6 @@ namespace BuildXL.Cache.MemoizationStore.Interfaces.Sessions
         /// <summary>
         ///     Initializes a new instance of the <see cref="Fingerprint"/> struct.
         /// </summary>
-        public Fingerprint(BinaryReader reader)
-        {
-            Contract.Requires(reader != null);
-            _length = reader.ReadByte();
-            _bytes = ReadOnlyFixedBytes.ReadFrom(reader, _length);
-        }
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="Fingerprint"/> struct.
-        /// </summary>
         public Fingerprint(int length, BinaryReader reader)
         {
             unchecked {
@@ -210,6 +200,17 @@ namespace BuildXL.Cache.MemoizationStore.Interfaces.Sessions
 
             writer.Write(_length);
             _bytes.Serialize(writer, _length);
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="Fingerprint"/> struct.
+        /// </summary>
+        public static Fingerprint Deserialize(BinaryReader reader)
+        {
+            Contract.Requires(reader != null);
+            var length = reader.ReadByte();
+            var buffer = ReadOnlyFixedBytes.ReadFrom(reader, length);
+            return new Fingerprint(buffer, length);
         }
 
         /// <summary>

--- a/Public/Src/Cache/MemoizationStore/Interfaces/Sessions/Fingerprint.cs
+++ b/Public/Src/Cache/MemoizationStore/Interfaces/Sessions/Fingerprint.cs
@@ -84,7 +84,7 @@ namespace BuildXL.Cache.MemoizationStore.Interfaces.Sessions
         /// </summary>
         public Fingerprint(BinaryReader reader)
         {
-            Console.WriteLine(reader != null);
+            Contract.Requires(reader != null);
             _length = reader.ReadByte();
             _bytes = ReadOnlyFixedBytes.ReadFrom(reader, _length);
         }

--- a/Public/Src/Cache/MemoizationStore/Interfaces/Sessions/StrongFingerprint.cs
+++ b/Public/Src/Cache/MemoizationStore/Interfaces/Sessions/StrongFingerprint.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics.ContractsLight;
+using System.IO;
 using BuildXL.Cache.ContentStore.Hashing;
 using BuildXL.Cache.ContentStore.Interfaces.Utils;
 
@@ -22,6 +24,16 @@ namespace BuildXL.Cache.MemoizationStore.Interfaces.Sessions
         }
 
         /// <summary>
+        ///     Initializes a new instance of the <see cref="StrongFingerprint" /> struct.
+        /// </summary>
+        public StrongFingerprint(BinaryReader reader)
+        {
+            Contract.Requires(reader != null);
+            WeakFingerprint = new Fingerprint(reader);
+            Selector = new Selector(reader);
+        }
+
+        /// <summary>
         ///     Gets weakFingerprint associated with this StrongFingerprint.
         /// </summary>
         public Fingerprint WeakFingerprint { get; }
@@ -30,6 +42,16 @@ namespace BuildXL.Cache.MemoizationStore.Interfaces.Sessions
         ///     Gets selector associated with this StrongFingerprint.
         /// </summary>
         public Selector Selector { get; }
+
+        /// <summary>
+        ///     Serialize whole value to a binary writer.
+        /// </summary>
+        public void Serialize(BinaryWriter writer)
+        {
+            Contract.Requires(writer != null);
+            WeakFingerprint.Serialize(writer);
+            Selector.Serialize(writer);
+        }
 
         /// <inheritdoc />
         public bool Equals(StrongFingerprint other)

--- a/Public/Src/Cache/MemoizationStore/InterfacesTest/Sessions/ContentHashListTests.cs
+++ b/Public/Src/Cache/MemoizationStore/InterfacesTest/Sessions/ContentHashListTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.IO;
 using System.Linq;
 using BuildXL.Cache.ContentStore.Hashing;
 using BuildXL.Cache.MemoizationStore.Interfaces.Sessions;
@@ -135,6 +136,48 @@ namespace BuildXL.Cache.MemoizationStore.InterfacesTest.Sessions
         public void RandomNullPayload()
         {
             Assert.Null(ContentHashList.Random().Payload);
+        }
+
+        [Fact]
+        public void SerializeRoundtrip()
+        {
+            var v = ContentHashList.Random();
+            using (var ms = new MemoryStream())
+            {
+                using (var bw = new BinaryWriter(ms))
+                {
+                    v.Serialize(bw);
+
+                    ms.Position = 0;
+
+                    using (var reader = new BinaryReader(ms))
+                    {
+                        var v2 = new ContentHashList(reader);
+                        Assert.Equal(v, v2);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void SerializeWithDeterminismRoundtrip()
+        {
+            var v = new ContentHashListWithDeterminism(ContentHashList.Random(), CacheDeterminism.None);
+            using (var ms = new MemoryStream())
+            {
+                using (var bw = new BinaryWriter(ms))
+                {
+                    v.Serialize(bw);
+
+                    ms.Position = 0;
+
+                    using (var reader = new BinaryReader(ms))
+                    {
+                        var v2 = new ContentHashListWithDeterminism(reader);
+                        Assert.Equal(v, v2);
+                    }
+                }
+            }
         }
     }
 }

--- a/Public/Src/Cache/MemoizationStore/InterfacesTest/Sessions/ContentHashListTests.cs
+++ b/Public/Src/Cache/MemoizationStore/InterfacesTest/Sessions/ContentHashListTests.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using BuildXL.Cache.ContentStore.Hashing;
 using BuildXL.Cache.MemoizationStore.Interfaces.Sessions;
+using BuildXL.Utilities;
 using Xunit;
 
 namespace BuildXL.Cache.MemoizationStore.InterfacesTest.Sessions
@@ -141,43 +142,29 @@ namespace BuildXL.Cache.MemoizationStore.InterfacesTest.Sessions
         [Fact]
         public void SerializeRoundtrip()
         {
-            var v = ContentHashList.Random();
-            using (var ms = new MemoryStream())
-            {
-                using (var bw = new BinaryWriter(ms))
-                {
-                    v.Serialize(bw);
+            var value = ContentHashList.Random();
+            Utilities.TestSerializationRoundtrip(value, value.Serialize, ContentHashList.Deserialize);
+        }
 
-                    ms.Position = 0;
-
-                    using (var reader = new BinaryReader(ms))
-                    {
-                        var v2 = new ContentHashList(reader);
-                        Assert.Equal(v, v2);
-                    }
-                }
-            }
+        [Fact]
+        public void SerializeRoundtripNonNullPayload()
+        {
+            var value = ContentHashList.Random(payload: new byte[] { 1, 2, 3 });
+            Utilities.TestSerializationRoundtrip(value, value.Serialize, ContentHashList.Deserialize);
         }
 
         [Fact]
         public void SerializeWithDeterminismRoundtrip()
         {
-            var v = new ContentHashListWithDeterminism(ContentHashList.Random(), CacheDeterminism.None);
-            using (var ms = new MemoryStream())
-            {
-                using (var bw = new BinaryWriter(ms))
-                {
-                    v.Serialize(bw);
+            var value = new ContentHashListWithDeterminism(ContentHashList.Random(), CacheDeterminism.None);
+            Utilities.TestSerializationRoundtrip(value, value.Serialize, ContentHashListWithDeterminism.Deserialize);
+        }
 
-                    ms.Position = 0;
-
-                    using (var reader = new BinaryReader(ms))
-                    {
-                        var v2 = new ContentHashListWithDeterminism(reader);
-                        Assert.Equal(v, v2);
-                    }
-                }
-            }
+        [Fact]
+        public void SerializeWithDeterminismRoundtripNoContentHashList()
+        {
+            var value = new ContentHashListWithDeterminism(null, CacheDeterminism.None);
+            Utilities.TestSerializationRoundtrip(value, value.Serialize, ContentHashListWithDeterminism.Deserialize);
         }
     }
 }

--- a/Public/Src/Cache/MemoizationStore/InterfacesTest/Sessions/FingerprintTests.cs
+++ b/Public/Src/Cache/MemoizationStore/InterfacesTest/Sessions/FingerprintTests.cs
@@ -256,41 +256,16 @@ namespace BuildXL.Cache.MemoizationStore.InterfacesTest.Sessions
         [Fact]
         public void BinaryRoundtrip()
         {
-            using (var ms = new MemoryStream())
-            {
-                using (var writer = new BinaryWriter(ms))
-                {
-                    var v1 = Fingerprint.Random();
-                    v1.Serialize(writer);
-                    ms.Position = 0;
-
-                    using (var reader = new BinaryReader(ms))
-                    {
-                        var v2 = new Fingerprint(reader);
-                        Assert.Equal(v1, v2);
-                    }
-                }
-            }
+            var value = Fingerprint.Random();
+            Utilities.TestSerializationRoundtrip(value, value.Serialize, Fingerprint.Deserialize);
         }
 
         [Fact]
         public void PartialBinaryRoundtrip()
         {
-            using (var ms = new MemoryStream())
-            {
-                using (var writer = new BinaryWriter(ms))
-                {
-                    var v1 = Fingerprint.Random();
-                    v1.SerializeBytes(writer);
-                    ms.Position = 0;
-
-                    using (var reader = new BinaryReader(ms))
-                    {
-                        var v2 = new Fingerprint(v1.Length, reader);
-                        Assert.Equal(v1, v2);
-                    }
-                }
-            }
+            var value = Fingerprint.Random();
+            Utilities.TestSerializationRoundtrip(value, value.Serialize,
+                reader => new Fingerprint(value.Length, reader));
         }
     }
 }

--- a/Public/Src/Cache/MemoizationStore/InterfacesTest/Sessions/FingerprintTests.cs
+++ b/Public/Src/Cache/MemoizationStore/InterfacesTest/Sessions/FingerprintTests.cs
@@ -264,7 +264,7 @@ namespace BuildXL.Cache.MemoizationStore.InterfacesTest.Sessions
         public void PartialBinaryRoundtrip()
         {
             var value = Fingerprint.Random();
-            Utilities.TestSerializationRoundtrip(value, value.Serialize,
+            Utilities.TestSerializationRoundtrip(value, value.SerializeBytes,
                 reader => new Fingerprint(value.Length, reader));
         }
     }

--- a/Public/Src/Cache/MemoizationStore/InterfacesTest/Sessions/SelectorTests.cs
+++ b/Public/Src/Cache/MemoizationStore/InterfacesTest/Sessions/SelectorTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.IO;
 using BuildXL.Cache.ContentStore.Hashing;
 using BuildXL.Cache.MemoizationStore.Interfaces.Sessions;
 using Xunit;
@@ -88,6 +89,48 @@ namespace BuildXL.Cache.MemoizationStore.InterfacesTest.Sessions
         public void RandomWithOutput()
         {
             Assert.NotNull(Selector.Random().Output);
+        }
+
+        [Fact]
+        public void SerializeRoundtrip()
+        {
+            var v = Selector.Random();
+            using (var ms = new MemoryStream())
+            {
+                using (var bw = new BinaryWriter(ms))
+                {
+                    v.Serialize(bw);
+
+                    ms.Position = 0;
+
+                    using (var reader = new BinaryReader(ms))
+                    {
+                        var v2 = new Selector(reader);
+                        Assert.Equal(v, v2);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void NullOutputSerializeRoundtrip()
+        {
+            var v = Selector.Random(outputLength: 0);
+            using (var ms = new MemoryStream())
+            {
+                using (var bw = new BinaryWriter(ms))
+                {
+                    v.Serialize(bw);
+
+                    ms.Position = 0;
+
+                    using (var reader = new BinaryReader(ms))
+                    {
+                        var v2 = new Selector(reader);
+                        Assert.Equal(v, v2);
+                    }
+                }
+            }
         }
     }
 }

--- a/Public/Src/Cache/MemoizationStore/InterfacesTest/Sessions/SelectorTests.cs
+++ b/Public/Src/Cache/MemoizationStore/InterfacesTest/Sessions/SelectorTests.cs
@@ -95,42 +95,14 @@ namespace BuildXL.Cache.MemoizationStore.InterfacesTest.Sessions
         public void SerializeRoundtrip()
         {
             var v = Selector.Random();
-            using (var ms = new MemoryStream())
-            {
-                using (var bw = new BinaryWriter(ms))
-                {
-                    v.Serialize(bw);
-
-                    ms.Position = 0;
-
-                    using (var reader = new BinaryReader(ms))
-                    {
-                        var v2 = new Selector(reader);
-                        Assert.Equal(v, v2);
-                    }
-                }
-            }
+            Utilities.TestSerializationRoundtrip(v, v.Serialize, Selector.Deserialize);
         }
 
         [Fact]
         public void NullOutputSerializeRoundtrip()
         {
             var v = Selector.Random(outputLength: 0);
-            using (var ms = new MemoryStream())
-            {
-                using (var bw = new BinaryWriter(ms))
-                {
-                    v.Serialize(bw);
-
-                    ms.Position = 0;
-
-                    using (var reader = new BinaryReader(ms))
-                    {
-                        var v2 = new Selector(reader);
-                        Assert.Equal(v, v2);
-                    }
-                }
-            }
+            Utilities.TestSerializationRoundtrip(v, v.Serialize, Selector.Deserialize);
         }
     }
 }

--- a/Public/Src/Cache/MemoizationStore/InterfacesTest/Sessions/StrongFingerprintTests.cs
+++ b/Public/Src/Cache/MemoizationStore/InterfacesTest/Sessions/StrongFingerprintTests.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using BuildXL.Cache.MemoizationStore.Interfaces.Sessions;
+using BuildXL.Utilities;
 using Xunit;
 
 namespace BuildXL.Cache.MemoizationStore.InterfacesTest.Sessions
@@ -74,22 +75,15 @@ namespace BuildXL.Cache.MemoizationStore.InterfacesTest.Sessions
         [Fact]
         public void SerializeRoundtrip()
         {
-            var v = StrongFingerprint.Random();
-            using (var ms = new MemoryStream())
-            {
-                using (var bw = new BinaryWriter(ms))
-                {
-                    v.Serialize(bw);
+            var value = StrongFingerprint.Random();
+            Utilities.TestSerializationRoundtrip(value, value.Serialize, StrongFingerprint.Deserialize);
+        }
 
-                    ms.Position = 0;
-
-                    using (var reader = new BinaryReader(ms))
-                    {
-                        var v2 = new StrongFingerprint(reader);
-                        Assert.Equal(v, v2);
-                    }
-                }
-            }
+        [Fact]
+        public void WeakFingerprintIsSerializedFirst()
+        {
+            var value = StrongFingerprint.Random();
+            Utilities.TestSerializationRoundtrip(value.WeakFingerprint, value.Serialize, Fingerprint.Deserialize);
         }
     }
 }

--- a/Public/Src/Cache/MemoizationStore/InterfacesTest/Sessions/StrongFingerprintTests.cs
+++ b/Public/Src/Cache/MemoizationStore/InterfacesTest/Sessions/StrongFingerprintTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.IO;
 using BuildXL.Cache.MemoizationStore.Interfaces.Sessions;
 using Xunit;
 
@@ -68,6 +69,27 @@ namespace BuildXL.Cache.MemoizationStore.InterfacesTest.Sessions
             var v1 = StrongFingerprint.Random();
             var v2 = StrongFingerprint.Random();
             Assert.NotEqual(v1.GetHashCode(), v2.GetHashCode());
+        }
+
+        [Fact]
+        public void SerializeRoundtrip()
+        {
+            var v = StrongFingerprint.Random();
+            using (var ms = new MemoryStream())
+            {
+                using (var bw = new BinaryWriter(ms))
+                {
+                    v.Serialize(bw);
+
+                    ms.Position = 0;
+
+                    using (var reader = new BinaryReader(ms))
+                    {
+                        var v2 = new StrongFingerprint(reader);
+                        Assert.Equal(v, v2);
+                    }
+                }
+            }
         }
     }
 }

--- a/Public/Src/Cache/MemoizationStore/InterfacesTest/Sessions/Utilities.cs
+++ b/Public/Src/Cache/MemoizationStore/InterfacesTest/Sessions/Utilities.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.IO;
+using BuildXL.Utilities;
+using Xunit;
+
+namespace BuildXL.Cache.MemoizationStore.InterfacesTest.Sessions
+{
+    public static class Utilities
+    {
+        public static void TestSerializationRoundtrip<T>(T expected, Action<BuildXLWriter> serializer, Func<BuildXLReader, T> deserializer)
+        {
+            using (var ms = new MemoryStream())
+            {
+                using (var bw = new BuildXLWriter(false, ms, false, false))
+                {
+                    serializer(bw);
+                    ms.Position = 0;
+
+                    using (var reader = new BuildXLReader(false, ms, false))
+                    {
+                        var deserialized = deserializer(reader);
+                        Assert.Equal(expected, deserialized);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Public/Src/Utilities/KeyValueStore/IKeyValueStore.cs
+++ b/Public/Src/Utilities/KeyValueStore/IKeyValueStore.cs
@@ -8,7 +8,7 @@ namespace BuildXL.Engine.Cache.KeyValueStores
     /// <summary>
     /// Interface for persistent key value stores.
     /// </summary>
-    public interface IKeyValueStore<in TKey, TValue>
+    public interface IKeyValueStore<TKey, TValue>
     {
         /// <summary>
         /// Adds a new entry or overwrites an existing entry.
@@ -98,5 +98,16 @@ namespace BuildXL.Engine.Cache.KeyValueStores
         /// The column family to use.
         /// </param>
         void ApplyBatch(IEnumerable<TKey> keys, IEnumerable<TValue> values, string columnFamilyName = null);
+
+        /// <summary>
+        /// Fetches keys and values with the same prefix. Order is dependant on the underlying store's guarantees.
+        /// </summary>
+        /// <param name="prefix">
+        /// Common prefix
+        /// </param>
+        /// <param name="columnFamilyName">
+        /// The column family to use.
+        /// </param>
+        IEnumerable<KeyValuePair<TKey, TValue>> PrefixSearch(TKey prefix, string columnFamilyName = null);
     }
 }

--- a/Public/Src/Utilities/KeyValueStore/KeyValueStoreAccessor.cs
+++ b/Public/Src/Utilities/KeyValueStore/KeyValueStoreAccessor.cs
@@ -576,6 +576,21 @@ namespace BuildXL.Engine.Cache.KeyValueStores
         /// <summary>
         /// Provides access to the underlying store.
         /// </summary>
+        /// <returns>
+        /// On success, <see cref="Unit.Void"/>;
+        /// on failure, a <see cref="Failure"/>.
+        /// </returns>
+        [System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptions] // allows catching exceptions from unmanaged code
+        public Possible<TResult> Use<TResult>(Func<IBuildXLKeyValueStore, TResult> use)
+        {
+            return Use(
+                (store, propagatedUse) => propagatedUse(store),
+                use);
+        }
+
+        /// <summary>
+        /// Provides access to the underlying store.
+        /// </summary>
         /// <param name="use">
         /// Function that take the store as a parameter.
         /// </param>

--- a/Public/Src/Utilities/KeyValueStore/RocksDb/RocksDbStore.cs
+++ b/Public/Src/Utilities/KeyValueStore/RocksDb/RocksDbStore.cs
@@ -735,7 +735,11 @@ namespace BuildXL.Engine.Cache.KeyValueStores
 
                 using (var iterator = m_store.NewIterator(columnFamilyInfo.Handle, readOptions))
                 {
-                    if (prefix != null)
+                    if (prefix == null || prefix.Length == 0)
+                    {
+                        iterator.SeekToFirst();
+                    }
+                    else
                     {
                         iterator.Seek(prefix);
                     }

--- a/Public/Src/Utilities/KeyValueStore/RocksDb/RocksDbStore.cs
+++ b/Public/Src/Utilities/KeyValueStore/RocksDb/RocksDbStore.cs
@@ -715,6 +715,69 @@ namespace BuildXL.Engine.Cache.KeyValueStores
             {
                 return new RocksDbStore(this);
             }
+
+            /// <inheritdoc />
+            public IEnumerable<KeyValuePair<string, string>> PrefixSearch(string prefix, string columnFamilyName = null)
+            {
+                return PrefixSearch(StringToBytes(prefix), columnFamilyName).Select(kvp => new KeyValuePair<string, string>(BytesToString(kvp.Key), BytesToString(kvp.Value)));
+            }
+
+            /// <inheritdoc />
+            public IEnumerable<KeyValuePair<byte[], byte[]>> PrefixSearch(byte[] prefix = null, string columnFamilyName = null)
+            {
+                // TODO(jubayard): there are multiple ways to implement prefix search in RocksDB. In particular, they 
+                // have a prefix seek API (see: https://github.com/facebook/rocksdb/wiki/Prefix-Seek-API-Changes ).
+                // However, it requires certain options to be set on the column family, so it could be problematic. We
+                // just use a simpler way. Could change if any performance issues arise out of this decision.
+                var columnFamilyInfo = GetColumnFamilyInfo(columnFamilyName);
+                var readOptions = new ReadOptions();
+                readOptions.SetTotalOrderSeek(true);
+
+                using (var iterator = m_store.NewIterator(columnFamilyInfo.Handle, readOptions))
+                {
+                    if (prefix != null)
+                    {
+                        iterator.Seek(prefix);
+                    }
+
+                    while (iterator.Valid())
+                    {
+                        var key = iterator.Key();
+                        if (!StartsWith(prefix, key))
+                        {
+                            break;
+                        }
+
+                        yield return new KeyValuePair<byte[], byte[]>(key, iterator.Value());
+
+                        iterator.Next();
+                    }
+                }
+            }
+
+            /// <nodoc />
+            private static bool StartsWith(byte[] prefix, byte[] key)
+            {
+                if (prefix == null || prefix.Length == 0)
+                {
+                    return true;
+                }
+
+                if (prefix.Length > key.Length)
+                {
+                    return false;
+                }
+
+                for (int i = 0; i < prefix.Length; ++i)
+                {
+                    if (key[i] != prefix[i])
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
         } // RocksDbStore
     } // KeyValueStoreAccessor
 }


### PR DESCRIPTION
There are a few big points that will not go in this PR, and will need to be done in the future:

- Moving the logic away from the ContentLocationDatabase into somewhere more appropriate. Before this happens, several classes have to be created in the Distributed Memoization Store layer, as well as deciding how we are going to share the RocksDB layer.
- Porting of MemoizationSessionTests. These require integration with the content layer and the previous point.
- `IsContentAvailable` requires integration with the content layer, and so will be left as a placeholder. This needs to be implemented, as it is part of the original SQLite implementation.
- Garbage collection and removal of content in general.

Also, please notice that all tests have been copy-pasted from our SQL memoization store tests, modulo minimal changes required to get them to run (i.e. removing async and extra function parameters)