### PR TITLE
Untrack Detours internal files during pip execution

### DIFF
--- a/Public/Src/Engine/Processes/ExternalToolSandboxedProcessExecutor.cs
+++ b/Public/Src/Engine/Processes/ExternalToolSandboxedProcessExecutor.cs
@@ -42,6 +42,10 @@ namespace BuildXL.Processes
             }
 
             string directory = Path.GetDirectoryName(executablePath);
+
+            // If the pip run by this sandboxed process executor tool also executes Detours, then that pip may access
+            // DetoursServices.pdb that is linked with this tool. Thus, we need to tell the pip to untrack the directories
+            // where DetoursServices are located.
             UntrackedScopes = new[] { Path.Combine(directory, "X86"), Path.Combine(directory, "X64") };
         }
 

--- a/Public/Src/Engine/Processes/ExternalToolSandboxedProcessExecutor.cs
+++ b/Public/Src/Engine/Processes/ExternalToolSandboxedProcessExecutor.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.Diagnostics.ContractsLight;
+using System.IO;
+using BuildXL.Utilities;
 
 namespace BuildXL.Processes
 {
@@ -21,12 +24,25 @@ namespace BuildXL.Processes
         public string ExecutablePath { get; }
 
         /// <summary>
+        /// Scopes that need to be untracked.
+        /// </summary>
+        public IEnumerable<string> UntrackedScopes { get; }
+
+        /// <summary>
         /// Creates an instance of <see cref="ExternalToolSandboxedProcessExecutor"/>
         /// </summary>
         public ExternalToolSandboxedProcessExecutor(string executablePath)
         {
             Contract.Requires(!string.IsNullOrWhiteSpace(executablePath));
             ExecutablePath = executablePath;
+
+            if (!File.Exists(ExecutablePath))
+            {
+                throw new BuildXLException($"Cannot find file '{ExecutablePath}' needed to externally execute process. Did you build all configurations?", rootCause: ExceptionRootCause.MissingRuntimeDependency);
+            }
+
+            string directory = Path.GetDirectoryName(executablePath);
+            UntrackedScopes = new[] { Path.Combine(directory, "X86"), Path.Combine(directory, "X64") };
         }
 
         /// <summary>

--- a/Public/Src/Engine/Processes/Internal/BinaryPaths.cs
+++ b/Public/Src/Engine/Processes/Internal/BinaryPaths.cs
@@ -9,15 +9,10 @@ namespace BuildXL.Processes.Internal
 {
     internal sealed class BinaryPaths
     {
-#pragma warning disable CA1823 // Unused field
-        private const string Debug = "Debug";
-        private const string Release = "Release";
-        private const string X86 = "X86";
-        private const string X64 = "X64";
-#pragma warning restore CA1823 // Unused field
-
         public readonly string DllNameX64;
         public readonly string DllNameX86;
+        public readonly string DllDirectoryX64;
+        public readonly string DllDirectoryX86;
 
         public BinaryPaths()
         {
@@ -28,13 +23,16 @@ namespace BuildXL.Processes.Internal
 
             VerifyFileExists(DllNameX86);
             VerifyFileExists(DllNameX64);
+
+            DllDirectoryX86 = Path.GetDirectoryName(DllNameX86);
+            DllDirectoryX64 = Path.GetDirectoryName(DllNameX64);
         }
 
         private static void VerifyFileExists(string fileName)
         {
             if (!File.Exists(fileName))
             {
-                throw new BuildXLException("Cannot find file needed to detour processes. Did you build all configurations? " + fileName, rootCause: ExceptionRootCause.MissingRuntimeDependency);
+                throw new BuildXLException($"Cannot find file '{fileName}' needed to detour processes. Did you build all configurations?", rootCause: ExceptionRootCause.MissingRuntimeDependency);
             }
         }
     }


### PR DESCRIPTION
When a Detoured pip includes loading Detours (like Vanguard component of code coverage), pip can access internal files that BuildXL engine itself uses. 

For example, the pip can access DetoursServices.pdb in the bin directory or in the server deployment directory of BuildXL, and this causes DFA. 

If a pip indeed depends on those Detours internal files, then the pip should not refer to the ones in the bin directory of the running BuildXL because they are untracked. The proper way is to consume them is from our released Detours package.

This PR pending on repro and testing data from customer.

[AB#1568098](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1568098)