### PR TITLE
Fix issue with VS2017 with preview language version.

### DIFF
--- a/Public/Src/IDE/Generator/CommonBuildFiles/CSharp.targets
+++ b/Public/Src/IDE/Generator/CommonBuildFiles/CSharp.targets
@@ -2,6 +2,9 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+
+    <!-- On Visual Studio 2017, the preview version is not supported, so fallback to using latest as language version  -->
+    <LangVersion Condition="'$(LangVersion)' == 'preview' AND '$(VisualStudioVersion)' == '15.0'">latest</LangVersion>
   </PropertyGroup>
 
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
This change allows VS2017 users to open a generated solution and still use C# 7.3 language features.

Without this change, VS2017 doesn't recognize 'latest' language version and switches to the default one which is C# 7 that causes a lot of errors in the IDE.