### PR TITLE
Remove duplicate Pin finished trace from BlobContentSession

### DIFF
--- a/Public/Src/Cache/ContentStore/Library/Sessions/ContentSessionBase.cs
+++ b/Public/Src/Cache/ContentStore/Library/Sessions/ContentSessionBase.cs
@@ -38,6 +38,9 @@ namespace BuildXL.Cache.ContentStore.Sessions
         public string Name { get; }
 
         /// <nodoc />
+        protected virtual bool TracePinFinished => true;
+
+        /// <nodoc />
         protected ContentSessionBase(string name)
         {
             Name = name;
@@ -80,6 +83,7 @@ namespace BuildXL.Cache.ContentStore.Sessions
                     Tracer,
                     () => PinCoreAsync(operationContext, contentHash, urgencyHint, _counters[ContentSessionBaseCounters.PinRetries]),
                     traceOperationStarted: false,
+                    traceOperationFinished: TracePinFinished,
                     extraEndMessage: _ => $"input=[{contentHash.ToShortString()}]",
                     counter: _counters[ContentSessionBaseCounters.Pin]));
         }

--- a/Public/Src/Cache/ContentStore/Vsts/BlobReadOnlyContentSession.cs
+++ b/Public/Src/Cache/ContentStore/Vsts/BlobReadOnlyContentSession.cs
@@ -171,6 +171,9 @@ namespace BuildXL.Cache.ContentStore.Vsts
         protected override void DisposeCore() => TempDirectory.Dispose();
 
         /// <inheritdoc />
+        protected override bool TracePinFinished => false; // Since this implementation calls PinBulk, it results in a duplicate stop message.
+
+        /// <inheritdoc />
         protected override async Task<PinResult> PinCoreAsync(
             OperationContext context, ContentHash contentHash, UrgencyHint urgencyHint, Counter retryCounter)
         {

--- a/Public/Src/Cache/ContentStore/Vsts/BlobReadOnlyContentSession.cs
+++ b/Public/Src/Cache/ContentStore/Vsts/BlobReadOnlyContentSession.cs
@@ -171,7 +171,7 @@ namespace BuildXL.Cache.ContentStore.Vsts
         protected override void DisposeCore() => TempDirectory.Dispose();
 
         /// <inheritdoc />
-        protected override bool TracePinFinished => false; // Since this implementation calls PinBulk, it results in a duplicate stop message.
+        protected override bool TracePinFinished => false; // Since this implementation calls PinBulk, which has its own tracing, it results in a duplicate stop message.
 
         /// <inheritdoc />
         protected override async Task<PinResult> PinCoreAsync(


### PR DESCRIPTION
Since the implementation consists of calling PinBulk, and PinBulk has its own end trace, this results in a duplicate trace.

Example:
PinBulk:     2019-07-09 20:13:34,178 325 DEBUG 3e9892f3-44b4-4039-9224-d98d565e6024 BlobContentSession.PinAsync stop 449.7661ms. result=[Success]. Hashes=[VSO0:CAA07181F68F78C30A56E0AAD64C3D4D541ECA9FDC7EABBAA580B8244FF8543800:Success]
Pin:            2019-07-09 20:13:34,178 325 DEBUG 3e9892f3-44b4-4039-9224-d98d565e6024 BlobContentSession.PinAsync stop 453.5394ms. result=[Success]. input=[VSO0:CAA07181F68F78C30A56E0AAD64C3D4D541ECA9FDC7EABBAA580B8244FF8543800]