### PR TITLE
Fix eviction logic in GetLruPages

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/NuCacheCollectionUtilities.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/NuCacheCollectionUtilities.cs
@@ -64,32 +64,6 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         }
 
         /// <summary>
-        /// Splits the IEnumerable into partition with max size of <paramref name="batchSize"/>.
-        /// </summary>
-        public static IEnumerable<IReadOnlyList<TItem>> Split<TItem>(this IEnumerable<TItem> enumerable, int batchSize)
-        {
-            Contract.Requires(enumerable != null);
-            Contract.Requires(batchSize > 0);
-
-            var batch = new List<TItem>(batchSize);
-            foreach (var item in enumerable)
-            {
-                batch.Add(item);
-
-                if (batch.Count == batchSize)
-                {
-                    yield return batch;
-                    batch = new List<TItem>(batchSize);
-                }
-            }
-
-            if (batch.Count != 0)
-            {
-                yield return batch;
-            }
-        }
-
-        /// <summary>
         /// Returns a difference between <paramref name="leftItems"/> sequence and <paramref name="rightItems"/> sequence assuming that both sequences are sorted.
         /// </summary>
         public static IEnumerable<(T item, MergeMode mode)> DistinctDiffSorted<T, TComparable>(

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/NuCacheCollectionUtilities.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/NuCacheCollectionUtilities.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.ContractsLight;
 using BuildXL.Cache.ContentStore.UtilitiesCore;
+using BuildXL.Utilities.Collections;
 
 namespace BuildXL.Cache.ContentStore.Distributed.NuCache
 {
@@ -54,6 +55,32 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                 }
 
                 batch.Add(list[i]);
+            }
+
+            if (batch.Count != 0)
+            {
+                yield return batch;
+            }
+        }
+
+        /// <summary>
+        /// Splits the IEnumerable into partition with max size of <paramref name="batchSize"/>.
+        /// </summary>
+        public static IEnumerable<IReadOnlyList<TItem>> Split<TItem>(this IEnumerable<TItem> enumerable, int batchSize)
+        {
+            Contract.Requires(enumerable != null);
+            Contract.Requires(batchSize > 0);
+
+            var batch = new List<TItem>(batchSize);
+            foreach (var item in enumerable)
+            {
+                batch.Add(item);
+
+                if (batch.Count == batchSize)
+                {
+                    yield return batch;
+                    batch = new List<TItem>(batchSize);
+                }
             }
 
             if (batch.Count != 0)
@@ -218,6 +245,119 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             else
             {
                 return CompareResult.LeftGreater;
+            }
+        }
+
+        public static IEnumerable<T> SkipOptimized<T>(this IReadOnlyList<T> original, int amountToSkip)
+        {
+            for (var i = amountToSkip; i < original.Count; i++)
+            {
+                yield return original[i];
+            }
+        }
+
+        /// <summary>
+        /// Takes an enumerable and takes n=pageSize elements from it. Processess the elements with a query, and inserts
+        /// them into a priority queue. It will then continue yielding elements of the queue, until it has less than
+        /// n elements, at which point it will take another n elements from the original enumerable and repeat the
+        /// process, adding them to the same priority queue. This process repeats until the original enumerable has no
+        /// more elements.
+        /// </summary>
+        public static IEnumerable<T> QueryAndOrderInPages<T>(IEnumerable<T> original, int pageSize, Comparer<T> comparer, Func<List<T>, IEnumerable<T>> query)
+        {
+            var source = original.GetEnumerator();
+            var queue = new PriorityQueue<T>(pageSize * 2, comparer);
+            var sourceHasItems = true;
+
+            while (true)
+            {
+                if (sourceHasItems && queue.Count < pageSize)
+                {
+                    var itemsToQuery = new List<T>(pageSize);
+                    for (var i = 0; i < pageSize && source.MoveNext(); i++)
+                    {
+                        itemsToQuery.Add(source.Current);
+                    }
+
+                    if (itemsToQuery.Count > 0)
+                    {
+                        var results = query(itemsToQuery);
+
+                        foreach (var result in results)
+                        {
+                            queue.Push(result);
+                        }
+                    }
+                    else
+                    {
+                        // No more items in the original IEnumerable. Stop trying to queue more items.
+                        sourceHasItems = false;
+                    }
+                }
+
+                if (queue.Count == 0)
+                {
+                    yield break;
+                }
+
+                yield return queue.Top;
+                queue.Pop();
+            }
+        }
+
+        public static IEnumerable<T> MergeOrdered<T>(IEnumerable<T> items1, IEnumerable<T> items2, IComparer<T> comparer)
+        {
+            var enumerator1 = items1.GetEnumerator();
+            var enumerator2 = items2.GetEnumerator();
+
+            T current1 = default;
+            T current2 = default;
+
+            bool next1 = TryMoveNext(enumerator1, ref current1);
+            bool next2 = TryMoveNext(enumerator2, ref current2);
+
+            while (next1 || next2)
+            {
+                while (next1)
+                {
+                    if (!next2 || comparer.Compare(current1, current2) <= 0)
+                    {
+                        yield return current1;
+                    }
+                    else
+                    {
+                        break;
+                    }
+
+                    next1 = TryMoveNext(enumerator1, ref current1);
+                }
+
+                while (next2)
+                {
+                    if (!next1 || comparer.Compare(current1, current2) > 0)
+                    {
+                        yield return current2;
+                    }
+                    else
+                    {
+                        break;
+                    }
+
+                    next2 = TryMoveNext(enumerator2, ref current2);
+                }
+            }
+
+            bool TryMoveNext(IEnumerator<T> enumerator, ref T current)
+            {
+                if (enumerator.MoveNext())
+                {
+                    current = enumerator.Current;
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
             }
         }
     }

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/NuCacheCollectionUtilities.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/NuCacheCollectionUtilities.cs
@@ -263,7 +263,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         /// process, adding them to the same priority queue. This process repeats until the original enumerable has no
         /// more elements.
         /// </summary>
-        public static IEnumerable<T> QueryAndOrderInPages<T>(IEnumerable<T> original, int pageSize, Comparer<T> comparer, Func<List<T>, IEnumerable<T>> query)
+        public static IEnumerable<T> QueryAndOrderInPages<T>(this IEnumerable<T> original, int pageSize, Comparer<T> comparer, Func<List<T>, IEnumerable<T>> query)
         {
             var source = original.GetEnumerator();
             var queue = new PriorityQueue<T>(pageSize * 2, comparer);

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/TransitioningContentLocationStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/TransitioningContentLocationStore.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BuildXL.Cache.ContentStore.Distributed.Redis;
+using BuildXL.Cache.ContentStore.Extensions;
 using BuildXL.Cache.ContentStore.Hashing;
 using BuildXL.Cache.ContentStore.Interfaces.Distributed;
 using BuildXL.Cache.ContentStore.Interfaces.Results;
@@ -273,7 +274,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             var localMid = contentHashesWithInfo.SkipOptimized(contentHashesWithInfo.Count / 2).QueryAndOrderInPages(pageSize, comparer, query);
 
             var mergedEnumerables = NuCacheCollectionUtilities.MergeOrdered(localOldest, localMid, comparer);
-            return mergedEnumerables.Split(pageSize);
+            return mergedEnumerables.GetPages(pageSize);
         }
 
         /// <inheritdoc />

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/TransitioningContentLocationStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/TransitioningContentLocationStore.cs
@@ -269,8 +269,8 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
 
             // We make sure that we we select a set of the newer content, to ensure that we at least look at newer content to see if it should be
             // evicted first due to having a high number of replicas. We do this by looking at the start as well as at middle of the list.
-            var localOldest = NuCacheCollectionUtilities.QueryAndOrderInPages(contentHashesWithInfo.Take(contentHashesWithInfo.Count / 2), pageSize, comparer, query);
-            var localMid = NuCacheCollectionUtilities.QueryAndOrderInPages(contentHashesWithInfo.SkipOptimized(contentHashesWithInfo.Count / 2), pageSize, comparer, query);
+            var localOldest = contentHashesWithInfo.Take(contentHashesWithInfo.Count / 2).QueryAndOrderInPages(pageSize, comparer, query);
+            var localMid = contentHashesWithInfo.SkipOptimized(contentHashesWithInfo.Count / 2).QueryAndOrderInPages(pageSize, comparer, query);
 
             var mergedEnumerables = NuCacheCollectionUtilities.MergeOrdered(localOldest, localMid, comparer);
             return mergedEnumerables.Split(pageSize);

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/TransitioningContentLocationStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/TransitioningContentLocationStore.cs
@@ -267,7 +267,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             Func<List<ContentHashWithLastAccessTimeAndReplicaCount>, IEnumerable<ContentHashWithLastAccessTimeAndReplicaCount>> query =
                 page => _localLocationStore.GetEffectiveLastAccessTimes(operationContext, page.SelectList(v => new ContentHashWithLastAccessTime(v.ContentHash, v.LastAccessTime))).ThrowIfFailure();
 
-            // We make sure that we we select a set of the newer content, to ensure that we at least look at newer content to see if it should be
+            // We make sure that we select a set of the newer content, to ensure that we at least look at newer content to see if it should be
             // evicted first due to having a high number of replicas. We do this by looking at the start as well as at middle of the list.
             var localOldest = contentHashesWithInfo.Take(contentHashesWithInfo.Count / 2).QueryAndOrderInPages(pageSize, comparer, query);
             var localMid = contentHashesWithInfo.SkipOptimized(contentHashesWithInfo.Count / 2).QueryAndOrderInPages(pageSize, comparer, query);

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/TransitioningContentLocationStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/TransitioningContentLocationStore.cs
@@ -2,13 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.ContractsLight;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web.UI.WebControls;
 using BuildXL.Cache.ContentStore.Distributed.Redis;
 using BuildXL.Cache.ContentStore.Hashing;
 using BuildXL.Cache.ContentStore.Interfaces.Distributed;


### PR DESCRIPTION
Change GetLruPages logic to have two queues, filled in pages; one with the oldest content, and one starting in the middle.