### PR TITLE
Revert #610: Discard MAC_LOOKUP reports relative to directory symlinks

### DIFF
--- a/Public/Src/Engine/Processes/SandboxedProcessFactory.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessFactory.cs
@@ -68,24 +68,6 @@ namespace BuildXL.Processes
             /// </summary>
             [CounterType(CounterType.Numeric)]
             SandboxedProcessLifeTimeMs,
-
-            /// <summary>
-            /// Aggregate time spent checking paths for directory symlinks
-            /// </summary>
-            [CounterType(CounterType.Stopwatch)]
-            DirectorySymlinkCheckingDuration,
-
-            /// <summary>
-            /// Number of paths queried for directory symlinks
-            /// </summary>
-            [CounterType(CounterType.Numeric)]
-            DirectorySymlinkPathsQueriedCount,
-
-            /// <summary>
-            /// Number of paths checked for directory symlinks (cache misses)
-            /// </summary>
-            [CounterType(CounterType.Numeric)]
-            DirectorySymlinkPathsCheckedCount,
         }
 
         /// <summary>


### PR DESCRIPTION
Expensive plus doesn't solve the problem.  Those paths should be discarded elsewhere (e.g., by the ObservedInputProcessor)

This reverts commit f6e1cab039b37b1cb1c13df3037fe3862da0b080.