### PR TITLE
Plumb TempCleaner through to PipExecutor to enable more robust file deletion

### DIFF
--- a/Public/Src/Engine/Scheduler/IPipExecutionEnvironment.cs
+++ b/Public/Src/Engine/Scheduler/IPipExecutionEnvironment.cs
@@ -189,6 +189,11 @@ namespace BuildXL.Scheduler
         /// VM initializer.
         /// </summary>
         VmInitializer VmInitializer { get; }
+
+        /// <summary>
+        /// Temp directory cleaner
+        /// </summary>
+        TempCleaner TempCleaner { get; }
     }
 
     /// <summary>

--- a/Public/Src/Engine/Scheduler/PipExecutor.cs
+++ b/Public/Src/Engine/Scheduler/PipExecutor.cs
@@ -1353,7 +1353,8 @@ namespace BuildXL.Scheduler
                                     buildEngineDirectory: configuration.Layout.BuildEngineDirectory,
                                     directoryTranslator: environment.DirectoryTranslator,
                                     remainingUserRetryCount: remainingUserRetries,
-                                    vmInitializer: environment.VmInitializer);
+                                    vmInitializer: environment.VmInitializer,
+                                    tempDirectoryCleaner: environment.TempCleaner);
 
                                 registerQueryRamUsageMb(
                                     () =>
@@ -2727,7 +2728,8 @@ namespace BuildXL.Scheduler
                 disableConHostSharing: configuration.Engine.DisableConHostSharing,
                 pipDataRenderer: pipDataRenderer,
                 directoryTranslator: environment.DirectoryTranslator,
-                vmInitializer: environment.VmInitializer);
+                vmInitializer: environment.VmInitializer,
+                tempDirectoryCleaner: environment.TempCleaner);
 
             if (!await executor.TryInitializeWarningRegexAsync())
             {

--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -145,7 +145,7 @@ namespace BuildXL.Scheduler
         /// <see cref="FingerprintStore"/> directory name.
         /// </summary>
         public const string FingerprintStoreDirectory = "FingerprintStore";
-        
+
         #endregion Constants
 
         #region State
@@ -252,7 +252,7 @@ namespace BuildXL.Scheduler
         /// <summary>
         /// Cleans temp directories in background
         /// </summary>
-        private readonly TempCleaner m_tempCleaner;
+        public TempCleaner TempCleaner { get; }
 
         /// <summary>
         /// The pip graph
@@ -1095,7 +1095,7 @@ namespace BuildXL.Scheduler
             // is complete. GetDummyProvenance may be called during execution (after the schedule phase)
             GetDummyProvenance();
 
-            m_tempCleaner = tempCleaner;
+            TempCleaner = tempCleaner;
 
             // Ensure that when the cancellationToken is signaled, we respond with the
             // internal cancellation process.
@@ -2621,7 +2621,7 @@ namespace BuildXL.Scheduler
             Contract.Requires(runnablePip.PipType == PipType.Process);
             Contract.Requires(runnablePip.Result.HasValue);
             // Only allow this to be null in testing
-            if (m_tempCleaner == null)
+            if (TempCleaner == null)
             {
                 Contract.Assert(m_testHooks != null);
                 return;
@@ -2642,7 +2642,7 @@ namespace BuildXL.Scheduler
             // temp directories are not considered as outputs.
             if (process.TempDirectory.IsValid)
             {
-                m_tempCleaner.RegisterDirectoryToDelete(process.TempDirectory.ToString(Context.PathTable), deleteRootDirectory: true);
+                TempCleaner.RegisterDirectoryToDelete(process.TempDirectory.ToString(Context.PathTable), deleteRootDirectory: true);
             }
 
             foreach (var additionalTempDirectory in process.AdditionalTempDirectories)
@@ -2650,7 +2650,7 @@ namespace BuildXL.Scheduler
                 // Unlike process.TempDirectory, which is invalid for pips without temp directories,
                 // AdditionalTempDirectories should not have invalid paths added
                 Contract.Requires(additionalTempDirectory.IsValid);
-                m_tempCleaner.RegisterDirectoryToDelete(additionalTempDirectory.ToString(Context.PathTable), deleteRootDirectory: true);
+                TempCleaner.RegisterDirectoryToDelete(additionalTempDirectory.ToString(Context.PathTable), deleteRootDirectory: true);
             }
 
             // Only for successful run scheduling temporary outputs for deletion
@@ -2661,7 +2661,7 @@ namespace BuildXL.Scheduler
                 // CanBeReferencedOrCached() is false for e.g. 'intermediate' outputs, and deleting them proactively can be a nice space saving
                 if (!output.CanBeReferencedOrCached())
                 {
-                    m_tempCleaner.RegisterFileToDelete(output.Path.ToString(Context.PathTable));
+                    TempCleaner.RegisterFileToDelete(output.Path.ToString(Context.PathTable));
                 }
             }
         }
@@ -4845,7 +4845,7 @@ namespace BuildXL.Scheduler
                 incrementalSchedulingStateFactory = new IncrementalSchedulingStateFactory(
                     loggingContext,
                     analysisMode: false,
-                    tempDirectoryCleaner: m_tempCleaner);
+                    tempDirectoryCleaner: TempCleaner);
             }
 
             if (m_fileChangeTracker.IsBuildingInitialChangeTrackingSet)

--- a/Public/Src/Engine/UnitTests/Scheduler/PipQueueTest.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/PipQueueTest.cs
@@ -592,6 +592,8 @@ namespace Test.BuildXL.Scheduler
             public ProcessInContainerManager ProcessInContainerManager { get; }
 
             public VmInitializer VmInitializer { get; }
+
+            public TempCleaner TempCleaner { get; }
         }
     }
 

--- a/Public/Src/Engine/UnitTests/Scheduler/Utils/DummyPipExecutionEnvironment.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/Utils/DummyPipExecutionEnvironment.cs
@@ -583,6 +583,8 @@ namespace Test.BuildXL.Scheduler.Utils
 
         public VmInitializer VmInitializer { get; }
 
+        public TempCleaner TempCleaner { get; }
+
         public SealDirectoryKind GetSealDirectoryKind(DirectoryArtifact directory)
         {
             if (m_knownSealedSourceDirectoriesAllDirectories.Contains(directory.Path))


### PR DESCRIPTION
One of our fallback file deletion strategies wasn't active for deleting output files prior to executing pips since the TempCleaner wasn't plumbed through. Office is experiencing a number of files that are failing to delete because of not having this strategy available.