### PR TITLE
Revert "Revert "Enable usage of Azure Blob Storage SAS tokens (#587)""

### DIFF
--- a/Public/Src/Cache/ContentStore/App/BuildXL.Cache.ContentStore.App.dsc
+++ b/Public/Src/Cache/ContentStore/App/BuildXL.Cache.ContentStore.App.dsc
@@ -42,6 +42,8 @@ namespace App {
             importFrom("Newtonsoft.Json").pkg,
 
             ManagedSdk.Factory.createBinary(importFrom("TransientFaultHandling.Core").Contents.all, r`lib/NET4/Microsoft.Practices.TransientFaultHandling.Core.dll`),
+
+            importFrom("WindowsAzure.Storage").pkg,
         ],
         tools: {
             csc: {

--- a/Public/Src/Cache/ContentStore/App/DistributedService.cs
+++ b/Public/Src/Cache/ContentStore/App/DistributedService.cs
@@ -4,10 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.ContractsLight;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using BuildXL.Cache.ContentStore.Distributed;
 using BuildXL.Cache.ContentStore.Distributed.Utilities;
 using BuildXL.Cache.ContentStore.Interfaces.Distributed;
 using BuildXL.Cache.ContentStore.Interfaces.FileSystem;
@@ -15,6 +16,8 @@ using BuildXL.Cache.ContentStore.Service;
 using BuildXL.Cache.Host.Configuration;
 using BuildXL.Cache.Host.Service;
 using CLAP;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Auth;
 using Newtonsoft.Json;
 
 // ReSharper disable once UnusedMember.Global
@@ -118,9 +121,80 @@ namespace BuildXL.Cache.ContentStore.App
             {
             }
 
-            public Task<Dictionary<string, string>> RetrieveKeyVaultSecretsAsync(List<string> secrets, CancellationToken token)
+            public Task<Dictionary<string, Secret>> RetrieveSecretsAsync(List<RetrieveSecretsRequest> requests, CancellationToken token)
             {
-                return Task.FromResult(secrets.ToDictionary(s => GetSecretStoreValue(s)));
+                var secrets = new Dictionary<string, Secret>();
+
+                foreach (var request in requests)
+                {
+                    Secret secret = null;
+
+                    var secretValue = GetSecretStoreValue(request.Name);
+                    if (string.IsNullOrEmpty(secretValue))
+                    {
+                        // Environment variables are null by default. Skip if that's the case
+                        continue;
+                    }
+
+                    switch (request.Kind)
+                    {
+                        case SecretKind.PlainText:
+                            // In this case, the value is expected to be an entire connection string
+                            secret = new PlainTextSecret(secretValue);
+                            break;
+                        case SecretKind.SasToken:
+                            secret = CreateSasTokenSecret(request, secretValue);
+                            break;
+                        default:
+                            throw new NotSupportedException($"It is expected that all supported credential kinds be handled when creating a DistributedService. {request.Kind} is unhandled.");
+                    }
+
+                    Contract.Requires(secret != null);
+                    secrets[request.Name] = secret;
+                }
+
+                return Task.FromResult(secrets);
+            }
+
+            private Secret CreateSasTokenSecret(RetrieveSecretsRequest request, string secretValue)
+            {
+                var resourceTypeVariableName = $"{request.Name}_ResourceType";
+                var resourceType = GetSecretStoreValue(resourceTypeVariableName);
+                if (string.IsNullOrEmpty(resourceType))
+                {
+                    throw new ArgumentNullException($"Missing environment variable {resourceTypeVariableName} that stores the resource type for secret {request.Name}");
+                }
+
+                switch (resourceType.ToLowerInvariant())
+                {
+                    case "storagekey":
+                        return CreateAzureStorageSasTokenSecret(request, secretValue);
+                    default:
+                        throw new NotSupportedException($"Unknown resource type {resourceType} for secret named {request.Name}. Check environment variable {resourceTypeVariableName} has a valid value.");
+                }
+            }
+
+            private Secret CreateAzureStorageSasTokenSecret(RetrieveSecretsRequest request, string secretValue)
+            {
+                // In this case, the environment variable is expected to hold an Azure Storage connection string
+                var cloudStorageAccount = CloudStorageAccount.Parse(secretValue);
+
+                // Create a godlike SAS token for the account, so that we don't need to reimplement the Central Secrets Service.
+                var sasToken = cloudStorageAccount.GetSharedAccessSignature(new SharedAccessAccountPolicy
+                {
+                    SharedAccessExpiryTime = null,
+                    Permissions = SharedAccessAccountPermissions.Add | SharedAccessAccountPermissions.Create | SharedAccessAccountPermissions.Delete | SharedAccessAccountPermissions.List | SharedAccessAccountPermissions.ProcessMessages | SharedAccessAccountPermissions.Read | SharedAccessAccountPermissions.Update | SharedAccessAccountPermissions.Write,
+                    Services = SharedAccessAccountServices.Blob,
+                    ResourceTypes = SharedAccessAccountResourceTypes.Object | SharedAccessAccountResourceTypes.Container | SharedAccessAccountResourceTypes.Service,
+                    Protocols = SharedAccessProtocol.HttpsOnly,
+                    IPAddressOrRange = null,
+                });
+
+                var internalSasToken = new SasToken() {
+                    Token = sasToken,
+                    StorageAccount = cloudStorageAccount.Credentials.AccountName,
+                };
+                return new UpdatingSasToken(internalSasToken);
             }
         }
     }

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStoreConfiguration.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStoreConfiguration.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.ContractsLight;
-using System.Linq;
 using BuildXL.Cache.ContentStore.Distributed.NuCache;
 using BuildXL.Cache.ContentStore.Distributed.NuCache.EventStreaming;
 using BuildXL.Cache.ContentStore.Distributed.Redis;

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/Secrets.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/Secrets.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics.ContractsLight;
+
+namespace BuildXL.Cache.ContentStore.Distributed
+{
+    /// <nodoc />
+    public enum SecretKind
+    {
+        /// <nodoc />
+        PlainText,
+
+        /// <nodoc />
+        SasToken
+    }
+
+    /// <nodoc />
+    public abstract class Secret
+    {
+    }
+
+    /// <nodoc />
+    public class PlainTextSecret : Secret
+    {
+        /// <nodoc />
+        public string Secret { get; }
+
+        /// <nodoc />
+        public PlainTextSecret(string secret)
+        {
+            Contract.Requires(!string.IsNullOrEmpty(secret));
+            Secret = secret;
+        }
+    }
+
+    /// <nodoc />
+    public class SasToken
+    {
+        /// <nodoc />
+        public string Token { get; set; }
+
+        /// <nodoc />
+        public string StorageAccount { get; set; }
+
+        /// <nodoc />
+        public string ResourcePath { get; set; }
+    }
+
+    /// <nodoc />
+    public class UpdatingSasToken : Secret
+    {
+        /// <nodoc />
+        public SasToken Token { get; private set; }
+
+        /// <nodoc />
+        public event EventHandler<SasToken> TokenUpdated;
+
+        /// <nodoc />
+        public UpdatingSasToken(SasToken token)
+        {
+            UpdateToken(token);
+        }
+
+        /// <nodoc />
+        public void UpdateToken(SasToken token)
+        {
+            Contract.Requires(token != null);
+            Token = token;
+            TokenUpdated?.Invoke(this, null);
+        }
+    }
+}

--- a/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/LocalLocationStoreDistributedContentTests.cs
+++ b/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/LocalLocationStoreDistributedContentTests.cs
@@ -26,7 +26,6 @@ using BuildXL.Cache.ContentStore.Interfaces.Time;
 using BuildXL.Cache.ContentStore.Interfaces.Tracing;
 using BuildXL.Cache.ContentStore.InterfacesTest.Results;
 using BuildXL.Cache.ContentStore.Stores;
-using BuildXL.Cache.ContentStore.Tracing.Internal;
 using BuildXL.Cache.ContentStore.UtilitiesCore;
 using BuildXL.Cache.ContentStore.Utils;
 using BuildXL.Utilities.Collections;
@@ -35,7 +34,6 @@ using ContentStoreTest.Distributed.ContentLocation;
 using ContentStoreTest.Distributed.Redis;
 using ContentStoreTest.Test;
 using FluentAssertions;
-using Microsoft.Azure.EventHubs;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Auth;
 using Xunit;
@@ -2220,7 +2218,6 @@ namespace ContentStoreTest.Distributed.Sessions
             var testBasePath = FileSystem.GetTempPath();
             var containerName = "checkpoints";
             var checkpointsKey = "checkpoints-eventhub";
-            var storageAccountEndpointSuffix = "core.windows.net";
 
             if (!ReadConfiguration(out var storageAccountKey, out var storageAccountName, out var eventHubConnectionString, out var eventHubName))
             {
@@ -2229,7 +2226,7 @@ namespace ContentStoreTest.Distributed.Sessions
             }
 
             var credentials = new StorageCredentials(storageAccountName, storageAccountKey);
-            var account = new CloudStorageAccount(credentials, storageAccountName, storageAccountEndpointSuffix, useHttps: true);
+            var account = new CloudStorageAccount(credentials, storageAccountName, endpointSuffix: null, useHttps: true);
 
             var sasToken = account.GetSharedAccessSignature(new SharedAccessAccountPolicy
             {
@@ -2242,7 +2239,7 @@ namespace ContentStoreTest.Distributed.Sessions
             var blobStoreCredentials = new StorageCredentials(sasToken);
 
             var blobCentralStoreConfiguration = new BlobCentralStoreConfiguration(
-                new AzureBlobStorageCredentials(blobStoreCredentials, storageAccountName, storageAccountEndpointSuffix),
+                new AzureBlobStorageCredentials(blobStoreCredentials, storageAccountName, endpointSuffix: null),
                 containerName,
                 checkpointsKey);
             var blobCentralStore = new BlobCentralStorage(blobCentralStoreConfiguration);

--- a/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
@@ -365,6 +365,9 @@ namespace BuildXL.Cache.Host.Configuration
         public string AzureStorageSecretName { get; set; }
 
         [DataMember]
+        public bool AzureBlobStorageUseSasTokens { get; set; } = false;
+
+        [DataMember]
         public string EventHubEpoch { get; set; } = ".LLS_V1.2";
 
         [DataMember]

--- a/Public/Src/Cache/DistributedCache.Host/Service/BuildXL.Cache.Host.Service.dsc
+++ b/Public/Src/Cache/DistributedCache.Host/Service/BuildXL.Cache.Host.Service.dsc
@@ -16,6 +16,8 @@ namespace Service {
             importFrom("BuildXL.Cache.ContentStore").Hashing.dll,
             importFrom("BuildXL.Cache.ContentStore").UtilitiesCore.dll,
             BuildXLSdk.Factory.createBinary(importFrom("TransientFaultHandling.Core").Contents.all, r`lib/NET4/Microsoft.Practices.TransientFaultHandling.Core.dll`),
+
+            importFrom("WindowsAzure.Storage").pkg,
         ],
         allowUnsafeBlocks: false
     });

--- a/Public/Src/Cache/DistributedCache.Host/Service/IDistributedCacheServiceHost.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Service/IDistributedCacheServiceHost.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using BuildXL.Cache.ContentStore.Distributed;
 
 namespace BuildXL.Cache.Host.Service
 {
@@ -36,6 +37,6 @@ namespace BuildXL.Cache.Host.Service
         /// <summary>
         /// Retrieves secrets from key vault
         /// </summary>
-        Task<Dictionary<string, string>> RetrieveKeyVaultSecretsAsync(List<string> secrets, CancellationToken token);
+        Task<Dictionary<string, Secret>> RetrieveSecretsAsync(List<RetrieveSecretsRequest> requests, CancellationToken token);
     }
 }

--- a/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.ContractsLight;
 using System.Linq;
+using System.Security;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,6 +26,7 @@ using BuildXL.Cache.ContentStore.Stores;
 using BuildXL.Cache.ContentStore.Utils;
 using BuildXL.Cache.Host.Configuration;
 using Microsoft.Practices.TransientFaultHandling;
+using Microsoft.WindowsAzure.Storage.Auth;
 
 namespace BuildXL.Cache.Host.Service.Internal
 {
@@ -266,13 +268,13 @@ namespace BuildXL.Cache.Host.Service.Internal
             ApplyIfNotNull(_distributedSettings.IsReconciliationEnabled, value => configuration.EnableReconciliation = value);
             ApplyIfNotNull(_distributedSettings.UseIncrementalCheckpointing, value => configuration.Checkpoint.UseIncrementalCheckpointing = value);
 
-            configuration.RedisGlobalStoreConnectionString = GetRequiredSecret(secrets, _distributedSettings.GlobalRedisSecretName);
+            configuration.RedisGlobalStoreConnectionString = ((PlainTextSecret) GetRequiredSecret(secrets, _distributedSettings.GlobalRedisSecretName)).Secret;
 
             if (_distributedSettings.SecondaryGlobalRedisSecretName != null)
             {
-                configuration.RedisGlobalStoreSecondaryConnectionString = GetRequiredSecret(
+                configuration.RedisGlobalStoreSecondaryConnectionString = ((PlainTextSecret) GetRequiredSecret(
                     secrets,
-                    _distributedSettings.SecondaryGlobalRedisSecretName);
+                    _distributedSettings.SecondaryGlobalRedisSecretName)).Secret;
             }
 
             ApplyIfNotNull(
@@ -284,8 +286,7 @@ namespace BuildXL.Cache.Host.Service.Internal
             ApplyIfNotNull(_distributedSettings.LocationEntryExpiryMinutes, value => configuration.LocationEntryExpiry = TimeSpan.FromMinutes(value));
 
             var storageCredentials = GetStorageCredentials(secrets, errorBuilder);
-            // We already retrieved storage connection strings, so the result should not be null.
-            Contract.Assert(storageCredentials != null);
+            Contract.Assert(storageCredentials != null && storageCredentials.Length > 0);
 
             var blobStoreConfiguration = new BlobCentralStoreConfiguration(
                 credentials: storageCredentials,
@@ -311,7 +312,7 @@ namespace BuildXL.Cache.Host.Service.Internal
 
             var eventStoreConfiguration = new EventHubContentLocationEventStoreConfiguration(
                 eventHubName: "eventhub",
-                eventHubConnectionString: GetRequiredSecret(secrets, _distributedSettings.EventHubSecretName),
+                eventHubConnectionString: ((PlainTextSecret)GetRequiredSecret(secrets, _distributedSettings.EventHubSecretName)).Secret,
                 consumerGroupName: "$Default",
                 epoch: _keySpace + _distributedSettings.EventHubEpoch);
 
@@ -321,43 +322,74 @@ namespace BuildXL.Cache.Host.Service.Internal
                 value => eventStoreConfiguration.MaxEventProcessingConcurrency = value);
         }
 
-        private AzureBlobStorageCredentials[] GetStorageCredentials(Dictionary<string, string> settings, StringBuilder errorBuilder)
+        private AzureBlobStorageCredentials[] GetStorageCredentials(Dictionary<string, Secret> secrets, StringBuilder errorBuilder)
         {
             var storageSecretNames = GetAzureStorageSecretNames(errorBuilder);
-            if (storageSecretNames == null)
+            // This would have failed earlier otherwise
+            Contract.Assert(storageSecretNames != null);
+
+            var credentials = new List<AzureBlobStorageCredentials>();
+            foreach (var secretName in storageSecretNames)
             {
-                return null;
+                var secret = GetRequiredSecret(secrets, secretName);
+
+                if (_distributedSettings.AzureBlobStorageUseSasTokens)
+                {
+                    var updatingSasToken = secret as UpdatingSasToken;
+                    Contract.Assert(!(updatingSasToken is null));
+
+                    credentials.Add(CreateAzureBlobCredentialsFromSasToken(updatingSasToken));
+                }
+                else
+                {
+                    var plainTextSecret = secret as PlainTextSecret;
+                    Contract.Assert(!(plainTextSecret is null));
+
+                    credentials.Add(new AzureBlobStorageCredentials(plainTextSecret.Secret));
+                }
             }
 
-            return storageSecretNames.Select(name => {
-                return new AzureBlobStorageCredentials(GetRequiredSecret(settings, name));
-            }).ToArray();
+            return credentials.ToArray();
+        }
+
+        private static AzureBlobStorageCredentials CreateAzureBlobCredentialsFromSasToken(UpdatingSasToken updatingSasToken)
+        {
+            var storageCredentials = new StorageCredentials(sasToken: updatingSasToken.Token.Token);
+            updatingSasToken.TokenUpdated += (token, sasToken) =>
+            {
+                storageCredentials.UpdateSASToken(sasToken.Token);
+            };
+
+            // The account name should never actually be updated, so its OK to take it from the initial token
+            var azureCredentials = new AzureBlobStorageCredentials(storageCredentials, updatingSasToken.Token.StorageAccount);
+            return azureCredentials;
         }
 
         private List<string> GetAzureStorageSecretNames(StringBuilder errorBuilder)
         {
-            List<string> secretNames = new List<string>();
-            if (_distributedSettings.AzureStorageSecretName != null)
+            var secretNames = new List<string>();
+            if (_distributedSettings.AzureStorageSecretName != null && !string.IsNullOrEmpty(_distributedSettings.AzureStorageSecretName))
             {
                 secretNames.Add(_distributedSettings.AzureStorageSecretName);
             }
 
-            if (_distributedSettings.AzureStorageSecretNames != null)
+            if (_distributedSettings.AzureStorageSecretNames != null && !_distributedSettings.AzureStorageSecretNames.Any(string.IsNullOrEmpty))
             {
                 secretNames.AddRange(_distributedSettings.AzureStorageSecretNames);
             }
 
-            if (secretNames.Count == 0)
+            if (secretNames.Count > 0)
             {
-                errorBuilder.Append(
-                    $"Unable to configure Azure Storage. {nameof(DistributedContentSettings.AzureStorageSecretName)} or {nameof(DistributedContentSettings.AzureStorageSecretNames)} configuration options should be provided. ");
-                return null;
+                return secretNames;
             }
 
-            return secretNames;
+            errorBuilder.Append(
+                $"Unable to configure Azure Storage. {nameof(DistributedContentSettings.AzureStorageSecretName)} or {nameof(DistributedContentSettings.AzureStorageSecretNames)} configuration options should be provided. ");
+            return null;
+
         }
 
-        private async Task<Dictionary<string, string>> TryRetrieveSecretsAsync(CancellationToken token, StringBuilder errorBuilder)
+        private async Task<Dictionary<string, Secret>> TryRetrieveSecretsAsync(CancellationToken token, StringBuilder errorBuilder)
         {
             _logger.Debug(
                 $"{nameof(_distributedSettings.EventHubSecretName)}: {_distributedSettings.EventHubSecretName}, " +
@@ -373,32 +405,68 @@ namespace BuildXL.Cache.Host.Service.Internal
                 return null;
             }
 
+            // Create the credentials requests
+            var retrieveSecretsRequests = new List<RetrieveSecretsRequest>();
+
             var storageSecretNames = GetAzureStorageSecretNames(errorBuilder);
             if (storageSecretNames == null)
             {
                 return null;
             }
 
-            if (_distributedSettings.EventHubSecretName != null &&
-                _distributedSettings.GlobalRedisSecretName != null)
+            var azureBlobStorageCredentialsKind = _distributedSettings.AzureBlobStorageUseSasTokens ? SecretKind.SasToken : SecretKind.PlainText;
+            retrieveSecretsRequests.AddRange(storageSecretNames.Select(secretName => new RetrieveSecretsRequest(secretName, azureBlobStorageCredentialsKind)));
+
+            if (string.IsNullOrEmpty(_distributedSettings.EventHubSecretName) ||
+                string.IsNullOrEmpty(_distributedSettings.GlobalRedisSecretName))
             {
-                var retryPolicy = CreateSecretsRetrievalRetryPolicy(_distributedSettings);
-                return await retryPolicy.ExecuteAsync(
-                    async () =>
-                    {
-                        return await _arguments.Host.RetrieveKeyVaultSecretsAsync(
-                            new List<string>(storageSecretNames)
-                            {
-                                _distributedSettings.EventHubSecretName,
-                                _distributedSettings.GlobalRedisSecretName,
-                                _distributedSettings.SecondaryGlobalRedisSecretName
-                            }.Where(s => s != null).ToList(),
-                            token);
-                    },
-                    token);
+                return null;
             }
 
-            return null;
+            retrieveSecretsRequests.Add(new RetrieveSecretsRequest(_distributedSettings.EventHubSecretName, SecretKind.PlainText));
+
+            retrieveSecretsRequests.Add(new RetrieveSecretsRequest(_distributedSettings.GlobalRedisSecretName, SecretKind.PlainText));
+            if (!string.IsNullOrEmpty(_distributedSettings.SecondaryGlobalRedisSecretName))
+            {
+                retrieveSecretsRequests.Add(new RetrieveSecretsRequest(_distributedSettings.SecondaryGlobalRedisSecretName, SecretKind.PlainText));
+            }
+
+            // Ask the host for credentials
+            var retryPolicy = CreateSecretsRetrievalRetryPolicy(_distributedSettings);
+            var secrets = await retryPolicy.ExecuteAsync(
+                async () => await _arguments.Host.RetrieveSecretsAsync(retrieveSecretsRequests, token),
+                token);
+            if (secrets == null)
+            {
+                return null;
+            }
+
+            // Validate requests match as expected
+            foreach (var request in retrieveSecretsRequests)
+            {
+                if (secrets.TryGetValue(request.Name, out var secret))
+                {
+                    bool typeMatch = true;
+                    switch (request.Kind)
+                    {
+                        case SecretKind.PlainText:
+                            typeMatch = secret is PlainTextSecret;
+                            break;
+                        case SecretKind.SasToken:
+                            typeMatch = secret is UpdatingSasToken;
+                            break;
+                        default:
+                            throw new NotSupportedException("The requested kind is missing support for secret request matching");
+                    }
+
+                    if (!typeMatch)
+                    {
+                        throw new SecurityException($"The credentials produced by the host for secret named {request.Name} do not match the expected kind");
+                    }
+                }
+            }
+
+            return secrets;
 
             bool appendIfNull(object value, string propertyName)
             {
@@ -428,9 +496,9 @@ namespace BuildXL.Cache.Host.Service.Internal
             }
         }
 
-        private static string GetRequiredSecret(Dictionary<string, string> secrets, string secretName)
+        private static Secret GetRequiredSecret(Dictionary<string, Secret> secrets, string secretName)
         {
-            if (!secrets.TryGetValue(secretName, out var value) || string.IsNullOrEmpty(value))
+            if (!secrets.TryGetValue(secretName, out var value))
             {
                 throw new KeyNotFoundException($"Missing secret: {secretName}");
             }

--- a/Public/Src/Cache/DistributedCache.Host/Service/RetrieveSecretsRequest.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Service/RetrieveSecretsRequest.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.ContractsLight;
+using BuildXL.Cache.ContentStore.Distributed;
+
+namespace BuildXL.Cache.Host.Service
+{
+    /// <summary>
+    /// Type to signal the host which kind of secret is expected to be returned
+    /// </summary>
+    public struct RetrieveSecretsRequest
+    {
+        public string Name { get; }
+
+        public SecretKind Kind { get; }
+
+        public RetrieveSecretsRequest(string name, SecretKind kind)
+        {
+            Contract.Requires(!string.IsNullOrEmpty(name));
+            Name = name;
+            Kind = kind;
+        }
+    }
+}


### PR DESCRIPTION
Reverts microsoft/BuildXL#625

This PR contains backwards-incompatible changes in one of our public interfaces, and is _expected_ to block our release pipeline until the internal system's change that adapts to this PR is in. Please rollback only if its absolutely necessary.