### PR TITLE
Change default value for unsafe_IgnoreUndeclaredAccessesUnderSharedOpaques

### DIFF
--- a/Public/Src/Utilities/Configuration/Mutable/UnsafeSandboxConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/UnsafeSandboxConfiguration.cs
@@ -26,7 +26,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             IgnoreGetFinalPathNameByHandle = false;
             MonitorZwCreateOpenQueryFile = true;
             IgnoreDynamicWritesOnAbsentProbes = false;
-            IgnoreUndeclaredAccessesUnderSharedOpaques = true;
+            IgnoreUndeclaredAccessesUnderSharedOpaques = false;
             // Make sure to update SafeOptions below if necessary when new flags are added
         }
 
@@ -36,8 +36,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
         /// </summary>
         public static readonly IUnsafeSandboxConfiguration SafeOptions = new UnsafeSandboxConfiguration()
         {
-            IgnorePreloadedDlls = false,
-            IgnoreUndeclaredAccessesUnderSharedOpaques = false,
+            IgnorePreloadedDlls = false,            
         };
 
         /// <nodoc />


### PR DESCRIPTION
The unsafe option was enabled by default so we are not causing customers lots of headache. By now, everyone should have had enough time to address any issues in their spec, so let's turn off the unsafe option (the option is still there, so customers can enable it if they need to unblock their builds). 