### PR TITLE
Make sure path is fully canonicalized when doing write in existing file analysis

### DIFF
--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/AllowedUndeclaredReadsTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/AllowedUndeclaredReadsTests.cs
@@ -407,6 +407,7 @@ namespace IntegrationTest.BuildXL.Scheduler
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [FactIfSupported(requiresWindowsBasedOperatingSystem: true)]
         public void WritingToExistentFileProducedBySamePipIsAllowed(bool varyPath)
         {
             // Run a pip that writes into a file twice: the second time, the file will exist. However, this should be allowed.

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/AllowedUndeclaredReadsTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/AllowedUndeclaredReadsTests.cs
@@ -404,10 +404,9 @@ namespace IntegrationTest.BuildXL.Scheduler
             AssertErrorEventLogged(LogEventId.DependencyViolationWriteOnExistingFile);
         }
 
-        [Theory]
+        [TheoryIfSupported(requiresWindowsBasedOperatingSystem: true)]
         [InlineData(true)]
         [InlineData(false)]
-        [FactIfSupported(requiresWindowsBasedOperatingSystem: true)]
         public void WritingToExistentFileProducedBySamePipIsAllowed(bool varyPath)
         {
             // Run a pip that writes into a file twice: the second time, the file will exist. However, this should be allowed.

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/AllowedUndeclaredReadsTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/AllowedUndeclaredReadsTests.cs
@@ -407,7 +407,7 @@ namespace IntegrationTest.BuildXL.Scheduler
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void WritingToExistentFileProducedBySamePipIsAllowed(bool varyPathCasing)
+        public void WritingToExistentFileProducedBySamePipIsAllowed(bool varyPath)
         {
             // Run a pip that writes into a file twice: the second time, the file will exist. However, this should be allowed.
             // This test complements WritingUndeclaredInputsUnderSharedOpaquesAreBlocked, since the check cannot be made purely based on file existence,
@@ -415,7 +415,8 @@ namespace IntegrationTest.BuildXL.Scheduler
             var outputFile = CreateOutputFileArtifact(SharedOpaqueDirectoryRoot);
             var pipBuilder = CreatePipBuilder(new Operation[] {
                 Operation.WriteFile(outputFile, doNotInfer: true),
-                Operation.WriteFile(outputFile, doNotInfer: true, changePathToAllUpperCase: varyPathCasing),
+                Operation.WriteFile(outputFile, doNotInfer: true, changePathToAllUpperCase: varyPath),
+                Operation.WriteFile(outputFile, doNotInfer: true, useLongPathPrefix: varyPath),
             });
             pipBuilder.AddOutputDirectory(DirectoryArtifact.CreateWithZeroPartialSealId(AbsolutePath.Create(Context.PathTable, SharedOpaqueDirectoryRoot)), SealDirectoryKind.SharedOpaque);
             pipBuilder.Options |= Process.Options.AllowUndeclaredSourceReads;

--- a/Public/Src/Utilities/UnitTests/Executables/TestProcess/Operation.cs
+++ b/Public/Src/Utilities/UnitTests/Executables/TestProcess/Operation.cs
@@ -27,6 +27,7 @@ namespace Test.BuildXL.Executables.TestProcess
         private const string StdErrMoniker = "stderr";
         private const string WaitToFinishMoniker = "wait";
         private const string AllUppercasePath = "allUpper";
+        private const string UseLongPathPrefix = "useLongPathPrefix";
 
         /// <summary>
         /// Returns an <code>IEnumerable</code> containing <paramref name="operation"/>
@@ -473,11 +474,15 @@ namespace Test.BuildXL.Executables.TestProcess
         /// Creates a write file operation that appends. The file is created if it does not exist.
         /// Writes random content to file at path if no content is specified.
         /// </summary>
-        public static Operation WriteFile(FileArtifact path, string content = null, bool doNotInfer = false, bool changePathToAllUpperCase = false)
+        public static Operation WriteFile(FileArtifact path, string content = null, bool doNotInfer = false, bool changePathToAllUpperCase = false, bool useLongPathPrefix = false)
         {
+            Contract.Assert(!changePathToAllUpperCase || !useLongPathPrefix, "Cannot specify changePathToAllUpperCase and useLongPathPrefix simultaneously");
+
+            string additionalArgs = changePathToAllUpperCase ? Operation.AllUppercasePath : useLongPathPrefix ? Operation.UseLongPathPrefix : null;
+
             return content == Environment.NewLine
-                ? new Operation(Type.AppendNewLine, path, doNotInfer: doNotInfer, additionalArgs: changePathToAllUpperCase? Operation.AllUppercasePath : null)
-                : new Operation(Type.WriteFile, path, content, doNotInfer: doNotInfer, additionalArgs: changePathToAllUpperCase ? Operation.AllUppercasePath : null);
+                ? new Operation(Type.AppendNewLine, path, doNotInfer: doNotInfer, additionalArgs: additionalArgs)
+                : new Operation(Type.WriteFile, path, content, doNotInfer: doNotInfer, additionalArgs: additionalArgs);
         }
 
         /// <summary>
@@ -800,6 +805,10 @@ namespace Test.BuildXL.Executables.TestProcess
                 if (AdditionalArgs == AllUppercasePath)
                 {
                     file = file.ToUpperInvariant();
+                }
+                if (AdditionalArgs == UseLongPathPrefix)
+                {
+                    file = "\\\\?\\" + file.ToUpperInvariant();
                 }
 
                 File.AppendAllText(file, content);

--- a/Public/Src/Utilities/UnitTests/Executables/TestProcess/Operation.cs
+++ b/Public/Src/Utilities/UnitTests/Executables/TestProcess/Operation.cs
@@ -478,7 +478,7 @@ namespace Test.BuildXL.Executables.TestProcess
         {
             Contract.Assert(!changePathToAllUpperCase || !useLongPathPrefix, "Cannot specify changePathToAllUpperCase and useLongPathPrefix simultaneously");
 
-            string additionalArgs = changePathToAllUpperCase ? Operation.AllUppercasePath : useLongPathPrefix ? Operation.UseLongPathPrefix : null;
+            string additionalArgs = changePathToAllUpperCase ? Operation.AllUppercasePath : (useLongPathPrefix ? Operation.UseLongPathPrefix : null);
 
             return content == Environment.NewLine
                 ? new Operation(Type.AppendNewLine, path, doNotInfer: doNotInfer, additionalArgs: additionalArgs)
@@ -808,7 +808,7 @@ namespace Test.BuildXL.Executables.TestProcess
                 }
                 if (AdditionalArgs == UseLongPathPrefix)
                 {
-                    file = "\\\\?\\" + file.ToUpperInvariant();
+                    file = @"\\?\" + file.ToUpperInvariant();
                 }
 
                 File.AppendAllText(file, content);


### PR DESCRIPTION
Paths like \\?\C:\foo.txt and C:\foo.txt are reported as different paths from detours. This PR changes the logic that deals with OverrideAllowWriteForExistingFiles to handle those paths as the same one.