### PR TITLE
Log an error as soon as ApiServer.MaterializeFile fails

### DIFF
--- a/Public/Src/Engine/Scheduler/ApiServer.cs
+++ b/Public/Src/Engine/Scheduler/ApiServer.cs
@@ -161,7 +161,7 @@ namespace BuildXL.Scheduler
             string absoluteFilePath = cmd.File.Path.ToString(m_context.PathTable);
 
             // if file materialization failed, log an error here immediately, so that this errors gets picked up as the root cause 
-            // (which is evetually used to compute the "ErrorBucket") instead of whatever fallout ends up happening (e.g., IPC pip fails)
+            // (i.e., the "ErrorBucket") instead of whatever fallout ends up happening (e.g., IPC pip fails)
             if (!succeeded)
             {
                 Tracing.Logger.Log.ErrorApiServerMaterializeFileFailed(m_loggingContext, absoluteFilePath, result.ToString());

--- a/Public/Src/Engine/Scheduler/ApiServer.cs
+++ b/Public/Src/Engine/Scheduler/ApiServer.cs
@@ -115,7 +115,7 @@ namespace BuildXL.Scheduler
             var materializeFileCmd = cmd as MaterializeFileCommand;
             if (materializeFileCmd != null)
             {
-                var result = await ExecuteCommandWithStats(ExecuteMaterializeFile, materializeFileCmd, ref m_numMaterializeFile);
+                var result = await ExecuteCommandWithStats(ExecuteMaterializeFileAsync, materializeFileCmd, ref m_numMaterializeFile);
                 return new Possible<IIpcResult>(result);
             }
 
@@ -140,9 +140,9 @@ namespace BuildXL.Scheduler
 
         /// <summary>
         /// Executes <see cref="MaterializeFileCommand"/>.  First check that <see cref="MaterializeFileCommand.File"/>
-        /// and <see cref="MaterializeFileCommand.FullFilePath"/> match, then delegates to <see cref="FileContentManager.TryMaterializeFile"/>.
+        /// and <see cref="MaterializeFileCommand.FullFilePath"/> match, then delegates to <see cref="FileContentManager.TryMaterializeFileAsync"/>.
         /// </summary>
-        private async Task<IIpcResult> ExecuteMaterializeFile(MaterializeFileCommand cmd)
+        private async Task<IIpcResult> ExecuteMaterializeFileAsync(MaterializeFileCommand cmd)
         {
             Contract.Requires(cmd != null);
 
@@ -156,8 +156,21 @@ namespace BuildXL.Scheduler
                     "file path ids differ; file = " + cmd.File.Path.ToString(m_context.PathTable) + ", file path = " + cmd.FullFilePath);
             }
 
-            bool succeeded = await m_fileContentManager.TryMaterializeFile(cmd.File);
-            Tracing.Logger.Log.ApiServerMaterializeFileExecuted(m_loggingContext, cmd.File.Path.ToString(m_context.PathTable), succeeded);
+            var result = await m_fileContentManager.TryMaterializeFileAsync(cmd.File);
+            bool succeeded = result == ArtifactMaterializationResult.Succeeded;
+            string absoluteFilePath = cmd.File.Path.ToString(m_context.PathTable);
+
+            // if file materialization failed, log an error here immediately, so that this errors gets picked up as the root cause 
+            // (which is evetually used to compute the "ErrorBucket") instead of whatever fallout ends up happening (e.g., IPC pip fails)
+            if (!succeeded)
+            {
+                Tracing.Logger.Log.ErrorApiServerMaterializeFileFailed(m_loggingContext, absoluteFilePath, result.ToString());
+            }
+            else
+            {
+                Tracing.Logger.Log.ApiServerMaterializeFileSucceeded(m_loggingContext, absoluteFilePath);
+            }
+
             return IpcResult.Success(cmd.RenderResult(succeeded));
         }
 

--- a/Public/Src/Engine/Scheduler/Artifacts/FileContentManager.cs
+++ b/Public/Src/Engine/Scheduler/Artifacts/FileContentManager.cs
@@ -1034,13 +1034,12 @@ namespace BuildXL.Scheduler.Artifacts
         /// <summary>
         /// Attempts to materialize the given file
         /// </summary>
-        public async Task<bool> TryMaterializeFile(FileArtifact outputFile)
+        public async Task<ArtifactMaterializationResult> TryMaterializeFileAsync(FileArtifact outputFile)
         {
             var producer = GetDeclaredProducer(outputFile);
             using (var operationContext = OperationTracker.StartOperation(PipExecutorCounter.FileContentManagerTryMaterializeFileDuration, m_host.LoggingContext))
             {
-                return ArtifactMaterializationResult.Succeeded
-                    == await TryMaterializeFilesAsync(producer, operationContext, new[] { outputFile }, materializatingOutputs: true, isDeclaredProducer: true);
+                return await TryMaterializeFilesAsync(producer, operationContext, new[] { outputFile }, materializatingOutputs: true, isDeclaredProducer: true);
             }
         }
 

--- a/Public/Src/Engine/Scheduler/Tracing/Log.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/Log.cs
@@ -3829,13 +3829,22 @@ namespace BuildXL.Scheduler.Tracing
         internal abstract void ApiServerInvalidOperation(LoggingContext loggingContext, string operation, string reason);
 
         [GeneratedEvent(
-            (ushort)EventId.ApiServerMaterializeFileExecuted,
+            (ushort)EventId.ApiServerMaterializeFileSucceeded,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,
             Keywords = (int)Keywords.UserMessage,
             EventTask = (ushort)Tasks.Scheduler,
-            Message = "[{ShortProductName} API Server] Operation MaterializeFile('{file}') executed. Succeeded: {succeeded}.")]
-        internal abstract void ApiServerMaterializeFileExecuted(LoggingContext loggingContext, string file, bool succeeded);
+            Message = "[{ShortProductName} API Server] Operation MaterializeFile('{file}') succeeded.")]
+        internal abstract void ApiServerMaterializeFileSucceeded(LoggingContext loggingContext, string file);
+
+        [GeneratedEvent(
+            (ushort)EventId.ErrorApiServerMaterializeFileFailed,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Error,
+            Keywords = (int)Keywords.UserMessage,
+            EventTask = (ushort)Tasks.Scheduler,
+            Message = "[{ShortProductName} API Server] Operation MaterializeFile('{file}') failed. Reason: {reason}.")]
+        internal abstract void ErrorApiServerMaterializeFileFailed(LoggingContext loggingContext, string file, string reason);
 
         [GeneratedEvent(
             (ushort)EventId.ApiServerReportStatisticsExecuted,

--- a/Public/Src/Utilities/Utilities/Tracing/EventId.cs
+++ b/Public/Src/Utilities/Utilities/Tracing/EventId.cs
@@ -1039,9 +1039,10 @@ namespace BuildXL.Utilities.Tracing
         ApiServerForwarderIpcServerMessage = 12100,
         ApiServerInvalidOperation = 12101,
         ApiServerOperationReceived = 12102,
-        ApiServerMaterializeFileExecuted = 12103,
+        ApiServerMaterializeFileSucceeded = 12103,
         ApiServerReportStatisticsExecuted = 12104,
         ApiServerGetSealedDirectoryContentExecuted = 12105,
+        ErrorApiServerMaterializeFileFailed = 12106,
 
         // Copy file cont'd.
         PipCopyFileSourceFileDoesNotExist = 12201,


### PR DESCRIPTION
When a file fails to be materialized in response to such a request from an IPC pip, the IPC pip ends up failing with an internal error, and the root cause of this failure (i.e., the "ErrorBucket") becomes "IpcPipFailed".

With this PR, an error message is logged as soon as a file fails to be materialized, so the ErrorBucket will end up pointing to the real root cause of this particular problem. 