### PR TITLE
Fix ImplicitPin comparison to HasFlag

### DIFF
--- a/Public/Src/Cache/ContentStore/Vsts/BlobReadOnlyContentSession.cs
+++ b/Public/Src/Cache/ContentStore/Vsts/BlobReadOnlyContentSession.cs
@@ -198,7 +198,7 @@ namespace BuildXL.Cache.ContentStore.Vsts
             string tempFile = null;
             try
             {
-                if (ImplicitPin == ImplicitPin.Get)
+                if (ImplicitPin.HasFlag(ImplicitPin.Get))
                 {
                     var pinResult = await PinAsync(context, contentHash, context.Token, urgencyHint).ConfigureAwait(false);
                     if (!pinResult.Succeeded)
@@ -267,7 +267,7 @@ namespace BuildXL.Cache.ContentStore.Vsts
                     return new PlaceFileResult(PlaceFileResult.ResultCode.NotPlacedAlreadyExists);
                 }
 
-                if (ImplicitPin == ImplicitPin.Get)
+                if (ImplicitPin.HasFlag(ImplicitPin.Get))
                 {
                     var pinResult = await PinAsync(context, contentHash, context.Token, urgencyHint).ConfigureAwait(false);
                     if (!pinResult.Succeeded)

--- a/Public/Src/Cache/ContentStore/Vsts/DedupReadOnlyContentSession.cs
+++ b/Public/Src/Cache/ContentStore/Vsts/DedupReadOnlyContentSession.cs
@@ -199,7 +199,7 @@ namespace BuildXL.Cache.ContentStore.Vsts
             string tempFile = null;
             try
             {
-                if (ImplicitPin == ImplicitPin.Get)
+                if (ImplicitPin.HasFlag(ImplicitPin.Get))
                 {
                     var pinResult = await PinAsync(context, contentHash, context.Token, urgencyHint).ConfigureAwait(false);
                     if (!pinResult.Succeeded)
@@ -276,7 +276,7 @@ namespace BuildXL.Cache.ContentStore.Vsts
                     return new PlaceFileResult(PlaceFileResult.ResultCode.NotPlacedAlreadyExists);
                 }
 
-                if (ImplicitPin == ImplicitPin.Get)
+                if (ImplicitPin.HasFlag(ImplicitPin.Get))
                 {
                     var pinResult = await PinAsync(context, contentHash, context.Token, urgencyHint).ConfigureAwait(false);
                     if (!pinResult.Succeeded)


### PR DESCRIPTION
A previous change made it so that the ImplicitPin enum was in the format of flags. However, comparisons were still being done with equals comparison instead of HasFlag