### PR TITLE
Cast globR to force well-typedness

### DIFF
--- a/Public/Src/Explorer/Server/BuildXL.Explorer.Server.dsc
+++ b/Public/Src/Explorer/Server/BuildXL.Explorer.Server.dsc
@@ -15,7 +15,7 @@ namespace Server {
         rootNamespace: "BuildXL.Explorer.Server",
         skipDocumentationGeneration: true,
         // We filter out obj and bin folders since we sometimes still develop with an msbuild file for F5 debugging of aspnet apps which is not yet available in BuildXL's IDE integraiotn.
-        sources: globR(d`.`, "*.cs").filter(f => !f.isWithin(d`obj`) && !f.isWithin(d`bin`)),
+        sources: (<File[]>globR(d`.`, "*.cs")).filter(f => !f.isWithin(d`obj`) && !f.isWithin(d`bin`)),
         references: [
             ...addIf(BuildXLSdk.isFullFramework,
               // TODO: revisit this!


### PR DESCRIPTION
This change doesn't fix the bug, but it's a band aid to make our selfhost a bit robust.

[AB#1574033](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1574033)