### PR TITLE
New constructor allows for null in Result<T> success case

### DIFF
--- a/Public/Src/Cache/ContentStore/Interfaces/Results/ResultOfT.cs
+++ b/Public/Src/Cache/ContentStore/Interfaces/Results/ResultOfT.cs
@@ -47,9 +47,9 @@ namespace BuildXL.Cache.ContentStore.Interfaces.Results
         /// </summary>
         public Result(T result, bool isNullAllowed)
         {
-            if (!isNullAllowed)
+            if (!isNullAllowed && result == null)
             {
-                Contract.Requires(result != null);
+                throw new ArgumentNullException(nameof(result));
             }
             
             _result = result;

--- a/Public/Src/Cache/ContentStore/Interfaces/Results/ResultOfT.cs
+++ b/Public/Src/Cache/ContentStore/Interfaces/Results/ResultOfT.cs
@@ -38,9 +38,20 @@ namespace BuildXL.Cache.ContentStore.Interfaces.Results
         /// <summary>
         /// Creates a success outcome.
         /// </summary>
-        public Result(T result)
+        public Result(T result) : this(result, isNullAllowed: false)
         {
-            Contract.Requires(result != null);
+        }
+
+        /// <summary>
+        /// Creates a success outcome specifing if the value can be null.
+        /// </summary>
+        public Result(T result, bool isNullAllowed)
+        {
+            if (!isNullAllowed)
+            {
+                Contract.Requires(result != null);
+            }
+            
             _result = result;
         }
 

--- a/Public/Src/Cache/ContentStore/Vsts/DedupReadOnlyContentSession.cs
+++ b/Public/Src/Cache/ContentStore/Vsts/DedupReadOnlyContentSession.cs
@@ -727,7 +727,7 @@ namespace BuildXL.Cache.ContentStore.Vsts
                     keepUntil = added.Receipts[dedupId].KeepUntil.KeepUntil;
                 });
 
-            return new Result<DateTime?>(keepUntil);
+            return new Result<DateTime?>(keepUntil, isNullAllowed: true);
         }
 
         #endregion


### PR DESCRIPTION
Sometimes we want to allow for null in a success result. Default still throws if result is null.