### PR TITLE
Fix the crash on the worker when master exits before attach

### DIFF
--- a/Public/Src/Engine/Dll/Distribution/Grpc/GrpcWorkerServer.cs
+++ b/Public/Src/Engine/Dll/Distribution/Grpc/GrpcWorkerServer.cs
@@ -76,7 +76,7 @@ namespace BuildXL.Engine.Distribution.Grpc
         public override Task<RpcResponse> Exit(BuildEndData message, ServerCallContext context)
         {
             m_workerService.ExitCallReceivedFromMaster();
-            m_workerService.Exit(timedOut: false, failure: message.Failure);
+            m_workerService.Exit(failure: message.Failure);
 
             return Task.FromResult(new RpcResponse());
         }

--- a/Public/Src/Engine/Dll/Distribution/Grpc/GrpcWorkerServer.cs
+++ b/Public/Src/Engine/Dll/Distribution/Grpc/GrpcWorkerServer.cs
@@ -75,7 +75,7 @@ namespace BuildXL.Engine.Distribution.Grpc
         /// <inheritdoc/>
         public override Task<RpcResponse> Exit(BuildEndData message, ServerCallContext context)
         {
-            m_workerService.BeforeExit();
+            m_workerService.ExitCallReceivedFromMaster();
             m_workerService.Exit(timedOut: false, failure: message.Failure);
 
             return Task.FromResult(new RpcResponse());

--- a/Public/Src/Engine/Dll/Distribution/InternalBond/BondWorkerServer.cs
+++ b/Public/Src/Engine/Dll/Distribution/InternalBond/BondWorkerServer.cs
@@ -90,7 +90,7 @@ namespace BuildXL.Engine.Distribution.InternalBond
         /// </summary>
         public override void Exit(Request<BuildEndData, Void> call)
         {
-            m_workerService.BeforeExit();
+            m_workerService.ExitCallReceivedFromMaster();
 
             call.Dispatch(new Void());
 

--- a/Public/Src/Engine/Dll/Distribution/InternalBond/BondWorkerServer.cs
+++ b/Public/Src/Engine/Dll/Distribution/InternalBond/BondWorkerServer.cs
@@ -94,7 +94,7 @@ namespace BuildXL.Engine.Distribution.InternalBond
 
             call.Dispatch(new Void());
 
-            m_workerService.Exit(timedOut: false, failure: call.RequestObject.Failure);
+            m_workerService.Exit(failure: call.RequestObject.Failure);
         }
 
         /// <nodoc/>

--- a/Public/Src/Engine/Dll/Distribution/NotifyMasterExecutionLogTarget.cs
+++ b/Public/Src/Engine/Dll/Distribution/NotifyMasterExecutionLogTarget.cs
@@ -15,7 +15,7 @@ namespace BuildXL.Engine.Distribution
     /// </summary>
     public class NotifyMasterExecutionLogTarget : ExecutionLogFileTarget
     {
-        private bool m_isDisposed = false;
+        private volatile bool m_isDisposed = false;
 
         internal NotifyMasterExecutionLogTarget(uint workerId, IMasterClient masterClient, PipExecutionContext context, Guid logId, int lastStaticAbsolutePathIndex, DistributionServices services)
             : this(new NotifyStream(workerId, masterClient, services), context, logId, lastStaticAbsolutePathIndex)

--- a/Public/Src/Engine/Dll/Distribution/WorkerService.cs
+++ b/Public/Src/Engine/Dll/Distribution/WorkerService.cs
@@ -223,7 +223,7 @@ namespace BuildXL.Engine.Distribution
                     {
                         // Fire-forget exit call with failure.
                         // If we fail to send notification to master, the worker should fail.
-                        ExitAsync(timedOut: false, failure: "Notify event failed to send to master");
+                        ExitAsync(failure: "Notify event failed to send to master", isUnexpected: true);
                         break;
                     }
                 }
@@ -295,7 +295,7 @@ namespace BuildXL.Engine.Distribution
             {
                 if ((TimestampUtilities.Timestamp - m_lastHeartbeatTimestamp) > EngineEnvironmentSettings.WorkerAttachTimeout)
                 {
-                    Exit(timedOut: true, failure: "Timed out waiting for attach request from master");
+                    Exit(failure: "Timed out waiting for attach request from master", isUnexpected: true);
                     return false;
                 }
             }
@@ -323,17 +323,15 @@ namespace BuildXL.Engine.Distribution
         /// <nodoc/>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("AsyncUsage", "AsyncFixer03:FireForgetAsyncVoid")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("AsyncUsage", "AsyncFixer02:MissingAsyncOpportunity")]
-        public async void ExitAsync(bool timedOut, string failure)
+        public async void ExitAsync(string failure, bool isUnexpected = false)
         {
             await Task.Yield();
-            Exit(timedOut, failure);
+            Exit(failure, isUnexpected);
         }
 
         /// <nodoc/>
-        public void Exit(bool timedOut, string failure)
+        public void Exit(string failure, bool isUnexpected = false)
         {
-            Analysis.IgnoreArgument(timedOut);
-
             m_buildResults.CompleteAdding();
             if (m_sendThread.IsAlive)
             {
@@ -361,11 +359,11 @@ namespace BuildXL.Engine.Distribution
                 m_hasFailures = true;
             }
 
-            if (timedOut && m_isMasterExited)
+            if (isUnexpected && m_isMasterExited)
             {
-                // If the worker experiences time-out for any operation (e.g., attach, call to master)
-                // after master exits the build, we should log a message to keep track of the frequency.
-                Logger.Log.DistributionWorkerTimeoutAfterMasterExits(m_appLoggingContext);
+                // If the worker unexpectedly exits the build after master exits the build, 
+                // we should log a message to keep track of the frequency.
+                Logger.Log.DistributionWorkerUnexpectedFailureAfterMasterExits(m_appLoggingContext);
             }
 
             m_exitCompletionSource.TrySetResult(reportSuccess);
@@ -442,7 +440,7 @@ namespace BuildXL.Engine.Distribution
                     cacheValidationContentHash.ToHex(),
                     possiblyStored.Failure.DescribeIncludingInnerFailures());
 
-                Exit(timedOut: true, "Failed to validate retrieve content from master via cache");
+                Exit("Failed to validate retrieve content from master via cache", isUnexpected: true);
                 return false;
             }
 
@@ -460,7 +458,7 @@ namespace BuildXL.Engine.Distribution
 
             if (!attachCompletionResult.Succeeded)
             {
-                Exit(timedOut: true, $"Failed to attach to master. Duration: {(int)attachCompletionResult.Duration.TotalMinutes}");
+                Exit($"Failed to attach to master. Duration: {(int)attachCompletionResult.Duration.TotalMinutes}", isUnexpected: true);
                 return true;
             }
             else
@@ -478,7 +476,7 @@ namespace BuildXL.Engine.Distribution
             // Unblock caller to make it a fire&forget event handler.
             await Task.Yield();
             Logger.Log.DistributionInactiveMaster(m_appLoggingContext, (int)EngineEnvironmentSettings.DistributionInactiveTimeout.Value.TotalMinutes);
-            ExitAsync(timedOut: true, "Connection timed out");
+            ExitAsync("Connection timed out", isUnexpected: true);
         }
 
         internal void SetLastHeartbeatTimestamp()

--- a/Public/Src/Engine/Dll/Tracing/Log.cs
+++ b/Public/Src/Engine/Dll/Tracing/Log.cs
@@ -887,13 +887,13 @@ namespace BuildXL.Engine.Tracing
         internal abstract void DistributionDebugMessage(LoggingContext loggingContext, string message);
 
         [GeneratedEvent(
-            (ushort)LogEventId.DistributionWorkerTimeoutAfterMasterExits,
+            (ushort)LogEventId.DistributionWorkerUnexpectedFailureAfterMasterExits,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,
             Keywords = (int)Keywords.UserMessage,
             EventTask = (ushort)Tasks.Distribution,
-            Message = "After we received exit request from the master, there is a timeout for a master-related call (e.g., attach, send response).")]
-        public abstract void DistributionWorkerTimeoutAfterMasterExits(LoggingContext context);
+            Message = "After we received an exit request from the master, worker exits with an unexpected reason due to a failure in one of the master-related calls (e.g., attach, notify).")]
+        public abstract void DistributionWorkerUnexpectedFailureAfterMasterExits(LoggingContext context);
 
         #endregion
 

--- a/Public/Src/Engine/Dll/Tracing/Log.cs
+++ b/Public/Src/Engine/Dll/Tracing/Log.cs
@@ -886,6 +886,15 @@ namespace BuildXL.Engine.Tracing
             Message = "DDB_DEBUG: {message}")]
         internal abstract void DistributionDebugMessage(LoggingContext loggingContext, string message);
 
+        [GeneratedEvent(
+            (ushort)LogEventId.DistributionWorkerTimeoutAfterMasterExits,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Verbose,
+            Keywords = (int)Keywords.UserMessage,
+            EventTask = (ushort)Tasks.Distribution,
+            Message = "After we received exit request from the master, there is a timeout for a master-related call (e.g., attach, send response).")]
+        public abstract void DistributionWorkerTimeoutAfterMasterExits(LoggingContext context);
+
         #endregion
 
         [GeneratedEvent(

--- a/Public/Src/Engine/Dll/Tracing/LogEventId.cs
+++ b/Public/Src/Engine/Dll/Tracing/LogEventId.cs
@@ -154,7 +154,7 @@ namespace BuildXL.Engine.Tracing
         // Double defined in EventId.cs
         //DistributionWorkerForwardedError = 7015,
         DistributionWorkerForwardedWarning = 7016,
-        DistributionWorkerTimeoutAfterMasterExits = 7017,
+        DistributionWorkerUnexpectedFailureAfterMasterExits = 7017,
 
         DistributionWorkerExecutePipRequest = 7019,
         DistributionWorkerFinishedPipRequest = 7020,

--- a/Public/Src/Engine/Dll/Tracing/LogEventId.cs
+++ b/Public/Src/Engine/Dll/Tracing/LogEventId.cs
@@ -154,6 +154,7 @@ namespace BuildXL.Engine.Tracing
         // Double defined in EventId.cs
         //DistributionWorkerForwardedError = 7015,
         DistributionWorkerForwardedWarning = 7016,
+        DistributionWorkerTimeoutAfterMasterExits = 7017,
 
         DistributionWorkerExecutePipRequest = 7019,
         DistributionWorkerFinishedPipRequest = 7020,


### PR DESCRIPTION
If master sends an exit message before worker completes the attachment, worker crashes due to calling 'Exit' twice.

[AB#1573927](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1573927)