### PR TITLE
Self-healing server deployment

### DIFF
--- a/Public/Src/App/Bxl/AppServer.cs
+++ b/Public/Src/App/Bxl/AppServer.cs
@@ -642,8 +642,10 @@ namespace BuildXL
 
             string uniqueAppName = GetStableAppServerName(lightConfig, clientApp.TimestampBasedHash, out variablesToPassThrough);
 
-            // First, try to connect to an already-running server.
-            NamedPipeClientStream clientStream = TryConnect(uniqueAppName);
+            // First, try to connect to an already-running server if its deployment is not out of date.
+            NamedPipeClientStream clientStream = ServerDeployment.IsServerDeploymentOutOfSync(serverDeploymentPath, clientApp, out _)
+                ? null
+                : TryConnect(uniqueAppName);
 
             // As a fallback, try starting a new server.
             if (clientStream == null)

--- a/Public/Src/App/Bxl/AppServer.cs
+++ b/Public/Src/App/Bxl/AppServer.cs
@@ -978,9 +978,6 @@ namespace BuildXL
                                         }
                                     },
                                     ex => {
-                                        // Make sure to poison the server deployment if an exception is caught, this forces the server bits
-                                        // to be re-deployed and helps clean up a broken deployment state.
-                                        ServerDeployment.PoisonServerDeployment(serverDeploymentDirectory);
                                         throw new BuildXLException("Error while reading data from server process. Server will be redeployed in subsequent invocation. Inner exception reason: " + ex?.Message, ex);
                                     });
                             }

--- a/Public/Src/App/Bxl/BuildXLApp.cs
+++ b/Public/Src/App/Bxl/BuildXLApp.cs
@@ -230,7 +230,7 @@ namespace BuildXL
             // We store this to log it once the appropriate listeners are set up
             m_serverModeStatusAndPerf = serverModeStatusAndPerf;
 
-            m_crashCollector = OperatingSystemHelper.IsUnixOS 
+            m_crashCollector = OperatingSystemHelper.IsUnixOS
                 ? new CrashCollectorMacOS(new[] { CrashType.BuildXL, CrashType.Kernel })
                 : null;
         }
@@ -968,21 +968,6 @@ namespace BuildXL
                     }
                 }))
             {
-                var appServer = m_appHost as AppServer;
-                if (appServer != null)
-                {
-                    // Verify the timestamp based hash.
-                    // Whether the hash in the file (ServerCacheDeployment.hash) is still same as the one that is passed during server creation.
-                    var hashInFile = ServerDeployment.GetDeploymentCacheHash(Path.GetFullPath(AppDomain.CurrentDomain.BaseDirectory));
-                    if (!string.Equals(hashInFile, appServer.TimestampBasedHash, StringComparison.OrdinalIgnoreCase))
-                    {
-                        // If the hashes do not match, the server will be killed and the client will start its own server deployment again.
-                        // The client will not observe any failures, so the user as well.
-                        Logger.Log.ServerDeploymentDirectoryHashMismatch(m_appLoggingContext, appServer.TimestampBasedHash, hashInFile);
-                        return AppResult.Create(ExitKind.InfrastructureError, null, string.Empty, killServer: true);
-                    }
-                }
-
                 result = run(pm);
             }
 

--- a/Public/Src/App/Bxl/Program.cs
+++ b/Public/Src/App/Bxl/Program.cs
@@ -123,7 +123,6 @@ namespace BuildXL
                     Console.WriteLine(Strings.App_ServerKilled);
                     return ExitCode.FromExitKind(ExitKind.BuildNotRequested);
                 case ServerMode.Reset:
-                    ServerDeployment.PoisonServerDeployment(lightConfig.ServerDeploymentDirectory);
                     break;
             }
 

--- a/Public/Src/App/Bxl/Program.cs
+++ b/Public/Src/App/Bxl/Program.cs
@@ -122,8 +122,6 @@ namespace BuildXL
                     ServerDeployment.KillServer(ServerDeployment.ComputeDeploymentDir(lightConfig.ServerDeploymentDirectory));
                     Console.WriteLine(Strings.App_ServerKilled);
                     return ExitCode.FromExitKind(ExitKind.BuildNotRequested);
-                case ServerMode.Reset:
-                    break;
             }
 
             ExitKind exitKind = lightConfig.Server != ServerMode.Disabled

--- a/Public/Src/App/Bxl/ServerDeployment.cs
+++ b/Public/Src/App/Bxl/ServerDeployment.cs
@@ -149,17 +149,7 @@ namespace BuildXL
             Assembly rootAssembly = Assembly.GetEntryAssembly();
             Contract.Assert(rootAssembly != null, "Could not look up entry assembly");
 
-            string assemblyFullPath = Path.Combine(serverDeploymentRoot, new FileInfo(AssemblyHelper.GetAssemblyLocation(rootAssembly)).Name);
-
-#if FEATURE_CORECLR
-            var frameworkDeploymentExtension = ".dll";
-            var selfcontainedDeploymentExtension = ".exe";
-
-            if (assemblyFullPath.Contains(frameworkDeploymentExtension))
-            {
-                assemblyFullPath = assemblyFullPath.Replace(frameworkDeploymentExtension, selfcontainedDeploymentExtension);
-            }
-#endif
+            string assemblyFullPath = Path.Combine(serverDeploymentRoot, new FileInfo(AssemblyHelper.GetThisProgramExeLocation()).Name);
 
             // Try kill process using Process.Kill.
             var killProcessResult = TryKillProcess(assemblyFullPath);
@@ -238,7 +228,7 @@ namespace BuildXL
         }
 
         /// <summary>
-        /// Returns a calculated hash of the content of the BuildXL binaries deployment server cache directory.
+        /// Calculates a hash of the contents of the BuildXL binaries from the server deployment directory.
         /// </summary>
         public static string GetDeploymentCacheHash(string deploymentDir)
         {
@@ -246,6 +236,9 @@ namespace BuildXL
             return serverDeployment.TimestampBasedHash.ToHex();
         }
 
+        /// <summary>
+        /// Checks if the deployed server bits are still up-to-date.
+        /// </summary>
         public static bool IsServerDeploymentOutOfSync(string serverDeploymentRoot, AppDeployment clientApp, out string deploymentDir)
         {
             deploymentDir = ComputeDeploymentDir(serverDeploymentRoot);

--- a/Public/Src/App/Bxl/ServerDeployment.cs
+++ b/Public/Src/App/Bxl/ServerDeployment.cs
@@ -32,11 +32,6 @@ namespace BuildXL
         // Folder name for the deployment cache, a subfolder of the running client app folder
         private const string ServerDeploymentDirectoryCache = "BuildXLServerDeploymentCache";
 
-        /// <summary>
-        /// Filename where the hash of the server deployment is stored
-        /// </summary>
-        public const string ServerDeploymentHashFilename = "ServerCacheDeployment.hash";
-
         private const string KillBuildXLServerCommandLine = "wmic";
         private const string KillBuildXLServerCommandLineArgs = @"process where ""ExecutablePath like '%{0}%'"" delete";
 
@@ -70,20 +65,12 @@ namespace BuildXL
         {
             Stopwatch st = Stopwatch.StartNew();
 
-            // Every time the server cache gets created, a file with the result of GetDeploymentHash is created, so we avoid computing this again
-            // The assumption is that nobody but this process modifies the server cache folder
-            string serverDeploymentHashFile = Path.Combine(destDir, ServerDeploymentHashFilename);
-
             // Deletes the existing cache directory if it exists, so we avoid accumulating garbage.
             if (Directory.Exists(destDir))
             {
                 // Check if the main root process (likely bxl.exe) is in use before attempting to delete, so we avoid partially deleting files
                 // Not completely bullet proof (there can be a race) but it is highly unlikely the process starts to be in use right after this check
                 KillServer(destDir);
-
-                // Delete the deployment hash file first to make sure the deployment cache cannot be used in case the
-                // cleanup of the other files is interrupted.
-                PoisonServerDeployment(destDir);
 
                 // Remove all files regardless of files being readonly
                 FileUtilities.DeleteDirectoryContents(destDir, true);
@@ -127,30 +114,15 @@ namespace BuildXL
             var destExe = Path.Combine(destDir, System.AppDomain.CurrentDomain.FriendlyName);
 
             // queue:1 means it runs in the background
-            var ngenArgs = "install " + destExe + " /queue:1";
-            bool runNgen = File.Exists(ngenExe);
-            if (runNgen)
+            if (File.Exists(ngenExe))
             {
+                var ngenArgs = "install " + destExe + " /queue:1";
                 ProcessStartInfo startInfo = new ProcessStartInfo(ngenExe, ngenArgs);
                 startInfo.UseShellExecute = false;
                 startInfo.CreateNoWindow = true;
                 Process.Start(startInfo);
             }
 #endif
-            using (var file = new StreamWriter(File.OpenWrite(serverDeploymentHashFile)))
-            {
-                file.WriteLine(clientApp.TimestampBasedHash);
-
-                // This isn't actually consumed. It is only used for debugging
-                file.WriteLine("Debug info:");
-#if !FEATURE_CORECLR
-                if (runNgen)
-                {
-                    file.WriteLine("Ran Ngen: " + ngenExe + " " + ngenArgs);
-                }
-#endif
-                file.WriteLine(clientApp.TimestampBasedHashDebug);
-            }
 
             ServerDeploymentCacheCreated cacheCreated = default(ServerDeploymentCacheCreated);
             cacheCreated.TimeToCreateServerCacheMilliseconds = st.ElapsedMilliseconds;
@@ -257,48 +229,12 @@ namespace BuildXL
         }
 
         /// <summary>
-        /// Poisons the server deployment to cause it to be redeployed
+        /// Returns a calculated hash of the content of the BuildXL binaries deployment server cache directory.
         /// </summary>
-        internal static void PoisonServerDeployment(string serverDeploymentRoot)
-        {
-            FileUtilities.DeleteFile(Path.Combine(ComputeDeploymentDir(serverDeploymentRoot), ServerDeploymentHashFilename), true);
-        }
-
-        /// <summary>
-        /// Returns a hash of the content of the BuildXL binaries deployment cache directory.
-        /// The deployment cache has to be created before calling this function
-        /// </summary>
-        [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope",
-            Justification = "StreamReader/StreamWriter takes ownership for disposal.")]
         public static string GetDeploymentCacheHash(string deploymentDir)
         {
-            const string UnknownHash = "ServerUnknown";
-            string filename = Path.Combine(deploymentDir, ServerDeploymentHashFilename);
-            if (!File.Exists(filename))
-            {
-                return UnknownHash;
-            }
-
-            try
-            {
-                using (var file = new StreamReader(File.Open(filename, FileMode.Open, FileAccess.Read, FileShare.Delete)))
-                {
-                    string hash = file.ReadLine();
-                    return hash;
-                }
-            }
-            catch (FileNotFoundException)
-            {
-                return UnknownHash;
-            }
-            catch (DirectoryNotFoundException)
-            {
-                return UnknownHash;
-            }
-            catch (IOException)
-            {
-                return UnknownHash;
-            }
+            AppDeployment serverDeployment = AppDeployment.ReadDeploymentManifest(deploymentDir, AppDeployment.ServerDeploymentManifestFileName);
+            return serverDeployment.TimestampBasedHash.ToHex();
         }
     }
 }

--- a/Public/Src/App/Bxl/Tracing/Log.cs
+++ b/Public/Src/App/Bxl/Tracing/Log.cs
@@ -43,7 +43,7 @@ namespace BuildXL.App.Tracing
         /// CAUTION!!
         ///
         /// WDG has Asimov telemetry listening to this event. Any change to an existing field will require a breaking change announcement
-        /// 
+        ///
         /// This event is only used for ETW and telemetry. The commandLine must be scrubbed so it doesn't overflow
         /// </summary>
         [GeneratedEvent(
@@ -51,7 +51,7 @@ namespace BuildXL.App.Tracing
             EventGenerators = EventGenerators.LocalAndTelemetry,
             EventLevel = Level.Verbose,
             EventOpcode = (byte)EventOpcode.Start,
-            // Prevent this from going to the log. It is only for ETW and telemetry. DominoInvocationForLocalLog is for the log. 
+            // Prevent this from going to the log. It is only for ETW and telemetry. DominoInvocationForLocalLog is for the log.
             Keywords = (int)Keywords.SelectivelyEnabled,
             Message = AppInvocationMessage)]
         public abstract void DominoInvocation(LoggingContext context, string commandLine, BuildInfo buildInfo, MachineInfo machineInfo, string sessionIdentifier, string relatedSessionIdentifier, string startupDirectory, string mainConfig);
@@ -351,16 +351,16 @@ namespace BuildXL.App.Tracing
             EventGenerators = EventGenerators.TelemetryOnly,
             EventLevel = Level.Critical,
             Message = "Telemetry Only")]
-        public abstract void DominoCatastrophicFailure(LoggingContext context, 
-            string exception, 
-            BuildInfo buildInfo, 
-            ExceptionRootCause rootCause, 
-            bool wasServer, 
-            string firstUserError, 
-            string lastUserError, 
-            string firstInsfrastructureError, 
-            string lastInfrastructureError, 
-            string firstInternalError, 
+        public abstract void DominoCatastrophicFailure(LoggingContext context,
+            string exception,
+            BuildInfo buildInfo,
+            ExceptionRootCause rootCause,
+            bool wasServer,
+            string firstUserError,
+            string lastUserError,
+            string firstInsfrastructureError,
+            string lastInfrastructureError,
+            string firstInternalError,
             string lastInternalError);
 
         [GeneratedEvent(
@@ -548,15 +548,6 @@ namespace BuildXL.App.Tracing
             EventTask = (ushort)Tasks.HostApplication,
             Message = "Telemetry timed out after {0} milliseconds. This session will have incomplete telemetry data")]
         public abstract void TelemetryShutdownTimeout(LoggingContext context, long milliseconds);
-        
-        [GeneratedEvent(
-            (ushort)EventId.ServerDeploymentDirectoryHashMismatch,
-            EventGenerators = EventGenerators.LocalOnly,
-            EventLevel = Level.Error,
-            Keywords = (int)Keywords.UserMessage,
-            EventTask = (ushort)Tasks.HostApplication,
-            Message = "ServerDeploymentDirectory hash mismatch: {ShortProductName} AppServer hash, {0} != ServerDeploymentDirectory hash, {1}. Re-running {ShortProductName} will fix the issue.")]
-        public abstract void ServerDeploymentDirectoryHashMismatch(LoggingContext context, string hashInMemory, string hashInFile);
 
         [GeneratedEvent(
             (ushort)EventId.EventCount,
@@ -749,12 +740,12 @@ namespace BuildXL.App.Tracing
         /// </summary>
         public static void LogDominoCompletion(LoggingContext context, int exitCode, ExitKind exitKind, ExitKind cloudBuildExitKind, string errorBucket, string bucketMessage, int processRunningTime, long utcTicks, bool inCloudBuild)
         {
-            Log.DominoCompletion(context, 
-                exitCode, 
-                exitKind.ToString(), 
-                errorBucket, 
+            Log.DominoCompletion(context,
+                exitCode,
+                exitKind.ToString(),
+                errorBucket,
                 // This isn't a command line but it should still be sanatized for sake of not overflowing in telemetry
-                ScrubCommandLine(bucketMessage, 1000, 1000), 
+                ScrubCommandLine(bucketMessage, 1000, 1000),
                 processRunningTime);
 
             // Sending a different event to CloudBuild ETW listener.

--- a/Public/Src/Utilities/Configuration/ServerMode.cs
+++ b/Public/Src/Utilities/Configuration/ServerMode.cs
@@ -19,11 +19,6 @@ namespace BuildXL.Utilities.Configuration
         Enabled,
 
         /// <summary>
-        /// Resets the server mode deployment and still performs a build
-        /// </summary>
-        Reset,
-
-        /// <summary>
         /// Kills the server process associated with this client. Does not perform a build
         /// </summary>
         Kill,

--- a/Public/Src/Utilities/Utilities/Tracing/EventId.cs
+++ b/Public/Src/Utilities/Utilities/Tracing/EventId.cs
@@ -97,7 +97,7 @@ namespace BuildXL.Utilities.Tracing
         PipTableStats = 75,
         PipWriterStats = 76,
         PipIpcFailedDueToInvalidInput = 77,
-        
+
         PipProcessStartExternalTool = 78,
         PipProcessFinishedExternalTool = 79,
         PipProcessStartExternalVm = 80,
@@ -421,7 +421,7 @@ namespace BuildXL.Utilities.Tracing
         UnexpectedCondition = 472,
         // was TelemetryRecoverableException = 473,
         TelemetryShutDownException = 474,
-        ServerDeploymentDirectoryHashMismatch = 475,
+        // was ServerDeploymentDirectoryHashMismatch = 475,
         TelemetryShutdownTimeout = 476,
 
         PipProcessDisallowedNtCreateFileAccessWarning = 480,


### PR DESCRIPTION
This PR introduces self-healing server deployments to address issues we've seen in environments where BuildXL deployment / update is automated and deployment directories get tempered with.

The deployment hashing adds around `80ms` on a SSD to the startup time if the the deployment directory is healthy, otherwise kills the server and redeploys the content to make sure we have a sane environment.