### PR TITLE
Add logging to GetLruPages

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/TransitioningContentLocationStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/TransitioningContentLocationStore.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.ContractsLight;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BuildXL.Cache.ContentStore.Distributed.Redis;
@@ -249,6 +250,8 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         {
             Contract.Assert(_configuration.HasReadOrWriteMode(ContentLocationMode.LocalLocationStore), "GetLruPages can only be called when local location store is enabled");
 
+            context.Debug($"GetLruPages start with contentHashesWithInfo.Count={contentHashesWithInfo.Count}, firstAge={contentHashesWithInfo.FirstOrDefault().Age}, lastAge={contentHashesWithInfo.LastOrDefault().Age}");
+
             var pageSize = _configuration.EvictionWindowSize;
 
             // Priority queue orders by least first. So we compare by last access time to get the least last access time (i.e. oldest) first.
@@ -274,6 +277,8 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                 {
                     priorityQueue.Push(lastAccessTimes[i]);
                 }
+
+                context.Debug($"GetLruPages page.First:(Age={page.First().Age}, EffectiveAge={page.First().EffectiveAge}), queue.Top:(Age={priorityQueue.Top.Age}, EffectiveAge={priorityQueue.Top.EffectiveAge})");
 
                 while (priorityQueue.Count >= pageSize)
                 {

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/TransitioningContentLocationStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/TransitioningContentLocationStore.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.ContractsLight;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BuildXL.Cache.ContentStore.Distributed.Redis;

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/TransitioningContentLocationStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/TransitioningContentLocationStore.cs
@@ -285,6 +285,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                     priorityQueue.Push(lastAccessTimes[i]);
                 }
 
+                //  Each page is guaranteed to have at least one entry.
                 first = page[0];
                 last = page[page.Count - 1];
                 context.Debug($"GetLruPages page.First:(Hash={first.ContentHash.ToShortString()}, Age={first.Age}, EffectiveAge={first.EffectiveAge}), page.Last:(Hash={last.ContentHash.ToShortString()}, Age={last.Age}, EffectiveAge={last.EffectiveAge}), queue.Top:(Age={priorityQueue.Top.Age}, EffectiveAge={priorityQueue.Top.EffectiveAge})");

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/TransitioningContentLocationStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/TransitioningContentLocationStore.cs
@@ -249,15 +249,13 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         {
             Contract.Assert(_configuration.HasReadOrWriteMode(ContentLocationMode.LocalLocationStore), "GetLruPages can only be called when local location store is enabled");
 
-            ContentHashWithLastAccessTimeAndReplicaCount first = default;
-            ContentHashWithLastAccessTimeAndReplicaCount last = default;
             if (contentHashesWithInfo.Count != 0)
             {
-                first = contentHashesWithInfo[0];
-                last = contentHashesWithInfo[contentHashesWithInfo.Count - 1];
-            }
+                var first = contentHashesWithInfo[0];
+                var last = contentHashesWithInfo[contentHashesWithInfo.Count - 1];
 
-            context.Debug($"GetLruPages start with contentHashesWithInfo.Count={contentHashesWithInfo.Count}, firstAge={first.Age}, lastAge={last.Age}");
+                context.Debug($"GetLruPages start with contentHashesWithInfo.Count={contentHashesWithInfo.Count}, firstAge={first.Age}, lastAge={last.Age}");
+            }
 
             var pageSize = _configuration.EvictionWindowSize;
 
@@ -285,10 +283,12 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                     priorityQueue.Push(lastAccessTimes[i]);
                 }
 
-                //  Each page is guaranteed to have at least one entry.
-                first = page[0];
-                last = page[page.Count - 1];
-                context.Debug($"GetLruPages page.First:(Hash={first.ContentHash.ToShortString()}, Age={first.Age}, EffectiveAge={first.EffectiveAge}), page.Last:(Hash={last.ContentHash.ToShortString()}, Age={last.Age}, EffectiveAge={last.EffectiveAge}), queue.Top:(Age={priorityQueue.Top.Age}, EffectiveAge={priorityQueue.Top.EffectiveAge})");
+                if (page.Count != 0)
+                {
+                    var first = page[0];
+                    var last = page[page.Count - 1];
+                    context.Debug($"GetLruPages page.First:(Hash={first.ContentHash.ToShortString()}, Age={first.Age}, EffectiveAge={first.EffectiveAge}), page.Last:(Hash={last.ContentHash.ToShortString()}, Age={last.Age}, EffectiveAge={last.EffectiveAge}), queue.Top:(Age={priorityQueue.Top.Age}, EffectiveAge={priorityQueue.Top.EffectiveAge})");
+                }
 
                 while (priorityQueue.Count >= pageSize)
                 {

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/TransitioningContentLocationStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/TransitioningContentLocationStore.cs
@@ -250,7 +250,15 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         {
             Contract.Assert(_configuration.HasReadOrWriteMode(ContentLocationMode.LocalLocationStore), "GetLruPages can only be called when local location store is enabled");
 
-            context.Debug($"GetLruPages start with contentHashesWithInfo.Count={contentHashesWithInfo.Count}, firstAge={contentHashesWithInfo.FirstOrDefault().Age}, lastAge={contentHashesWithInfo.LastOrDefault().Age}");
+            ContentHashWithLastAccessTimeAndReplicaCount first = default;
+            ContentHashWithLastAccessTimeAndReplicaCount last = default;
+            if (contentHashesWithInfo.Count != 0)
+            {
+                first = contentHashesWithInfo[0];
+                last = contentHashesWithInfo[contentHashesWithInfo.Count - 1];
+            }
+
+            context.Debug($"GetLruPages start with contentHashesWithInfo.Count={contentHashesWithInfo.Count}, firstAge={first.Age}, lastAge={last.Age}");
 
             var pageSize = _configuration.EvictionWindowSize;
 
@@ -278,7 +286,9 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                     priorityQueue.Push(lastAccessTimes[i]);
                 }
 
-                context.Debug($"GetLruPages page.First:(Age={page.First().Age}, EffectiveAge={page.First().EffectiveAge}), queue.Top:(Age={priorityQueue.Top.Age}, EffectiveAge={priorityQueue.Top.EffectiveAge})");
+                first = page[0];
+                last = page[page.Count - 1];
+                context.Debug($"GetLruPages page.First:(Hash={first.ContentHash.ToShortString()}, Age={first.Age}, EffectiveAge={first.EffectiveAge}), page.Last:(Hash={last.ContentHash.ToShortString()}, Age={last.Age}, EffectiveAge={last.EffectiveAge}), queue.Top:(Age={priorityQueue.Top.Age}, EffectiveAge={priorityQueue.Top.EffectiveAge})");
 
                 while (priorityQueue.Count >= pageSize)
                 {

--- a/Public/Src/Cache/ContentStore/Interfaces/Stores/ContentHashWithLastAccessTimeAndReplicaCount.cs
+++ b/Public/Src/Cache/ContentStore/Interfaces/Stores/ContentHashWithLastAccessTimeAndReplicaCount.cs
@@ -39,6 +39,12 @@ namespace BuildXL.Cache.ContentStore.Interfaces.Stores
         /// </summary>
         public readonly DateTime? EffectiveLastAccessTime;
 
+        /// <nodoc />
+        public TimeSpan Age => DateTime.UtcNow - LastAccessTime;
+
+        /// <nodoc />
+        public TimeSpan? EffectiveAge => EffectiveLastAccessTime == null ? (TimeSpan?)null : DateTime.UtcNow - EffectiveLastAccessTime.Value;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ContentHashWithLastAccessTimeAndReplicaCount"/> struct.
         /// </summary>


### PR DESCRIPTION
Per call to GetLruPages, log the count of contentHashesWithInfo, and the age (not effective age) of the first and last element.

Per page, log the age and effective age of the first and last element of the page, and of the top element of the priority queue.