### PR TITLE
Fix DFA when building BuildXL explorer in CB

### DIFF
--- a/Public/Sdk/Experimental/NodeJs/Yarn/yarn.dsc
+++ b/Public/Sdk/Experimental/NodeJs/Yarn/yarn.dsc
@@ -170,6 +170,8 @@ export function install(args: Arguments) : Result {
                         ...(args.privateCache ? [] : [
                             // We don't have a private cache so untrack the appdata cache folder
                             d`${Context.getMount("LocalAppData").path}/yarn`,
+                            // CB creates a junction from %LocalAppData%\yarn to d:\dbs\profile\bxlint\appdata\local\yarn
+                            d`d:/dbs/profile/bxlint/appdata/local/yarn`,
                         ]),
                     ],
                 },


### PR DESCRIPTION
BuildXL explorer is built using Yarn. When Yarn write to its cache, and users do not specify the cache location, then the default behavior is to write to `C:/Users/<user>/AppData/Local/Yarn/cache`. Unfortunately, CB creates a junction from `C:/Users/<user>/AppData/Local/Yarn` to `d:/dbs/profile/bxlint/appdata/local/yarn`. Without a proper directory translation, such a write can result in disallowed file accesses.

[AB#1573693](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1573693)