### PR TITLE
Upgrade to Microsoft.Build.Prediction 0.3.0

### DIFF
--- a/config.dsc
+++ b/config.dsc
@@ -445,7 +445,7 @@ config({
                 { id: "System.CodeDom", version: "4.4.0"},
 
                 // Used for MSBuild input/output prediction
-                { id: "Microsoft.Build.Prediction", version: "0.2.0" },
+                { id: "Microsoft.Build.Prediction", version: "0.3.0" },
 
                 { id: "SharpZipLib", version: "1.1.0" },
 


### PR DESCRIPTION
Notes on this Microsoft.Build.Prediction release: https://github.com/microsoft/MSBuildPrediction/releases/tag/v0.3.0

Full set of changes: https://github.com/microsoft/MSBuildPrediction/compare/v0.2.0...v0.3.0