### PR TITLE
MachineName truncates the machine name

### DIFF
--- a/Public/Src/Cache/ContentStore/App/DistributedService.cs
+++ b/Public/Src/Cache/ContentStore/App/DistributedService.cs
@@ -77,7 +77,7 @@ namespace BuildXL.Cache.ContentStore.App
                             useCompression: useCompressionForCopies,
                             bufferSize: bufferSizeForGrpcCopies)
                         : (IAbsolutePathFileCopier)new DistributedCopier(),
-                    pathTransformer: useDistributedGrpc ? new GrpcDistributedPathTransformer() : (IAbsolutePathTransformer)new DistributedPathTransformer(),
+                    pathTransformer: useDistributedGrpc ? new GrpcDistributedPathTransformer(_logger) : (IAbsolutePathTransformer)new DistributedPathTransformer(),
                     dcs: dcs,
                     host: host,
                     cacheName: cacheName,

--- a/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcDistributedPathTransformer.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcDistributedPathTransformer.cs
@@ -5,11 +5,13 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.Sockets;
 using System.Text;
 using BuildXL.Cache.ContentStore.Extensions;
 using BuildXL.Cache.ContentStore.Hashing;
 using BuildXL.Cache.ContentStore.Interfaces.Distributed;
 using BuildXL.Cache.ContentStore.Interfaces.FileSystem;
+using BuildXL.Cache.ContentStore.Interfaces.Logging;
 using BuildXL.Cache.ContentStore.Interfaces.Utils;
 using BuildXL.Cache.ContentStore.Utils;
 
@@ -21,23 +23,33 @@ namespace BuildXL.Cache.ContentStore.Distributed.Utilities
     public class GrpcDistributedPathTransformer : IAbsolutePathTransformer
     {
         private readonly IReadOnlyDictionary<AbsolutePath, AbsolutePath> _junctionsByDirectory;
-        private static readonly string _localMachineName = System.Net.Dns.GetHostName();
+        private readonly string _localMachineName;
         internal const string BlobFileExtension = ".blob";
 
         /// <nodoc />
-        public GrpcDistributedPathTransformer()
+        public GrpcDistributedPathTransformer(ILogger logger)
         {
+            try
+            {
+                _localMachineName = System.Net.Dns.GetHostName();
+            }
+            catch (Exception e)
+            {
+                logger.Warning($"Failed to get machine name from `Dns.GetHostName`. Falling back to `Environment.MachineName`. {e.ToString()}");
+                _localMachineName = Environment.MachineName;
+            }
+
             _junctionsByDirectory = new Dictionary<AbsolutePath, AbsolutePath>();
         }
 
         /// <nodoc />
-        public GrpcDistributedPathTransformer(IReadOnlyDictionary<string, string> junctionsByDirectory)
+        public GrpcDistributedPathTransformer(IReadOnlyDictionary<string, string> junctionsByDirectory, ILogger logger) : this(logger)
         {
             _junctionsByDirectory = junctionsByDirectory.ToDictionary(kvp => new AbsolutePath(kvp.Key), kvp => new AbsolutePath(kvp.Value));
         }
 
         /// <nodoc />
-        public GrpcDistributedPathTransformer(IReadOnlyDictionary<AbsolutePath, AbsolutePath> junctionsByDirectory)
+        public GrpcDistributedPathTransformer(IReadOnlyDictionary<AbsolutePath, AbsolutePath> junctionsByDirectory, ILogger logger) : this(logger)
         {
             _junctionsByDirectory = junctionsByDirectory;
         }

--- a/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcDistributedPathTransformer.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcDistributedPathTransformer.cs
@@ -21,7 +21,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Utilities
     public class GrpcDistributedPathTransformer : IAbsolutePathTransformer
     {
         private readonly IReadOnlyDictionary<AbsolutePath, AbsolutePath> _junctionsByDirectory;
-        private static readonly string _localMachineName = Environment.MachineName;
+        private static readonly string _localMachineName = System.Net.Dns.GetHostName();
         internal const string BlobFileExtension = ".blob";
 
         /// <nodoc />


### PR DESCRIPTION
`Environment.MachineName` truncates the name of the machine to 15 characters. `Dns.GetHostName()` gives the full machine name.

Found this when attempting to surface content from `TSE-PERFBENCH-02`. Other machines would try to connect to `TSE-PERFBENCH-0`, which doesn't exist.