### PR TITLE
Revert a drop deployment change

### DIFF
--- a/Public/Src/Tools/DropDaemon/Tool.DropDaemon.dsc
+++ b/Public/Src/Tools/DropDaemon/Tool.DropDaemon.dsc
@@ -50,34 +50,13 @@ export namespace DropDaemon {
         internalsVisibleTo: [
             "Test.Tool.DropDaemon",
         ]
-    });
-
-    const temporarySdkDropNextToEngineFolder = d`${Context.getBuildEngineDirectory()}/Sdk/Sdk.Drop/bin`;
-    const temporaryDropDaemonTool : Transformer.ToolDefinition = {
-        exe: f`${temporarySdkDropNextToEngineFolder}/DropDaemon.exe`,
-        runtimeDirectoryDependencies: [
-            Transformer.sealSourceDirectory({
-                root: temporarySdkDropNextToEngineFolder,
-                include: "allDirectories",
-            }), 
-        ],
-        untrackedDirectoryScopes: [
-            Context.getUserHomeDirectory(),
-            d`${Context.getMount("ProgramData").path}`,
-        ],
-        dependsOnWindowsDirectories: true,
-        dependsOnAppDataDirectory: true,
-        prepareTempDirectory: true,
-    };
+    });    
 
     @@public
-    export const tool = !BuildXLSdk.isDropToolingEnabled 
-        ? undefined 
-        : temporaryDropDaemonTool;
-        // : BuildXLSdk.deployManagedTool({
-        // tool: exe,
-        // options: toolTemplate,
-        // });
+    export const tool = !BuildXLSdk.isDropToolingEnabled ? undefined : BuildXLSdk.deployManagedTool({
+        tool: exe,
+        options: toolTemplate,
+    });
 
     @@public
     export const deployment: Deployment.Definition = !BuildXLSdk.isDropToolingEnabled ? undefined : {


### PR DESCRIPTION
#570 introduced a temporary hack to drop deployment/usage logic -- we started using the drop from the LKG rather than the locally built one. This PR reverts that change since it is no longer needed.