### PR TITLE
Add binding redirect of WindowsAzure.Storage in DropDaemon

### DIFF
--- a/Public/Src/Tools/DropDaemon/DropDaemon.exe.config
+++ b/Public/Src/Tools/DropDaemon/DropDaemon.exe.config
@@ -45,6 +45,10 @@
         <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.5.1.0" newVersion="4.5.1.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.3.3.0" newVersion="9.3.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 


### PR DESCRIPTION
While testing Dedup drops: System.IO.FileLoadException: Could not load file or assembly 'Microsoft.WindowsAzure.Storage, Version=8.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35' or one of its dependencies.