### PR TITLE
Revamp incremental nuget spec generation

### DIFF
--- a/Public/Src/FrontEnd/Nuget/Tracing/Log.cs
+++ b/Public/Src/FrontEnd/Nuget/Tracing/Log.cs
@@ -350,6 +350,15 @@ namespace BuildXL.FrontEnd.Nuget.Tracing
         public abstract void NugetFailedGenerationResultFromDownloadedPackage(LoggingContext context, string package, string message);
 
         [GeneratedEvent(
+            (ushort)LogEventId.NugetFailedToWriteGeneratedSpecStateFile,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Warning,
+            Keywords = (int)Keywords.UserMessage,
+            EventTask = (ushort)Tasks.Parser,
+            Message = "Nuget resolver failed to write generated spec state file. Spec will be regenerated on future invocations: {message}")]
+        public abstract void NugetFailedToWriteGeneratedSpecStateFile(LoggingContext context, string message);
+
+        [GeneratedEvent(
             (ushort)LogEventId.NugetConcurrencyLevel,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,

--- a/Public/Src/FrontEnd/Nuget/Tracing/LogEventId.cs
+++ b/Public/Src/FrontEnd/Nuget/Tracing/LogEventId.cs
@@ -47,5 +47,6 @@ namespace BuildXL.FrontEnd.Nuget.Tracing
         NugetFailedDownloadPackagesAndGenerateSpecs,
         NugetFailedDownloadPackage,
         NugetFailedGenerationResultFromDownloadedPackage,
+        NugetFailedToWriteGeneratedSpecStateFile,
     }
 }

--- a/Public/Src/FrontEnd/Sdk/PackageDownloadResult.cs
+++ b/Public/Src/FrontEnd/Sdk/PackageDownloadResult.cs
@@ -134,12 +134,9 @@ namespace BuildXL.FrontEnd.Sdk
         public PackageSource Source { get; }
 
         /// <summary>
-        /// True if the generated spec's format hasn't been changed.
+        /// Identitifier for the files making up the package
         /// </summary>
-        /// <remarks>
-        /// Property should be used only when <see cref="Source"/> is PackageSource.FromDisk.
-        /// </remarks>
-        public bool SpecsFormatIsUpToDate { get; }
+        public string FingerprintHash { get; }
 
         /// <nodoc />
         public bool IsValid => Contents.Count != 0 && TargetLocation.IsValid;
@@ -150,41 +147,44 @@ namespace BuildXL.FrontEnd.Sdk
             AbsolutePath targetLocation,
             IReadOnlyList<RelativePath> contents,
             PackageSource source,
-            bool specsFormatIsUpToDate = false)
+            string fingerprint = null)
         {
             m_packageIdentity = packageIdentity;
             TargetLocation = targetLocation;
             Contents = contents;
             Source = source;
-            SpecsFormatIsUpToDate = specsFormatIsUpToDate;
+            FingerprintHash = fingerprint;
         }
 
         /// <nodoc />
         public static PackageDownloadResult RecoverableError(PackageIdentity packageIdentity) => FromCache(
             packageIdentity,
             AbsolutePath.Invalid,
-            CollectionUtilities.EmptyArray<RelativePath>());
+            CollectionUtilities.EmptyArray<RelativePath>(),
+            string.Empty);
 
         /// <nodoc />
         public static PackageDownloadResult FromDisk(
             PackageIdentity packageIdentity,
             AbsolutePath targetLocation,
             IReadOnlyList<RelativePath> contents,
-            bool specsFormatIsUpToDate)
-            => new PackageDownloadResult(packageIdentity, targetLocation, contents, PackageSource.Disk, specsFormatIsUpToDate);
+            string fingerprint)
+            => new PackageDownloadResult(packageIdentity, targetLocation, contents, PackageSource.Disk, fingerprint);
         
         /// <nodoc />
         public static PackageDownloadResult FromCache(
             PackageIdentity packageIdentity,
             AbsolutePath targetLocation,
-            IReadOnlyList<RelativePath> contents)
-            => new PackageDownloadResult(packageIdentity, targetLocation, contents, PackageSource.Cache);
+            IReadOnlyList<RelativePath> contents,
+            string fingerprint)
+            => new PackageDownloadResult(packageIdentity, targetLocation, contents, PackageSource.Cache, fingerprint);
         
         /// <nodoc />
         public static PackageDownloadResult FromRemote(
             PackageIdentity packageIdentity,
             AbsolutePath targetLocation,
-            IReadOnlyList<RelativePath> contents)
-            => new PackageDownloadResult(packageIdentity, targetLocation, contents, PackageSource.RemoteStore);
+            IReadOnlyList<RelativePath> contents,
+            string fingerprint)
+            => new PackageDownloadResult(packageIdentity, targetLocation, contents, PackageSource.RemoteStore, fingerprint);
     }
 }

--- a/Public/Src/FrontEnd/UnitTests/Nuget/NugetResolverUnitTests.cs
+++ b/Public/Src/FrontEnd/UnitTests/Nuget/NugetResolverUnitTests.cs
@@ -95,8 +95,9 @@ namespace Test.BuildXL.FrontEnd.Nuget
             XAssert.IsTrue(result.Succeeded);
             XAssert.IsTrue(result.Result.IsValid);
             var generatedContent = result.Result.GetParent(pathTable).ToString(pathTable);
-
-            XAssert.AreEqual(2, Directory.EnumerateFiles(generatedContent, "*.*", SearchOption.AllDirectories).Count());
+            var expectedGeneratedSpecCount = 2;
+            var expectedGeneratedMetataFileCount = 1;
+            XAssert.AreEqual(expectedGeneratedSpecCount + expectedGeneratedMetataFileCount, Directory.EnumerateFiles(generatedContent, "*.*", SearchOption.AllDirectories).Count());
 
             // package file is tested already
             var packageDsc = Path.Combine(generatedContent, "package.dsc");
@@ -108,6 +109,49 @@ namespace Test.BuildXL.FrontEnd.Nuget
             XAssert.IsTrue(packageText.Contains("packageRoot = d`"));
             XAssert.IsTrue(packageText.Contains("f`${packageRoot}/Folder/a.txt`"));
             XAssert.IsTrue(packageText.Contains("f`${packageRoot}/Folder/b.txt`"));
+        }
+
+        [Fact]
+        public void TestSpecGeneratorIncrementality()
+        {
+            // make sure we can generate a package
+            var specOutput = GenerateSpecAndValidateExistence("1.2");
+
+            // Delete the file and make sure that it is correctly recreated
+            File.Delete(specOutput);
+            specOutput = GenerateSpecAndValidateExistence("1.2");
+
+            // Scribble some marker at the end of the file. Use this to make sure the file isn't regenerated if
+            // nothing else changes
+            const string DummyMarker = "DummyMarker";
+            File.AppendAllText(specOutput, DummyMarker);
+            specOutput = GenerateSpecAndValidateExistence("1.2");
+            XAssert.IsTrue(File.ReadAllText(specOutput).Contains(DummyMarker));
+
+            // Change the version of the package (which flows into the fingerprint). This should cause the package
+            // to get regenerated
+            specOutput = GenerateSpecAndValidateExistence("1.3");
+            XAssert.IsFalse(File.ReadAllText(specOutput).Contains(DummyMarker));
+        }
+
+        private string GenerateSpecAndValidateExistence(string version)
+        {
+            // Setup state
+            var pathTable = m_testContext.PathTable;
+            var packageOnDisk = CreateTestPackageOnDisk(includeScriptSpec: false, version: version);
+            var nugetResolver = CreateWorkspaceNugetResolverForTesting();
+            var analyzedPackage = nugetResolver.AnalyzeNugetPackage(packageOnDisk, false);
+            XAssert.IsTrue(analyzedPackage.Succeeded);
+            var allPackages = new Dictionary<string, NugetAnalyzedPackage> { [packageOnDisk.Package.Id] = analyzedPackage.Result };
+            XAssert.IsTrue(analyzedPackage.Succeeded);
+
+            // Generate a spec. We just look at the first result since there's only one spec
+            var results = nugetResolver.GenerateSpecsForDownloadedPackages(allPackages);
+            var result = results.FirstOrDefault().Value;
+            XAssert.IsTrue(result.Succeeded);
+            var path = result.Result.ToString(pathTable);
+            XAssert.IsTrue(File.Exists(path));
+            return path;
         }
 
         [Fact]
@@ -222,11 +266,13 @@ $@"module({{
                 PackageDownloadResult.FromCache(
                     new PackageIdentity("nuget", packageName, version, string.Empty),
                     AbsolutePath.Create(m_testContext.PathTable, pkgFolder),
-                    relativePaths)
+                    relativePaths,
+                    packageName + version + pkgFolder)
                 : PackageDownloadResult.FromRemote(
                     new PackageIdentity("nuget", packageName, version, string.Empty),
                     AbsolutePath.Create(m_testContext.PathTable, pkgFolder),
-                    relativePaths);
+                    relativePaths,
+                    packageName + version + pkgFolder);
         }
 
         private RelativePath CreateFile(string pkgFolder, string relativePath, string contents)

--- a/Public/Src/FrontEnd/UnitTests/Nuget/PackageGenerator.cs
+++ b/Public/Src/FrontEnd/UnitTests/Nuget/PackageGenerator.cs
@@ -41,7 +41,8 @@ namespace Test.BuildXL.FrontEnd.Nuget
                 PackageDownloadResult.FromRemote(
                     new PackageIdentity("nuget", nugetPackage.Id, nugetPackage.Version, nugetPackage.Alias),
                     AbsolutePath.Create(m_context.PathTable, A("X", "Pkgs", "TestPkg", "1.999", "TestPkg.nuspec")),
-                    paths));
+                    paths,
+                    "testPackageHash"));
 
             return NugetAnalyzedPackage.TryAnalyzeNugetPackage(m_context, m_monikers, XDocument.Parse(xml), packageOnDisk, packagesOnConfig, false);
         }

--- a/RunCheckInTests.cmd
+++ b/RunCheckInTests.cmd
@@ -142,7 +142,7 @@ endlocal && exit /b 0
     call :StatusMessage !stepName!
         echo Running BuildXL on the CoreCLR, preparing a few things...
         robocopy %ENLISTMENTROOT%\Out\Bin\debug\win-x64 %NETCOREROOT% /E /MT:8 /NS /NC /NFL /NDL /NP
-        call :RunBxlCoreClr /p:[Sdk.BuildXL]microsoftInternal=1 /f:spec='%ENLISTMENTROOT%\Public\Src\Utilities\Collections\*' /c:%ENLISTMENTROOT%\config.dsc /server- /cacheGraph-
+        call :RunBxlCoreClr /p:[Sdk.BuildXL]microsoftInternal=1 /f:spec='%ENLISTMENTROOT%\Public\Src\Utilities\Collections\*' /c:%ENLISTMENTROOT%\config.dsc /server- /cacheGraph- /logsToRetain:20
         set CORECLR_ERRORLEVEL=%ERRORLEVEL%
         rmdir /s /q %NETCOREROOT%
         if !CORECLR_ERRORLEVEL! NEQ 0 (exit /b 1)

--- a/RunCheckInTests.cmd
+++ b/RunCheckInTests.cmd
@@ -10,7 +10,7 @@ set SCRIPTROOT=%~dp0Shared\Scripts\
 set EXE_DIR=%~dp0out\Bin\Debug\net472
 set FINGERPRINT_ERROR_DIR=\\fsu\shares\MsEng\Domino\RunCheckInTests-FingerprintErrorReports
 set BUILDXL_ARGS=
-set RUN_PART_A=0
+set RUN_PART_A=1
 set RUN_PART_B=1
 set MINIMAL_LAB=0
 
@@ -69,7 +69,6 @@ if EXIST %ENLISTMENTROOT%\Out\frontend\Nuget\specs (
     rmdir /S /Q %ENLISTMENTROOT%\Out\frontend\Nuget\specs
 )
 
-echo NUGET_CREDENTIALPROVIDERS_PATH %NUGET_CREDENTIALPROVIDERS_PATH%
 set start=%time%
 set stepName=Building 'debug\net472' and 'debug\win-x64' using Lkg and deploying to RunCheckinTests
 call :StatusMessage %stepName%
@@ -138,7 +137,6 @@ endlocal && exit /b 0
     exit /b 0
 
 :PartB
-echo NUGET_CREDENTIALPROVIDERS_PATH %NUGET_CREDENTIALPROVIDERS_PATH%
     set start=!time!
     set stepName=Running BuildXL on the CoreCLR with a minimal end to end scenario
     call :StatusMessage !stepName!
@@ -150,7 +148,6 @@ echo NUGET_CREDENTIALPROVIDERS_PATH %NUGET_CREDENTIALPROVIDERS_PATH%
         if !CORECLR_ERRORLEVEL! NEQ 0 (exit /b 1)
     call :RecordStep "!stepName!" !start!
 
-echo NUGET_CREDENTIALPROVIDERS_PATH %NUGET_CREDENTIALPROVIDERS_PATH%
     set start=!time!
     set stepName=Running Example DotNetCoreBuild on CoreCLR
     call :StatusMessage !stepName!
@@ -160,7 +157,6 @@ echo NUGET_CREDENTIALPROVIDERS_PATH %NUGET_CREDENTIALPROVIDERS_PATH%
         if !EXAMPLE_BUILD_ERRORLEVEL! NEQ 0 (exit /b 1)
     call :RecordStep "!stepName!" !start!
 
-echo NUGET_CREDENTIALPROVIDERS_PATH %NUGET_CREDENTIALPROVIDERS_PATH%
     set start=!time!
     set stepName=Performing a /cleanonly build
     call :StatusMessage !stepName!
@@ -168,7 +164,6 @@ echo NUGET_CREDENTIALPROVIDERS_PATH %NUGET_CREDENTIALPROVIDERS_PATH%
         if !ERRORLEVEL! NEQ 0 (exit /b 1)
     call :RecordStep "!stepName!" !start!
 
-echo NUGET_CREDENTIALPROVIDERS_PATH %NUGET_CREDENTIALPROVIDERS_PATH%
     set start=!time!
     set stepName=Building detached to produce stable fingerprints file
     call :StatusMessage !stepName!
@@ -186,7 +181,6 @@ echo NUGET_CREDENTIALPROVIDERS_PATH %NUGET_CREDENTIALPROVIDERS_PATH%
         if !ERRORLEVEL! NEQ 0 (exit /b 1)
     call :RecordStep "!stepName!" !start!
 
-echo NUGET_CREDENTIALPROVIDERS_PATH %NUGET_CREDENTIALPROVIDERS_PATH%
     set start=!time!
     set stepName=Building using BuildXL a second time to ensure all tasks are cached
     call :StatusMessage !stepName!
@@ -198,13 +192,11 @@ echo NUGET_CREDENTIALPROVIDERS_PATH %NUGET_CREDENTIALPROVIDERS_PATH%
         call :RunBxl /cacheGraph- /scriptShowSlowest -Use RunCheckinTests -minimal %BUILDXL_ARGS% /incrementalScheduling- /TraceInfo:RunCheckinTests=CompareFingerprints2 /logsDirectory:!COMPARE_FINGERPRINTS_LOGS_DIR! -SharedCacheMode disable /logPrefix:!SECOND_PREFIX!
         if !ERRORLEVEL! NEQ 0 (exit /b 1)
 
-echo NUGET_CREDENTIALPROVIDERS_PATH %NUGET_CREDENTIALPROVIDERS_PATH%
         REM Produce a fingerprint file of the second run.
         set SECOND_FINGERPRINT_LOG=!COMPARE_FINGERPRINTS_LOGS_DIR!!SECOND_PREFIX!.fgrprnt.txt
         %EXE_DIR%\bxlAnalyzer.exe /mode:FingerprintText /xl:!COMPARE_FINGERPRINTS_LOGS_DIR!!SECOND_PREFIX!.xlg /compress- /o:!SECOND_FINGERPRINT_LOG!
         if !ERRORLEVEL! NEQ 0 (exit /b 1)
 
-echo NUGET_CREDENTIALPROVIDERS_PATH %NUGET_CREDENTIALPROVIDERS_PATH%
         REM Compare fingerprints
         fc !FIRST_FINGERPRINT_LOG! !SECOND_FINGERPRINT_LOG! > !SECOND_FINGERPRINT_LOG!.diff.txt
         if !ERRORLEVEL! NEQ 0 (
@@ -223,7 +215,6 @@ echo NUGET_CREDENTIALPROVIDERS_PATH %NUGET_CREDENTIALPROVIDERS_PATH%
             exit /b 1
         )
 
-echo NUGET_CREDENTIALPROVIDERS_PATH %NUGET_CREDENTIALPROVIDERS_PATH%
         REM verify fully cached
         call :VerifyLogIsFullyCached !COMPARE_FINGERPRINTS_LOGS_DIR!!SECOND_PREFIX!.log
         if !ERRORLEVEL! NEQ 0 (
@@ -389,9 +380,9 @@ echo NUGET_CREDENTIALPROVIDERS_PATH %NUGET_CREDENTIALPROVIDERS_PATH%
     )
     REM BUG: 1199393: Temporary have to hack the generated nuspecs since the coreclr run doesn't run under b:
     rmdir /s/q %ENLISTMENTROOT%\Out\frontend\Nuget\specs
-
     REM Restore credential provider path.
     set NUGET_CREDENTIALPROVIDERS_PATH=%OLD_NUGET_CREDENTIALPROVIDERS_PATH%
+
     exit /b 0
 
 :VerifyLogIsFullyCached

--- a/RunCheckInTests.cmd
+++ b/RunCheckInTests.cmd
@@ -10,7 +10,7 @@ set SCRIPTROOT=%~dp0Shared\Scripts\
 set EXE_DIR=%~dp0out\Bin\Debug\net472
 set FINGERPRINT_ERROR_DIR=\\fsu\shares\MsEng\Domino\RunCheckInTests-FingerprintErrorReports
 set BUILDXL_ARGS=
-set RUN_PART_A=1
+set RUN_PART_A=0
 set RUN_PART_B=1
 set MINIMAL_LAB=0
 
@@ -69,6 +69,7 @@ if EXIST %ENLISTMENTROOT%\Out\frontend\Nuget\specs (
     rmdir /S /Q %ENLISTMENTROOT%\Out\frontend\Nuget\specs
 )
 
+echo NUGET_CREDENTIALPROVIDERS_PATH %NUGET_CREDENTIALPROVIDERS_PATH%
 set start=%time%
 set stepName=Building 'debug\net472' and 'debug\win-x64' using Lkg and deploying to RunCheckinTests
 call :StatusMessage %stepName%
@@ -137,6 +138,7 @@ endlocal && exit /b 0
     exit /b 0
 
 :PartB
+echo NUGET_CREDENTIALPROVIDERS_PATH %NUGET_CREDENTIALPROVIDERS_PATH%
     set start=!time!
     set stepName=Running BuildXL on the CoreCLR with a minimal end to end scenario
     call :StatusMessage !stepName!
@@ -148,6 +150,7 @@ endlocal && exit /b 0
         if !CORECLR_ERRORLEVEL! NEQ 0 (exit /b 1)
     call :RecordStep "!stepName!" !start!
 
+echo NUGET_CREDENTIALPROVIDERS_PATH %NUGET_CREDENTIALPROVIDERS_PATH%
     set start=!time!
     set stepName=Running Example DotNetCoreBuild on CoreCLR
     call :StatusMessage !stepName!
@@ -157,6 +160,7 @@ endlocal && exit /b 0
         if !EXAMPLE_BUILD_ERRORLEVEL! NEQ 0 (exit /b 1)
     call :RecordStep "!stepName!" !start!
 
+echo NUGET_CREDENTIALPROVIDERS_PATH %NUGET_CREDENTIALPROVIDERS_PATH%
     set start=!time!
     set stepName=Performing a /cleanonly build
     call :StatusMessage !stepName!
@@ -164,6 +168,7 @@ endlocal && exit /b 0
         if !ERRORLEVEL! NEQ 0 (exit /b 1)
     call :RecordStep "!stepName!" !start!
 
+echo NUGET_CREDENTIALPROVIDERS_PATH %NUGET_CREDENTIALPROVIDERS_PATH%
     set start=!time!
     set stepName=Building detached to produce stable fingerprints file
     call :StatusMessage !stepName!
@@ -181,6 +186,7 @@ endlocal && exit /b 0
         if !ERRORLEVEL! NEQ 0 (exit /b 1)
     call :RecordStep "!stepName!" !start!
 
+echo NUGET_CREDENTIALPROVIDERS_PATH %NUGET_CREDENTIALPROVIDERS_PATH%
     set start=!time!
     set stepName=Building using BuildXL a second time to ensure all tasks are cached
     call :StatusMessage !stepName!
@@ -192,11 +198,13 @@ endlocal && exit /b 0
         call :RunBxl /cacheGraph- /scriptShowSlowest -Use RunCheckinTests -minimal %BUILDXL_ARGS% /incrementalScheduling- /TraceInfo:RunCheckinTests=CompareFingerprints2 /logsDirectory:!COMPARE_FINGERPRINTS_LOGS_DIR! -SharedCacheMode disable /logPrefix:!SECOND_PREFIX!
         if !ERRORLEVEL! NEQ 0 (exit /b 1)
 
+echo NUGET_CREDENTIALPROVIDERS_PATH %NUGET_CREDENTIALPROVIDERS_PATH%
         REM Produce a fingerprint file of the second run.
         set SECOND_FINGERPRINT_LOG=!COMPARE_FINGERPRINTS_LOGS_DIR!!SECOND_PREFIX!.fgrprnt.txt
         %EXE_DIR%\bxlAnalyzer.exe /mode:FingerprintText /xl:!COMPARE_FINGERPRINTS_LOGS_DIR!!SECOND_PREFIX!.xlg /compress- /o:!SECOND_FINGERPRINT_LOG!
         if !ERRORLEVEL! NEQ 0 (exit /b 1)
 
+echo NUGET_CREDENTIALPROVIDERS_PATH %NUGET_CREDENTIALPROVIDERS_PATH%
         REM Compare fingerprints
         fc !FIRST_FINGERPRINT_LOG! !SECOND_FINGERPRINT_LOG! > !SECOND_FINGERPRINT_LOG!.diff.txt
         if !ERRORLEVEL! NEQ 0 (
@@ -215,6 +223,7 @@ endlocal && exit /b 0
             exit /b 1
         )
 
+echo NUGET_CREDENTIALPROVIDERS_PATH %NUGET_CREDENTIALPROVIDERS_PATH%
         REM verify fully cached
         call :VerifyLogIsFullyCached !COMPARE_FINGERPRINTS_LOGS_DIR!!SECOND_PREFIX!.log
         if !ERRORLEVEL! NEQ 0 (
@@ -364,6 +373,7 @@ endlocal && exit /b 0
     REM BUG: 1199393: Temporary have to hack the generated nuspecs since the coreclr run doesn't run under b:
     rmdir /s/q %ENLISTMENTROOT%\Out\frontend\Nuget\specs
     set cmd=%NETCOREROOT%\bxl.exe %*
+    set OLD_NUGET_CREDENTIALPROVIDERS_PATH=%NUGET_CREDENTIALPROVIDERS_PATH%
     set NUGET_CREDENTIALPROVIDERS_PATH=%ENLISTMENTROOT%\Shared\Tools
     echo %cmd%
     call %cmd%
@@ -380,6 +390,8 @@ endlocal && exit /b 0
     REM BUG: 1199393: Temporary have to hack the generated nuspecs since the coreclr run doesn't run under b:
     rmdir /s/q %ENLISTMENTROOT%\Out\frontend\Nuget\specs
 
+    REM Restore credential provider path.
+    set NUGET_CREDENTIALPROVIDERS_PATH=%OLD_NUGET_CREDENTIALPROVIDERS_PATH%
     exit /b 0
 
 :VerifyLogIsFullyCached

--- a/RunCheckInTests.cmd
+++ b/RunCheckInTests.cmd
@@ -364,6 +364,7 @@ endlocal && exit /b 0
     REM BUG: 1199393: Temporary have to hack the generated nuspecs since the coreclr run doesn't run under b:
     rmdir /s/q %ENLISTMENTROOT%\Out\frontend\Nuget\specs
     set cmd=%NETCOREROOT%\bxl.exe %*
+    set NUGET_CREDENTIALPROVIDERS_PATH=%ENLISTMENTROOT%\Shared\Tools
     echo %cmd%
     call %cmd%
     if %ERRORLEVEL% NEQ 0 (


### PR DESCRIPTION
The nuget spec generation incrementality was based on a "PackageHash" file which was tied to the materialization of outputs on disk but not the actual generation of the spec file. This was problematic for a number of reasons:
- If spec generation was incomplete or never ran, the spec would be locked in the bad state
- If the format of the PackageHash file gets updated in a way that only impacted spec generation, there was nothing to re-emit the file once spec generation ran again.
The result of these was that the specs would sometimes not get generated when they needed to and other times get stuck getting regenerated every build. On my machine 90% of packages were trapped in the always regenerate mode.

This change decouples the state tracking of fetching the package contents from the spec generation. This allows the lifetime of the state tracking file to align with writing out the spec file. It is self-healing on previously downloaded packages and allows me to now not regenerate any spec files when nothing changes. I'm hopeful it will also address the weird things we see every now and then that force us to nuke our generated specs. 

If it doesn't address the weird things I'd like us to just remove the incrementality for spec generation since prior to this change the incremental generation wouldn't have been providing much benefit anyway.