### PR TITLE
Discard reported accesses on non-canonical paths

### DIFF
--- a/Public/Src/Engine/Processes/SandboxedProcessFactory.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessFactory.cs
@@ -79,7 +79,13 @@ namespace BuildXL.Processes
             /// Number of paths queried for directory symlinks
             /// </summary>
             [CounterType(CounterType.Numeric)]
-            DirectorySymlinkPathsQueriedCount
+            DirectorySymlinkPathsQueriedCount,
+
+            /// <summary>
+            /// Number of paths with directory symlinks that were discarded
+            /// </summary>
+            [CounterType(CounterType.Numeric)]
+            DirectorySymlinkPathsDiscardedCount
         }
 
         /// <summary>

--- a/Public/Src/Engine/Processes/SandboxedProcessFactory.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessFactory.cs
@@ -82,6 +82,12 @@ namespace BuildXL.Processes
             DirectorySymlinkPathsQueriedCount,
 
             /// <summary>
+            /// Number of paths checked for directory symlinks (cache misses)
+            /// </summary>
+            [CounterType(CounterType.Numeric)]
+            DirectorySymlinkPathsCheckedCount,
+
+            /// <summary>
             /// Number of paths with directory symlinks that were discarded
             /// </summary>
             [CounterType(CounterType.Numeric)]

--- a/Public/Src/Engine/Processes/SandboxedProcessFactory.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessFactory.cs
@@ -68,6 +68,18 @@ namespace BuildXL.Processes
             /// </summary>
             [CounterType(CounterType.Numeric)]
             SandboxedProcessLifeTimeMs,
+
+            /// <summary>
+            /// Aggregate time spent checking paths for directory symlinks
+            /// </summary>
+            [CounterType(CounterType.Stopwatch)]
+            DirectorySymlinkCheckingDuration,
+
+            /// <summary>
+            /// Number of paths queried for directory symlinks
+            /// </summary>
+            [CounterType(CounterType.Numeric)]
+            DirectorySymlinkPathsQueriedCount
         }
 
         /// <summary>

--- a/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
@@ -2935,6 +2935,7 @@ namespace BuildXL.Processes
                             firstAccess.ManifestPath.IsValid &&
                             PathContainsSymlinks(firstAccess.ManifestPath.GetParent(m_context.PathTable)))
                         {
+                            Counters.IncrementCounter(SandboxedProcessCounters.DirectorySymlinkPathsDiscardedCount);
                             continue;
                         }
 


### PR DESCRIPTION
Concretely, discard observed accesses that have a single MacLookup report on a path that contains directory symlinks.

Reason:
  - observed accesses computed here should only contain fully expanded paths to avoid ambiguity;
  - on Mac, all access reports except for MacLookup report fully expanded paths, so only MacLookup paths need to be curated

[AB#1573235](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1573235)