### PR TITLE
Downgrade PipTempDirectoryCleanupError to an Infrastructure error

### DIFF
--- a/Public/Src/Engine/Processes/Tracing/Log.cs
+++ b/Public/Src/Engine/Processes/Tracing/Log.cs
@@ -720,7 +720,7 @@ namespace BuildXL.Processes.Tracing
             (ushort)LogEventId.PipTempDirectoryCleanupError,
             EventLevel = Level.Error,
             EventGenerators = EventGenerators.LocalOnly,
-            Keywords = (int)Keywords.UserMessage,
+            Keywords = (int)(Keywords.UserMessage | Keywords.InfrastructureError),
             EventTask = (int)Tasks.PipExecutor,
             Message = EventConstants.PipPrefix + "Failed to clean temp directory at '{directory}'. Pip will not be executed. {exceptionMessage}")]
         public abstract void PipTempDirectoryCleanupError(LoggingContext context, long pipSemiStableHash, string pipDescription, string directory, string exceptionMessage);


### PR DESCRIPTION
We see this error come through when mssense or other machine specific processes lock files and prevent the temp directory cleanup from happening.

This plus [AB#1572556](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1572556) should address [AB#1555813](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1555813)