### PR TITLE
Make deployment of experimental tool conditional temporarily

### DIFF
--- a/Public/Sdk/SelfHost/BuildXL/BuildXLSdk.dsc
+++ b/Public/Sdk/SelfHost/BuildXL/BuildXLSdk.dsc
@@ -155,6 +155,12 @@ namespace Flags {
      */
     @@public
     export const buildRequiredAdminPrivilegeTestInVm = Environment.getFlag("[Sdk.BuildXL]BuildRequiredAdminPrivilegeTestInVm");
+
+    /**
+     * Whether we deploy experimental tools.
+     */
+    @@public
+    export const deployExperimentalTools = Environment.getFlag("[Sdk.BuildXL]deployExperimentalTools");
 }
 
 @@public

--- a/Public/Src/Deployment/buildXL.dsc
+++ b/Public/Src/Deployment/buildXL.dsc
@@ -62,19 +62,23 @@ namespace BuildXL {
                             }).exe
                         ]
                     },
-                    {
-                        subfolder: r`NinjaGraphBuilder`,
-                        contents: [
-                            importFrom("BuildXL.Tools").NinjaGraphBuilder.exe,
-                            importFrom("BuildXL.Tools.Ninjson").pkg.contents
-                        ]
-                    },
-                    {
-                        subfolder: r`CMakeRunner`,
-                        contents: [
-                            importFrom("BuildXL.Tools").CMakeRunner.exe,
-                        ]
-                    },
+                    ...(BuildXLSdk.Flags.deployExperimentalTools
+                        ? [
+                            {
+                                subfolder: r`NinjaGraphBuilder`,
+                                contents: [
+                                    importFrom("BuildXL.Tools").NinjaGraphBuilder.exe,
+                                    importFrom("BuildXL.Tools.Ninjson").pkg.contents
+                                ]
+                            },
+                            {
+                                subfolder: r`CMakeRunner`,
+                                contents: [
+                                    importFrom("BuildXL.Tools").CMakeRunner.exe,
+                                ]
+                            }
+                          ]
+                        : []),
                     {
                         subfolder: r`SandboxedProcessExecutor`,
                         contents: [


### PR DESCRIPTION
Rolling builds are failing because our NuGet packages exceed the size limit.

This change make deployment experimental tools conditional temporarily to unblock rolling builds.