### PR TITLE
Pin optimizations for DedupContentStore

### DIFF
--- a/Public/Src/Cache/ContentStore/Vsts/BackingContentStore.cs
+++ b/Public/Src/Cache/ContentStore/Vsts/BackingContentStore.cs
@@ -39,6 +39,8 @@ namespace BuildXL.Cache.ContentStore.Vsts
         private readonly IAbsFileSystem _fileSystem;
         private readonly IArtifactHttpClientFactory _artifactHttpClientFactory;
         private readonly TimeSpan _timeToKeepContent;
+        private readonly TimeSpan _pinInlineThreshold;
+        private readonly TimeSpan _ignorePinThreshold;
         private IArtifactHttpClient _artifactHttpClient;
         private readonly bool _useDedupStore;
 
@@ -53,12 +55,16 @@ namespace BuildXL.Cache.ContentStore.Vsts
         /// <param name="fileSystem">Filesystem used to read/write files.</param>
         /// <param name="artifactHttpClientFactory">Backing Store HTTP client factory.</param>
         /// <param name="timeToKeepContent">Minimum time-to-live for accessed content.</param>
+        /// <param name="pinInlineThreshold">Maximum time-to-live to inline pin calls.</param>
+        /// <param name="ignorePinThreshold">Minimum time-to-live to ignore pin calls.</param>
         /// <param name="downloadBlobsThroughBlobStore">Flag for BlobStore: If enabled, gets blobs through BlobStore. If false, gets blobs from the Azure Uri.</param>
         /// <param name="useDedupStore">Determines whether or not DedupStore is used for content. Must be used in tandem with Dedup hashes.</param>
         public BackingContentStore(
             IAbsFileSystem fileSystem,
             IArtifactHttpClientFactory artifactHttpClientFactory,
             TimeSpan timeToKeepContent,
+            TimeSpan pinInlineThreshold,
+            TimeSpan ignorePinThreshold,
             bool downloadBlobsThroughBlobStore = false,
             bool useDedupStore = false)
         {
@@ -67,6 +73,8 @@ namespace BuildXL.Cache.ContentStore.Vsts
             _fileSystem = fileSystem;
             _artifactHttpClientFactory = artifactHttpClientFactory;
             _timeToKeepContent = timeToKeepContent;
+            _pinInlineThreshold = pinInlineThreshold;
+            _ignorePinThreshold = ignorePinThreshold;
             _downloadBlobsThroughBlobStore = downloadBlobsThroughBlobStore;
             _useDedupStore = useDedupStore;
         }
@@ -140,7 +148,7 @@ namespace BuildXL.Cache.ContentStore.Vsts
             if (_useDedupStore)
             {
                 return new CreateSessionResult<IReadOnlyContentSession>(new DedupReadOnlyContentSession(
-                    _fileSystem, name, implicitPin, _artifactHttpClient as IDedupStoreHttpClient, _timeToKeepContent));
+                    _fileSystem, name, implicitPin, _artifactHttpClient as IDedupStoreHttpClient, _timeToKeepContent, _pinInlineThreshold, _ignorePinThreshold));
             }
 
             return new CreateSessionResult<IReadOnlyContentSession>(new BlobReadOnlyContentSession(
@@ -154,7 +162,7 @@ namespace BuildXL.Cache.ContentStore.Vsts
             if (_useDedupStore)
             {
                 return new CreateSessionResult<IContentSession>(new DedupContentSession(
-                    context, _fileSystem, name, implicitPin, _artifactHttpClient as IDedupStoreHttpClient, _timeToKeepContent));
+                    context, _fileSystem, name, implicitPin, _artifactHttpClient as IDedupStoreHttpClient, _timeToKeepContent, _pinInlineThreshold, _ignorePinThreshold));
             }
 
             return new CreateSessionResult<IContentSession>(new BlobContentSession(

--- a/Public/Src/Cache/ContentStore/Vsts/DedupContentSession.cs
+++ b/Public/Src/Cache/ContentStore/Vsts/DedupContentSession.cs
@@ -40,8 +40,10 @@ namespace BuildXL.Cache.ContentStore.Vsts
             ImplicitPin implicitPin,
             IDedupStoreHttpClient dedupStoreHttpClient,
             TimeSpan timeToKeepContent,
+            TimeSpan pinInlineThreshold,
+            TimeSpan ignorePinThreshold,
             int maxConnections = DefaultMaxConnections)
-            : base(fileSystem, name, implicitPin, dedupStoreHttpClient, timeToKeepContent, maxConnections)
+            : base(fileSystem, name, implicitPin, dedupStoreHttpClient, timeToKeepContent, pinInlineThreshold, ignorePinThreshold, maxConnections)
         {
             _artifactFileSystem = VstsFileSystem.Instance;
             _uploadSession = DedupStoreClient.CreateUploadSession(

--- a/Public/Src/Cache/ContentStore/Vsts/DedupReadOnlyContentSession.cs
+++ b/Public/Src/Cache/ContentStore/Vsts/DedupReadOnlyContentSession.cs
@@ -705,7 +705,7 @@ namespace BuildXL.Cache.ContentStore.Vsts
                 {
                     // For the reason explained above, this case where children need to be pinned should never happen.
                     // However, as a best aproximation, we take the min of all the children, which always outlive the parent.
-                    keepUntil = needAction.Receipts.Select(r => r.Value.KeepUntil.KeepUntil).MinOrDefault();
+                    keepUntil = needAction.Receipts.Select(r => r.Value.KeepUntil.KeepUntil).Min();
                 },
                 (added) =>
                 {

--- a/Public/Src/Cache/ContentStore/Vsts/DedupReadOnlyContentSession.cs
+++ b/Public/Src/Cache/ContentStore/Vsts/DedupReadOnlyContentSession.cs
@@ -195,6 +195,7 @@ namespace BuildXL.Cache.ContentStore.Vsts
 
             if (timeLeft > _ignorePinThreshold)
             {
+                Tracer.Debug(context, $"Pin ignored bacause keepUntil has remaining time [{timeLeft}] that is greater than the ignorePinThreshold");
                 _dedupCounters[Counters.PinIgnored].Increment();
                 return PinResult.Success;
             }
@@ -203,6 +204,7 @@ namespace BuildXL.Cache.ContentStore.Vsts
 
             if (timeLeft < _pinInlineThreshold)
             {
+                Tracer.Debug(context, $"Pin inlined bacause keepUntil has remaining time [{timeLeft}] that is less than the pinInlineThreshold");
                 _dedupCounters[Counters.PinInlined].Increment();
                 return await task;
             }

--- a/Public/Src/Cache/ContentStore/Vsts/DedupReadOnlyContentSession.cs
+++ b/Public/Src/Cache/ContentStore/Vsts/DedupReadOnlyContentSession.cs
@@ -128,6 +128,8 @@ namespace BuildXL.Cache.ContentStore.Vsts
         /// <param name="implicitPin">Policy determining whether or not content should be automatically pinned on adds or gets.</param>
         /// <param name="dedupStoreHttpClient">Backing DedupStore http client.</param>
         /// <param name="timeToKeepContent">Minimum time-to-live for accessed content.</param>
+        /// <param name="pinInlineThreshold">Maximum time-to-live to inline pin calls.</param>
+        /// <param name="ignorePinThreshold">Minimum time-to-live to ignore pin calls.</param>
         /// <param name="maxConnections">The maximum number of outboud connections to VSTS.</param>
         public DedupReadOnlyContentSession(
             IAbsFileSystem fileSystem,

--- a/Public/Src/Cache/ContentStore/Vsts/DedupReadOnlyContentSession.cs
+++ b/Public/Src/Cache/ContentStore/Vsts/DedupReadOnlyContentSession.cs
@@ -21,7 +21,6 @@ using BuildXL.Cache.ContentStore.Interfaces.FileSystem;
 using BuildXL.Cache.ContentStore.Interfaces.Results;
 using BuildXL.Cache.ContentStore.Interfaces.Sessions;
 using BuildXL.Cache.ContentStore.Interfaces.Stores;
-using BuildXL.Cache.ContentStore.Interfaces.Utils;
 using BuildXL.Cache.ContentStore.Sessions;
 using BuildXL.Cache.ContentStore.Tracing;
 using BuildXL.Cache.ContentStore.UtilitiesCore;
@@ -129,6 +128,8 @@ namespace BuildXL.Cache.ContentStore.Vsts
             ImplicitPin implicitPin,
             IDedupStoreHttpClient dedupStoreHttpClient,
             TimeSpan timeToKeepContent,
+            TimeSpan pinInlineThreshold,
+            TimeSpan ignorePinThreshold,
             int maxConnections = DefaultMaxConnections)
             : base(name)
         {
@@ -142,6 +143,9 @@ namespace BuildXL.Cache.ContentStore.Vsts
             TempDirectory = new DisposableDirectory(fileSystem);
             ConnectionGate = new SemaphoreSlim(maxConnections);
             EndDateTime = DateTime.UtcNow + timeToKeepContent;
+
+            _pinInlineThreshold = pinInlineThreshold;
+            _ignorePinThreshold = ignorePinThreshold;
         }
 
         /// <summary>

--- a/Public/Src/Cache/ContentStore/Vsts/DedupReadOnlyContentSession.cs
+++ b/Public/Src/Cache/ContentStore/Vsts/DedupReadOnlyContentSession.cs
@@ -114,7 +114,7 @@ namespace BuildXL.Cache.ContentStore.Vsts
         ///     Expiration time of content in VSTS
         ///     Note: Determined by configurable timeToKeepContent. This is usually defined to be on the order of days.
         /// </summary>
-        protected DateTime EndDateTime;
+        protected readonly DateTime EndDateTime;
 
         private readonly TimeSpan _pinInlineThreshold;
 

--- a/Public/Src/Cache/MemoizationStore/Vsts/BuildCacheCache.cs
+++ b/Public/Src/Cache/MemoizationStore/Vsts/BuildCacheCache.cs
@@ -60,6 +60,8 @@ namespace BuildXL.Cache.MemoizationStore.Vsts
         /// <param name="backingContentStoreHttpClientFactory">Factory for creating a backing store http client.</param>
         /// <param name="maxFingerprintSelectorsToFetch">Maximum number of selectors to enumerate.</param>
         /// <param name="timeToKeepUnreferencedContent">Initial time-to-live for unreferenced content.</param>
+        /// <param name="pinInlineThreshold">Maximum time-to-live to inline pin calls.</param>
+        /// <param name="ignorePinThreshold">Minimum time-to-live to ignore pin calls.</param>
         /// <param name="minimumTimeToKeepContentHashLists">Minimum time-to-live for created or referenced ContentHashLists.</param>
         /// <param name="rangeOfTimeToKeepContentHashLists">Range of time beyond the minimum for the time-to-live of created or referenced ContentHashLists.</param>
         /// <param name="logger">A logger for tracing.</param>
@@ -79,6 +81,8 @@ namespace BuildXL.Cache.MemoizationStore.Vsts
             IArtifactHttpClientFactory backingContentStoreHttpClientFactory,
             int maxFingerprintSelectorsToFetch,
             TimeSpan timeToKeepUnreferencedContent,
+            TimeSpan pinInlineThreshold,
+            TimeSpan ignorePinThreshold,
             TimeSpan minimumTimeToKeepContentHashLists,
             TimeSpan rangeOfTimeToKeepContentHashLists,
             ILogger logger,
@@ -102,7 +106,7 @@ namespace BuildXL.Cache.MemoizationStore.Vsts
             _tracer = new BuildCacheCacheTracer(logger, nameof(BuildCacheCache));
 
             _backingContentStore = new BackingContentStore(
-                fileSystem, backingContentStoreHttpClientFactory, timeToKeepUnreferencedContent, downloadBlobsThroughBlobStore, useDedupStore);
+                fileSystem, backingContentStoreHttpClientFactory, timeToKeepUnreferencedContent, pinInlineThreshold, ignorePinThreshold, downloadBlobsThroughBlobStore, useDedupStore);
 
             if (useDedupStore)
             {

--- a/Public/Src/Cache/MemoizationStore/Vsts/BuildCacheCacheFactory.cs
+++ b/Public/Src/Cache/MemoizationStore/Vsts/BuildCacheCacheFactory.cs
@@ -38,6 +38,8 @@ namespace BuildXL.Cache.MemoizationStore.Vsts
                 new BackingContentStoreHttpClientFactory(new Uri(cacheConfig.CacheServiceContentEndpoint), vssCredentialsFactory, TimeSpan.FromMinutes(cacheConfig.HttpSendTimeoutMinutes), cacheConfig.UseAad),
                 cacheConfig.MaxFingerprintSelectorsToFetch,
                 TimeSpan.FromDays(cacheConfig.DaysToKeepUnreferencedContent),
+                TimeSpan.FromMinutes(cacheConfig.PinInlineThresholdMinutes),
+                TimeSpan.FromHours(cacheConfig.IgnorePinThresholdHours),
                 TimeSpan.FromDays(cacheConfig.DaysToKeepContentBags),
                 TimeSpan.FromDays(cacheConfig.RangeOfDaysToKeepContentBags),
                 logger,

--- a/Public/Src/Cache/MemoizationStore/Vsts/BuildCacheServiceConfiguration.cs
+++ b/Public/Src/Cache/MemoizationStore/Vsts/BuildCacheServiceConfiguration.cs
@@ -21,6 +21,16 @@ namespace BuildXL.Cache.MemoizationStore.Vsts
         public const int DefaultDaysToKeepUnreferencedContent = 1;
 
         /// <summary>
+        /// Gets or sets the threshold to inline pin calls instead of doing them in the background.
+        /// </summary>
+        public const int DefaultPinInlineThresholdMinutes = 15;
+
+        /// <summary>
+        /// Gets or sets the threshold to ignore pin calls.
+        /// </summary>
+        public const int DefaultIgnorePinThresholdHours = 16;
+
+        /// <summary>
         /// Default minimum number of days to keep content bags and referenced content.
         /// </summary>
         public const int DefaultDaysToKeepContentBags = 7;
@@ -134,6 +144,18 @@ namespace BuildXL.Cache.MemoizationStore.Vsts
         /// </summary>
         [DataMember]
         public int DaysToKeepUnreferencedContent { get; set; } = DefaultDaysToKeepUnreferencedContent;
+
+        /// <summary>
+        /// Gets or sets the number of days to keep content before it is referenced by metadata.
+        /// </summary>
+        [DataMember]
+        public int PinInlineThresholdMinutes { get; set; } = DefaultPinInlineThresholdMinutes;
+
+        /// <summary>
+        /// Gets or sets the number of days to keep content before it is referenced by metadata.
+        /// </summary>
+        [DataMember]
+        public int IgnorePinThresholdHours { get; set; } = DefaultIgnorePinThresholdHours;
 
         /// <summary>
         /// Gets or sets the minimum number of days to keep content bags and referenced content.

--- a/Public/Src/Cache/MemoizationStore/VstsTest/BuildCacheSimulationTests.cs
+++ b/Public/Src/Cache/MemoizationStore/VstsTest/BuildCacheSimulationTests.cs
@@ -105,6 +105,8 @@ namespace BuildXL.Cache.MemoizationStore.VstsTest
                 backingContentStoreHttpClientFactory,
                 BuildCacheServiceConfiguration.DefaultMaxFingerprintSelectorsToFetch,
                 TimeSpan.FromDays(BuildCacheServiceConfiguration.DefaultDaysToKeepUnreferencedContent),
+                TimeSpan.FromMinutes(BuildCacheServiceConfiguration.DefaultPinInlineThresholdMinutes),
+                TimeSpan.FromMinutes(BuildCacheServiceConfiguration.DefaultIgnorePinThresholdHours),
                 expiryMinimum.GetValueOrDefault(TimeSpan.FromDays(BuildCacheServiceConfiguration.DefaultDaysToKeepContentBags)),
                 expiryRange.GetValueOrDefault(TimeSpan.FromDays(BuildCacheServiceConfiguration.DefaultRangeOfDaysToKeepContentBags)),
                 logger,

--- a/Public/Src/Cache/VerticalStore/BuildCacheAdapter/BuildCacheCacheConfig.cs
+++ b/Public/Src/Cache/VerticalStore/BuildCacheAdapter/BuildCacheCacheConfig.cs
@@ -111,7 +111,10 @@ namespace BuildXL.Cache.BuildCacheAdapter
                 HttpSendTimeoutMinutes = HttpSendTimeoutMinutes,
                 DownloadBlobsThroughBlobStore = DownloadBlobsThroughBlobStore,
                 UseDedupStore = UseDedupStore,
-                OverrideUnixFileAccessMode = OverrideUnixFileAccessMode
+                OverrideUnixFileAccessMode = OverrideUnixFileAccessMode,
+                ImplicitPin = ImplicitPin,
+                IgnorePinThresholdHours = IgnorePinThresholdHours,
+                PinInlineThresholdMinutes = PinInlineThresholdMinutes
             };
         }
     }

--- a/Public/Src/Cache/VerticalStore/BuildCacheAdapter/BuildCacheFactory.cs
+++ b/Public/Src/Cache/VerticalStore/BuildCacheAdapter/BuildCacheFactory.cs
@@ -54,6 +54,8 @@ namespace BuildXL.Cache.BuildCacheAdapter
         //     "DownloadBlobsThroughBlobStore":{25}
         //     "UseDedupStore":{26}
         //     "OverrideUnixFileAccessMode":{27}
+        //     "DefaultPinInlineThresholdMinutes":{28}
+        //     "DefaultIgnorePinThresholdHours":{29}
         // }
         private sealed class Config : BuildCacheCacheConfig
         {

--- a/Public/Src/Cache/VerticalStore/BuildCacheAdapter/DistributedBuildCacheFactory.cs
+++ b/Public/Src/Cache/VerticalStore/BuildCacheAdapter/DistributedBuildCacheFactory.cs
@@ -67,6 +67,8 @@ namespace BuildXL.Cache.BuildCacheAdapter
         //     "DisableContent":{28}
         //     "OverrideUnixFileAccessMode":{29}
         //     "ImplicitPin":{30}
+        //     "DefaultPinInlineThresholdMinutes":{31}
+        //     "DefaultIgnorePinThresholdHours":{32}
         // }
         private sealed class Config : BuildCacheCacheConfig
         {


### PR DESCRIPTION
Since pin is a potentially expensive operation in DedupContentStore, optimizations have been made.

Before deciding if a pin is going to be made, there is a quick check of the current keepUntil value of the tree.
Depending on the current keepUntil:
- The pin operation will be ignored if it is greater than some threshold
- The pin operation will be inlined if it is lower than some other threshold
- The pin operation will be done asynchronously and will return success otherwise.