### PR TITLE
Demystify exceptions in exception logging.

### DIFF
--- a/Public/Src/Cache/ContentStore/Interfaces/Results/ResultBase.cs
+++ b/Public/Src/Cache/ContentStore/Interfaces/Results/ResultBase.cs
@@ -15,6 +15,13 @@ namespace BuildXL.Cache.ContentStore.Interfaces.Results
     public class ResultBase
     {
         /// <summary>
+        /// Global preprocessor for error text for result errors. This allows for the exception string demystification code
+        /// to be injected dynamically without requiring a dependency on BuildXL.Utilities. Generally adding new dependencies
+        /// to this assembly is an involved process so this is here as a workaround.
+        /// </summary>
+        internal static Func<Exception, string> ResultExceptionTextProcessor { get; set; }
+
+        /// <summary>
         /// Constructor for creating successful result instances.
         /// </summary>
         protected ResultBase()
@@ -42,17 +49,22 @@ namespace BuildXL.Cache.ContentStore.Interfaces.Results
                 ErrorMessage = string.IsNullOrEmpty(message)
                     ? other.Result.ErrorMessage
                     : $"{message}: {other.Result.ErrorMessage}";
-                Diagnostics = other.Result.Diagnostics;
+                _hasLazyDiagnostics = other.Result._hasLazyDiagnostics;
+                _diagnostics = other.Result._diagnostics;
                 IsCancelled = other.Result.IsCancelled;
                 Exception = other.InnerException;
             }
             else
             {
+                // NOTE: The use of Exception.Message is intentional here as
+                // the full exception string is captured in the ResultBase.Diagnostics
+                // property
                 ErrorMessage = string.IsNullOrEmpty(message)
-                    ? $"{exception.GetType().Name}: {exception}"
-                    : $"{message}: {exception.GetType().Name}: {exception}";
+                    ? $"{exception.GetType().Name}: {exception.Message}"
+                    : $"{message}: {exception.GetType().Name}: {exception.Message}";
 
-                Diagnostics = CreateDiagnostics(exception);
+                // Indicate that diagnostics should lazily be computed from exception.
+                _hasLazyDiagnostics = true;
                 Exception = exception;
             }
         }
@@ -67,7 +79,8 @@ namespace BuildXL.Cache.ContentStore.Interfaces.Results
             ErrorMessage = string.IsNullOrEmpty(message)
                 ? other.ErrorMessage
                 : $"{message}: {other.ErrorMessage}";
-            Diagnostics = other.Diagnostics;
+            _diagnostics = other._diagnostics;
+            _hasLazyDiagnostics = other._hasLazyDiagnostics;
             Exception = other.Exception;
             IsCancelled = other.IsCancelled;
         }
@@ -103,9 +116,32 @@ namespace BuildXL.Cache.ContentStore.Interfaces.Results
         public readonly string ErrorMessage;
 
         /// <summary>
+        /// Indicates that diagnostics should lazily be computed from exception
+        /// </summary>
+        private bool _hasLazyDiagnostics;
+        private string _diagnostics;
+
+        /// <summary>
         /// Optional verbose diagnostic information about the result (either error or success).
         /// </summary>
-        public string Diagnostics;
+        public string Diagnostics
+        {
+            get
+            {
+                // Lazily initialize diagnostics (if specified)
+                if (_hasLazyDiagnostics && _diagnostics == null && Exception != null)
+                {
+                    _diagnostics = CreateDiagnostics(Exception);
+                }
+
+                return _diagnostics;
+            }
+            set
+            {
+                _hasLazyDiagnostics = false;
+                _diagnostics = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets elapsed time of corresponding call.
@@ -219,6 +255,21 @@ namespace BuildXL.Cache.ContentStore.Interfaces.Results
                    (exception is AggregateException ae && ae.Flatten().InnerExceptions.Any(e => IsCritical(e)));
         }
 
+        /// <summary>
+        /// Gets a preprocessed equivalent of <see cref="Exception.ToString"/> if <see cref="ResultBase.ResultExceptionTextProcessor"/> is specified. Otherwise,
+        /// just returns <see cref="Exception.ToString"/>.
+        /// </summary>
+        internal static string GetExceptionString(Exception ex)
+        {
+            var processErrorText = ResultExceptionTextProcessor;
+            if (processErrorText != null)
+            {
+                return processErrorText(ex);
+            }
+
+            return ex.ToString();
+        }
+
         private static string CreateDiagnostics(Exception exception)
         {
             // Consider using Demystifier here.
@@ -235,15 +286,14 @@ namespace BuildXL.Cache.ContentStore.Interfaces.Results
                     }
 
                     sb.AppendLine("Exception #" + i);
-                    sb.Append(e);
+                    sb.Append(GetExceptionString(e));
                     i++;
                 }
 
                 return sb.ToString();
             }
 
-            return exception.ToString();
+            return GetExceptionString(exception);
         }
-
     }
 }

--- a/Public/Src/Cache/ContentStore/Library/Logging/Logger.cs
+++ b/Public/Src/Cache/ContentStore/Library/Logging/Logger.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BuildXL.Cache.ContentStore.Interfaces.Logging;
+using BuildXL.Cache.ContentStore.Interfaces.Results;
 using BuildXL.Cache.ContentStore.Timers;
 
 namespace BuildXL.Cache.ContentStore.Logging
@@ -168,7 +169,7 @@ namespace BuildXL.Cache.ContentStore.Logging
         public void Error(Exception exception, string messageFormat, params object[] messageArgs)
         {
             var messageIn = string.Format(CultureInfo.CurrentCulture, messageFormat, messageArgs);
-            var message = string.Format(CultureInfo.CurrentCulture, "{0}, Exception=[{1}]", messageIn, exception);
+            var message = string.Format(CultureInfo.CurrentCulture, "{0}, Exception=[{1}]", messageIn, ResultBase.GetExceptionString(exception));
             LogString(Severity.Error, message);
             Flush();
         }

--- a/Public/Src/Cache/ContentStore/Library/Tracing/OperationContext.cs
+++ b/Public/Src/Cache/ContentStore/Library/Tracing/OperationContext.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using BuildXL.Cache.ContentStore.Interfaces.Logging;
 using BuildXL.Cache.ContentStore.Interfaces.Results;
 using BuildXL.Cache.ContentStore.Interfaces.Tracing;
+using BuildXL.Utilities;
 using BuildXL.Utilities.Tracing;
 
 namespace BuildXL.Cache.ContentStore.Tracing.Internal
@@ -17,6 +18,14 @@ namespace BuildXL.Cache.ContentStore.Tracing.Internal
     /// </summary>
     public readonly struct OperationContext
     {
+        static OperationContext()
+        {
+            // Ensure result exceptions are demystified.
+            // This class is called almost ubiquitously by code utilizing the cache. So this ensures that most
+            // cases are covered without needing to handle all executables.
+            BuildXL.Cache.ContentStore.Utils.ResultsExtensions.InitializeResultExceptionPreprocessing();
+        }
+
         /// <summary>
         /// Tracing context for an operation.
         /// </summary>

--- a/Public/Src/Cache/ContentStore/Library/Utils/ResultsExtensions.cs
+++ b/Public/Src/Cache/ContentStore/Library/Utils/ResultsExtensions.cs
@@ -2,11 +2,25 @@
 using System.Diagnostics.ContractsLight;
 using BuildXL.Cache.ContentStore.Interfaces.Results;
 using BuildXL.Cache.ContentStore.Synchronization;
+using BuildXL.Utilities;
 
 namespace BuildXL.Cache.ContentStore.Utils
 {
     internal static class ResultsExtensions
     {
+        /// <summary>
+        /// Ensures result exceptions are demystified.
+        /// </summary>
+        internal static void InitializeResultExceptionPreprocessing()
+        {
+            if (ResultBase.ResultExceptionTextProcessor == null)
+            {
+
+                // Ensure exception strings have demystified stack tracks
+                ResultBase.ResultExceptionTextProcessor = ex => ex.ToStringDemystified();
+            }
+        }
+
         /// <nodoc />
         public static TResult WithLockAcquisitionDuration<TResult, TLockKey>(this TResult result, in LockSet<TLockKey>.LockHandle handle)
             where TResult : ResultBase

--- a/Public/Src/Cache/ContentStore/Library/Utils/ResultsExtensions.cs
+++ b/Public/Src/Cache/ContentStore/Library/Utils/ResultsExtensions.cs
@@ -15,7 +15,6 @@ namespace BuildXL.Cache.ContentStore.Utils
         {
             if (ResultBase.ResultExceptionTextProcessor == null)
             {
-
                 // Ensure exception strings have demystified stack tracks
                 ResultBase.ResultExceptionTextProcessor = ex => ex.ToStringDemystified();
             }

--- a/Public/Src/Cache/DistributedCache.Host/Service/DistributedCacheServiceFacade.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Service/DistributedCacheServiceFacade.cs
@@ -30,7 +30,6 @@ namespace BuildXL.Cache.Host.Service
 
             var factory = new ContentServerFactory(arguments);
 
-            // await _lifetimeManager.StartingService();
             await host.OnStartingServiceAsync();
 
             using (var server = factory.Create())
@@ -39,16 +38,12 @@ namespace BuildXL.Cache.Host.Service
 
                 try
                 {
-                    // Removed this, because it is kind-of useless...
-                    // _serviceHealthyAction(false);
-
                     var startupResult = await server.StartupAsync(context);
                     if (!startupResult)
                     {
                         throw new CacheException(startupResult.ToString());
                     }
 
-                    // _serviceHealthyAction(true);
                     host.OnStartedService();
 
                     logger.Info("Service started");
@@ -66,7 +61,6 @@ namespace BuildXL.Cache.Host.Service
                         logger.Warning("Failed to shutdown local content server: {0}", result);
                     }
 
-                    // await _lifetimeManager.TeardownCompleted();
                     host.OnTeardownCompleted();
                 }
             }

--- a/Public/Src/Utilities/Utilities/Ben.Demystifier/ExceptionExtentions.cs
+++ b/Public/Src/Utilities/Utilities/Ben.Demystifier/ExceptionExtentions.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Collections.Generic.Enumerable;
 using System.Reflection;
+using BuildXL.Utilities;
 
 namespace System.Diagnostics
 {
@@ -54,8 +55,7 @@ namespace System.Diagnostics
         {
             try
             {
-                var originalToString = exception.ToString();
-                // Need to trigger string computation first to materialized the stack trace
+                Analysis.IgnoreResult(exception.ToString(), "Need to trigger string computation first to materialized the stack trace");
                 var originalStacks = new Dictionary<Exception, string>();
                 exception.Demystify(originalStacks);
 


### PR DESCRIPTION
1. Add global processor for exceptions to ResultBase to avoid adding a dependency BuildXL.Utilities. This is initialized in static constructor of OperationContext which is used pervasively in cache codebase.
2. Lazily compute diagnostics instead of eagerly since they may not ever be used.
3. Switch ResultBase.ErrorMessage to only capture Exception.Message (this was the original behavior which was likely changed accidentally to cleanup uses of Exception.Message in cases where Exception.ToString() is not captured for logging).