### PR TITLE
Execution analyzer incomplete input warning 

### DIFF
--- a/Public/Src/Tools/Execution.Analyzer/AnalysisInput.cs
+++ b/Public/Src/Tools/Execution.Analyzer/AnalysisInput.cs
@@ -107,15 +107,17 @@ namespace BuildXL.Execution.Analyzer
             return true;
         }
 
-        public void ReadExecutionLog(IExecutionLogTarget analyzer)
+        public bool ReadExecutionLog(IExecutionLogTarget analyzer)
         {
             using (var disposableLogReader = LoadExecutionLog(analyzer))
             {
                 if (disposableLogReader?.Value != null)
                 {
-                    disposableLogReader.Value.ReadAllEvents();
+                    return disposableLogReader.Value.ReadAllEvents();
                 }
             }
+
+            return false;
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]

--- a/Public/Src/Tools/Execution.Analyzer/Analyzer.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzer.cs
@@ -43,19 +43,19 @@ namespace BuildXL.Execution.Analyzer
         /// <summary>
         /// Prepares the analyzer and reads the execution log events into the analyzer
         /// </summary>
-        public void ReadExecutionLog(bool prepare = true)
+        public bool ReadExecutionLog(bool prepare = true)
         {
             if (prepare)
             {
                 Prepare();
             }
 
-            ReadEvents();
+            return ReadEvents();
         }
 
-        protected virtual void ReadEvents()
+        protected virtual bool ReadEvents()
         {
-            Input.ReadExecutionLog(this);
+            return Input.ReadExecutionLog(this);
         }
 
         #region Utility Methods

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/CacheMiss/FingerprintStoreAnalyzer.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/CacheMiss/FingerprintStoreAnalyzer.cs
@@ -179,7 +179,7 @@ namespace BuildXL.Execution.Analyzer
             m_model = new AnalysisModel(CachedGraph);
         }
 
-        protected override void ReadEvents()
+        protected override bool ReadEvents()
         {
             // Do nothing. This analyzer does not read events.
         }

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/CacheMiss/FingerprintStoreAnalyzer.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/CacheMiss/FingerprintStoreAnalyzer.cs
@@ -182,6 +182,7 @@ namespace BuildXL.Execution.Analyzer
         protected override bool ReadEvents()
         {
             // Do nothing. This analyzer does not read events.
+            return true;
         }
 
         public static string GetStoreLocation(AnalysisInput analysisInput, string storeSuffix = "")
@@ -251,12 +252,12 @@ namespace BuildXL.Execution.Analyzer
 
             if (m_oldReader.StoreVersion != m_newReader.StoreVersion)
             {
-                WriteLine($"WARNING: Format version numbers of the fingerprint store do not match. Old: {m_oldReader.StoreVersion}, New: {m_newReader.StoreVersion}."); 
+                WriteLine($"WARNING: Format version numbers of the fingerprint store do not match. Old: {m_oldReader.StoreVersion}, New: {m_newReader.StoreVersion}.");
             }
 
             if (SemiStableHashToRun != -1)
             {
-                var firstMiss = cacheMissList.FirstOrDefault(x => PipTable.GetPipSemiStableHash(x.PipId) == SemiStableHashToRun);                
+                var firstMiss = cacheMissList.FirstOrDefault(x => PipTable.GetPipSemiStableHash(x.PipId) == SemiStableHashToRun);
                 if (firstMiss.CacheMissType == PipCacheMissType.Invalid)
                 {
                     foreach (var pipId in PipTable.StableKeys)
@@ -312,7 +313,7 @@ namespace BuildXL.Execution.Analyzer
         private void AnalyzePip(PipCacheMissInfo miss, Process pip, TextWriter writer)
         {
             string pipUniqueOutputHashStr = null;
-           
+
             if ((pip as Process).TryComputePipUniqueOutputHash(PathTable, out var pipUniqueOutputHash, m_model.CachedGraph.MountPathExpander))
             {
                 pipUniqueOutputHashStr = pipUniqueOutputHash.ToString();

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/FailedPipInputAnalyzer.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/FailedPipInputAnalyzer.cs
@@ -144,7 +144,7 @@ namespace BuildXL.Execution.Analyzer
 
         }
 
-        protected override void ReadEvents()
+        protected override bool ReadEvents()
         {
             // NOTE: We read the execution log twice. First to collect failed pips, then to
             // collect file access data. This is a memory optimization because loading all file accesses
@@ -153,7 +153,7 @@ namespace BuildXL.Execution.Analyzer
             // First pass to get failed pips and transitive dependencies
             Console.WriteLine("Pass 1 of 2: Collect failed pips");
             m_pass = Pass.CollectFailedPips;
-            base.ReadEvents();
+            var result = base.ReadEvents();
 
             Console.WriteLine("Computing failed pip transitive dependency closure");
 
@@ -163,7 +163,7 @@ namespace BuildXL.Execution.Analyzer
             // Second pass to collect file access data
             Console.WriteLine("Pass 2 of 2: Collect file accesses pips");
             m_pass = Pass.CollectFileAccesses;
-            base.ReadEvents();
+            return result && base.ReadEvents();
         }
 
         public override bool CanHandleWorkerEvents => true;

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/FailedPipsDumpAnalyzer.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/FailedPipsDumpAnalyzer.cs
@@ -173,18 +173,18 @@ namespace BuildXL.Execution.Analyzer
             return new DiffAnalyzer(input, this);
         }
 
-        protected override void ReadEvents()
+        protected override bool ReadEvents()
         {
             // NOTE: Read the execution log twice on a failed XLG. First to collect failed pips, then to
             // collect file access data. This is a memory optimization because loading all file accesses
             // can use a lot of memory.
 
             // First pass to get failed pips and transitive dependencies
-             var stopwatch = new System.Diagnostics.Stopwatch();
+            var stopwatch = new System.Diagnostics.Stopwatch();
             stopwatch.Start();
             Console.WriteLine($"Pass 1 of 2: Collect failed pips");
             m_pass = Pass.CollectFailedPips;
-            base.ReadEvents();
+            var result = base.ReadEvents();
             stopwatch.Stop();
             Console.WriteLine($"Done reading pass 1 : duration = [{stopwatch.Elapsed}]");
 
@@ -198,9 +198,11 @@ namespace BuildXL.Execution.Analyzer
             Console.WriteLine("Pass 2 of 2: Collect file accesses pips");
             stopwatch.Start();
             m_pass = Pass.CollectFileAccesses;
-            base.ReadEvents();
+            result &= base.ReadEvents();
             stopwatch.Stop();
             Console.WriteLine($"Done reading pass 2 : duration = [{stopwatch.Elapsed}]");
+
+            return result;
         }
 
         public override int Analyze()

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/PipFingerprintAnalyzer.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/PipFingerprintAnalyzer.cs
@@ -95,7 +95,7 @@ namespace BuildXL.Execution.Analyzer
             m_storeLocation = FingerprintStoreAnalyzer.GetStoreLocation(analysisInput);
         }
 
-        protected override void ReadEvents()
+        protected override bool ReadEvents()
         {
             // Do nothing. This analyzer does not read events.
         }

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/PipFingerprintAnalyzer.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/PipFingerprintAnalyzer.cs
@@ -98,6 +98,7 @@ namespace BuildXL.Execution.Analyzer
         protected override bool ReadEvents()
         {
             // Do nothing. This analyzer does not read events.
+            return true;
         }
 
         /// <summary>

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/RequiredDependencyAnalyzer.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/RequiredDependencyAnalyzer.cs
@@ -298,7 +298,7 @@ namespace BuildXL.Execution.Analyzer
             simulator.OutputDirectory = OutputFilePath;
             if (!simulator.ReadExecutionLog())
             {
-                Console.Error.WriteLine("ExecutionLog possibly truncated, results may be incomplete!");
+                Args.TruncatedXlgWarning();
             }
 
             Console.WriteLine($"Simulating [Analyzing]");

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/RequiredDependencyAnalyzer.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/RequiredDependencyAnalyzer.cs
@@ -296,7 +296,10 @@ namespace BuildXL.Execution.Analyzer
             simulator.ExecutionData.DataflowGraph = m_mutableGraph;
 
             simulator.OutputDirectory = OutputFilePath;
-            simulator.ReadExecutionLog();
+            if (!simulator.ReadExecutionLog())
+            {
+                Console.Error.WriteLine("ExecutionLog possibly truncated, results may be incomplete!");
+            }
 
             Console.WriteLine($"Simulating [Analyzing]");
             simulator.Analyze();

--- a/Public/Src/Tools/Execution.Analyzer/Args.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Args.cs
@@ -340,7 +340,7 @@ namespace BuildXL.Execution.Analyzer
         public static void TruncatedXlgWarning()
         {
             ConsoleColor originalColor = Console.ForegroundColor;
-            Console.ForegroundColor = ConsoleColor.Red;
+            Console.ForegroundColor = ConsoleColor.Yellow;
             Console.Error.WriteLine("WARNING: Execution log file possibly truncated, results may be incomplete!");
             Console.ForegroundColor = originalColor;
         }

--- a/Public/Src/Tools/Execution.Analyzer/Args.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Args.cs
@@ -337,6 +337,14 @@ namespace BuildXL.Execution.Analyzer
             }
         }
 
+        public static void TruncatedXlgWarning()
+        {
+            ConsoleColor originalColor = Console.ForegroundColor;
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.Error.WriteLine("WARNING: Execution log file possibly truncated, results may be incomplete!");
+            Console.ForegroundColor = originalColor;
+        }
+
         public int Analyze()
         {
             if (m_analyzer == null)
@@ -383,7 +391,7 @@ namespace BuildXL.Execution.Analyzer
 
             if (!dataIsComplete)
             {
-                Console.Error.WriteLine("ExecutionLog possibly truncated, results may be incomplete!");
+                TruncatedXlgWarning();
             }
 
             var exitCode = m_analyzer.Analyze();


### PR DESCRIPTION
[AB#1568097](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1568097)

This PR adjusts the execution analyzer to emit a warning to std error if the xlg data read is possibly incomplete. We define incompleteness by an event payload read length miss-match.