### PR TITLE
Dedup pin optimizations only with nodes, not chunks

### DIFF
--- a/Public/Src/Cache/ContentStore/Vsts/DedupReadOnlyContentSession.cs
+++ b/Public/Src/Cache/ContentStore/Vsts/DedupReadOnlyContentSession.cs
@@ -718,9 +718,9 @@ namespace BuildXL.Cache.ContentStore.Vsts
                 (notFound) => { /* Do nothing */ },
                 (needAction) =>
                 {
-                        // For the reason explained above, this case where children need to be pinned should never happen.
-                        // However, as a best aproximation, we take the min of all the children, which always outlive the parent.
-                        keepUntil = needAction.Receipts.Select(r => r.Value.KeepUntil.KeepUntil).Min();
+                    // For the reason explained above, this case where children need to be pinned should never happen.
+                    // However, as a best aproximation, we take the min of all the children, which always outlive the parent.
+                    keepUntil = needAction.Receipts.Select(r => r.Value.KeepUntil.KeepUntil).Min();
                 },
                 (added) =>
                 {


### PR DESCRIPTION
Errors were happening when performing the pin optimization, since it was made with only nodes in mind, and not chunks. Chunks don't need optimizing, so just call the regular implementation with them.