### PR TITLE
Improve execution analyzer parsing for pip semi-stable hash

### DIFF
--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/CacheMiss/CacheDumpAnalyzer.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/CacheMiss/CacheDumpAnalyzer.cs
@@ -31,7 +31,7 @@ namespace BuildXL.Execution.Analyzer
                 else if (opt.Name.StartsWith("pip", StringComparison.OrdinalIgnoreCase) ||
                     opt.Name.StartsWith("p", StringComparison.OrdinalIgnoreCase))
                 {
-                    semistableHash = Convert.ToInt64(ParseStringOption(opt).ToUpperInvariant().Replace("PIP", ""), 16);
+                    semistableHash = ParseSemistableHash(opt);
                 }
                 else
                 {

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/CacheMiss/FingerprintStoreAnalyzer.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/CacheMiss/FingerprintStoreAnalyzer.cs
@@ -21,7 +21,6 @@ namespace BuildXL.Execution.Analyzer
         public Analyzer InitializeFingerprintStoreAnalyzer(AnalysisInput oldAnalysisInput, AnalysisInput newAnalysisInput)
         {
             string outputDirectory = null;
-            string sshString = null;
             bool allPips = false;
             bool noBanner = false;
             long sshValue = -1;
@@ -35,7 +34,7 @@ namespace BuildXL.Execution.Analyzer
                 else if(opt.Name.Equals("pip", StringComparison.OrdinalIgnoreCase) ||
                     opt.Name.Equals("p", StringComparison.OrdinalIgnoreCase))
                 {
-                    sshString = ParseStringOption(opt);
+                    sshValue = ParseSemistableHash(opt);
                 }
                 else if (opt.Name.StartsWith("allPips", StringComparison.OrdinalIgnoreCase))
                 {
@@ -56,19 +55,9 @@ namespace BuildXL.Execution.Analyzer
                 throw new Exception("'outputDirectory' is required.");
             }
 
-            if (allPips && sshString != null)
+            if (allPips && sshValue != -1)
             {
                 throw new Exception("'allPips' can't be true if pipId is set.");
-            }
-
-            if (sshString != null)
-            {
-                if (!sshString.StartsWith(Pip.SemiStableHashPrefix, StringComparison.OrdinalIgnoreCase))
-                {
-                    throw new Exception(string.Format("Invalid pip: '{0}'. Id must be a semistable hash that starts with Pip i.e.: PipC623BCE303738C69", sshString));
-                }
-
-                sshValue = Convert.ToInt64(sshString.Substring(3), 16);
             }
 
             return new FingerprintStoreAnalyzer(oldAnalysisInput, newAnalysisInput)

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/ProcessRunScriptAnalyzer.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/ProcessRunScriptAnalyzer.cs
@@ -46,7 +46,7 @@ namespace BuildXL.Execution.Analyzer
                 else if (opt.Name.Equals("pip", StringComparison.OrdinalIgnoreCase) ||
                     opt.Name.Equals("p", StringComparison.OrdinalIgnoreCase))
                 {
-                    pipId = Convert.ToInt64(ParseStringOption(opt), 16);
+                    pipId = ParseSemistableHash(opt);
                 }
                 else if (opt.Name.Equals("pipInput", StringComparison.OrdinalIgnoreCase))
                 {

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/CosineDumpPip/CosineDumpPip.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/CosineDumpPip/CosineDumpPip.cs
@@ -36,12 +36,7 @@ namespace BuildXL.Execution.Analyzer
                 }
                 else if (opt.Name.Equals(PipHashOption, StringComparison.OrdinalIgnoreCase))
                 {
-                    string sshAsString = ParseStringOption(opt);
-                    if (!sshAsString.StartsWith(Pip.SemiStableHashPrefix, StringComparison.OrdinalIgnoreCase))
-                    {
-                        throw Error($"Invalid pip:{sshAsString}. Id must be a semistable hash that starts with the prefix '{Pip.SemiStableHashPrefix}' i.e.: {Pip.SemiStableHashPrefix}C623BCE303738C69");
-                    }
-                    filters.PipSemiStableHash = Convert.ToInt64(sshAsString.Substring(3), 16);
+                    filters.PipSemiStableHash = ParseSemistableHash(opt);
                 }
                 else if (opt.Name.Equals(PipTypeOption, StringComparison.OrdinalIgnoreCase))
                 {

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/DevAnalyzer.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/DevAnalyzer.cs
@@ -28,7 +28,7 @@ namespace BuildXL.Execution.Analyzer
                 else if (opt.Name.StartsWith("pip", StringComparison.OrdinalIgnoreCase) ||
                     opt.Name.StartsWith("p", StringComparison.OrdinalIgnoreCase))
                 {
-                    pipId = Convert.ToInt64(ParseStringOption(opt), 16);
+                    pipId = ParseSemistableHash(opt);
                 }
                 else
                 {

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/DumpPipAnalyzer.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/DumpPipAnalyzer.cs
@@ -36,13 +36,7 @@ namespace BuildXL.Execution.Analyzer
                 else if (opt.Name.Equals("pip", StringComparison.OrdinalIgnoreCase) ||
                          opt.Name.Equals("p", StringComparison.OrdinalIgnoreCase))
                 {
-                    var sshAsString = ParseStringOption(opt);
-                    if (!sshAsString.StartsWith(Pip.SemiStableHashPrefix, StringComparison.OrdinalIgnoreCase))
-                    {
-                        throw Error("Invalid pip: '' {0}. Id must be a semistable hash that starts with Pip i.e.: PipC623BCE303738C69", sshAsString);
-                    }
-
-                    semiStableHash = Convert.ToInt64(sshAsString.Substring(3), 16);
+                    semiStableHash = ParseSemistableHash(opt);
                 }
                 else if (opt.Name.Equals("useOriginalPaths", StringComparison.OrdinalIgnoreCase) ||
                          opt.Name.Equals("u", StringComparison.OrdinalIgnoreCase))

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/DumpProcess.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/DumpProcess.cs
@@ -44,7 +44,7 @@ namespace BuildXL.Execution.Analyzer
                 else if (opt.Name.StartsWith("pip", StringComparison.OrdinalIgnoreCase) ||
                    opt.Name.StartsWith("p", StringComparison.OrdinalIgnoreCase))
                 {
-                    semistableHash = Convert.ToInt64(ParseStringOption(opt), 16);
+                    semistableHash = ParseSemistableHash(opt);
                 }
                 else if (opt.Name.StartsWith("root", StringComparison.OrdinalIgnoreCase) ||
                     opt.Name.StartsWith("r", StringComparison.OrdinalIgnoreCase))

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/ObservedAccessAnalyzer.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/ObservedAccessAnalyzer.cs
@@ -30,7 +30,7 @@ namespace BuildXL.Execution.Analyzer
                 else if (opt.Name.Equals("pip", StringComparison.OrdinalIgnoreCase) ||
                    opt.Name.Equals("p", StringComparison.OrdinalIgnoreCase))
                 {
-                    targetPip = Convert.ToInt64(ParseStringOption(opt), 16);
+                    targetPip = ParseSemistableHash(opt);
                 }
                 else if (opt.Name.TrimEnd('-', '+').Equals("sortPaths", StringComparison.OrdinalIgnoreCase))
                 {

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/ProcessDetouringAnalyzer.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/ProcessDetouringAnalyzer.cs
@@ -30,7 +30,7 @@ namespace BuildXL.Execution.Analyzer
                 else if (opt.Name.StartsWith("pip", StringComparison.OrdinalIgnoreCase) ||
                     opt.Name.StartsWith("p", StringComparison.OrdinalIgnoreCase))
                 {
-                    semistableHash = Convert.ToInt64(ParseStringOption(opt), 16);
+                    semistableHash = ParseSemistableHash(opt);
                 }
                 else
                 {

--- a/Public/Src/Tools/Execution.Analyzer/Args.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Args.cs
@@ -5,9 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.ContractsLight;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using BuildXL.Pips.Operations;
 using BuildXL.Storage;
 using BuildXL.ToolSupport;
 using BuildXL.Utilities;
@@ -603,8 +605,13 @@ namespace BuildXL.Execution.Analyzer
 
         public long ParseSemistableHash(Option opt)
         {
-            var adjustedOption = new Option() { Name = opt.Name, Value = opt.Value.ToUpper().Replace("PIP", "") };
-            return Convert.ToInt64(ParseStringOption(adjustedOption), 16);
+            var adjustedOption = new Option() { Name = opt.Name, Value = opt.Value.ToUpper().Replace(Pip.SemiStableHashPrefix.ToUpper(), "") };
+            if (!Int64.TryParse(ParseStringOption(adjustedOption), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out long sshValue) || sshValue == 0)
+            {
+                throw Error("Invalid pip: {0}. Id must be a semistable hash that starts with Pip i.e.: PipC623BCE303738C69", opt.Value);
+            }
+
+            return sshValue;
         }
     }
 


### PR DESCRIPTION
Switch analyzers to use a shared method ParseSemistableHash for parsing
pip SSH. 
Also exit gracefully when invalid hash is specified instead of crashing