### PR TITLE
Increase default timeout for TelemetryShutdown to 2 mins

### DIFF
--- a/Public/Src/Utilities/Instrumentation/Common/AriaV2StaticState.cs
+++ b/Public/Src/Utilities/Instrumentation/Common/AriaV2StaticState.cs
@@ -19,7 +19,7 @@ namespace BuildXL.Utilities.Instrumentation.Common
         public const int AriaMaxPropertyLength = 100;
 
         private static readonly object s_syncRoot = new object();
-        private static readonly TimeSpan s_defaultShutdownTimeout = TimeSpan.FromSeconds(20);
+        private static readonly TimeSpan s_defaultShutdownTimeout = TimeSpan.FromMinutes(2);
         private static readonly string s_ariaTelemetryDBName = "Aria.db";
 
         private static bool s_hasBeenInitialized;


### PR DESCRIPTION
There are a few hundred sessions everyday hitting timeout during TelemetryShutdown (DX0476). This results in no final statistics events for those builds. Root cause isn't known but mitigation is to bump the timeout.