### PR TITLE
Stop sending Statistic, BulkStatistic, and others to telemetry

### DIFF
--- a/Public/Src/Engine/Scheduler/Tracing/Log.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/Log.cs
@@ -3401,7 +3401,7 @@ namespace BuildXL.Scheduler.Tracing
 
         [GeneratedEvent(
             (int)EventId.InvalidMetadataStaticOutputNotFound,
-            EventGenerators = EventGenerators.LocalAndTelemetry,
+            EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Warning,
             Keywords = (int)Keywords.UserMessage,
             EventTask = (int)Tasks.Scheduler,
@@ -3410,7 +3410,7 @@ namespace BuildXL.Scheduler.Tracing
 
         [GeneratedEvent(
             (int)EventId.InvalidMetadataRequiredOutputIsAbsent,
-            EventGenerators = EventGenerators.LocalAndTelemetry,
+            EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Warning,
             Keywords = (int)Keywords.UserMessage,
             EventTask = (int)Tasks.Scheduler,
@@ -3844,7 +3844,7 @@ namespace BuildXL.Scheduler.Tracing
 
         [GeneratedEvent(
             (ushort)LogEventId.UnexpectedlySmallObservedInputCount,
-            EventGenerators = EventGenerators.LocalAndTelemetry,
+            EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,
             Keywords = (int)Keywords.UserMessage,
             EventTask = (ushort)Tasks.Storage,
@@ -3968,7 +3968,7 @@ namespace BuildXL.Scheduler.Tracing
 
         [GeneratedEvent(
             (ushort)LogEventId.CreateSymlinkFromSymlinkMap,
-            EventGenerators = EventGenerators.LocalAndTelemetryAndStatistic,
+            EventGenerators = EventGenerators.LocalOnly | Generators.Statistics,
             EventLevel = Level.Verbose,
             Keywords = (int)Keywords.UserMessage,
             EventTask = (ushort)Tasks.Storage,

--- a/Public/Src/Engine/Scheduler/Tracing/Log.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/Log.cs
@@ -3401,7 +3401,7 @@ namespace BuildXL.Scheduler.Tracing
 
         [GeneratedEvent(
             (int)EventId.InvalidMetadataStaticOutputNotFound,
-            EventGenerators = EventGenerators.LocalOnly,
+            EventGenerators = EventGenerators.LocalOnly, 
             EventLevel = Level.Warning,
             Keywords = (int)Keywords.UserMessage,
             EventTask = (int)Tasks.Scheduler,

--- a/Public/Src/FrontEnd/Core/Tracing/Log.cs
+++ b/Public/Src/FrontEnd/Core/Tracing/Log.cs
@@ -990,7 +990,7 @@ namespace BuildXL.FrontEnd.Core.Tracing
 
         [GeneratedEvent(
             (ushort)LogEventId.ScriptFilesReloadedWithNoWarningsOrErrors,
-            EventGenerators = EventGenerators.LocalAndTelemetry,
+            EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Error,
             EventTask = (ushort)Tasks.Parser,
             Message = "{reloadedSpecCount} spec(s) were reloaded during {ShortProductName} invocation but no error or warning was logged. This behavior could drasitcally compromise system's performance and should be fixed. Stack trace that triggered file reloading: \r\n{stackTrace}",
@@ -999,7 +999,7 @@ namespace BuildXL.FrontEnd.Core.Tracing
 
         [GeneratedEvent(
             (ushort)LogEventId.ReportDestructionCone,
-            EventGenerators = EventGenerators.LocalAndTelemetry,
+            EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,
             EventTask = (ushort)Tasks.Parser,
             Message = "Destruction cone (changed/affected/required/all specs): {numChanged}/{numAffected}/{numRequired}/{numAll}",

--- a/Public/Src/Utilities/Instrumentation/Tracing/Log.cs
+++ b/Public/Src/Utilities/Instrumentation/Tracing/Log.cs
@@ -31,7 +31,7 @@ namespace BuildXL.Tracing
         /// </summary>
         [GeneratedEvent(
             (ushort)EventId.Statistic,
-            EventGenerators = EventGenerators.LocalAndTelemetry,
+            EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,
             EventTask = (ushort)Tasks.CommonInfrastructure,
             Message = "{statistic.Name}={statistic.Value}",
@@ -67,7 +67,7 @@ namespace BuildXL.Tracing
         /// </remarks>
         [GeneratedEvent(
             (ushort)EventId.BulkStatistic,
-            EventGenerators = EventGenerators.TelemetryOnly | Generators.Statistics,
+            EventGenerators = Generators.Statistics,
             EventLevel = Level.Verbose,
             EventTask = (ushort)Tasks.CommonInfrastructure,
             Message = "N/A",

--- a/Public/Src/Utilities/Storage/Tracing/Log.cs
+++ b/Public/Src/Utilities/Storage/Tracing/Log.cs
@@ -76,7 +76,7 @@ namespace BuildXL.Storage.Tracing
 
         [GeneratedEvent(
             (int)LogEventId.SavingChangeTracker,
-            EventGenerators = EventGenerators.LocalAndTelemetry,
+            EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,
             EventTask = (ushort)Tasks.ChangeDetection,
             Keywords = (int)(Keywords.UserMessage | Keywords.Performance),
@@ -402,7 +402,7 @@ namespace BuildXL.Storage.Tracing
 
         [GeneratedEvent(
             (int)LogEventId.StorageLoadFileContentTable,
-            EventGenerators = EventGenerators.LocalAndTelemetry,
+            EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,
             Keywords = (int)Keywords.UserMessage,
             EventTask = (int)Tasks.Storage,
@@ -673,7 +673,7 @@ namespace BuildXL.Storage.Tracing
 
         [GeneratedEvent(
             (ushort)LogEventId.ConflictDirectoryMembershipFingerprint,
-            EventGenerators = EventGenerators.LocalAndTelemetry,
+            EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,
             Keywords = (int)Keywords.UserMessage,
             EventTask = (ushort)Tasks.Storage,


### PR DESCRIPTION
This stops sending telemetry for Statistic and BulkStatistic in separate events. They will still get sent in the FinalStatistics table which is much more convenient for consumption anyway. The Statistic ETW event still gets called so there's no change to listeners of that.

Also stops sending telemetry for some other events that don't look useful anymore.

[AB#1467942](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1467942)