### PR TITLE
Remove Net461 bits from our build

### DIFF
--- a/Public/Sdk/SelfHost/BuildXL/BuildXLSdk.dsc
+++ b/Public/Sdk/SelfHost/BuildXL/BuildXLSdk.dsc
@@ -14,7 +14,6 @@ import * as XUnit from "Sdk.Managed.Testing.XUnit";
 import * as QTest from "Sdk.Managed.Testing.QTest";
 import * as Frameworks from "Sdk.Managed.Frameworks";
 import * as Net451 from "Sdk.Managed.Frameworks.Net451";
-import * as Net461 from "Sdk.Managed.Frameworks.Net461";
 import * as Net472 from "Sdk.Managed.Frameworks.Net472";
 
 import * as ResXPreProcessor from "Sdk.BuildXL.Tools.ResXPreProcessor";
@@ -26,13 +25,11 @@ import * as Contracts from "Tse.RuntimeContracts";
 export * from "Sdk.Managed";
 
 @@public
-export const NetFx = qualifier.targetFramework === "net472" ?
-                        Net472.withQualifier({targetFramework: "net472"}).NetFx :
-                        qualifier.targetFramework === "net461" ?
-                            Net461.withQualifier({targetFramework: "net461"}).NetFx :
-                            Net451.withQualifier({targetFramework: "net451"}).NetFx;
+export const NetFx = qualifier.targetFramework === "net451" 
+    ? Net451.withQualifier({targetFramework: "net451"}).NetFx
+    : Net472.withQualifier({targetFramework: "net472"}).NetFx
+    ;
 
-const testTag = "test";
 export const publicKey = "0024000004800000940000000602000000240000525341310004000001000100BDD83CF6A918814F5B0395F20B6AA573B872FCDDB8B121F162BDD7D5EB302146B2EA6D7E6551279FF9D62E7BEA417ACAE39BADC6E6DECFE45BA7B3AD70AF432A1AA587343AA67647A4D402A0E2D011A9758AAB9F0F8D1C911D554331E8176BE34592BADC08BC94BBD892AF7BCB72AC613F37E4B57A6E18599535211FEF8A7EBA";
 
 const envVarNamePrefix = "[Sdk.BuildXL]";
@@ -102,14 +99,14 @@ export interface TestResult extends Managed.TestResult {
 export const isDotNetCoreBuild : boolean = qualifier.targetFramework === "netcoreapp3.0" || qualifier.targetFramework === "netstandard2.0";
 
 @@public
-export const isFullFramework : boolean = qualifier.targetFramework === "net451" || qualifier.targetFramework === "net461" || qualifier.targetFramework === "net472";
+export const isFullFramework : boolean = qualifier.targetFramework === "net451" || qualifier.targetFramework === "net472";
 
 @@public
 export const isTargetRuntimeOsx : boolean = qualifier.targetRuntime === "osx-x64";
 
 /** Only run unit tests for one qualifier and also don't run tests which target macOS on Windows */
 @@public
-export const restrictTestRunToDebugNet461OnWindows =
+export const restrictTestRunToSomeQualifiers =
     qualifier.configuration !== "debug" ||
     // Running tests for .NET Core App 3.0 and 4.7.2 frameworks only.
     (qualifier.targetFramework !== "netcoreapp3.0" && qualifier.targetFramework !== "net472") ||
@@ -445,23 +442,23 @@ function processArguments(args: Arguments, targetType: Csc.TargetType) : Argumen
                     "FEATURE_THROTTLE_EVAL_SCHEDULER"
                 ),
                 ...addIf(qualifier.targetFramework === "net451", "NET_FRAMEWORK_451"),
-                ...addIf(qualifier.targetFramework === "net461", "NET_FRAMEWORK_461"),
                 ...addIf(qualifier.targetFramework === "net472", "NET_FRAMEWORK_472")
             ],
             references: [
                 ...(args.skipDefaultReferences ? [] : [
                     ...(isDotNetCoreBuild ? [] : [
                         NetFx.System.Threading.Tasks.dll,
-                        ...(qualifier.targetFramework === "net472")
+                        ...(qualifier.targetFramework === "net451"
                             ? [
-                                importFrom("System.Threading.Tasks.Dataflow").pkg,
+                                // net451 needs an explicit reference to ValueTuple
+                                importFrom("System.ValueTuple").pkg,
+                                // net451 does not have its own version of TPL Data flow types
+                                importFrom("Microsoft.Tpl.Dataflow").pkg,
                             ]
                             : [
-                                // 472 doesn't need an explicit reference to ValueTuple
-                                Managed.Factory.createBinary(importFrom("System.ValueTuple").Contents.all, r`lib/portable-net40+sl4+win8+wp8/System.ValueTuple.dll`),
-                                // 472 has its own version of TPL Data flow types
-                                importFrom("Microsoft.Tpl.Dataflow").pkg,
-                            ],
+                                importFrom("System.Threading.Tasks.Dataflow").pkg,
+                            ]
+                        )
                     ]),
                     ...(qualifier.targetFramework === "netstandard2.0" ? [] : [
                         importFrom("BuildXL.Utilities.Instrumentation").Common.dll,
@@ -595,13 +592,13 @@ function processTestArguments(args: Managed.TestArguments) : Managed.TestArgumen
             ]),
         ],
         references: [
-            ...(qualifier.targetFramework === "net451" ? [] : [
+            ...addIf(qualifier.targetFramework !== "net451",
                 importFrom("BuildXL.Utilities.UnitTests").TestUtilities.dll,
-                importFrom("BuildXL.Utilities.UnitTests").TestUtilities.XUnit.dll,
-            ]),
-            ...(isDotNetCoreBuild ? [] : [
-                importFrom("System.Runtime.Serialization.Primitives").pkg,
-            ]),
+                importFrom("BuildXL.Utilities.UnitTests").TestUtilities.XUnit.dll
+            ),
+            ...addIf(isFullFramework,
+                importFrom("System.Runtime.Serialization.Primitives").pkg
+            ),
         ],
         skipTestRun: Context.isWindowsOS() && qualifier.targetRuntime === "osx-x64",
         runTestArgs: {

--- a/Public/Sdk/SelfHost/BuildXL/Qualifiers.dsc
+++ b/Public/Sdk/SelfHost/BuildXL/Qualifiers.dsc
@@ -29,18 +29,7 @@ export interface DefaultQualifier extends Qualifier {
 @@public
 export interface DefaultQualifierWithNet451 extends Qualifier {
     configuration: "debug" | "release";
-    targetFramework: "net451" | "net461" | "net472" | "netcoreapp3.0";
-    targetRuntime: "win-x64" | "osx-x64";
-}
-
-
-/**
- * Qualifier for projects that support DotNetCore
- */
-@@public
-export interface DefaultQualifierWithNet461 extends Qualifier {
-    configuration: "debug" | "release";
-    targetFramework: "net461" | "net472" | "netcoreapp3.0";
+    targetFramework: "net451" | "net472" | "netcoreapp3.0";
     targetRuntime: "win-x64" | "osx-x64";
 }
 
@@ -50,13 +39,13 @@ export interface DefaultQualifierWithNet461 extends Qualifier {
 @@public
 export interface DefaultQualifierWithNet451AndNetStandard20 extends Qualifier {
     configuration: "debug" | "release";
-    targetFramework: "net451" | "net461" | "net472" | "netcoreapp3.0" | "netstandard2.0";
+    targetFramework: "net451" | "net472" | "netcoreapp3.0" | "netstandard2.0";
     targetRuntime: "win-x64" | "osx-x64";
 }
 
 export interface AllSupportedQualifiers extends Qualifier {
     configuration: "debug" | "release";
-    targetFramework: "net451" | "net461" | "net472" | "netcoreapp3.0" | "netstandard2.0";
+    targetFramework: "net451" | "net472" | "netcoreapp3.0" | "netstandard2.0";
     targetRuntime: "win-x64" | "osx-x64";
 }
 

--- a/Public/Sdk/SelfHost/Libraries/MSBuild/msbuild.dsc
+++ b/Public/Sdk/SelfHost/Libraries/MSBuild/msbuild.dsc
@@ -17,17 +17,18 @@ export const msbuildReferences: Managed.ManagedNugetPackage[] = [
 /** Runtime content for tests */
 @@public
 export const msbuildRuntimeContent = [
-    BuildXLSdk.isDotNetCoreBuild ? importFrom("System.Threading.Tasks.Dataflow").pkg : importFrom("DataflowForMSBuild").pkg,
     importFrom("System.Numerics.Vectors").pkg,
     importFrom("Microsoft.Build.Runtime").pkg,
     ...BuildXLSdk.isDotNetCoreBuild ? [
         importFrom("Microsoft.NETCore.App.210").pkg,
         importFrom("System.Text.Encoding.CodePages").withQualifier({targetFramework: "netstandard2.0"}).pkg,
+        importFrom("System.Threading.Tasks.Dataflow").pkg ,
         importFrom("Microsoft.Build.Tasks.Core").withQualifier({targetFramework: "netstandard2.0"}).pkg,
         importFrom("Microsoft.Build.Runtime").Contents.all.getFile(r`contentFiles/any/netcoreapp2.1/MSBuild.dll`),
         importFrom("Microsoft.Build.Runtime").Contents.all.getFile(r`contentFiles/any/netcoreapp2.1/MSBuild.runtimeconfig.json`),
     ]
     : [
+        importFrom("DataflowForMSBuild").pkg,
         importFrom("Microsoft.Build.Runtime").Contents.all.getFile(r`contentFiles/any/net472/MSBuild.exe`),
         importFrom("Microsoft.Build.Runtime").Contents.all.getFile(r`contentFiles/any/net472/MSBuild.exe.config`),
     ],

--- a/Public/Sdk/SelfHost/Libraries/RocksDbSharp/rocksDbSharp.dsc
+++ b/Public/Sdk/SelfHost/Libraries/RocksDbSharp/rocksDbSharp.dsc
@@ -4,7 +4,7 @@
 import * as Managed from "Sdk.Managed";
 import * as Deployment from "Sdk.Deployment";
 
-export declare const qualifier: {targetFramework: "netcoreapp3.0" | "netstandard1.6" | "net472" | "net461" | "net451" | "net45" };
+export declare const qualifier: {targetFramework: "netcoreapp3.0" | "net472" | "net451" };
 
 const nativePackage = importFrom("RocksDbNative").pkg;
 const managedPackage = importFrom("RocksDbSharpSigned").withQualifier({targetFramework: "net451"}).pkg;

--- a/Public/Sdk/SelfHost/Libraries/Sqlite/sqlite.dsc
+++ b/Public/Sdk/SelfHost/Libraries/Sqlite/sqlite.dsc
@@ -4,24 +4,23 @@
 import * as Deployment from "Sdk.Deployment";
 
 export declare const qualifier : {
-    targetFramework: "netcoreapp3.0" | "net472" | "net461" | "net451",
+    targetFramework: "netcoreapp3.0" | "netstandard2.0" | "net472" | "net451",
     targetRuntime: "osx-x64" | "win-x64"
 };
 
 // Any qualifier will do here - we only want to directly access the contents.
-const SQLiteCorePackageContents = importFrom("System.Data.SQLite.Core").Contents.all;
+const pkgContents = importFrom("System.Data.SQLite.Core").Contents.all;
 
 function getInteropFile() : File {
     switch (qualifier.targetFramework)
     {
         case "netcoreapp3.0":
-            return SQLiteCorePackageContents.getFile(r`runtimes/${qualifier.targetRuntime}/native/netstandard2.0/SQLite.Interop.dll`);
+        case "netstandard2.0":
+            return pkgContents.getFile(r`runtimes/${qualifier.targetRuntime}/native/netstandard2.0/SQLite.Interop.dll`);
         case "net472":
-            return SQLiteCorePackageContents.getFile("build/net46/x64/SQLite.Interop.dll");
-        case "net461":
-            return SQLiteCorePackageContents.getFile("build/net46/x64/SQLite.Interop.dll");
+            return pkgContents.getFile("build/net46/x64/SQLite.Interop.dll");
         case "net451":
-            return SQLiteCorePackageContents.getFile("build/net451/x64/SQLite.Interop.dll");
+            return pkgContents.getFile("build/net451/x64/SQLite.Interop.dll");
         default:
             Contract.fail("Unsupported target framework for x64 SQLite.Interop.dll");
     }

--- a/Public/Sdk/SelfHost/RuntimeContracts/RuntimeContracts.dsc
+++ b/Public/Sdk/SelfHost/RuntimeContracts/RuntimeContracts.dsc
@@ -5,7 +5,7 @@ import * as Managed from "Sdk.Managed";
 
 export declare const qualifier: {
     configuration: "debug" | "release";
-    targetFramework: "netcoreapp3.0" | "netstandard2.0" | "netstandard1.1" | "net472" | "net462" | "net461" | "net46" | "net452" | "net451" | "net45";
+    targetFramework: "netcoreapp3.0" | "netstandard2.0" | "net472" | "net451";
 };
 
 /** Configures which asserts should be checked at runtime. */

--- a/Public/Src/App/Bxl/Bxl.dsc
+++ b/Public/Src/App/Bxl/Bxl.dsc
@@ -36,10 +36,6 @@ namespace Main {
                 ...addIfLazy(BuildXLSdk.Flags.isVstsArtifactsEnabled, () => [
                     importFrom("BuildXL.Cache.VerticalStore").BuildCacheAdapter.dll
                 ]),
-
-                // net461 of SQLite is compatible .netstandard 2.0
-                // we use net461 because there is no .netstandard 2.0 nuget distribution
-                importFrom("System.Data.SQLite.Core").withQualifier({targetFramework: "net461"}).pkg,
             ] : [
                 NetFx.System.IO.Compression.dll,
                 NetFx.System.IO.Compression.FileSystem.dll,
@@ -79,6 +75,7 @@ namespace Main {
             importFrom("BuildXL.FrontEnd").CMake.dll,
             importFrom("BuildXL.FrontEnd").Sdk.dll,
             importFrom("Newtonsoft.Json").pkg,
+            importFrom("System.Data.SQLite.Core").pkg,
         ],
         internalsVisibleTo: [
             "IntegrationTest.BuildXL.Scheduler",

--- a/Public/Src/App/UnitTests/IntegrationTest.BuildXL.Executable/IntegrationTest.BuildXL.Executable.dsc
+++ b/Public/Src/App/UnitTests/IntegrationTest.BuildXL.Executable/IntegrationTest.BuildXL.Executable.dsc
@@ -11,7 +11,7 @@ namespace IntegrationTest.BuildXL.Executable {
 
     export declare const qualifier : {
         configuration: "debug" | "release",
-        targetFramework: "net461" | "net472" | "netcoreapp3.0" | "netstandard2.0",
+        targetFramework: "net472" | "netcoreapp3.0" | "netstandard2.0",
         targetRuntime: "win-x64"
     };
 

--- a/Public/Src/Cache/ContentStore/App/BuildXL.Cache.ContentStore.App.dsc
+++ b/Public/Src/Cache/ContentStore/App/BuildXL.Cache.ContentStore.App.dsc
@@ -15,15 +15,13 @@ namespace App {
         appConfig: f`App.Config`,
         references: [
             ...(BuildXLSdk.isDotNetCoreBuild ? [
-                importFrom("CLAP").withQualifier({targetFramework:"net451"}).pkg,
                 importFrom("Microsoft.Azure.Kusto.Data.NETStandard").pkg,
                 importFrom("Microsoft.Azure.Kusto.Ingest.NETStandard").pkg,
                 importFrom("Microsoft.Azure.Kusto.Cloud.Platform.Azure.NETStandard").pkg,
                 importFrom("Microsoft.Azure.Kusto.Cloud.Platform.NETStandard").pkg,
                 importFrom("Microsoft.Extensions.PlatformAbstractions").withQualifier({targetFramework: "net472"}).pkg,
             ] : [
-                importFrom("CLAP").pkg,
-                importFrom("Microsoft.Azure.Kusto.Ingest").withQualifier({targetFramework: "net462"}).pkg,
+                importFrom("Microsoft.Azure.Kusto.Ingest").withQualifier({targetFramework: "net472"}).pkg,
             ]
             ),
             UtilitiesCore.dll,
@@ -35,6 +33,9 @@ namespace App {
             importFrom("BuildXL.Cache.MemoizationStore").Distributed.dll,
             importFrom("BuildXL.Cache.DistributedCache.Host").Service.dll,
             importFrom("BuildXL.Cache.DistributedCache.Host").Configuration.dll,
+
+            // CLAP only exists for full framework net35. Ignoring the fact that this doesn't work on netcoreapp
+            importFrom("CLAP").withQualifier({targetFramework:"net472"}).pkg, 
 
             importFrom("Grpc.Core").pkg,
             importFrom("Google.Protobuf").pkg,

--- a/Public/Src/Cache/ContentStore/Distributed/BuildXL.Cache.ContentStore.Distributed.dsc
+++ b/Public/Src/Cache/ContentStore/Distributed/BuildXL.Cache.ContentStore.Distributed.dsc
@@ -10,7 +10,7 @@ namespace Distributed {
         (qualifier.targetFramework === 'net472' || qualifier.targetFramework === 'net451') ? importFrom("Microsoft.Azure.EventHubs").withQualifier({targetFramework: 'net461'}).pkg : importFrom("Microsoft.Azure.EventHubs").pkg,
         // Microsoft.Azure.EventHubs removes 'System.Diagnostics.DiagnosticSource' as the dependency to avoid deployment issue for .netstandard2.0, but this dependency
         // is required for non-.net core builds.
-        ...((qualifier.targetFramework === 'net472' || qualifier.targetFramework === 'net451' || qualifier.targetFramework === 'net461')
+        ...((qualifier.targetFramework === 'net472' || qualifier.targetFramework === 'net451')
             ? [ importFrom("System.Diagnostics.DiagnosticSource").pkg, importFrom("Microsoft.IdentityModel.Tokens").pkg,importFrom("Microsoft.IdentityModel.Logging").pkg ] 
             : []),
 

--- a/Public/Src/Cache/ContentStore/DistributedTest/BuildXL.Cache.ContentStore.Distributed.Test.dsc
+++ b/Public/Src/Cache/ContentStore/DistributedTest/BuildXL.Cache.ContentStore.Distributed.Test.dsc
@@ -13,7 +13,7 @@ namespace DistributedTest {
                     untrackTestDirectory: true,
                     parallelBucketCount: 8,
                 },
-            skipTestRun: BuildXLSdk.restrictTestRunToDebugNet461OnWindows,
+            skipTestRun: BuildXLSdk.restrictTestRunToSomeQualifiers,
             references: [
                 ...addIf(BuildXLSdk.isFullFramework,
                     NetFx.System.IO.dll,

--- a/Public/Src/Cache/ContentStore/GrpcTest/BuildXL.Cache.ContentStore.Grpc.Test.dsc
+++ b/Public/Src/Cache/ContentStore/GrpcTest/BuildXL.Cache.ContentStore.Grpc.Test.dsc
@@ -9,8 +9,13 @@ namespace GrpcTest {
         runTestArgs: {
             parallelGroups: [ "Integration" ],
         },
-        skipTestRun: BuildXLSdk.restrictTestRunToDebugNet461OnWindows,
+        skipTestRun: BuildXLSdk.restrictTestRunToSomeQualifiers,
         references: [
+            ...addIf(BuildXLSdk.isFullFramework,
+                NetFx.System.Xml.dll,
+                NetFx.System.Xml.Linq.dll
+            ),
+
             App.exe, // Tests launch the server, so this needs to be deployed.
             Grpc.dll,
             Test.dll,
@@ -20,19 +25,9 @@ namespace GrpcTest {
             UtilitiesCore.dll,
             InterfacesTest.dll,
 
-            ...addIf(BuildXLSdk.isFullFramework,
-                NetFx.System.Xml.dll,
-                NetFx.System.Xml.Linq.dll
-            ),
-
-            ...(BuildXLSdk.isDotNetCoreBuild
-                // TODO: This is to get a .Net Core build, but it may not pass tests
-                ? [importFrom("System.Data.SQLite").withQualifier({targetFramework: "net461"}).pkg]
-                : [importFrom("System.Data.SQLite").pkg]
-            ),
-
             importFrom("Grpc.Core").pkg,
             importFrom("Google.Protobuf").pkg,
+            importFrom("System.Data.SQLite").pkg,
             ...BuildXLSdk.fluentAssertionsWorkaround,
         ],
         runtimeContent: [

--- a/Public/Src/Cache/ContentStore/InterfacesTest/BuildXL.Cache.ContentStore.Interfaces.Test.dsc
+++ b/Public/Src/Cache/ContentStore/InterfacesTest/BuildXL.Cache.ContentStore.Interfaces.Test.dsc
@@ -7,7 +7,7 @@ namespace InterfacesTest {
     export const dll = BuildXLSdk.test({
         assemblyName: "BuildXL.Cache.ContentStore.Interfaces.Test",
         sources: globR(d`.`,"*.cs"),
-        skipTestRun: BuildXLSdk.restrictTestRunToDebugNet461OnWindows,
+        skipTestRun: BuildXLSdk.restrictTestRunToSomeQualifiers,
         references: [
             UtilitiesCore.dll,
             Hashing.dll,

--- a/Public/Src/Cache/ContentStore/Library/BuildXL.Cache.ContentStore.Library.dsc
+++ b/Public/Src/Cache/ContentStore/Library/BuildXL.Cache.ContentStore.Library.dsc
@@ -10,15 +10,10 @@ namespace Library {
         assemblyName: "BuildXL.Cache.ContentStore",
         sources: globR(d`.`,"*.cs"),
         references: [
-            ...(BuildXLSdk.isDotNetCoreBuild ? [
-                // TODO: This is to get a .Net Core build, but it may not pass tests
-                importFrom("System.Data.SQLite.Core").withQualifier({targetFramework: "net461"}).pkg,
-            ] :
-            [
-                importFrom("System.Data.SQLite.Core").pkg,
+            ...addIf(BuildXLSdk.isFullFramework,
                 NetFx.System.Data.dll,
-                NetFx.System.Runtime.Serialization.dll,
-            ]),
+                NetFx.System.Runtime.Serialization.dll
+            ),
             ...importFrom("BuildXL.Utilities").Native.securityDlls,
             UtilitiesCore.dll,
             Hashing.dll,
@@ -30,6 +25,7 @@ namespace Library {
             importFrom("BuildXL.Cache.DistributedCache.Host").Configuration.dll,
             importFrom("Grpc.Core").pkg,
             importFrom("Google.Protobuf").pkg,
+            importFrom("System.Data.SQLite.Core").pkg,
             importFrom("System.Interactive.Async").pkg,
 
             BuildXLSdk.Factory.createBinary(importFrom("TransientFaultHandling.Core").Contents.all, r`lib/NET4/Microsoft.Practices.TransientFaultHandling.Core.dll`),

--- a/Public/Src/Cache/ContentStore/Test/BuildXL.Cache.ContentStore.Test.dsc
+++ b/Public/Src/Cache/ContentStore/Test/BuildXL.Cache.ContentStore.Test.dsc
@@ -12,23 +12,13 @@ namespace Test {
         runTestArgs: {
             parallelGroups: categoriesToRunInParallel,
         },
-        skipTestRun: BuildXLSdk.restrictTestRunToDebugNet461OnWindows,
+        skipTestRun: BuildXLSdk.restrictTestRunToSomeQualifiers,
         references: [
-            ...(BuildXLSdk.isDotNetCoreBuild ? [
-                // TODO: This is to get a .Net Core build, but it may not pass tests
-                importFrom("System.Data.SQLite").withQualifier({targetFramework: "net461"}).pkg,
-                importFrom("System.Data.SQLite.Core").withQualifier({targetFramework: "net461"}).pkg,
-                importFrom("System.Data.SQLite.Linq").withQualifier({targetFramework: "net461"}).pkg,
-            ] :
-            [
-                importFrom("System.Data.SQLite").pkg,
-                importFrom("System.Data.SQLite.Core").pkg,
-                importFrom("System.Data.SQLite.Linq").pkg,
-                importFrom("System.Data.SQLite.EF6").pkg,
+            ...addIf(BuildXLSdk.isFullFramework,
                 NetFx.System.Xml.dll,
                 NetFx.System.Xml.Linq.dll,
-                NetFx.System.Runtime.Serialization.dll,
-            ]),
+                NetFx.System.Runtime.Serialization.dll
+            ),
             // TODO: This needs to be renamed to just utilities... but it is in a package in public/src
             importFrom("BuildXL.Utilities").dll,
             importFrom("BuildXL.Utilities").Native.dll,
@@ -40,6 +30,8 @@ namespace Test {
             Library.dll,
             App.exe, // Tests launch the server, so this needs to be deployed.
             BuildXLSdk.Factory.createBinary(importFrom("TransientFaultHandling.Core").Contents.all, r`lib/NET4/Microsoft.Practices.TransientFaultHandling.Core.dll`),
+
+            importFrom("System.Data.SQLite.Core").pkg,
 
             ...importFrom("BuildXL.Utilities").Native.securityDlls,
             ...BuildXLSdk.fluentAssertionsWorkaround,

--- a/Public/Src/Cache/ContentStore/Vsts/BuildXL.Cache.ContentStore.Vsts.dsc
+++ b/Public/Src/Cache/ContentStore/Vsts/BuildXL.Cache.ContentStore.Vsts.dsc
@@ -18,7 +18,9 @@ namespace Vsts {
             importFrom("BuildXL.Utilities").dll,
             importFrom("BuildXL.Utilities").Native.dll,
             importFrom("WindowsAzure.Storage").pkg,
-            ...addIf(BuildXLSdk.isDotNetCoreBuild, importFrom("Microsoft.IdentityModel.Clients.ActiveDirectory").pkg),
+            ...addIf(BuildXLSdk.isDotNetCoreBuild, 
+                importFrom("Microsoft.IdentityModel.Clients.ActiveDirectory").pkg
+            ),
             importFrom("Microsoft.VisualStudio.Services.BlobStore.Client").pkg,
             importFrom("Microsoft.VisualStudio.Services.Client").pkg,
             importFrom("Microsoft.VisualStudio.Services.InteractiveClient").pkg,

--- a/Public/Src/Cache/MemoizationStore/App/BuildXL.Cache.MemoizationStore.App.dsc
+++ b/Public/Src/Cache/MemoizationStore/App/BuildXL.Cache.MemoizationStore.App.dsc
@@ -8,22 +8,16 @@ namespace App {
         sources: globR(d`.`,"*.cs"),
         appConfig: f`App.Config`,
         references: [
-            ...(BuildXLSdk.isDotNetCoreBuild
-                // TODO: This is to get a .Net Core build, but it may not pass tests
-                ? [importFrom("System.Data.SQLite.Core").withQualifier({targetFramework:"net461"}).pkg]
-                : [importFrom("System.Data.SQLite.Core").pkg]
-            ),
-            ...(BuildXLSdk.isDotNetCoreBuild
-                // TODO: This is to get a .Net Core build, but it may not pass tests
-                ? [importFrom("CLAP").withQualifier({targetFramework:"net451"}).pkg]
-                : [importFrom("CLAP").pkg]
-            ),
             ContentStore.UtilitiesCore.dll,
             ContentStore.Interfaces.dll,
             ContentStore.Library.dll,
             Interfaces.dll,
             Library.dll,
 
+            // CLAP only exists for full framework net35. Ignoring the fact that this doesn't work on netcoreapp
+            importFrom("CLAP").withQualifier({targetFramework:"net472"}).pkg, 
+
+            importFrom("System.Data.SQLite.Core").pkg,
             importFrom("System.Interactive.Async").pkg,
         ],
         tools: {

--- a/Public/Src/Cache/MemoizationStore/DistributedTest/BuildXL.Cache.MemoizationStore.Distributed.Test.dsc
+++ b/Public/Src/Cache/MemoizationStore/DistributedTest/BuildXL.Cache.MemoizationStore.Distributed.Test.dsc
@@ -6,7 +6,7 @@ namespace DistributedTest {
     export const dll = BuildXLSdk.isDotNetCoreBuild ? undefined : BuildXLSdk.test({
         assemblyName: "BuildXL.Cache.MemoizationStore.Distributed.Test",
         sources: globR(d`.`,"*.cs"),
-        skipTestRun: BuildXLSdk.restrictTestRunToDebugNet461OnWindows,
+        skipTestRun: BuildXLSdk.restrictTestRunToSomeQualifiers,
         references: [
             ...addIf(BuildXLSdk.isFullFramework,
                 NetFx.System.Xml.dll,

--- a/Public/Src/Cache/MemoizationStore/InterfacesTest/BuildXL.Cache.MemoizationStore.Interfaces.Test.dsc
+++ b/Public/Src/Cache/MemoizationStore/InterfacesTest/BuildXL.Cache.MemoizationStore.Interfaces.Test.dsc
@@ -6,7 +6,7 @@ namespace InterfacesTest {
     export const dll = BuildXLSdk.test({
         assemblyName: "BuildXL.Cache.MemoizationStore.Interfaces.Test",
         sources: globR(d`.`,"*.cs"),
-        skipTestRun: BuildXLSdk.restrictTestRunToDebugNet461OnWindows,
+        skipTestRun: BuildXLSdk.restrictTestRunToSomeQualifiers,
         references: [
             ContentStore.UtilitiesCore.dll,
             ContentStore.Hashing.dll,

--- a/Public/Src/Cache/MemoizationStore/Library/BuildXL.Cache.MemoizationStore.Library.dsc
+++ b/Public/Src/Cache/MemoizationStore/Library/BuildXL.Cache.MemoizationStore.Library.dsc
@@ -7,14 +7,9 @@ namespace Library {
         assemblyName: "BuildXL.Cache.MemoizationStore",
         sources: globR(d`.`,"*.cs"),
         references: [
-            ...(BuildXLSdk.isDotNetCoreBuild ? [
-                // TODO: This is to get a .Net Core build, but it may not pass tests
-                importFrom("System.Data.SQLite.Core").withQualifier({targetFramework: "net461"}).pkg,
-            ] :
-            [
-                importFrom("System.Data.SQLite.Core").pkg,
-                NetFx.System.Data.dll,
-            ]),
+            ...addIf(BuildXLSdk.isFullFramework,
+                NetFx.System.Data.dll
+            ),
             ContentStore.Distributed.dll,
             ContentStore.UtilitiesCore.dll,
             ContentStore.Grpc.dll,
@@ -27,6 +22,7 @@ namespace Library {
             importFrom("BuildXL.Cache.DistributedCache.Host").Service.dll,
             importFrom("BuildXL.Utilities").dll,
 
+            importFrom("System.Data.SQLite.Core").pkg,
             importFrom("System.Interactive.Async").pkg,
 
             importFrom("Grpc.Core").pkg,

--- a/Public/Src/Cache/MemoizationStore/Test/BuildXL.Cache.MemoizationStore.Test.dsc
+++ b/Public/Src/Cache/MemoizationStore/Test/BuildXL.Cache.MemoizationStore.Test.dsc
@@ -6,7 +6,7 @@ namespace Test {
     export const dll = BuildXLSdk.cacheTest({
         assemblyName: "BuildXL.Cache.MemoizationStore.Test",
         sources: globR(d`.`,"*.cs"),
-        skipTestRun: BuildXLSdk.restrictTestRunToDebugNet461OnWindows,
+        skipTestRun: BuildXLSdk.restrictTestRunToSomeQualifiers,
         runTestArgs: {
             skipGroups: ["Performance"], // Don't run the performance tests in our normal validation flow
             parallelBucketCount: 12,
@@ -16,12 +16,6 @@ namespace Test {
                 NetFx.System.Data.dll,
                 NetFx.System.Xml.dll,
                 NetFx.System.Xml.Linq.dll
-            ),
-            ...(BuildXLSdk.isDotNetCoreBuild
-                // TODO: This is to get a .Net Core build, but it may not pass tests
-                ? [importFrom("System.Data.SQLite.Core").withQualifier({targetFramework: "net461"}).pkg]
-                // Gets around issue of 461 needed netstandard 2.0 lib
-                : [importFrom("System.Data.SQLite.Core").pkg]
             ),
             ContentStore.Distributed.dll,
             ContentStore.Hashing.dll,
@@ -36,6 +30,7 @@ namespace Test {
             Library.dll,
 
             importFrom("BuildXL.Utilities").dll,
+            importFrom("System.Data.SQLite.Core").pkg,
             importFrom("System.Interactive.Async").pkg,
             ...BuildXLSdk.fluentAssertionsWorkaround,
         ],

--- a/Public/Src/Cache/MemoizationStore/VstsApp/BuildXL.Cache.MemoizationStore.Vsts.App.dsc
+++ b/Public/Src/Cache/MemoizationStore/VstsApp/BuildXL.Cache.MemoizationStore.Vsts.App.dsc
@@ -7,11 +7,6 @@ namespace VstsApp {
         assemblyName: "BuildXL.MemoizationStoreVstsApp",
         sources: globR(d`.`,"*.cs"),
         references: [
-            ...(BuildXLSdk.isDotNetCoreBuild
-                // TODO: This is to get a .Net Core build, but it may not pass tests
-                ? [importFrom("CLAP").withQualifier({targetFramework:"net451"}).pkg]
-                : [importFrom("CLAP").pkg]
-            ),
             Vsts.dll,
             Interfaces.dll,
             ContentStore.Hashing.dll,
@@ -19,6 +14,10 @@ namespace VstsApp {
             ContentStore.Interfaces.dll,
             ContentStore.Library.dll,
             ContentStore.Vsts.dll,
+            
+            // CLAP only exists for full framework net35. Ignoring the fact that this doesn't work on netcoreapp
+            importFrom("CLAP").withQualifier({targetFramework:"net472"}).pkg, 
+
             importFrom("Microsoft.VisualStudio.Services.Client").pkg,
             ...BuildXLSdk.visualStudioServicesArtifactServicesSharedPkg,
         ],

--- a/Public/Src/Cache/MemoizationStore/VstsTest/BuildXL.Cache.MemoizationStore.Vsts.Test.dsc
+++ b/Public/Src/Cache/MemoizationStore/VstsTest/BuildXL.Cache.MemoizationStore.Vsts.Test.dsc
@@ -7,7 +7,7 @@ namespace VstsTest {
         assemblyName: "BuildXL.Cache.MemoizationStore.Vsts.Test",
         sources: globR(d`.`,"*.cs"),
         appConfig: f`App.Config`,
-        skipTestRun: BuildXLSdk.restrictTestRunToDebugNet461OnWindows,
+        skipTestRun: BuildXLSdk.restrictTestRunToSomeQualifiers,
         references: [
             ...addIfLazy(BuildXLSdk.isFullFramework, () => [
                 NetFx.System.Xml.dll,

--- a/Public/Src/Deployment/NugetPackages.dsc
+++ b/Public/Src/Deployment/NugetPackages.dsc
@@ -63,19 +63,19 @@ namespace NugetPackages {
         dependencies: [
             { id: `${packageNamePrefix}.Cache.Interfaces`, version: Branding.Nuget.packageVersion},
 
-            importFrom("Microsoft.Tpl.Dataflow").withQualifier({targetFramework: "net461"}).pkg,
-            importFrom("System.Interactive.Async").withQualifier({targetFramework: "net461"}).pkg,
-            importFrom("Grpc.Core").withQualifier({ targetFramework: "net461" }).pkg,
-            importFrom("Google.Protobuf").withQualifier({ targetFramework: "net461" }).pkg,
-            importFrom("StackExchange.Redis.StrongName").withQualifier({ targetFramework: "net461" }).pkg,
+            importFrom("Microsoft.Tpl.Dataflow").withQualifier({targetFramework: "net472"}).pkg,
+            importFrom("System.Interactive.Async").withQualifier({targetFramework: "net472"}).pkg,
+            importFrom("Grpc.Core").withQualifier({ targetFramework: "net472" }).pkg,
+            importFrom("Google.Protobuf").withQualifier({ targetFramework: "net472" }).pkg,
+            importFrom("StackExchange.Redis.StrongName").withQualifier({ targetFramework: "net472" }).pkg,
 
             ...BuildXLSdk.withQualifier({
-                targetFramework: "net461",
+                targetFramework: "net472",
                 targetRuntime: "win-x64",
                 configuration: qualifier.configuration
             }).visualStudioServicesArtifactServicesSharedPkg,
 
-            importFrom("Microsoft.VisualStudio.Services.BlobStore.Client").withQualifier({ targetFramework: "net461" }).pkg,
+            importFrom("Microsoft.VisualStudio.Services.BlobStore.Client").withQualifier({ targetFramework: "net472" }).pkg,
         ]
     });
 
@@ -83,8 +83,8 @@ namespace NugetPackages {
         id: `${packageNamePrefix}.Cache.Interfaces`,
         deployment: Cache.NugetPackages.interfaces,
         dependencies: [
-            importFrom("Microsoft.Tpl.Dataflow").withQualifier({targetFramework: "net461"}).pkg,
-            importFrom("System.Interactive.Async").withQualifier({targetFramework: "net461"}).pkg,
+            importFrom("Microsoft.Tpl.Dataflow").withQualifier({targetFramework: "net472"}).pkg,
+            importFrom("System.Interactive.Async").withQualifier({targetFramework: "net472"}).pkg,
         ]
     });
 

--- a/Public/Src/Deployment/cache.NugetPackages.dsc
+++ b/Public/Src/Deployment/cache.NugetPackages.dsc
@@ -9,16 +9,13 @@ namespace Cache.NugetPackages {
     export declare const qualifier : { configuration: "debug" | "release"};
 
     const Net451ContentStore = importFrom("BuildXL.Cache.ContentStore").withQualifier({ configuration: qualifier.configuration, targetFramework: "net451", targetRuntime: "win-x64" });
-    const Net461ContentStore = importFrom("BuildXL.Cache.ContentStore").withQualifier({ configuration: qualifier.configuration, targetFramework: "net461", targetRuntime: "win-x64" });
     const Net472ContentStore = importFrom("BuildXL.Cache.ContentStore").withQualifier({ configuration: qualifier.configuration, targetFramework: "net472", targetRuntime: "win-x64" });
     const WinX64ContentStore = importFrom("BuildXL.Cache.ContentStore").withQualifier({ configuration: qualifier.configuration, targetFramework: "netcoreapp3.0", targetRuntime: "win-x64" });
 
     const Net451MemoizationStore = importFrom("BuildXL.Cache.MemoizationStore").withQualifier({ configuration: qualifier.configuration, targetFramework: "net451", targetRuntime: "win-x64" });
-    const Net461MemoizationStore = importFrom("BuildXL.Cache.MemoizationStore").withQualifier({ configuration: qualifier.configuration, targetFramework: "net461", targetRuntime: "win-x64" });
     const Net472MemoizationStore = importFrom("BuildXL.Cache.MemoizationStore").withQualifier({ configuration: qualifier.configuration, targetFramework: "net472", targetRuntime: "win-x64" });
     const WinX64MemoizationStore = importFrom("BuildXL.Cache.MemoizationStore").withQualifier({ configuration: qualifier.configuration, targetFramework: "netcoreapp3.0", targetRuntime: "win-x64" });
 
-    const Net461DistributedCacheHost = importFrom("BuildXL.Cache.DistributedCache.Host").withQualifier({ configuration: qualifier.configuration, targetFramework: "net461", targetRuntime: "win-x64" });
     const Net472DistributedCacheHost = importFrom("BuildXL.Cache.DistributedCache.Host").withQualifier({ configuration: qualifier.configuration, targetFramework: "net472", targetRuntime: "win-x64" });
     const WinX64DistributedCacheHost = importFrom("BuildXL.Cache.DistributedCache.Host").withQualifier({ configuration: qualifier.configuration, targetFramework: "netcoreapp3.0", targetRuntime: "win-x64" });
 
@@ -27,10 +24,10 @@ namespace Cache.NugetPackages {
             {
                 subfolder: r`tools`,
                 contents: [
-                    Net461ContentStore.App.exe,
-                    Net461MemoizationStore.App.exe,
-                    Net461DistributedCacheHost.Configuration.dll,
-                    Net461DistributedCacheHost.Service.dll,
+                    Net472ContentStore.App.exe,
+                    Net472MemoizationStore.App.exe,
+                    Net472DistributedCacheHost.Configuration.dll,
+                    Net472DistributedCacheHost.Service.dll,
                 ]
             },
         ]
@@ -40,54 +37,45 @@ namespace Cache.NugetPackages {
         contents: [
             // ContentStore.Distributed
             Nuget.createAssemblyLayout(Net451ContentStore.Distributed.dll),
-            Nuget.createAssemblyLayout(Net461ContentStore.Distributed.dll),
             Nuget.createAssemblyLayout(Net472ContentStore.Distributed.dll),
             Nuget.createAssemblyLayout(WinX64ContentStore.Distributed.dll),
             // ContentStore.Library
             Nuget.createAssemblyLayout(Net451ContentStore.Library.dll),
-            Nuget.createAssemblyLayout(Net461ContentStore.Library.dll),
             Nuget.createAssemblyLayout(Net472ContentStore.Library.dll),
             Nuget.createAssemblyLayout(WinX64ContentStore.Library.dll),
             // ContentStore.Grpc
             Nuget.createAssemblyLayout(Net451ContentStore.Grpc.dll),
-            Nuget.createAssemblyLayout(Net461ContentStore.Grpc.dll),
             Nuget.createAssemblyLayout(Net472ContentStore.Grpc.dll),
             Nuget.createAssemblyLayout(WinX64ContentStore.Grpc.dll),
 
             // ContentStore.Vsts
             ...addIfLazy(BuildXLSdk.Flags.isVstsArtifactsEnabled, () => [
                 Nuget.createAssemblyLayout(Net451ContentStore.Vsts.dll),
-                Nuget.createAssemblyLayout(Net461ContentStore.Vsts.dll),
                 Nuget.createAssemblyLayout(Net472ContentStore.Vsts.dll)
             ]),
 
             // ContentStore.VstsInterfaces
             Nuget.createAssemblyLayout(Net451ContentStore.VstsInterfaces.dll),
-            Nuget.createAssemblyLayout(Net461ContentStore.VstsInterfaces.dll),
             Nuget.createAssemblyLayout(Net472ContentStore.VstsInterfaces.dll),
             Nuget.createAssemblyLayout(WinX64ContentStore.VstsInterfaces.dll),
 
             // MemoizationStore.Distributed
             Nuget.createAssemblyLayout(Net451MemoizationStore.Distributed.dll),
-            Nuget.createAssemblyLayout(Net461MemoizationStore.Distributed.dll),
             Nuget.createAssemblyLayout(Net472MemoizationStore.Distributed.dll),
             Nuget.createAssemblyLayout(WinX64MemoizationStore.Distributed.dll),
             // MemoizationStore.Library
             Nuget.createAssemblyLayout(Net451MemoizationStore.Library.dll),
-            Nuget.createAssemblyLayout(Net461MemoizationStore.Library.dll),
             Nuget.createAssemblyLayout(Net472MemoizationStore.Library.dll),
             Nuget.createAssemblyLayout(WinX64MemoizationStore.Library.dll),
 
             // MemoizationStore.Vsts
             ...addIfLazy(BuildXLSdk.Flags.isVstsArtifactsEnabled, () => [
                 Nuget.createAssemblyLayout(Net451MemoizationStore.Vsts.dll),
-                Nuget.createAssemblyLayout(Net461MemoizationStore.Vsts.dll),
                 Nuget.createAssemblyLayout(Net472MemoizationStore.Vsts.dll)
             ]),
 
             // MemoizationStore.VstsInterfaces
             Nuget.createAssemblyLayout(Net451MemoizationStore.VstsInterfaces.dll),
-            Nuget.createAssemblyLayout(Net461MemoizationStore.VstsInterfaces.dll),
             Nuget.createAssemblyLayout(Net472MemoizationStore.VstsInterfaces.dll),
             Nuget.createAssemblyLayout(WinX64MemoizationStore.VstsInterfaces.dll),
 
@@ -105,7 +93,6 @@ namespace Cache.NugetPackages {
         contents: [
             // ContentStore.Interfaces
             Nuget.createAssemblyLayout(Net451ContentStore.Interfaces.dll),
-            Nuget.createAssemblyLayout(Net461ContentStore.Interfaces.dll),
             Nuget.createAssemblyLayout(Net472ContentStore.Interfaces.dll),
             Nuget.createAssemblyLayout(WinX64ContentStore.Interfaces.dll),
             Nuget.createAssemblyLayout(importFrom("BuildXL.Cache.ContentStore").Interfaces.withQualifier(
@@ -114,7 +101,6 @@ namespace Cache.NugetPackages {
 
             // MemoizationStore.Interfaces
             Nuget.createAssemblyLayout(Net451MemoizationStore.Interfaces.dll),
-            Nuget.createAssemblyLayout(Net461MemoizationStore.Interfaces.dll),
             Nuget.createAssemblyLayout(Net472MemoizationStore.Interfaces.dll),
             Nuget.createAssemblyLayout(WinX64MemoizationStore.Interfaces.dll),
         ]
@@ -124,7 +110,6 @@ namespace Cache.NugetPackages {
         contents: [
             // ContentStore.Hashing
             Nuget.createAssemblyLayout(Net451ContentStore.Hashing.dll),
-            Nuget.createAssemblyLayout(Net461ContentStore.Hashing.dll),
             Nuget.createAssemblyLayout(Net472ContentStore.Hashing.dll),
             Nuget.createAssemblyLayout(WinX64ContentStore.Hashing.dll),
             Nuget.createAssemblyLayout(importFrom("BuildXL.Cache.ContentStore").Hashing.withQualifier(
@@ -133,7 +118,6 @@ namespace Cache.NugetPackages {
 
             // ContentStore.UtilitiesCore
             Nuget.createAssemblyLayout(Net451ContentStore.UtilitiesCore.dll),
-            Nuget.createAssemblyLayout(Net461ContentStore.UtilitiesCore.dll),
             Nuget.createAssemblyLayout(Net472ContentStore.UtilitiesCore.dll),
             Nuget.createAssemblyLayout(WinX64ContentStore.UtilitiesCore.dll),
             Nuget.createAssemblyLayout(importFrom("BuildXL.Cache.ContentStore").UtilitiesCore.withQualifier(

--- a/Public/Src/Engine/Processes/BuildXL.Processes.dsc
+++ b/Public/Src/Engine/Processes/BuildXL.Processes.dsc
@@ -6,7 +6,7 @@ import * as Shared from "Sdk.Managed.Shared";
 import * as SysMng from "System.Management";
 
 namespace Processes {
-    export declare const qualifier : BuildXLSdk.DefaultQualifierWithNet461;
+    export declare const qualifier : BuildXLSdk.DefaultQualifier;
 
     @@public
     export const dll = BuildXLSdk.library({

--- a/Public/Src/Tools/Execution.Analyzer/BxlAnalyzer.dsc
+++ b/Public/Src/Tools/Execution.Analyzer/BxlAnalyzer.dsc
@@ -29,11 +29,6 @@ namespace Execution.Analyzer {
                 NetFx.System.Net.Http.dll,
                 NetFx.System.Runtime.Serialization.dll
             ),
-            ...(BuildXLSdk.isDotNetCoreBuild 
-                // There is a bug in the dotnetcore generation of this package
-                ? [importFrom("Microsoft.IdentityModel.Clients.ActiveDirectory").withQualifier({targetFramework: "netstandard1.3"}).pkg]
-                : [importFrom("Microsoft.IdentityModel.Clients.ActiveDirectory").pkg]
-            ),
             importFrom("BuildXL.Cache.VerticalStore").Interfaces.dll,
             importFrom("BuildXL.Cache.ContentStore").Hashing.dll,
             importFrom("BuildXL.Cache.ContentStore").UtilitiesCore.dll,
@@ -57,6 +52,7 @@ namespace Execution.Analyzer {
             importFrom("BuildXL.Utilities").Collections.dll,
             importFrom("BuildXL.Utilities").Configuration.dll,
             importFrom("Newtonsoft.Json").pkg,
+            importFrom("Microsoft.IdentityModel.Clients.ActiveDirectory").pkg,
             importFrom("Microsoft.TeamFoundationServer.Client").pkg,
             importFrom("Microsoft.VisualStudio.Services.Client").pkg,
             importFrom("Microsoft.VisualStudio.Services.InteractiveClient").pkg,

--- a/Public/Src/Utilities/System.FormattableString/System.FormattableString.dsc
+++ b/Public/Src/Utilities/System.FormattableString/System.FormattableString.dsc
@@ -6,7 +6,7 @@ namespace System.FormattableString {
     // the BuildXL assemblies are referenced directly in an environment that targets .NET 4.6+.
     // When BuildXL codebase will move to 4.6 or .NET Core, this project can be easily removed and that's the only change that will be needed.
     @@public
-    export const dll = (BuildXLSdk.isDotNetCoreBuild || qualifier.targetFramework === "net461" || qualifier.targetFramework === "net472") ? undefined : BuildXLSdk.library({
+    export const dll = (qualifier.targetFramework !== "net451") ? undefined : BuildXLSdk.library({
         assemblyName: "System.FormattableString",
         skipDefaultReferences: true,
         sources: globR(d`.`, "*.cs"),

--- a/Public/Src/Utilities/Utilities/BuildXL.Utilities.dsc
+++ b/Public/Src/Utilities/Utilities/BuildXL.Utilities.dsc
@@ -21,12 +21,10 @@ export const dll = BuildXLSdk.library({
         importFrom("BuildXL.Utilities.Instrumentation").Common.dll,
         ...addIfLazy(BuildXLSdk.isDotNetCoreBuild, () => [
             importFrom("Microsoft.Win32.Registry").pkg,
+            importFrom("System.Security.Cryptography.ProtectedData").pkg
         ]),
         ...BuildXLSdk.tplPackages,
         importFrom("Newtonsoft.Json").pkg,
-        ...addIf(BuildXLSdk.isDotNetCoreBuild, 
-                importFrom("System.Security.Cryptography.ProtectedData").withQualifier({targetFramework: "netstandard2.0"}).pkg
-        ),
     ],
     defineConstants: qualifier.configuration === "debug" ? ["DebugStringTable"] : [],
     internalsVisibleTo: [


### PR DESCRIPTION
The last consumer of the net461 bits in our nuget package has upgraded to net472, so we can finally remove them from our build.
We have one straggling consumer of net451 who will hopefull upgarde soon to netcoreapp3 or to net472.