### PR TITLE
Add DeleteFile tests that exercise deleting an executing process

### DIFF
--- a/Public/Src/Engine/Dll/DirectoryScrubber.cs
+++ b/Public/Src/Engine/Dll/DirectoryScrubber.cs
@@ -32,7 +32,7 @@ namespace BuildXL.Engine
         private readonly HashSet<string> m_blockedPaths;
         private readonly int m_maxDegreeParallelism;
         private readonly MountPathExpander m_mountPathExpander;
-        private readonly ITempDirectoryCleaner m_tempDirectoryCleaner;
+        private readonly ITempCleaner m_tempDirectoryCleaner;
 
         // Directories that can be scrubbed but cannot be deleted.
         private readonly HashSet<string> m_nonDeletableRootDirectories;
@@ -64,7 +64,7 @@ namespace BuildXL.Engine
             IEnumerable<string> nonDeletableRootDirectories,
             MountPathExpander mountPathExpander,
             int maxDegreeParallelism,
-            ITempDirectoryCleaner tempDirectoryCleaner = null)
+            ITempCleaner tempDirectoryCleaner = null)
         {
             m_loggingContext = loggingContext;
             m_loggingConfiguration = loggingConfiguration;

--- a/Public/Src/Engine/Dll/Engine.cs
+++ b/Public/Src/Engine/Dll/Engine.cs
@@ -208,7 +208,7 @@ namespace BuildXL.Engine
 
         /// <summary>
         /// TempCleaner responsible for cleaning registered directories or files in the background.
-        /// This is owned by the outermost layer that calls <see cref="FileUtilities.DeleteFile(string, bool, ITempDirectoryCleaner)"/>, the engine.
+        /// This is owned by the outermost layer that calls <see cref="FileUtilities.DeleteFile(string, bool, ITempCleaner)"/>, the engine.
         /// </summary>
         private TempCleaner m_tempCleaner;
 

--- a/Public/Src/Engine/Dll/EngineSchedule.cs
+++ b/Public/Src/Engine/Dll/EngineSchedule.cs
@@ -745,7 +745,7 @@ namespace BuildXL.Engine
             LoggingContext loggingContext,
             IConfiguration configuration,
             IEnumerable<string> nonScrubbablePaths,
-            ITempDirectoryCleaner tempCleaner)
+            ITempCleaner tempCleaner)
         {
             var pathsToScrub = new List<string>();
             if (configuration.Engine.Scrub && mountPathExpander != null)
@@ -837,7 +837,7 @@ namespace BuildXL.Engine
             PathTable pathTable,
             IConfiguration configuration,
             IEnumerable<string> extraNonScrubbablePaths,
-            [CanBeNull] ITempDirectoryCleaner tempCleaner)
+            [CanBeNull] ITempCleaner tempCleaner)
         {
             var nonScrubbablePaths = new List<string>(new[]
             {
@@ -1999,7 +1999,7 @@ namespace BuildXL.Engine
             PipGraphCacheDescriptor cacheDescriptor,
             EngineSerializer serializer,
             FileContentTable fileContentTable,
-            ITempDirectoryCleaner tempDirectoryCleaner)
+            ITempCleaner tempDirectoryCleaner)
         {
             if (cacheDescriptor != null)
             {

--- a/Public/Src/Engine/Dll/EngineTestHooksData.cs
+++ b/Public/Src/Engine/Dll/EngineTestHooksData.cs
@@ -72,7 +72,7 @@ namespace BuildXL.Engine
         /// <summary>
         /// The temp directory the Engine used for initializing its <see cref="TempCleaner"/>
         /// The <see cref="TempCleaner"/>'s temp directory is passed into 
-        /// <see cref="BuildXL.Native.IO.FileUtilities.DeleteFile(string, bool, BuildXL.Native.IO.ITempDirectoryCleaner)"/>
+        /// <see cref="BuildXL.Native.IO.FileUtilities.DeleteFile(string, bool, BuildXL.Native.IO.ITempCleaner)"/>
         /// for move-deleting files
         /// </summary>
         public string TempCleanerTempDirectory { get; set; } = null;

--- a/Public/Src/Engine/Dll/OutputCleaner.cs
+++ b/Public/Src/Engine/Dll/OutputCleaner.cs
@@ -28,7 +28,7 @@ namespace BuildXL.Engine
             Func<DirectoryArtifact, bool> isOutputDir,
             IList<FileOrDirectoryArtifact> filesOrDirectoriesToDelete,
             PathTable pathTable,
-            ITempDirectoryCleaner tempDirectoryCleaner = null)
+            ITempCleaner tempDirectoryCleaner = null)
         {
             int fileFailCount = 0;
             int fileSuccessCount = 0;

--- a/Public/Src/Engine/Dll/Serialization/EngineSerializer.cs
+++ b/Public/Src/Engine/Dll/Serialization/EngineSerializer.cs
@@ -64,7 +64,7 @@ namespace BuildXL.Engine
         private object m_correlationId;
         private readonly bool m_useCompression;
         private readonly FileSystemStreamProvider m_readStreamProvider;
-        private readonly ITempDirectoryCleaner m_tempDirectoryCleaner;
+        private readonly ITempCleaner m_tempDirectoryCleaner;
 
         /// <summary>
         /// Constructor
@@ -77,7 +77,7 @@ namespace BuildXL.Engine
             bool debug = false,
             bool readOnly = false,
             FileSystemStreamProvider readStreamProvider = null,
-            ITempDirectoryCleaner tempDirectoryCleaner = null)
+            ITempCleaner tempDirectoryCleaner = null)
         {
             Contract.Requires(loggingContext != null);
             Contract.Requires(engineCacheLocation != null);

--- a/Public/Src/Engine/Dll/SymlinkDefinitionFileProvider.cs
+++ b/Public/Src/Engine/Dll/SymlinkDefinitionFileProvider.cs
@@ -36,7 +36,7 @@ namespace BuildXL.Engine
             MasterService masterService,
             CacheInitializationTask cacheInitializerTask,
             PipExecutionContext context,
-            ITempDirectoryCleaner tempDirectoryCleaner = null)
+            ITempCleaner tempDirectoryCleaner = null)
         {
             var pathTable = context.PathTable;
             bool isDistributedMaster = configuration.Distribution.BuildRole == DistributedBuildRoles.Master;

--- a/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
@@ -151,7 +151,7 @@ namespace BuildXL.Processes
 
         private readonly int m_remainingUserRetryCount;
 
-        private readonly ITempDirectoryCleaner m_tempDirectoryCleaner;
+        private readonly ITempCleaner m_tempDirectoryCleaner;
 
         private readonly ReadOnlyHashSet<AbsolutePath> m_sharedOpaqueDirectoryRoots;
 
@@ -187,7 +187,7 @@ namespace BuildXL.Processes
             PipEnvironment pipEnvironment,
             bool validateDistribution,
             IDirectoryArtifactContext directoryArtifactContext,
-            ITempDirectoryCleaner tempDirectoryCleaner,
+            ITempCleaner tempDirectoryCleaner,
             ISandboxedProcessLogger logger = null,
             Action<int> processIdListener = null,
             PipFragmentRenderer pipDataRenderer = null,

--- a/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
@@ -187,6 +187,7 @@ namespace BuildXL.Processes
             PipEnvironment pipEnvironment,
             bool validateDistribution,
             IDirectoryArtifactContext directoryArtifactContext,
+            ITempDirectoryCleaner tempDirectoryCleaner,
             ISandboxedProcessLogger logger = null,
             Action<int> processIdListener = null,
             PipFragmentRenderer pipDataRenderer = null,
@@ -195,7 +196,6 @@ namespace BuildXL.Processes
             int remainingUserRetryCount = 0,
             bool isQbuildIntegrated = false,
             VmInitializer vmInitializer = null,
-            ITempDirectoryCleaner tempDirectoryCleaner = null,
             SubstituteProcessExecutionInfo shimInfo = null)
         {
             Contract.Requires(pip != null);
@@ -206,6 +206,8 @@ namespace BuildXL.Processes
             Contract.Requires(pipEnvironment != null);
             Contract.Requires(directoryArtifactContext != null);
             Contract.Requires(processInContainerManager != null);
+            // The tempDirectoryCleaner must not be null since it is relied upon for robust file deletion
+            Contract.Requires(tempDirectoryCleaner != null);
 
             m_context = context;
             m_loggingContext = loggingContext;

--- a/Public/Src/Engine/Scheduler/Artifacts/FileContentManager.cs
+++ b/Public/Src/Engine/Scheduler/Artifacts/FileContentManager.cs
@@ -69,7 +69,7 @@ namespace BuildXL.Scheduler.Artifacts
     public sealed class FileContentManager : IQueryableFileContentManager
     {
         private const int MAX_SYMLINK_TRAVERSALS = 100;
-        private readonly ITempDirectoryCleaner m_tempDirectoryCleaner;
+        private readonly ITempCleaner m_tempDirectoryCleaner;
 
         #region Internal State
 
@@ -241,7 +241,7 @@ namespace BuildXL.Scheduler.Artifacts
             IFileContentManagerHost host,
             IOperationTracker operationTracker,
             SymlinkDefinitions symlinkDefinitions = null,
-            ITempDirectoryCleaner tempDirectoryCleaner = null)
+            ITempCleaner tempDirectoryCleaner = null)
         {
             m_host = host;
             ArtifactContentCache = new ElidingArtifactContentCacheWrapper(host.ArtifactContentCache);

--- a/Public/Src/Engine/Scheduler/Artifacts/SymlinkDefinitions.cs
+++ b/Public/Src/Engine/Scheduler/Artifacts/SymlinkDefinitions.cs
@@ -77,7 +77,7 @@ namespace BuildXL.Scheduler.Artifacts
             PathTable pathTable,
             string filePath,
             string symlinksDebugPath,
-            ITempDirectoryCleaner tempDirectoryCleaner = null)
+            ITempCleaner tempDirectoryCleaner = null)
         {
             try
             {

--- a/Public/Src/Engine/Scheduler/IPipExecutionEnvironment.cs
+++ b/Public/Src/Engine/Scheduler/IPipExecutionEnvironment.cs
@@ -194,7 +194,7 @@ namespace BuildXL.Scheduler
         /// <summary>
         /// Temp directory cleaner
         /// </summary>
-        ITempDirectoryCleaner TempCleaner { get; }
+        ITempCleaner TempCleaner { get; }
     }
 
     /// <summary>

--- a/Public/Src/Engine/Scheduler/IPipExecutionEnvironment.cs
+++ b/Public/Src/Engine/Scheduler/IPipExecutionEnvironment.cs
@@ -6,6 +6,7 @@ using BuildXL.Engine.Cache;
 using BuildXL.Engine.Cache.Artifacts;
 using BuildXL.Ipc.Common;
 using BuildXL.Ipc.Interfaces;
+using BuildXL.Native.IO;
 using BuildXL.Pips;
 using BuildXL.Pips.Operations;
 using BuildXL.Processes.Containers;
@@ -193,7 +194,7 @@ namespace BuildXL.Scheduler
         /// <summary>
         /// Temp directory cleaner
         /// </summary>
-        TempCleaner TempCleaner { get; }
+        ITempDirectoryCleaner TempCleaner { get; }
     }
 
     /// <summary>

--- a/Public/Src/Engine/Scheduler/IncrementalScheduling/GraphAgnosticIncrementalSchedulingState.cs
+++ b/Public/Src/Engine/Scheduler/IncrementalScheduling/GraphAgnosticIncrementalSchedulingState.cs
@@ -213,7 +213,7 @@ namespace BuildXL.Scheduler.IncrementalScheduling
         /// <summary>
         /// Cleaner that can register directories or files to be cleaned in the background
         /// </summary>
-        private readonly ITempDirectoryCleaner m_tempDirectoryCleaner;
+        private readonly ITempCleaner m_tempDirectoryCleaner;
 
         /// <summary>
         /// Envelope for serialization
@@ -268,7 +268,7 @@ namespace BuildXL.Scheduler.IncrementalScheduling
             bool pipGraphChanged,
             PipGraphSequenceNumber pipGraphSequenceNumber,
             int indexToGraphLogs,
-            ITempDirectoryCleaner tempDirectoryCleaner = null)
+            ITempCleaner tempDirectoryCleaner = null)
         {
             Contract.Requires(loggingContext != null);
             Contract.Requires(atomicSaveToken.IsValid);
@@ -316,7 +316,7 @@ namespace BuildXL.Scheduler.IncrementalScheduling
             PipGraph pipGraph,
             IConfiguration configuration,
             ContentHash preserveOutputSalt,
-            ITempDirectoryCleaner tempDirectoryCleaner = null)
+            ITempCleaner tempDirectoryCleaner = null)
         {
             Contract.Requires(loggingContext != null);
             Contract.Requires(atomicSaveToken.IsValid);
@@ -1275,7 +1275,7 @@ namespace BuildXL.Scheduler.IncrementalScheduling
         }
 
         /// <inheritdoc />
-        public IIncrementalSchedulingState Reuse(LoggingContext loggingContext, PipGraph pipGraph, IConfiguration configuration, ContentHash preserveOutputSalt, ITempDirectoryCleaner tempDirectoryCleaner = null)
+        public IIncrementalSchedulingState Reuse(LoggingContext loggingContext, PipGraph pipGraph, IConfiguration configuration, ContentHash preserveOutputSalt, ITempCleaner tempDirectoryCleaner = null)
         {
             Contract.Requires(loggingContext != null);
 
@@ -1326,7 +1326,7 @@ namespace BuildXL.Scheduler.IncrementalScheduling
             ContentHash preserveOutputSalt,
             string incrementalSchedulingStatePath,
             bool analysisModeOnly = false,
-            ITempDirectoryCleaner tempDirectoryCleaner = null)
+            ITempCleaner tempDirectoryCleaner = null)
         {
             Contract.Requires(loggingContext != null);
             Contract.Requires(analysisModeOnly || atomicSaveToken.IsValid);

--- a/Public/Src/Engine/Scheduler/IncrementalScheduling/IIncrementalSchedulingState.cs
+++ b/Public/Src/Engine/Scheduler/IncrementalScheduling/IIncrementalSchedulingState.cs
@@ -77,6 +77,6 @@ namespace BuildXL.Scheduler.IncrementalScheduling
         /// A logging context needs to be given because the logging context maintained by this instance of <see cref="IIncrementalSchedulingState"/> can be
         /// associated with some previous build.
         /// </remarks>
-        IIncrementalSchedulingState Reuse(LoggingContext loggingContext, PipGraph pipGraph, IConfiguration configuration, ContentHash preserveOutputSalt, ITempDirectoryCleaner tempDirectoryCleaner);
+        IIncrementalSchedulingState Reuse(LoggingContext loggingContext, PipGraph pipGraph, IConfiguration configuration, ContentHash preserveOutputSalt, ITempCleaner tempDirectoryCleaner);
     }
 }

--- a/Public/Src/Engine/Scheduler/IncrementalScheduling/IncrementalSchedulingStateFactory.cs
+++ b/Public/Src/Engine/Scheduler/IncrementalScheduling/IncrementalSchedulingStateFactory.cs
@@ -18,7 +18,7 @@ namespace BuildXL.Scheduler.IncrementalScheduling
     {
         private readonly LoggingContext m_loggingContext;
 
-        private readonly ITempDirectoryCleaner m_tempDirectoryCleaner;
+        private readonly ITempCleaner m_tempDirectoryCleaner;
 
         private readonly bool m_analysisMode;
 
@@ -28,7 +28,7 @@ namespace BuildXL.Scheduler.IncrementalScheduling
         public IncrementalSchedulingStateFactory(
             LoggingContext loggingContext,
             bool analysisMode = false,            
-            ITempDirectoryCleaner tempDirectoryCleaner = null)
+            ITempCleaner tempDirectoryCleaner = null)
         {
             Contract.Requires(loggingContext != null);
 

--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -252,7 +252,7 @@ namespace BuildXL.Scheduler
         /// <summary>
         /// Cleans temp directories in background
         /// </summary>
-        public ITempDirectoryCleaner TempCleaner { get; }
+        public ITempCleaner TempCleaner { get; }
 
         /// <summary>
         /// The pip graph
@@ -994,7 +994,7 @@ namespace BuildXL.Scheduler
             LoggingContext loggingContext,
             string buildEngineFingerprint,
             DirectoryMembershipFingerprinterRuleSet directoryMembershipFingerprinterRules = null,
-            ITempDirectoryCleaner tempCleaner = null,
+            ITempCleaner tempCleaner = null,
             Task<PipRuntimeTimeTable> runningTimeTableTask = null,
             PerformanceCollector performanceCollector = null,
             string fingerprintSalt = null,

--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -252,7 +252,7 @@ namespace BuildXL.Scheduler
         /// <summary>
         /// Cleans temp directories in background
         /// </summary>
-        public TempCleaner TempCleaner { get; }
+        public ITempDirectoryCleaner TempCleaner { get; }
 
         /// <summary>
         /// The pip graph
@@ -994,7 +994,7 @@ namespace BuildXL.Scheduler
             LoggingContext loggingContext,
             string buildEngineFingerprint,
             DirectoryMembershipFingerprinterRuleSet directoryMembershipFingerprinterRules = null,
-            TempCleaner tempCleaner = null,
+            ITempDirectoryCleaner tempCleaner = null,
             Task<PipRuntimeTimeTable> runningTimeTableTask = null,
             PerformanceCollector performanceCollector = null,
             string fingerprintSalt = null,

--- a/Public/Src/Engine/Scheduler/TempCleaner.cs
+++ b/Public/Src/Engine/Scheduler/TempCleaner.cs
@@ -16,9 +16,9 @@ namespace BuildXL.Scheduler
     /// Leaving the directory itself not deleted may save work in the subsequent build.
     /// This is used for cleaning <see cref="BuildXL.Pips.Operations.Process.TempDirectory"/>,
     /// <see cref="BuildXL.Pips.Operations.Process.AdditionalTempDirectories"/>.
-    /// It is also used as a <see cref="ITempDirectoryCleaner"/> implementation and cleans <see cref="TempCleaner.TempDirectory"/>.
+    /// It is also used as a <see cref="ITempCleaner"/> implementation and cleans <see cref="TempCleaner.TempDirectory"/>.
     /// </summary>
-    public sealed class TempCleaner : ITempDirectoryCleaner
+    public sealed class TempCleaner : ITempCleaner
     {
         /// <summary>
         /// Simple holder that stores path information.

--- a/Public/Src/Engine/UnitTests/EngineTestUtilities/TestSchedulerFactory.cs
+++ b/Public/Src/Engine/UnitTests/EngineTestUtilities/TestSchedulerFactory.cs
@@ -4,18 +4,19 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.ContractsLight;
+using System.IO;
+using BuildXL.Engine;
 using BuildXL.Engine.Cache;
 using BuildXL.Engine.Cache.Artifacts;
 using BuildXL.Engine.Cache.Fingerprints.TwoPhase;
-using BuildXL.Engine;
 using BuildXL.Pips;
 using BuildXL.Processes;
 using BuildXL.Scheduler;
 using BuildXL.Scheduler.Graph;
 using BuildXL.Storage;
 using BuildXL.Utilities;
-using BuildXL.Utilities.Tracing;
 using BuildXL.Utilities.Configuration;
+using BuildXL.Utilities.Tracing;
 
 namespace Test.BuildXL.TestUtilities
 {
@@ -137,7 +138,8 @@ namespace Test.BuildXL.TestUtilities
                 configuration: configuration,
                 fileAccessWhitelist: fileAccessWhiteList,
                 testHooks: testHooks,
-                buildEngineFingerprint: null);
+                buildEngineFingerprint: null,
+                tempCleaner: new TestMoveDeleteCleaner(Path.Combine(Environment.GetEnvironmentVariable("TEMP"), "MoveDeletionTemp")));
         }
     }
 }

--- a/Public/Src/Engine/UnitTests/Processes.Detours/PipExecutorDetoursTest.cs
+++ b/Public/Src/Engine/UnitTests/Processes.Detours/PipExecutorDetoursTest.cs
@@ -149,7 +149,8 @@ namespace Test.BuildXL.Processes.Detours
                 directoryArtifactContext: TestDirectoryArtifactContext.Empty,
                 buildEngineDirectory: binDirectory,
                 directoryTranslator: directoryTranslator,
-                isQbuildIntegrated: isQuickBuildIntegrated).RunAsync(sandboxedKextConnection: GetSandboxedKextConnection());
+                isQbuildIntegrated: isQuickBuildIntegrated,
+                tempDirectoryCleaner: MoveDeleteCleaner).RunAsync(sandboxedKextConnection: GetSandboxedKextConnection());
         }
 
         [Fact]

--- a/Public/Src/Engine/UnitTests/Processes.Detours/SandboxedProcessPipExecutorTest.cs
+++ b/Public/Src/Engine/UnitTests/Processes.Detours/SandboxedProcessPipExecutorTest.cs
@@ -2020,36 +2020,36 @@ namespace Test.BuildXL.Processes.Detours
             }
         }
 
-        private static Task AssertProcessFailsExecution(
+        private Task AssertProcessFailsExecution(
             BuildXLContext context,
             ISandboxConfiguration config,
             Process process,
             FileAccessWhitelist fileAccessWhitelist = null,
             SandboxedProcessPipExecutionResultWrapper resultWrapper = null)
         {
-            return AssertProcessCompletesWithStatus(SandboxedProcessPipExecutionStatus.ExecutionFailed, context, config, process, fileAccessWhitelist, resultWrapper);
+            return AssertProcessCompletesWithStatusAsync(SandboxedProcessPipExecutionStatus.ExecutionFailed, context, config, process, fileAccessWhitelist, resultWrapper);
         }
 
-        private static Task AssertProcessFailsPreparation(
+        private Task AssertProcessFailsPreparation(
             BuildXLContext context,
             ISandboxConfiguration config,
             Process process,
             FileAccessWhitelist fileAccessWhitelist = null)
         {
-            return AssertProcessCompletesWithStatus(SandboxedProcessPipExecutionStatus.PreparationFailed, context, config, process, fileAccessWhitelist);
+            return AssertProcessCompletesWithStatusAsync(SandboxedProcessPipExecutionStatus.PreparationFailed, context, config, process, fileAccessWhitelist);
         }
 
-        private static Task AssertProcessSucceedsAsync(
+        private Task AssertProcessSucceedsAsync(
             BuildXLContext context,
             ISandboxConfiguration config,
             Process process,
             FileAccessWhitelist fileAccessWhitelist = null,
             IDirectoryArtifactContext directoryArtifactContext = null)
         {
-            return AssertProcessCompletesWithStatus(SandboxedProcessPipExecutionStatus.Succeeded, context, config, process, fileAccessWhitelist, directoryArtifactContext: directoryArtifactContext);
+            return AssertProcessCompletesWithStatusAsync(SandboxedProcessPipExecutionStatus.Succeeded, context, config, process, fileAccessWhitelist, directoryArtifactContext: directoryArtifactContext);
         }
 
-        private static async Task AssertProcessCompletesWithStatus(
+        private async Task AssertProcessCompletesWithStatusAsync(
             SandboxedProcessPipExecutionStatus status,
             BuildXLContext context,
             ISandboxConfiguration config,
@@ -2087,7 +2087,7 @@ namespace Test.BuildXL.Processes.Detours
             return File.ReadAllText(path, maybeOutput.Item2);
         }
 
-        private static Task<SandboxedProcessPipExecutionResult> RunProcess(
+        private Task<SandboxedProcessPipExecutionResult> RunProcess(
             BuildXLContext context,
             ISandboxConfiguration config,
             Process process,
@@ -2115,7 +2115,8 @@ namespace Test.BuildXL.Processes.Detours
                 false,
                 new PipEnvironment(),
                 validateDistribution: false,
-                directoryArtifactContext: directoryArtifactContext ?? TestDirectoryArtifactContext.Empty).RunAsync(sandboxedKextConnection: GetSandboxedKextConnection());
+                directoryArtifactContext: directoryArtifactContext ?? TestDirectoryArtifactContext.Empty,
+                tempDirectoryCleaner: MoveDeleteCleaner).RunAsync(sandboxedKextConnection: GetSandboxedKextConnection());
         }
 
         private static void VerifyExitCode(BuildXLContext context, SandboxedProcessPipExecutionResult result, int expectedExitCode)

--- a/Public/Src/Engine/UnitTests/Processes.Detours/SandboxedProcessPipExecutorWindowsCallTest.cs
+++ b/Public/Src/Engine/UnitTests/Processes.Detours/SandboxedProcessPipExecutorWindowsCallTest.cs
@@ -178,7 +178,7 @@ namespace Test.BuildXL.Processes.Detours
                 }
                 else
                 {
-                    await AssertProcessCompletesWithStatus(
+                    await AssertProcessCompletesWithStatusAsync(
                         SandboxedProcessPipExecutionStatus.ExecutionFailed,
                         context,
                         config,

--- a/Public/Src/Engine/UnitTests/Processes/Containers/ContainerSandboxExecutorIntegrationTests.cs
+++ b/Public/Src/Engine/UnitTests/Processes/Containers/ContainerSandboxExecutorIntegrationTests.cs
@@ -187,7 +187,7 @@ namespace Test.BuildXL.Processes
             }
         }
 
-        private static Task<SandboxedProcessPipExecutionResult> RunProcess(BuildXLContext context, Process pip, bool failUnexpectedFileAccesses = true)
+        private Task<SandboxedProcessPipExecutionResult> RunProcess(BuildXLContext context, Process pip, bool failUnexpectedFileAccesses = true)
         {
             var loggingContext = CreateLoggingContextForTest();
 
@@ -207,6 +207,7 @@ namespace Test.BuildXL.Processes
                             disableConHostSharing: false,
                             pipEnvironment: new PipEnvironment(),
                             validateDistribution: false,
+                            tempDirectoryCleaner: new TestMoveDeleteCleaner(TestOutputDirectory),
                             directoryArtifactContext: TestDirectoryArtifactContext.Empty).RunAsync();
         }
 

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SchedulerIntegrationTestBase.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SchedulerIntegrationTestBase.cs
@@ -317,7 +317,7 @@ namespace Test.BuildXL.Scheduler
         /// Runs the scheduler using the instance member PipGraph and Configuration objects. This will also carry over
         /// any state from any previous run such as the cache
         /// </summary>
-        public ScheduleRunResult RunScheduler(SchedulerTestHooks testHooks = null, SchedulerState schedulerState = null, RootFilter filter = null, ITempDirectoryCleaner tempCleaner = null, IEnumerable<(Pip before, Pip after)> constraintExecutionOrder = null)
+        public ScheduleRunResult RunScheduler(SchedulerTestHooks testHooks = null, SchedulerState schedulerState = null, RootFilter filter = null, ITempCleaner tempCleaner = null, IEnumerable<(Pip before, Pip after)> constraintExecutionOrder = null)
         {
             if (m_graphWasModified || m_lastGraph == null)
             {
@@ -351,7 +351,7 @@ namespace Test.BuildXL.Scheduler
         /// </summary>
         public ScheduleRunResult RunSchedulerSpecific(
             PipGraph graph,
-            ITempDirectoryCleaner tempCleaner,
+            ITempCleaner tempCleaner,
             SchedulerTestHooks testHooks = null, 
             SchedulerState schedulerState = null,
             RootFilter filter = null,

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SchedulerIntegrationTestBase.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SchedulerIntegrationTestBase.cs
@@ -317,7 +317,7 @@ namespace Test.BuildXL.Scheduler
         /// Runs the scheduler using the instance member PipGraph and Configuration objects. This will also carry over
         /// any state from any previous run such as the cache
         /// </summary>
-        public ScheduleRunResult RunScheduler(SchedulerTestHooks testHooks = null, SchedulerState schedulerState = null, RootFilter filter = null, TempCleaner tempCleaner = null, IEnumerable<(Pip before, Pip after)> constraintExecutionOrder = null)
+        public ScheduleRunResult RunScheduler(SchedulerTestHooks testHooks = null, SchedulerState schedulerState = null, RootFilter filter = null, ITempDirectoryCleaner tempCleaner = null, IEnumerable<(Pip before, Pip after)> constraintExecutionOrder = null)
         {
             if (m_graphWasModified || m_lastGraph == null)
             {
@@ -326,7 +326,10 @@ namespace Test.BuildXL.Scheduler
             }
             
             m_graphWasModified = false;
-            return RunSchedulerSpecific(m_lastGraph, testHooks, schedulerState, filter, tempCleaner, constraintExecutionOrder);
+            
+            return RunSchedulerSpecific(m_lastGraph, 
+                (tempCleaner != null ? tempCleaner : MoveDeleteCleaner),
+                testHooks, schedulerState, filter , constraintExecutionOrder);
         }
         
         public NodeId GetProducerNode(FileArtifact file) => PipGraphBuilder.GetProducerNode(file);
@@ -347,11 +350,11 @@ namespace Test.BuildXL.Scheduler
         /// Runs the scheduler allowing various options to be specifically set
         /// </summary>
         public ScheduleRunResult RunSchedulerSpecific(
-            PipGraph graph, 
+            PipGraph graph,
+            ITempDirectoryCleaner tempCleaner,
             SchedulerTestHooks testHooks = null, 
             SchedulerState schedulerState = null,
             RootFilter filter = null,
-            TempCleaner tempCleaner = null,
             IEnumerable<(Pip before, Pip after)> constraintExecutionOrder = null)
         {
             // This is a new logging context to be used just for this instantiation of the scheduler. That way it can

--- a/Public/Src/Engine/UnitTests/Scheduler/PipQueueTest.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/PipQueueTest.cs
@@ -594,7 +594,7 @@ namespace Test.BuildXL.Scheduler
 
             public VmInitializer VmInitializer { get; }
 
-            public ITempDirectoryCleaner TempCleaner { get; }
+            public ITempCleaner TempCleaner { get; }
         }
     }
 

--- a/Public/Src/Engine/UnitTests/Scheduler/PipQueueTest.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/PipQueueTest.cs
@@ -97,7 +97,7 @@ namespace Test.BuildXL.Scheduler
                     maxDegreeOfParallelism: (Environment.ProcessorCount + 2) / 3,
                     debug: false))
                 {
-                    var executionEnvironment = new PipQueueTestExecutionEnvironment(context, config, pipTable, GetSandboxedKextConnection());
+                    var executionEnvironment = new PipQueueTestExecutionEnvironment(context, config, pipTable, Path.Combine(TestOutputDirectory, "temp"), GetSandboxedKextConnection());
 
                     Func<RunnablePip, Task<PipResult>> taskFactory = async (runnablePip) =>
                         {
@@ -292,7 +292,7 @@ namespace Test.BuildXL.Scheduler
 
             private readonly IFileMonitoringViolationAnalyzer m_disabledFileMonitoringViolationAnalyzer = new DisabledFileMonitoringViolationAnalyzer();
             
-            public PipQueueTestExecutionEnvironment(BuildXLContext context, IConfiguration configuration, PipTable pipTable, IKextConnection sandboxedKextConnection = null)
+            public PipQueueTestExecutionEnvironment(BuildXLContext context, IConfiguration configuration, PipTable pipTable, string tempDirectory, IKextConnection sandboxedKextConnection = null)
             {
                 Contract.Requires(context != null);
                 Contract.Requires(configuration != null);
@@ -319,6 +319,7 @@ namespace Test.BuildXL.Scheduler
                 m_producers = new ConcurrentDictionary<FileArtifact, Pip>();
                 m_filesystemView = new TestPipGraphFilesystemView(Context.PathTable);
                 var fileSystemView = new FileSystemView(Context.PathTable, m_filesystemView, LocalDiskContentStore);
+                TempCleaner = new TestMoveDeleteCleaner(tempDirectory);
 
                 State = new PipExecutionState(
                     configuration,
@@ -593,7 +594,7 @@ namespace Test.BuildXL.Scheduler
 
             public VmInitializer VmInitializer { get; }
 
-            public TempCleaner TempCleaner { get; }
+            public ITempDirectoryCleaner TempCleaner { get; }
         }
     }
 

--- a/Public/Src/Engine/UnitTests/Scheduler/SchedulerTest.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/SchedulerTest.cs
@@ -1306,6 +1306,7 @@ namespace Test.BuildXL.Scheduler
                 failedPips: overriddenFailedPips,
                 ipcProvider: ipcProvider,
                 journalState: m_journalState,
+                tempCleaner: MoveDeleteCleaner,
                 testHooks: testHooks);
 
             bool success = m_scheduler.InitForMaster(LoggingContext, filter);
@@ -2608,9 +2609,9 @@ namespace Test.BuildXL.Scheduler
                 fileContentTable: m_fileContentTable,
                 fileAccessWhitelist: new FileAccessWhitelist(Context),
                 configuration: configuration,
-                tempCleaner: null,
                 cache: cache,
-                testHooks: new SchedulerTestHooks());
+                testHooks: new SchedulerTestHooks(),
+                tempCleaner: MoveDeleteCleaner);
 
             newScheduler.InitForMaster(LoggingContext, filter);
 

--- a/Public/Src/Engine/UnitTests/Scheduler/TestScheduler.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/TestScheduler.cs
@@ -1,9 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.ContractsLight;
+using System.Threading.Tasks;
 using BuildXL.Cache.ContentStore.Hashing;
 using BuildXL.Engine.Cache;
 using BuildXL.Ipc.Interfaces;
+using BuildXL.Native.IO;
 using BuildXL.Pips;
 using BuildXL.Pips.Operations;
 using BuildXL.Processes;
@@ -12,14 +17,10 @@ using BuildXL.Scheduler.Fingerprints;
 using BuildXL.Scheduler.Graph;
 using BuildXL.Storage;
 using BuildXL.Utilities;
-using BuildXL.Utilities.Instrumentation.Common;
 using BuildXL.Utilities.Configuration;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Diagnostics.ContractsLight;
-using System.Threading.Tasks;
-using Test.BuildXL.TestUtilities.Xunit;
+using BuildXL.Utilities.Instrumentation.Common;
 using BuildXL.Utilities.VmCommandProxy;
+using Test.BuildXL.TestUtilities.Xunit;
 
 namespace Test.BuildXL.Scheduler
 {
@@ -55,7 +56,7 @@ namespace Test.BuildXL.Scheduler
             IConfiguration configuration,
             FileAccessWhitelist fileAccessWhitelist,
             DirectoryMembershipFingerprinterRuleSet directoryMembershipFingerprinterRules = null,
-            TempCleaner tempCleaner = null,
+            ITempDirectoryCleaner tempCleaner = null,
             PipRuntimeTimeTable runningTimeTable = null,
             JournalState journalState = null,
             PerformanceCollector performanceCollector = null,

--- a/Public/Src/Engine/UnitTests/Scheduler/TestScheduler.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/TestScheduler.cs
@@ -56,7 +56,7 @@ namespace Test.BuildXL.Scheduler
             IConfiguration configuration,
             FileAccessWhitelist fileAccessWhitelist,
             DirectoryMembershipFingerprinterRuleSet directoryMembershipFingerprinterRules = null,
-            ITempDirectoryCleaner tempCleaner = null,
+            ITempCleaner tempCleaner = null,
             PipRuntimeTimeTable runningTimeTable = null,
             JournalState journalState = null,
             PerformanceCollector performanceCollector = null,

--- a/Public/Src/Engine/UnitTests/Scheduler/Utils/DummyPipExecutionEnvironment.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/Utils/DummyPipExecutionEnvironment.cs
@@ -584,7 +584,7 @@ namespace Test.BuildXL.Scheduler.Utils
 
         public VmInitializer VmInitializer { get; }
 
-        public ITempDirectoryCleaner TempCleaner => new TestMoveDeleteCleaner(Path.Combine(Environment.GetEnvironmentVariable("TEMP"), "moveDeletionTemp"));
+        public ITempCleaner TempCleaner => new TestMoveDeleteCleaner(Path.Combine(Environment.GetEnvironmentVariable("TEMP"), "moveDeletionTemp"));
 
         public SealDirectoryKind GetSealDirectoryKind(DirectoryArtifact directory)
         {

--- a/Public/Src/Engine/UnitTests/Scheduler/Utils/DummyPipExecutionEnvironment.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/Utils/DummyPipExecutionEnvironment.cs
@@ -37,6 +37,7 @@ using BuildXL.Utilities.Tracing;
 using BuildXL.Utilities.Configuration;
 using KextConnection = BuildXL.Processes.KextConnection;
 using BuildXL.Utilities.VmCommandProxy;
+using Test.BuildXL.TestUtilities;
 
 namespace Test.BuildXL.Scheduler.Utils
 {
@@ -583,7 +584,7 @@ namespace Test.BuildXL.Scheduler.Utils
 
         public VmInitializer VmInitializer { get; }
 
-        public TempCleaner TempCleaner { get; }
+        public ITempDirectoryCleaner TempCleaner => new TestMoveDeleteCleaner(Path.Combine(Environment.GetEnvironmentVariable("TEMP"), "moveDeletionTemp"));
 
         public SealDirectoryKind GetSealDirectoryKind(DirectoryArtifact directory)
         {

--- a/Public/Src/Utilities/Native/IO/FileUtilities.cs
+++ b/Public/Src/Utilities/Native/IO/FileUtilities.cs
@@ -138,12 +138,12 @@ namespace BuildXL.Native.IO
             return s_fileSystem.TryRemoveDirectory(path, out hr);
         }
 
-        /// <see cref="IFileUtilities.DeleteDirectoryContents(string, bool, Func{string, bool}, ITempDirectoryCleaner, CancellationToken?)"/>
+        /// <see cref="IFileUtilities.DeleteDirectoryContents(string, bool, Func{string, bool}, ITempCleaner, CancellationToken?)"/>
         public static void DeleteDirectoryContents(
             string path, 
             bool deleteRootDirectory = false, 
             Func<string, bool> shouldDelete = null, 
-            ITempDirectoryCleaner tempDirectoryCleaner = null,
+            ITempCleaner tempDirectoryCleaner = null,
             CancellationToken? cancellationToken = default) =>
             s_fileUtilities.DeleteDirectoryContents(path, deleteRootDirectory, shouldDelete, tempDirectoryCleaner, cancellationToken);
 
@@ -263,8 +263,8 @@ namespace BuildXL.Native.IO
             bool openAsync = true,
             bool allowExcludeFileShareDelete = false) => s_fileUtilities.CreateReplacementFile(path, fileShare, openAsync, allowExcludeFileShareDelete);
 
-        /// <see cref="IFileUtilities.DeleteFile(string, bool, ITempDirectoryCleaner)"/>
-        public static void DeleteFile(string path, bool waitUntilDeletionFinished = true, ITempDirectoryCleaner tempDirectoryCleaner = null) =>
+        /// <see cref="IFileUtilities.DeleteFile(string, bool, ITempCleaner)"/>
+        public static void DeleteFile(string path, bool waitUntilDeletionFinished = true, ITempCleaner tempDirectoryCleaner = null) =>
             s_fileUtilities.DeleteFile(path, waitUntilDeletionFinished, tempDirectoryCleaner);
 
         /// <see cref="IFileUtilities.PosixDeleteMode"/>
@@ -298,8 +298,8 @@ namespace BuildXL.Native.IO
             }
         }
 
-        /// <see cref="IFileUtilities.TryDeleteFile(string, bool, ITempDirectoryCleaner)"/>
-        public static Possible<Unit, RecoverableExceptionFailure> TryDeleteFile(string path, bool waitUntilDeletionFinished = true, ITempDirectoryCleaner tempDirectoryCleaner = null) =>
+        /// <see cref="IFileUtilities.TryDeleteFile(string, bool, ITempCleaner)"/>
+        public static Possible<Unit, RecoverableExceptionFailure> TryDeleteFile(string path, bool waitUntilDeletionFinished = true, ITempCleaner tempDirectoryCleaner = null) =>
             s_fileUtilities.TryDeleteFile(path, waitUntilDeletionFinished, tempDirectoryCleaner);
 
         /// <summary>
@@ -307,7 +307,7 @@ namespace BuildXL.Native.IO
         /// </summary>
         /// <param name="fileOrDirectoryPath">Path to file or directory to be deleted, if exists.</param>
         /// <param name="tempDirectoryCleaner">Temporary directory cleaner.</param>
-        public static Possible<Unit, Failure> TryDeletePathIfExists(string fileOrDirectoryPath, ITempDirectoryCleaner tempDirectoryCleaner = null)
+        public static Possible<Unit, Failure> TryDeletePathIfExists(string fileOrDirectoryPath, ITempCleaner tempDirectoryCleaner = null)
         {
             if (FileExistsNoFollow(fileOrDirectoryPath))
             {

--- a/Public/Src/Utilities/Native/IO/IFileUtilities.cs
+++ b/Public/Src/Utilities/Native/IO/IFileUtilities.cs
@@ -74,7 +74,7 @@ namespace BuildXL.Native.IO
             string path, 
             bool deleteRootDirectory, 
             Func<string, bool> shouldDelete, 
-            ITempDirectoryCleaner tempDirectoryCleaner = null, 
+            ITempCleaner tempDirectoryCleaner = null, 
             CancellationToken? cancellationToken = default);
 
         /// <summary>
@@ -184,7 +184,7 @@ namespace BuildXL.Native.IO
         /// <exception cref="BuildXLException">
         /// Thrown if the file deletion fails in a recoverable manner (e.g. access denied).
         /// </exception>
-        void DeleteFile(string path, bool waitUntilDeletionFinished, ITempDirectoryCleaner tempDirectoryCleaner = null);
+        void DeleteFile(string path, bool waitUntilDeletionFinished, ITempCleaner tempDirectoryCleaner = null);
 
         /// <summary>
         /// Controls the applicability of POSIX delete.
@@ -194,7 +194,7 @@ namespace BuildXL.Native.IO
         /// <summary>
         /// Variant of <see cref="DeleteFile"/> returning a <see cref="Possible{TResult,TOtherwise}"/> rather than throwing.
         /// </summary>
-        Possible<Unit, RecoverableExceptionFailure> TryDeleteFile(string path, bool waitUntilDeletionFinished, ITempDirectoryCleaner tempDirectoryCleaner = null);
+        Possible<Unit, RecoverableExceptionFailure> TryDeleteFile(string path, bool waitUntilDeletionFinished, ITempCleaner tempDirectoryCleaner = null);
 
         /// <summary>
         /// Attempts to move file to a temporary directory that will be garbage collected in the future.

--- a/Public/Src/Utilities/Native/IO/ITempCleaner.cs
+++ b/Public/Src/Utilities/Native/IO/ITempCleaner.cs
@@ -10,7 +10,7 @@ namespace BuildXL.Native.IO
     /// Some attempt to clean <see cref="TempDirectory"/> should occur by the time 
     /// class instance is disposed. 
     /// </summary>
-    public interface ITempDirectoryCleaner : IDisposable
+    public interface ITempCleaner : IDisposable
     {
         /// <summary>
         /// Returns the path to a temporary directory owned and cleaned by the implementor

--- a/Public/Src/Utilities/Native/IO/ITempDirectoryCleaner.cs
+++ b/Public/Src/Utilities/Native/IO/ITempDirectoryCleaner.cs
@@ -16,5 +16,20 @@ namespace BuildXL.Native.IO
         /// Returns the path to a temporary directory owned and cleaned by the implementor
         /// </summary>
         string TempDirectory { get; }
+
+
+        /// <summary>
+        /// Registers a file to delete.
+        /// </summary>
+        void RegisterFileToDelete(string path);
+
+        /// <summary>
+        /// Registers a directory to delete.
+        /// </summary>
+        /// <remarks>
+        /// The contents of registered directory will be deleted. The directory itself will be deleted
+        /// if <paramref name="deleteRootDirectory"/> is true.
+        /// </remarks>
+        void RegisterDirectoryToDelete(string path, bool deleteRootDirectory);
     }
 }

--- a/Public/Src/Utilities/Native/IO/Unix/FileUtilities.Unix.cs
+++ b/Public/Src/Utilities/Native/IO/Unix/FileUtilities.Unix.cs
@@ -45,7 +45,7 @@ namespace BuildXL.Native.IO.Unix
             string path,
             bool deleteRootDirectory = false,
             Func<string, bool> shouldDelete = null,
-            ITempDirectoryCleaner tempDirectoryCleaner = null,
+            ITempCleaner tempDirectoryCleaner = null,
             CancellationToken? cancellationToken = default)
         {
             DeleteDirectoryContentsInternal(path, deleteRootDirectory, shouldDelete, tempDirectoryCleaner, cancellationToken);
@@ -55,7 +55,7 @@ namespace BuildXL.Native.IO.Unix
             string path,
             bool deleteRootDirectory,
             Func<string, bool> shouldDelete,
-            ITempDirectoryCleaner tempDirectoryCleaner,
+            ITempCleaner tempDirectoryCleaner,
             CancellationToken? cancellationToken)
         {
             int remainingChildCount = 0;
@@ -135,7 +135,7 @@ namespace BuildXL.Native.IO.Unix
         public Possible<Unit, RecoverableExceptionFailure> TryDeleteFile(
             string path,
             bool waitUntilDeletionFinished = true,
-            ITempDirectoryCleaner tempDirectoryCleaner = null)
+            ITempCleaner tempDirectoryCleaner = null)
         {
             try
             {
@@ -159,7 +159,7 @@ namespace BuildXL.Native.IO.Unix
         public void DeleteFile(
             string path,
             bool waitUntilDeletionFinished = true,
-            ITempDirectoryCleaner tempDirectoryCleaner = null)
+            ITempCleaner tempDirectoryCleaner = null)
         {
             Contract.Requires(!string.IsNullOrEmpty(path));
             bool successfullyDeletedFile = false;

--- a/Public/Src/Utilities/Native/IO/Windows/FileUtilities.Win.cs
+++ b/Public/Src/Utilities/Native/IO/Windows/FileUtilities.Win.cs
@@ -115,7 +115,7 @@ namespace BuildXL.Native.IO.Windows
             string path,
             bool deleteRootDirectory = false,
             Func<string, bool> shouldDelete = null,
-            ITempDirectoryCleaner tempDirectoryCleaner = null,
+            ITempCleaner tempDirectoryCleaner = null,
             CancellationToken? cancellationToken = default)
         {
             var maybeExistence = s_fileSystem.TryProbePathExistence(path, followSymlink: true);
@@ -156,7 +156,7 @@ namespace BuildXL.Native.IO.Windows
             string directoryPath,
             bool deleteRootDirectory,
             Func<string, bool> shouldDelete = null,
-            ITempDirectoryCleaner tempDirectoryCleaner = null,
+            ITempCleaner tempDirectoryCleaner = null,
             CancellationToken? cancellationToken = default)
         {
             var defaultDeleteCheck = new Func<string, bool>(p => true);
@@ -306,7 +306,7 @@ namespace BuildXL.Native.IO.Windows
         /// </summary>
         /// <param name="directoryPath">The empty directory to delete</param>
         /// <param name="tempDirectoryCleaner">provides and cleans a temp directory for move-deletes</param>
-        private void DeleteEmptyDirectoryHelper(string directoryPath, ITempDirectoryCleaner tempDirectoryCleaner)
+        private void DeleteEmptyDirectoryHelper(string directoryPath, ITempCleaner tempDirectoryCleaner)
         {
             // Attempt 1: POSIX delete
             if (PosixDeleteMode == PosixDeleteMode.RunFirst && RunPosixDelete(directoryPath, out _))
@@ -346,7 +346,7 @@ namespace BuildXL.Native.IO.Windows
         /// <param name="directoryPath">The empty directory to delete</param>
         /// <param name="tempDirectoryCleaner">provides and cleans a temp directory for move-deletes</param>
         /// <param name="logFailures">Whether information about failures should be logged</param>
-        private void DeleteEmptyDirectory(string directoryPath, ITempDirectoryCleaner tempDirectoryCleaner, bool logFailures = true)
+        private void DeleteEmptyDirectory(string directoryPath, ITempCleaner tempDirectoryCleaner, bool logFailures = true)
         {
             try
             {
@@ -435,7 +435,7 @@ namespace BuildXL.Native.IO.Windows
         }
 
         /// <inheritdoc />
-        public Possible<Unit, RecoverableExceptionFailure> TryDeleteFile(string path, bool waitUntilDeletionFinished = true, ITempDirectoryCleaner tempDirectoryCleaner = null)
+        public Possible<Unit, RecoverableExceptionFailure> TryDeleteFile(string path, bool waitUntilDeletionFinished = true, ITempCleaner tempDirectoryCleaner = null)
         {
             try
             {
@@ -457,7 +457,7 @@ namespace BuildXL.Native.IO.Windows
         }
 
         /// <inheritdoc />
-        public void DeleteFile(string path, bool waitUntilDeletionFinished = true, ITempDirectoryCleaner tempDirectoryCleaner = null)
+        public void DeleteFile(string path, bool waitUntilDeletionFinished = true, ITempCleaner tempDirectoryCleaner = null)
         {
             Contract.Requires(!string.IsNullOrEmpty(path));
 
@@ -531,7 +531,7 @@ namespace BuildXL.Native.IO.Windows
         /// if retried again in the future.</returns>
         /// <exception cref="BuildXLException">Thrown when setting file attributes fails for an unknown cause and retries
         /// won't help.</exception>
-        private bool DeleteFileInternal(string path, ITempDirectoryCleaner tempDirectoryCleaner, out OpenFileResult deleteResult)
+        private bool DeleteFileInternal(string path, ITempCleaner tempDirectoryCleaner, out OpenFileResult deleteResult)
         {
             Contract.Requires(!string.IsNullOrEmpty(path));
             LoggingContext context = Events.StaticContext;

--- a/Public/Src/Utilities/UnitTests/Storage.Untracked/FileUtilitiesTests.Unsafe.cs
+++ b/Public/Src/Utilities/UnitTests/Storage.Untracked/FileUtilitiesTests.Unsafe.cs
@@ -558,8 +558,11 @@ namespace Test.BuildXL.Storage
         [Fact]
         public void MoveTempDeletionCanReplaceRunningExecutable()
         {
-            string exeCopy = GetFullPath("DummyWaiterCopy");
-            File.Copy(DummyWaiter.GetDummyWaiterExeLocation(), exeCopy);
+            // Make a copy of DummyWaiter.exe to use as the test subject for deleting a running executable.
+            // Keep the copy in the same directory as the original since it will need runtime dlls
+            string dummyWaiterLocation = DummyWaiter.GetDummyWaiterExeLocation();
+            string exeCopy = dummyWaiterLocation + ".copy.exe";
+            File.Copy(dummyWaiterLocation, exeCopy);
 
             using (var waiter = DummyWaiter.RunAndWait(exeCopy))
             {

--- a/Public/Src/Utilities/UnitTests/Storage.Untracked/FileUtilitiesTests.Unsafe.cs
+++ b/Public/Src/Utilities/UnitTests/Storage.Untracked/FileUtilitiesTests.Unsafe.cs
@@ -14,6 +14,7 @@ using BuildXL.Native.IO;
 using BuildXL.Utilities;
 using BuildXL.Utilities.Tracing;
 using Microsoft.Win32.SafeHandles;
+using Test.BuildXL.TestUtilities;
 using Test.BuildXL.TestUtilities.Xunit;
 using Xunit;
 using static BuildXL.Native.IO.Windows.FileUtilitiesWin;
@@ -548,6 +549,47 @@ namespace Test.BuildXL.Storage
                 {
                     XAssert.AreEqual(0, fs.Length);
                 }
+            }
+        }
+
+        /// <remarks>
+        /// BuildXL's CreateHardlink method relies on CreateHardlinkW, which requires WriteAttributes access on the file.
+        /// </remarks>
+        [Fact]
+        public void MoveTempDeletionCanReplaceRunningExecutable()
+        {
+            string exeCopy = GetFullPath("DummyWaiterCopy");
+            File.Copy(DummyWaiter.GetDummyWaiterExeLocation(), exeCopy);
+
+            using (var waiter = DummyWaiter.RunAndWait(exeCopy))
+            {
+                BuildXLException caughtException = null;
+                try
+                {
+                    FileUtilities.DeleteFile(exeCopy);
+                }
+                catch (BuildXLException ex)
+                {
+                    caughtException = ex;
+                }
+
+                XAssert.IsNotNull(caughtException, "Expected deletion without a tempCleaner to fail");
+                XAssert.IsTrue(File.Exists(exeCopy));
+
+                caughtException = null;
+
+
+                try
+                {
+                    FileUtilities.DeleteFile(exeCopy, tempDirectoryCleaner: MoveDeleteCleaner);
+                }
+                catch (BuildXLException ex)
+                {
+                    caughtException = ex;
+                }
+
+                XAssert.IsNull(caughtException, "Expected deletion with a MoveDeleteCleaner to succeed");
+                XAssert.IsFalse(File.Exists(exeCopy));
             }
         }
 

--- a/Public/Src/Utilities/UnitTests/Storage/DummyWaiter.cs
+++ b/Public/Src/Utilities/UnitTests/Storage/DummyWaiter.cs
@@ -28,9 +28,9 @@ namespace Test.BuildXL.Storage
             m_executablePath = exePath;
         }
 
-        public static DummyWaiter RunAndWait()
+        public static DummyWaiter RunAndWait(string exePath = null)
         {
-            string exePath = GetDummyWaiterExeLocation();
+            exePath = !string.IsNullOrEmpty(exePath) ? exePath : GetDummyWaiterExeLocation();
             if (!File.Exists(exePath))
             {
                 throw new BuildXLException("Expected to find DummyWaiter.exe at " + exePath);

--- a/Public/Src/Utilities/UnitTests/TestUtilities.XUnit/XAssert.cs
+++ b/Public/Src/Utilities/UnitTests/TestUtilities.XUnit/XAssert.cs
@@ -415,7 +415,7 @@ namespace Test.BuildXL.TestUtilities.Xunit
         {
             Assert.True(
                 value != null,
-                "Expected value to not be null" +
+                "Expected value to not be null " +
                 GetMessage(format, args));
         }
 
@@ -431,7 +431,7 @@ namespace Test.BuildXL.TestUtilities.Xunit
         {
             Assert.True(
                 value == null,
-                "Expected object to be null" +
+                "Expected object to be null " +
                 GetMessage(format, args));
         }
 

--- a/Public/Src/Utilities/UnitTests/TestUtilities/TestMoveDeleteCleaner.cs
+++ b/Public/Src/Utilities/UnitTests/TestUtilities/TestMoveDeleteCleaner.cs
@@ -39,5 +39,17 @@ namespace Test.BuildXL.TestUtilities
         {
             FileUtilities.DeleteDirectoryContents(TempDirectory, deleteRootDirectory: true);
         }
+
+        /// <inheritdoc />
+        public void RegisterDirectoryToDelete(string path, bool deleteRootDirectory)
+        {
+            // noop
+        }
+
+        /// <inheritdoc />
+        public void RegisterFileToDelete(string path)
+        {
+            // noop
+        }
     }
 }

--- a/Public/Src/Utilities/UnitTests/TestUtilities/TestMoveDeleteCleaner.cs
+++ b/Public/Src/Utilities/UnitTests/TestUtilities/TestMoveDeleteCleaner.cs
@@ -8,12 +8,12 @@ using BuildXL.Native.IO;
 namespace Test.BuildXL.TestUtilities
 {
     /// <summary>
-    /// This is minimal implementation of <see cref="ITempDirectoryCleaner"/> for unit tests or test bases
-    /// This can be passed into <see cref="FileUtilities.DeleteDirectoryContents(string, bool, System.Func{string, bool}, ITempDirectoryCleaner, CancellationToken?)"/>
-    /// and <see cref="FileUtilities.DeleteFile(string, bool, ITempDirectoryCleaner)"/> to enable move-deletes,
+    /// This is minimal implementation of <see cref="ITempCleaner"/> for unit tests or test bases
+    /// This can be passed into <see cref="FileUtilities.DeleteDirectoryContents(string, bool, System.Func{string, bool}, ITempCleaner, CancellationToken?)"/>
+    /// and <see cref="FileUtilities.DeleteFile(string, bool, ITempCleaner)"/> to enable move-deletes,
     /// which are more reliable and less prone to unexected exceptions than Windows delete.
     /// </summary>
-    public class TestMoveDeleteCleaner : ITempDirectoryCleaner
+    public class TestMoveDeleteCleaner : ITempCleaner
     {
         /// <summary>
         /// Suggested name for <see cref="TempDirectory"/>


### PR DESCRIPTION
Also remove ability to instantiate a PipExecutor without a temp cleaner so we don't refactor away the reference.

For sanity, focus on the first 2 commits. The third is a mechanical rename.