### PR TITLE
Increase telemetry flush timeout in CloudBuild

### DIFF
--- a/Public/Src/App/Bxl/BuildXLApp.cs
+++ b/Public/Src/App/Bxl/BuildXLApp.cs
@@ -152,6 +152,9 @@ namespace BuildXL
 
         private readonly CrashCollectorMacOS m_crashCollector;
 
+        // Allow a longer Aria telemetry flush time in CloudBuild since we're more willing to wait at the tail of builds there
+        private TimeSpan TelemetryFlushTimeout => m_configuration.InCloudBuild() ? TimeSpan.FromMinutes(1) : AriaV2StaticState.DefaultShutdownTimeout;
+
         /// <nodoc />
         [SuppressMessage("Microsoft.Reliability", "CA2000:DisposeObjectsBeforeLosingScope")]
         public BuildXLApp(
@@ -951,9 +954,7 @@ namespace BuildXL
                         Stopwatch sw = Stopwatch.StartNew();
                         Exception telemetryShutdownException;
                         
-                        // Allow a longer Aria telemetry flush time in CloudBuild since we're more willing to wait at the tail of builds there
-                        TimeSpan telemetryFlushTimeout = m_configuration.InCloudBuild() ? TimeSpan.FromMinutes(1) : AriaV2StaticState.DefaultShutdownTimeout;
-                        var shutdownResult = AriaV2StaticState.TryShutDown(telemetryFlushTimeout, out telemetryShutdownException);
+                        var shutdownResult = AriaV2StaticState.TryShutDown(TelemetryFlushTimeout, out telemetryShutdownException);
                         switch (shutdownResult)
                         {
                             case AriaV2StaticState.ShutDownResult.Failure:

--- a/Public/Src/App/Bxl/BuildXLApp.cs
+++ b/Public/Src/App/Bxl/BuildXLApp.cs
@@ -950,8 +950,10 @@ namespace BuildXL
                     {
                         Stopwatch sw = Stopwatch.StartNew();
                         Exception telemetryShutdownException;
-
-                        var shutdownResult = AriaV2StaticState.TryShutDown(out telemetryShutdownException);
+                        
+                        // Allow a longer Aria telemetry flush time in CloudBuild since we're more willing to wait at the tail of builds there
+                        TimeSpan telemetryFlushTimeout = m_configuration.InCloudBuild() ? TimeSpan.FromMinutes(1) : AriaV2StaticState.DefaultShutdownTimeout;
+                        var shutdownResult = AriaV2StaticState.TryShutDown(telemetryFlushTimeout, out telemetryShutdownException);
                         switch (shutdownResult)
                         {
                             case AriaV2StaticState.ShutDownResult.Failure:

--- a/Public/Src/Utilities/Instrumentation/AriaNative/lib/AriaLogger.cpp
+++ b/Public/Src/Utilities/Instrumentation/AriaNative/lib/AriaLogger.cpp
@@ -15,7 +15,7 @@ AriaLogger::AriaLogger(const char* token, const char *dbPath)
     dbPath_ = dbPath;
 
     auto& config = LogManager::GetLogConfiguration();
-    config[CFG_INT_MAX_TEARDOWN_TIME] = 15;
+    config[CFG_INT_MAX_TEARDOWN_TIME] = 60;
     // config[CFG_STR_CACHE_FILE_PATH] = dbPath; // not necessary
 
     logger_ = LogManager::Initialize(token);

--- a/Public/Src/Utilities/Instrumentation/Common/AriaV2StaticState.cs
+++ b/Public/Src/Utilities/Instrumentation/Common/AriaV2StaticState.cs
@@ -18,8 +18,10 @@ namespace BuildXL.Utilities.Instrumentation.Common
         /// <nodoc />
         public const int AriaMaxPropertyLength = 100;
 
+        /// <nodoc />
+        public static readonly TimeSpan DefaultShutdownTimeout = TimeSpan.FromSeconds(20);
+
         private static readonly object s_syncRoot = new object();
-        private static readonly TimeSpan s_defaultShutdownTimeout = TimeSpan.FromSeconds(20);
         private static readonly string s_ariaTelemetryDBName = "Aria.db";
 
         private static bool s_hasBeenInitialized;
@@ -80,7 +82,7 @@ namespace BuildXL.Utilities.Instrumentation.Common
         /// </summary>
         public static ShutDownResult TryShutDown(out Exception exception)
         {
-            return TryShutDown(s_defaultShutdownTimeout, out exception);
+            return TryShutDown(DefaultShutdownTimeout, out exception);
         }
 
         /// <summary>


### PR DESCRIPTION
In a relatively small percentage of builds in CloudBuild we're hitting the telemetry flush timeout. Increase the timeout in CloudBuild where we're ok with a longer build tail for sake of getting the complete telemetry data.

Fixes [AB#1540805](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1540805)