### PR TITLE
DistributedContentCopier stops trying when copy fails with out of disk space

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
@@ -346,7 +346,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
                                 Tracer.Warning(
                                     context,
                                     $"{AttemptTracePrefix(attemptCount)} {lastErrorMessage} Not trying another replica.");
-                                return (result: new ErrorResult(copyFileResult).AsResult<PutResult>(), retry: !(copyFileResult.Exception?.HasHresult(Hresult.DiskFull) ?? true));
+                                return (result: new ErrorResult(copyFileResult).AsResult<PutResult>(), retry: !copyFileResult.Exception?.HasHresult(Hresult.DiskFull) ?? true);
                             case CopyFileResult.ResultCode.CopyTimeoutError:
                                 lastErrorMessage = $"Could not copy file with hash {hashInfo.ContentHash.ToShortString()} from path {sourcePath} to path {tempLocation} due to copy timeout: {copyFileResult}";
                                 Tracer.Warning(

--- a/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
@@ -346,7 +346,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
                                 Tracer.Warning(
                                     context,
                                     $"{AttemptTracePrefix(attemptCount)} {lastErrorMessage} Not trying another replica.");
-                                return (result: new ErrorResult(copyFileResult).AsResult<PutResult>(), retry: true);
+                                return (result: new ErrorResult(copyFileResult).AsResult<PutResult>(), retry: !(copyFileResult.Exception?.HasHresult(Hresult.DiskFull) ?? true));
                             case CopyFileResult.ResultCode.CopyTimeoutError:
                                 lastErrorMessage = $"Could not copy file with hash {hashInfo.ContentHash.ToShortString()} from path {sourcePath} to path {tempLocation} due to copy timeout: {copyFileResult}";
                                 Tracer.Warning(

--- a/Public/Src/Cache/ContentStore/Interfaces/FileSystem/Hresult.cs
+++ b/Public/Src/Cache/ContentStore/Interfaces/FileSystem/Hresult.cs
@@ -25,6 +25,7 @@ namespace BuildXL.Cache.ContentStore.Interfaces.FileSystem
         /// </summary>
         public const uint DiskFull = 0x80070070;
 
+        /// <nodoc />
         public static bool HasHresult(this Exception e, uint hresult) => ((uint)e.HResult) == hresult;
     }
 }

--- a/Public/Src/Cache/ContentStore/Interfaces/FileSystem/Hresult.cs
+++ b/Public/Src/Cache/ContentStore/Interfaces/FileSystem/Hresult.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace BuildXL.Cache.ContentStore.Interfaces.FileSystem
 {
     /// <summary>
@@ -17,5 +19,12 @@ namespace BuildXL.Cache.ContentStore.Interfaces.FileSystem
         ///     FILE_EXISTS
         /// </summary>
         public const uint FileExists = 0x80070050;
+
+        /// <summary>
+        ///     ERROR_DISK_FULL
+        /// </summary>
+        public const uint DiskFull = 0x80070070;
+
+        public static bool HasHresult(this Exception e, uint hresult) => ((uint)e.HResult) == hresult;
     }
 }


### PR DESCRIPTION
Fixes [AB#1474275](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1474275)

DistributedContentCopier should not retry when copy fails with out of disk space