### PR TITLE
Allow RocksDB to perform log rotation

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/RocksDbContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/RocksDbContentLocationDatabase.cs
@@ -123,7 +123,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                 Tracer.Info(context, $"Creating rocksdb store at '{storeLocation}'.");
 
                 var possibleStore = KeyValueStoreAccessor.Open(storeLocation,
-                    additionalColumns: new[] { nameof(Columns.ClusterState), nameof(Columns.Metadata) });
+                    additionalColumns: new[] { nameof(Columns.ClusterState), nameof(Columns.Metadata) }, rotateLogs: true);
                 if (possibleStore.Succeeded)
                 {
                     var oldKeyValueStore = _keyValueStore;

--- a/Public/Src/Utilities/KeyValueStore/RocksDb/RocksDbStore.cs
+++ b/Public/Src/Utilities/KeyValueStore/RocksDb/RocksDbStore.cs
@@ -140,13 +140,22 @@ namespace BuildXL.Engine.Cache.KeyValueStores
             /// If a store already exists at the given directory, whether any columns that mismatch the the columns that were passed into the constructor
             /// should be dropped. This will cause data loss and can only be applied in read-write mode.
             /// </param>
+            /// <param name="rotateLogs">
+            /// Have RocksDb rotate logs, useful for debugging performance issues. It will rotate logs every 12 hours, 
+            /// up to a maximum of 60 logs (i.e. 30 days). When the maximum amount of logs is reached, the oldest logs
+            /// are overwritten in a circular fashion.
+            /// 
+            /// Every time the RocksDb instance is open, the current log file is truncated, which means that if you
+            /// open the DB more than once in a 12 hour period, you will only have partial information.
+            /// </param>
             public RocksDbStore(
                 string storeDirectory,
                 bool defaultColumnKeyTracked = false,
                 IEnumerable<string> additionalColumns = null,
                 IEnumerable<string> additionalKeyTrackedColumns = null,
                 bool readOnly = false,
-                bool dropMismatchingColumns = false)
+                bool dropMismatchingColumns = false,
+                bool rotateLogs = false)
             {
                 m_storeDirectory = storeDirectory;
 
@@ -197,14 +206,17 @@ namespace BuildXL.Engine.Cache.KeyValueStores
                     .SetBlockBasedTableFactory(blockBasedTableOptions)
                     .SetPrefixExtractor(SliceTransform.CreateNoOp());
 
-                // Maximum number of information log files
-                m_defaults.DbOptions.SetKeepLogFileNum(1000);
+                if (rotateLogs)
+                {
+                    // Maximum number of information log files
+                    m_defaults.DbOptions.SetKeepLogFileNum(60);
 
-                // Do not rotate information logs based on file size
-                m_defaults.DbOptions.SetMaxLogFileSize(0);
+                    // Do not rotate information logs based on file size
+                    m_defaults.DbOptions.SetMaxLogFileSize(0);
 
-                // How long before we rotate the current information log file
-                m_defaults.DbOptions.SetLogFileTimeToRoll((ulong)TimeSpan.FromHours(1).Seconds);
+                    // How long before we rotate the current information log file
+                    m_defaults.DbOptions.SetLogFileTimeToRoll((ulong)TimeSpan.FromHours(12).Seconds);
+                }
 
                 m_columns = new Dictionary<string, ColumnFamilyInfo>();
 

--- a/Public/Src/Utilities/KeyValueStore/RocksDb/RocksDbStore.cs
+++ b/Public/Src/Utilities/KeyValueStore/RocksDb/RocksDbStore.cs
@@ -197,6 +197,15 @@ namespace BuildXL.Engine.Cache.KeyValueStores
                     .SetBlockBasedTableFactory(blockBasedTableOptions)
                     .SetPrefixExtractor(SliceTransform.CreateNoOp());
 
+                // Maximum number of information log files
+                m_defaults.DbOptions.SetKeepLogFileNum(1000);
+
+                // Do not rotate information logs based on file size
+                m_defaults.DbOptions.SetMaxLogFileSize(0);
+
+                // How long before we rotate the current information log file
+                m_defaults.DbOptions.SetLogFileTimeToRoll((ulong)TimeSpan.FromHours(1).Seconds);
+
                 m_columns = new Dictionary<string, ColumnFamilyInfo>();
 
                 additionalColumns = additionalColumns ?? CollectionUtilities.EmptyArray<string>();


### PR DESCRIPTION
As of today, RocksDB logs are overwritten every time the DB is open and we only keep one file, so that means all logs are lost on every service restart.

This is inadequate for debugging purposes, as the log contains very useful information; for example: compaction rates in the different levels of the LSM tree, file read latencies, read and write amplification, among others.

I'm not sure these are the values we want, the first two are the defaults, and the third I just set to 1 hour, but we may want to rotate at a different cadence. 