### PR TITLE
Catch all exceptions that can be thrown when connecting to channel

### DIFF
--- a/Public/Src/Engine/Dll/Distribution/Grpc/ClientConnectionManager.cs
+++ b/Public/Src/Engine/Dll/Distribution/Grpc/ClientConnectionManager.cs
@@ -203,7 +203,7 @@ namespace BuildXL.Engine.Distribution.Grpc
                 await Channel.ConnectAsync(DateTime.UtcNow.Add(timeout));
                 Logger.Log.GrpcTrace(m_loggingContext, $"Connected to {Channel.Target}. ChannelState {Channel.State}. Duration {watch.ElapsedMilliseconds}ms");
             }
-            catch (OperationCanceledException e)
+            catch (Exception e)
             {
                 Logger.Log.GrpcTrace(m_loggingContext, $"Failed to connect to {Channel.Target}. Duration {watch.ElapsedMilliseconds}ms. ChannelState {Channel.State}. Failure {e.Message}");
                 return false;

--- a/Public/Src/Engine/Dll/Distribution/Grpc/ClientConnectionManager.cs
+++ b/Public/Src/Engine/Dll/Distribution/Grpc/ClientConnectionManager.cs
@@ -193,6 +193,7 @@ namespace BuildXL.Engine.Distribution.Grpc
                 lastFailure: failure);
         }
 
+
         private async Task<bool> TryConnectChannelAsync(TimeSpan timeout, string operation, Stopwatch watch = null)
         {
             watch = watch ?? Stopwatch.StartNew();
@@ -205,7 +206,10 @@ namespace BuildXL.Engine.Distribution.Grpc
             }
             catch (Exception e)
             {
+#pragma warning disable EPC12 // Suspicious exception handling: only Message property is observed in exception block.
                 Logger.Log.GrpcTrace(m_loggingContext, $"Failed to connect to {Channel.Target}. Duration {watch.ElapsedMilliseconds}ms. ChannelState {Channel.State}. Failure {e.Message}");
+#pragma warning restore EPC12 // Suspicious exception handling: only Message property is observed in exception block.
+
                 return false;
             }
 


### PR DESCRIPTION
It is perfectly fine to catch all exceptions there as there is only one operation in the try block and that operation is a grpc call. 