### PR TITLE
Stable Nuget content enumeration

### DIFF
--- a/Public/Src/FrontEnd/Nuget/NugetAnalyzedPackage.cs
+++ b/Public/Src/FrontEnd/Nuget/NugetAnalyzedPackage.cs
@@ -169,7 +169,7 @@ namespace BuildXL.FrontEnd.Nuget
             var libs = new MultiValueDictionary<NugetTargetFramework, RelativePath>();
             var assemblyToTargetFramework = new MultiValueDictionary<PathAtom, NugetTargetFramework>();
 
-            foreach (var relativePath in PackageOnDisk.Contents)
+            foreach (var relativePath in PackageOnDisk.Contents.OrderBy(path => path.ToString(stringTable)))
             {
                 // This is a dll. Check if it is in a lib folder or ref folder.
                 var atoms = relativePath.GetAtoms();
@@ -238,12 +238,6 @@ namespace BuildXL.FrontEnd.Nuget
                 var history = ForceFullFrameworkQualifiersOnly ?
                     NugetFrameworkMonikers.FullFrameworkVersionHistory :
                     NugetFrameworkMonikers.WellknownMonikers.ToList();
-
-                // TODO: Remove this once we have a LKG with ForceFullFrameworkQualifiersOnly on spec generation
-                if (Id.Equals("Bond.NET"))
-                {
-                    history = NugetFrameworkMonikers.FullFrameworkVersionHistory;
-                }
 
                 foreach (var moniker in history)
                 {

--- a/Public/Src/Utilities/Native/IO/OpenFileStatus.cs
+++ b/Public/Src/Utilities/Native/IO/OpenFileStatus.cs
@@ -90,7 +90,7 @@ namespace BuildXL.Native.IO
         /// Whether the status is one that should be treated as a nonexistent file
         /// </summary>
         /// <remarks>
-        /// CODESYNC: <see cref="Windows.FileSystemWin.IsHresultNonesixtent(int)"/>
+        /// CODESYNC: <see cref="Windows.FileSystemWin.IsHresultNonexistent(int)"/>
         /// </remarks>
         public static bool IsNonexistent(this OpenFileStatus status)
         {

--- a/config.microsoftInternal.dsc
+++ b/config.microsoftInternal.dsc
@@ -8,7 +8,7 @@ const isMicrosoftInternal = Environment.getFlag("[Sdk.BuildXL]microsoftInternal"
 // Or they contain code which is internal and can't be open sourced due to tying into Microsoft internal systems.
 // The dependent code is still open sourced, but not compiled in the public repo.
 export const pkgs = isMicrosoftInternal ? [
-    { id: "Bond.NET", version: "3.2.0" },
+    { id: "Bond.NET", version: "3.2.0", forceFullFrameworkQualifiersOnly: true },
     { id: "Bond.Core.NET", version: "3.2.0" },
     { id: "Bond.Rpc.NET", version: "3.2.0" },
     { id: "BuildXL.DeviceMap", version: "0.0.1" },


### PR DESCRIPTION
Ignore unstable enumeration when analyzing Nuget package contents, this fixes issues when packages are initially downloaded instead fed from cache.