### PR TITLE
Break out FileNotFound on PipProcessStartFailed into a separate UserError

### DIFF
--- a/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
@@ -785,8 +785,7 @@ namespace BuildXL.Processes
                                 LocationData location = m_pip.Provenance.Token;
                                 string specFile = location.Path.ToString(m_pathTable);
 
-                                Tracing.Logger.Log.PipProcessStartFailed(m_loggingContext, m_pip.SemiStableHash, m_pip.GetDescription(m_context), 2,
-                                    string.Format(CultureInfo.InvariantCulture, "File '{0}' was not found on disk. The tool is referred in '{1}({2})'.", info.FileName, specFile, location.Position));
+                                Tracing.Logger.Log.PipProcessFileNotFound(m_loggingContext, m_pip.SemiStableHash, m_pip.GetDescription(m_context), 2, info.FileName, specFile, location.Position);
                             }
                             else if (ex.LogEventErrorCode == NativeIOConstants.ErrorPartialCopy && (processLaunchRetryCount < ProcessLaunchRetryCountMax))
                             {

--- a/Public/Src/Engine/Processes/Tracing/Log.cs
+++ b/Public/Src/Engine/Processes/Tracing/Log.cs
@@ -76,6 +76,15 @@ namespace BuildXL.Processes.Tracing
         public abstract void PipProcessStartFailed(LoggingContext context, long pipSemiStableHash, string pipDescription, int errorCode, string message);
 
         [GeneratedEvent(
+            (int)LogEventId.PipProcessFileNotFound,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Error,
+            Keywords = (int)(Keywords.UserMessage | Keywords.UserError),
+            EventTask = (int)Tasks.PipExecutor,
+            Message = EventConstants.PipPrefix + "Process start failed with error code {2:X8}: File '{3}' was not found on disk. The tool is referred to in '{4}({5})'.")]
+        public abstract void PipProcessFileNotFound(LoggingContext context, long pipSemiStableHash, string pipDescription, int errorCode, string filename, string specFile, int position);
+
+        [GeneratedEvent(
             (int)LogEventId.PipProcessFinished,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,

--- a/Public/Src/Engine/Processes/Tracing/LogEventId.cs
+++ b/Public/Src/Engine/Processes/Tracing/LogEventId.cs
@@ -20,7 +20,7 @@ namespace BuildXL.Processes.Tracing
         PipProcessStartFailed = 11,
         PipProcessFinished = 12,
         PipProcessFinishedFailed = 13,
-        // was PipProcessDisallowedFileAccessError = 14,
+        PipProcessFileNotFound = 14,
         PipProcessTookTooLongWarning = 15,
         PipProcessTookTooLongError = 16,
         PipProcessStandardOutput = 17,

--- a/Public/Src/Utilities/Utilities/Tracing/EventId.cs
+++ b/Public/Src/Utilities/Utilities/Tracing/EventId.cs
@@ -28,7 +28,7 @@ namespace BuildXL.Utilities.Tracing
         PipProcessStartFailed = 11,
         PipProcessFinished = 12,
         PipProcessFinishedFailed = 13,
-        // was PipProcessDisallowedFileAccessError = 14,
+        // elsewhere,
         PipProcessTookTooLongWarning = 15,
         PipProcessTookTooLongError = 16,
         PipProcessStandardOutput = 17,


### PR DESCRIPTION
A FileNotFound error when we start a process pip should be a user error since the user is who specifies the location of the process to launch. This needs to be broken out from the general PipProcessStartFailed since that can represent other issues that would be internal errors.

Fixes: [AB#1569598](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1569598)