### PR TITLE
Fix DummyWaiter wrapper in getting executable path

### DIFF
--- a/Public/Src/Utilities/UnitTests/Storage/DummyWaiter.cs
+++ b/Public/Src/Utilities/UnitTests/Storage/DummyWaiter.cs
@@ -57,7 +57,7 @@ namespace Test.BuildXL.Storage
         /// </summary>
         /// <remarks>
         /// In the past we created a copy of the executable because CAS denies write attributes needed for hardlink creation
-        /// to the executable. CAS should no longer denies the write attributes. Also, by copying only the executable, dotnet
+        /// to the executable. CAS no longer denies the write attributes. Also, by copying only the executable, dotnet
         /// won't work.
         /// </remarks>
         public static string GetDummyWaiterExeLocation()

--- a/Public/Src/Utilities/UnitTests/Storage/DummyWaiter.cs
+++ b/Public/Src/Utilities/UnitTests/Storage/DummyWaiter.cs
@@ -36,35 +36,34 @@ namespace Test.BuildXL.Storage
                 throw new BuildXLException("Expected to find DummyWaiter.exe at " + exePath);
             }
 
-            var startInfo = new ProcessStartInfo(exePath)
-                            {
-                                CreateNoWindow = true,
-                                RedirectStandardInput = true,
-                                UseShellExecute = false
-                            };
-            Process process = Process.Start(startInfo);
+            Process process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = exePath,
+                    CreateNoWindow = true,
+                    RedirectStandardInput = true,
+                    UseShellExecute = false
+                }
+            };
+
+            process.Start();
+
             return new DummyWaiter(exePath, process);
         }
 
         /// <summary>
-        /// Creates and returns the location of a COPY of the exe deployed with <see cref="ExecutableName"/>.
-        /// The copy can be mutated or have its file permissions changed, unlike the actual exe which will be a hardlink
-        /// into the CAS.
+        /// Returns the location of the exe deployed with <see cref="ExecutableName"/>.
         /// </summary>
+        /// <remarks>
+        /// In the past we created a copy of the executable because CAS denies write attributes needed for hardlink creation
+        /// to the executable. CAS should no longer denies the write attributes. Also, by copying only the executable, dotnet
+        /// won't work.
+        /// </remarks>
         public static string GetDummyWaiterExeLocation()
         {
             string currentCodeFolder = Path.GetDirectoryName(AssemblyHelper.GetAssemblyLocation(typeof(DummyWaiter).GetTypeInfo().Assembly));
-            Contract.Assume(currentCodeFolder != null);
-
-            string dummyWaiterExecutableCopy = Path.Combine(Environment.GetEnvironmentVariable("TEMP"), "Copied" + ExecutableName);
-
-            if (!File.Exists(dummyWaiterExecutableCopy))
-            {
-                string dummyWaiterExeLocation = Path.GetFullPath(Path.Combine(currentCodeFolder, ExecutableName));
-                File.Copy(dummyWaiterExeLocation, dummyWaiterExecutableCopy);
-            }
-
-            return dummyWaiterExecutableCopy;
+            return Path.GetFullPath(Path.Combine(currentCodeFolder, ExecutableName));
         }
 
         public void Dispose()


### PR DESCRIPTION
DummyWaiter executable was copied to a temp location first because creating hardlink to it is not allowed as CAS denied write attributes. CAS should no longer do that now.

Due to this copy, DummyWaiter.exe won't work when run with dotnet.

[AB#1572010](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1572010)