### PR TITLE
Enable grpc and earlyWorkerRelease by default

### DIFF
--- a/Public/Src/App/Bxl/Args.cs
+++ b/Public/Src/App/Bxl/Args.cs
@@ -309,11 +309,11 @@ namespace BuildXL
                             opt => loggingConfiguration.Diagnostic |= CommandLineUtilities.ParseEnumOption<DiagnosticLevels>(opt)),
                         OptionHandlerFactory.CreateBoolOption(
                             "earlyWorkerRelease",
-                            sign => schedulingConfiguration.EarlyWorkerRelease = sign),
+                            sign => distributionConfiguration.EarlyWorkerRelease = sign),
                         OptionHandlerFactory.CreateOption(
                             "earlyWorkerReleaseMultiplier",
                             opt =>
-                            schedulingConfiguration.EarlyWorkerReleaseMultiplier = CommandLineUtilities.ParseDoubleOption(opt, 0, 5)),
+                            distributionConfiguration.EarlyWorkerReleaseMultiplier = CommandLineUtilities.ParseDoubleOption(opt, 0, 5)),
                         OptionHandlerFactory.CreateBoolOption(
                             "enforceAccessPoliciesOnDirectoryCreation",
                             sign => sandboxConfiguration.EnforceAccessPoliciesOnDirectoryCreation = sign),

--- a/Public/Src/Engine/Dll/Engine.cs
+++ b/Public/Src/Engine/Dll/Engine.cs
@@ -1104,7 +1104,7 @@ namespace BuildXL.Engine
             // When replicating outputs to workers, workers cannot be released early.
             if (mutableConfig.Distribution.ReplicateOutputsToWorkers == true)
             {
-                mutableConfig.Schedule.EarlyWorkerRelease = false;
+                mutableConfig.Distribution.EarlyWorkerRelease = false;
             }
 
             return success;

--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -2057,7 +2057,7 @@ namespace BuildXL.Scheduler
                     m_pipQueue.AdjustIOParallelDegree(m_perfInfo);
                 }
 
-                if (m_scheduleConfiguration.EarlyWorkerRelease && IsDistributedMaster)
+                if (m_configuration.Distribution.EarlyWorkerRelease && IsDistributedMaster)
                 {
                     PerformEarlyReleaseWorker(numProcessPipsPending, numProcessPipsAllocatedSlots);
                 }

--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -2081,7 +2081,7 @@ namespace BuildXL.Scheduler
 
             // If the available remote workers perform at that multiplier capacity in future, how many process pips we can concurrently execute:
             int totalProcessSlots = LocalWorker.TotalProcessSlots +
-               (int)Math.Ceiling(m_scheduleConfiguration.EarlyWorkerReleaseMultiplier * Workers.Where(a => a.IsRemote && a.IsAvailable).Sum(a => a.TotalProcessSlots));
+               (int)Math.Ceiling(m_configuration.Distribution.EarlyWorkerReleaseMultiplier * Workers.Where(a => a.IsRemote && a.IsAvailable).Sum(a => a.TotalProcessSlots));
 
             // Release worker if numProcessPipsWaiting can be satisfied by remaining workers
             if (numProcessPipsWaiting > 0 && (numProcessPipsWaiting < totalProcessSlots - workerToReleaseCandidate.TotalProcessSlots))

--- a/Public/Src/Utilities/Configuration/IDistributionConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/IDistributionConfiguration.cs
@@ -58,5 +58,15 @@ namespace BuildXL.Utilities.Configuration
         /// Minimum number of workers that BuildXL needs to connect within a fixed time; otherwise BuildXL will fail.
         /// </summary>
         int MinimumWorkers { get; }
+
+        /// <summary>
+        /// Indicates whether the remote workers should be released early in case of insufficient amount of work. 
+        /// </summary>
+        bool EarlyWorkerRelease { get; }
+
+        /// <summary>
+        /// Specifies the capacity multiplier when we start releasing the workers.
+        /// </summary>
+        double EarlyWorkerReleaseMultiplier { get; }
     }
 }

--- a/Public/Src/Utilities/Configuration/IScheduleConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/IScheduleConfiguration.cs
@@ -306,15 +306,5 @@ namespace BuildXL.Utilities.Configuration
         /// Indicates whether historic cpu information should be used to decide the weight of process pips.
         /// </summary>
         bool UseHistoricalCpuUsageInfo { get; }
-
-        /// <summary>
-        /// Indicates whether the remote workers should be released early in case of insufficient amount of work. 
-        /// </summary>
-        bool EarlyWorkerRelease { get; }
-
-        /// <summary>
-        /// Specifies the capacity multiplier when we start releasing the workers.
-        /// </summary>
-        double EarlyWorkerReleaseMultiplier { get; }
     }
 }

--- a/Public/Src/Utilities/Configuration/Mutable/DistributionConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/DistributionConfiguration.cs
@@ -19,9 +19,9 @@ namespace BuildXL.Utilities.Configuration.Mutable
             // Local worker is always connected.
             MinimumWorkers = 1;
 
-#if FEATURE_CORECLR
             IsGrpcEnabled = true;
-#endif
+            EarlyWorkerRelease = true;
+            EarlyWorkerReleaseMultiplier = 0.5;
         }
 
         /// <nodoc />
@@ -38,6 +38,8 @@ namespace BuildXL.Utilities.Configuration.Mutable
             DistributeCacheLookups = template.DistributeCacheLookups;
             MinimumWorkers = template.MinimumWorkers;
             IsGrpcEnabled = template.IsGrpcEnabled;
+            EarlyWorkerRelease = template.EarlyWorkerRelease;
+            EarlyWorkerReleaseMultiplier = template.EarlyWorkerReleaseMultiplier;
         }
 
         /// <inhertidoc />
@@ -70,5 +72,11 @@ namespace BuildXL.Utilities.Configuration.Mutable
 
         /// <inhertidoc />
         public int MinimumWorkers { get; set; }
+
+        /// <inheritdoc />
+        public bool EarlyWorkerRelease { get; set; }
+
+        /// <inheritdoc />
+        public double EarlyWorkerReleaseMultiplier { get; set; }
     }
 }

--- a/Public/Src/Utilities/Configuration/Mutable/ScheduleConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/ScheduleConfiguration.cs
@@ -71,8 +71,6 @@ namespace BuildXL.Utilities.Configuration.Mutable
             SkipHashSourceFile = false;
 
             UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing = false;
-
-            EarlyWorkerReleaseMultiplier = 0.5;
         }
 
         /// <nodoc />
@@ -136,8 +134,6 @@ namespace BuildXL.Utilities.Configuration.Mutable
             SkipHashSourceFile = template.SkipHashSourceFile;
 
             UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing = template.UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing;
-            EarlyWorkerRelease = template.EarlyWorkerRelease;
-            EarlyWorkerReleaseMultiplier = template.EarlyWorkerReleaseMultiplier;
         }
 
         /// <inheritdoc />
@@ -318,11 +314,5 @@ namespace BuildXL.Utilities.Configuration.Mutable
 
         /// <inheritdoc />
         public bool UseHistoricalCpuUsageInfo { get; set; }
-
-        /// <inheritdoc />
-        public bool EarlyWorkerRelease { get; set; }
-
-        /// <inheritdoc />
-        public double EarlyWorkerReleaseMultiplier { get; set; }
     }
 }


### PR DESCRIPTION
I enabled both features by default. They were already enabled for all automatically-generated Office queues. I also moved earlyWorkerRelease arg from SchedulerConfiguration to DistributionConfiguration. 