### PR TITLE
Add dbeventcount verification unit test and fix proto bug

### DIFF
--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SchedulerIntegrationTestBase.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SchedulerIntegrationTestBase.cs
@@ -53,6 +53,8 @@ namespace Test.BuildXL.Scheduler
 
         private PipGraph m_lastGraph;
 
+        public PipGraph LastGraph => m_lastGraph;
+
         private JournalState m_journalState;
 
         /// <summary>

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/XLGPlusPlus/Events.proto
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/XLGPlusPlus/Events.proto
@@ -43,23 +43,28 @@ message EventTypeQuery{
 // ie: ChooseWorkerCpu ---> PipExecutionStep_ChooseWorkerCpu
 
 enum ExecutionEventId{
-    FileArtifactContentDecided = 0;
-    WorkerList = 1;
-    ExecutionEventId_PipExecutionPerformance = 2;
-    DirectoryMembershipHashed = 3;
+    // Since we are using ExecutionEventId as in the key and protobuf 
+    // does not serialize default values, the pattern matching was bugging out. 
+    // A solution is to have an "invalid" enum constant take position 0. 
+    ExecutionEventId_Invalid = 0;
+
+    FileArtifactContentDecided = 1;
+    WorkerList = 2;
+    ExecutionEventId_PipExecutionPerformance = 3;
+    DirectoryMembershipHashed = 4;
 
     // Deprecated in favor of ProcessFingerprintComputation (enum 10)
-    ObservedInputs = 4; 
+    ObservedInputs = 5; 
 
-    ProcessExecutionMonitoringReported = 5;
-    ExecutionEventId_ExtraEventDataReported = 6;
-    DependencyViolationReported = 7;
-    PipExecutionStepPerformanceReported = 8;
-    ResourceUsageReported = 9;
-    ProcessFingerprintComputation = 10;
-    PipCacheMiss = 11;
-    PipExecutionDirectoryOutputs = 12;
-    BxlInvocation = 13;
+    ProcessExecutionMonitoringReported = 6;
+    ExecutionEventId_ExtraEventDataReported = 7;
+    DependencyViolationReported = 8;
+    PipExecutionStepPerformanceReported = 9;
+    ResourceUsageReported = 10;
+    ProcessFingerprintComputation = 11;
+    PipCacheMiss = 12;
+    PipExecutionDirectoryOutputs = 13;
+    BxlInvocation = 14;
 }
 
 enum PipOutputOrigin{

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/XLGPlusPlus/XLGToDBAnalyzer.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/XLGPlusPlus/XLGToDBAnalyzer.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using BuildXL.Analyzers.Core.XLGPlusPlus;
 using BuildXL.Engine.Cache.KeyValueStores;
 using BuildXL.Scheduler.Tracing;
 using BuildXL.ToolSupport;
@@ -186,7 +187,7 @@ namespace BuildXL.Execution.Analyzer
                 Value = (uint)m_eventCount
             };
 
-            WriteToDb(Encoding.ASCII.GetBytes("EventCount"), ec.ToByteArray());
+            WriteToDb(Encoding.ASCII.GetBytes(XldbDataStore.EventCountKey), ec.ToByteArray());
             return 0;
         }
 

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/XLGPlusPlus/XldbDataStore.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/XLGPlusPlus/XldbDataStore.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.ContractsLight;
+using System.Text;
 using BuildXL.Engine.Cache.KeyValueStores;
 using BuildXL.Execution.Analyzer.Xldb;
 using BuildXL.Utilities;
@@ -18,6 +19,7 @@ namespace BuildXL.Analyzers.Core.XLGPlusPlus
         /// </summary>
         private KeyValueStoreAccessor Accessor { get; set; }
         private Dictionary<ExecutionEventId, MessageParser> m_eventParserDictionary = new Dictionary<ExecutionEventId, MessageParser>();
+        public static string EventCountKey = "EventCount";
 
         /// <summary>
         /// Open the datastore and populate the KeyValueStoreAccessor for the XLG++ DB
@@ -125,6 +127,11 @@ namespace BuildXL.Analyzers.Core.XLGPlusPlus
         public IEnumerable<string> GetProcessExecutionMonitoringReportedEvents() => GetEventsByType(ExecutionEventId.ProcessExecutionMonitoringReported);
 
         /// <summary>
+        /// Gets all the Process Execution Monitoring Reported Events
+        /// </summary>
+        public IEnumerable<string> GetProcessFingerprintComputationEvents() => GetEventsByType(ExecutionEventId.ProcessFingerprintComputation);
+
+        /// <summary>
         /// Gets all the Extra Event Data Reported Events
         /// </summary>
         public IEnumerable<string> GetExtraEventDataReportedEvents() => GetEventsByType(ExecutionEventId.ExtraEventDataReported);
@@ -158,6 +165,24 @@ namespace BuildXL.Analyzers.Core.XLGPlusPlus
         /// Gets all the Pip Execution Directory Outputs Events
         /// </summary>
         public IEnumerable<string> GetPipExecutionDirectoryOutputsEvents() => GetEventsByType(ExecutionEventId.PipExecutionDirectoryOutputs);
+
+        /// <summary>
+        /// Gets the total number of stored xlg events in the database
+        /// </summary>
+        public uint GetEventCount()
+        {
+            uint eventCount = 0;
+
+            Analysis.IgnoreResult(
+                Accessor.Use(database =>
+                {
+                    database.TryGetValue(Encoding.ASCII.GetBytes(EventCountKey), out var eventCountObj);
+                    eventCount = EventCount.Parser.ParseFrom(eventCountObj).Value;
+                })
+            );
+
+            return eventCount;
+        }
 
         /// <summary>
         /// Closes the connection to the DB

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/XLGPlusPlus/XldbDataStore.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/XLGPlusPlus/XldbDataStore.cs
@@ -19,7 +19,7 @@ namespace BuildXL.Analyzers.Core.XLGPlusPlus
         /// </summary>
         private KeyValueStoreAccessor Accessor { get; set; }
         private Dictionary<ExecutionEventId, MessageParser> m_eventParserDictionary = new Dictionary<ExecutionEventId, MessageParser>();
-        public static string EventCountKey = "EventCount";
+        public const string EventCountKey = "EventCount";
 
         /// <summary>
         /// Open the datastore and populate the KeyValueStoreAccessor for the XLG++ DB

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/XLGPlusPlus/XldbProtobufExtensions.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/XLGPlusPlus/XldbProtobufExtensions.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Diagnostics;
 using System.Linq;
 using BuildXL.Cache.MemoizationStore.Interfaces.Sessions;
 using BuildXL.Pips;

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/XLGPlusPlus/XldbProtobufExtensions.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/XLGPlusPlus/XldbProtobufExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using BuildXL.Cache.MemoizationStore.Interfaces.Sessions;
 using BuildXL.Pips;
@@ -390,7 +391,6 @@ namespace BuildXL.Execution.Analyzer
         public static Xldb.PipExecutionDirectoryOutputsEvent ToPipExecutionDirectoryOutputsEvent(this PipExecutionDirectoryOutputs data, uint workerID, PathTable pathTable)
         {
             var Uuid = Guid.NewGuid().ToString();
-
             var pipExecDirectoryOutputEvent = new Xldb.PipExecutionDirectoryOutputsEvent();
             pipExecDirectoryOutputEvent.UUID = Uuid;
             pipExecDirectoryOutputEvent.WorkerID = workerID;

--- a/Public/Src/Tools/UnitTests/Analyzers/XLGToDBAnalyzerTests.cs
+++ b/Public/Src/Tools/UnitTests/Analyzers/XLGToDBAnalyzerTests.cs
@@ -87,6 +87,7 @@ namespace Test.Tool.Analyzers
             var fileOne = FileArtifact.CreateOutputFile(Combine(TestDirPath, "foo.txt"));
             var fileTwo = FileArtifact.CreateOutputFile(Combine(TestDirPath, "bar.txt"));
             var dirOne = Path.Combine(ReadonlyRoot, "baz");
+
             Directory.CreateDirectory(dirOne);
             File.WriteAllText(Path.Combine(dirOne, "abc.txt"), "text");
             File.WriteAllText(Path.Combine(dirOne, "xyz.txt"), "text12");
@@ -114,34 +115,29 @@ namespace Test.Tool.Analyzers
             }).Process;
 
             var buildA = RunScheduler().AssertSuccess();
-
             var analyzerRes = RunAnalyzer(buildA).AssertSuccess();
 
             var dataStore = new XldbDataStore(storeDirectory: OutputDirPath.ToString(Context.PathTable));
-            var pipCount = LastGraph.RetrievePipReferencesOfType(PipType.Process).Count();
-            var fileCount = LastGraph.AllFiles.Count();
+            
+            // As per Mike's offline comment, non-zero vs zero event count tests for now until we can rent out some mac machines
+            // and figure out the true reason why the windows and mac event log counts differ by so much 
 
-            if (OperatingSystemHelper.IsUnixOS)
-            {
-                XAssert.AreEqual(fileCount + 1, dataStore.GetFileArtifactContentDecidedEvents().Count());
-            }
-            else
-            {
-                XAssert.AreEqual(fileCount, dataStore.GetFileArtifactContentDecidedEvents().Count());
-            }
+            // For these tests, there should be a non-zero number of events logged
+            XAssert.AreNotEqual(0, dataStore.GetFileArtifactContentDecidedEvents().Count());
+            XAssert.AreNotEqual(0, dataStore.GetPipExecutionPerformanceEvents().Count());
+            XAssert.AreNotEqual(0, dataStore.GetDirectoryMembershipHashedEvents().Count());
+            XAssert.AreNotEqual(0, dataStore.GetProcessExecutionMonitoringReportedEvents().Count());
+            XAssert.AreNotEqual(0, dataStore.GetProcessFingerprintComputationEvents().Count());
+            XAssert.AreNotEqual(0, dataStore.GetExtraEventDataReportedEvents().Count());
+            XAssert.AreNotEqual(0, dataStore.GetPipExecutionStepPerformanceReportedEvents().Count());
+            XAssert.AreNotEqual(0, dataStore.GetPipCacheMissEvents().Count());
+            XAssert.AreNotEqual(0, dataStore.GetStatusReportedEvents().Count());
+            XAssert.AreNotEqual(0, dataStore.GetBXLInvocationEvents().Count());
+            XAssert.AreNotEqual(0, dataStore.GetPipExecutionDirectoryOutputsEvents().Count());
 
+            // For these tests, there should be no events logged
             XAssert.AreEqual(0, dataStore.GetWorkerListEvents().Count());
-            XAssert.AreEqual(pipCount, dataStore.GetPipExecutionPerformanceEvents().Count());
-            XAssert.AreEqual(1, dataStore.GetDirectoryMembershipHashedEvents().Count());
-            XAssert.AreEqual(pipCount, dataStore.GetProcessExecutionMonitoringReportedEvents().Count());
-            XAssert.AreEqual(8, dataStore.GetProcessFingerprintComputationEvents().Count());
-            XAssert.AreEqual(1, dataStore.GetExtraEventDataReportedEvents().Count());
             XAssert.AreEqual(0, dataStore.GetDependencyViolationReportedEvents().Count());
-            XAssert.AreEqual(42, dataStore.GetPipExecutionStepPerformanceReportedEvents().Count());
-            XAssert.AreEqual(pipCount, dataStore.GetPipCacheMissEvents().Count());
-            XAssert.AreEqual(1, dataStore.GetStatusReportedEvents().Count());
-            XAssert.AreEqual(1, dataStore.GetBXLInvocationEvents().Count());
-            XAssert.AreEqual(4, dataStore.GetPipExecutionDirectoryOutputsEvents().Count());
         }
     }
 }

--- a/Public/Src/Tools/UnitTests/Analyzers/XLGToDBAnalyzerTests.cs
+++ b/Public/Src/Tools/UnitTests/Analyzers/XLGToDBAnalyzerTests.cs
@@ -118,17 +118,19 @@ namespace Test.Tool.Analyzers
             var analyzerRes = RunAnalyzer(buildA).AssertSuccess();
 
             var dataStore = new XldbDataStore(storeDirectory: OutputDirPath.ToString(Context.PathTable));
+            var pipCount = LastGraph.RetrievePipReferencesOfType(PipType.Process).Count();
 
-            XAssert.AreEqual(dataStore.GetFileArtifactContentDecidedEvents().Count(), LastGraph.AllFiles.Count());
+            var files = string.Join(", ", LastGraph.AllFiles.ToList().Select(i => i.Path.ToString(Context.PathTable, PathFormat.HostOs)));
+            XAssert.AreEqual(dataStore.GetFileArtifactContentDecidedEvents().Count(), LastGraph.AllFiles.Count(), files);
             XAssert.AreEqual(dataStore.GetWorkerListEvents().Count(), 0);
-            XAssert.AreEqual(dataStore.GetPipExecutionPerformanceEvents().Count(), LastGraph.RetrievePipReferencesOfType(PipType.Process).Count());
+            XAssert.AreEqual(dataStore.GetPipExecutionPerformanceEvents().Count(), pipCount);
             XAssert.AreEqual(dataStore.GetDirectoryMembershipHashedEvents().Count(), 1);
-            XAssert.AreEqual(dataStore.GetProcessExecutionMonitoringReportedEvents().Count(), LastGraph.RetrievePipReferencesOfType(PipType.Process).Count());
+            XAssert.AreEqual(dataStore.GetProcessExecutionMonitoringReportedEvents().Count(), pipCount);
             XAssert.AreEqual(dataStore.GetProcessFingerprintComputationEvents().Count(), 8);
             XAssert.AreEqual(dataStore.GetExtraEventDataReportedEvents().Count(), 1);
             XAssert.AreEqual(dataStore.GetDependencyViolationReportedEvents().Count(), 0);
             XAssert.AreEqual(dataStore.GetPipExecutionStepPerformanceReportedEvents().Count(), 42);
-            XAssert.AreEqual(dataStore.GetPipCacheMissEvents().Count(), 4);
+            XAssert.AreEqual(dataStore.GetPipCacheMissEvents().Count(), pipCount);
             XAssert.AreEqual(dataStore.GetStatusReportedEvents().Count(), 1);
             XAssert.AreEqual(dataStore.GetBXLInvocationEvents().Count(), 1);
             XAssert.AreEqual(dataStore.GetPipExecutionDirectoryOutputsEvents().Count(), 4);

--- a/Public/Src/Tools/UnitTests/Analyzers/XLGToDBAnalyzerTests.cs
+++ b/Public/Src/Tools/UnitTests/Analyzers/XLGToDBAnalyzerTests.cs
@@ -119,21 +119,29 @@ namespace Test.Tool.Analyzers
 
             var dataStore = new XldbDataStore(storeDirectory: OutputDirPath.ToString(Context.PathTable));
             var pipCount = LastGraph.RetrievePipReferencesOfType(PipType.Process).Count();
+            var fileCount = LastGraph.AllFiles.Count();
 
-            var files = string.Join(", ", LastGraph.AllFiles.ToList().Select(i => i.Path.ToString(Context.PathTable, PathFormat.HostOs)));
-            XAssert.AreEqual(dataStore.GetFileArtifactContentDecidedEvents().Count(), LastGraph.AllFiles.Count(), files);
-            XAssert.AreEqual(dataStore.GetWorkerListEvents().Count(), 0);
-            XAssert.AreEqual(dataStore.GetPipExecutionPerformanceEvents().Count(), pipCount);
-            XAssert.AreEqual(dataStore.GetDirectoryMembershipHashedEvents().Count(), 1);
-            XAssert.AreEqual(dataStore.GetProcessExecutionMonitoringReportedEvents().Count(), pipCount);
-            XAssert.AreEqual(dataStore.GetProcessFingerprintComputationEvents().Count(), 8);
-            XAssert.AreEqual(dataStore.GetExtraEventDataReportedEvents().Count(), 1);
-            XAssert.AreEqual(dataStore.GetDependencyViolationReportedEvents().Count(), 0);
-            XAssert.AreEqual(dataStore.GetPipExecutionStepPerformanceReportedEvents().Count(), 42);
-            XAssert.AreEqual(dataStore.GetPipCacheMissEvents().Count(), pipCount);
-            XAssert.AreEqual(dataStore.GetStatusReportedEvents().Count(), 1);
-            XAssert.AreEqual(dataStore.GetBXLInvocationEvents().Count(), 1);
-            XAssert.AreEqual(dataStore.GetPipExecutionDirectoryOutputsEvents().Count(), 4);
+            if (OperatingSystemHelper.IsUnixOS)
+            {
+                XAssert.AreEqual(fileCount + 1, dataStore.GetFileArtifactContentDecidedEvents().Count());
+            }
+            else
+            {
+                XAssert.AreEqual(fileCount, dataStore.GetFileArtifactContentDecidedEvents().Count());
+            }
+
+            XAssert.AreEqual(0, dataStore.GetWorkerListEvents().Count());
+            XAssert.AreEqual(pipCount, dataStore.GetPipExecutionPerformanceEvents().Count());
+            XAssert.AreEqual(1, dataStore.GetDirectoryMembershipHashedEvents().Count());
+            XAssert.AreEqual(pipCount, dataStore.GetProcessExecutionMonitoringReportedEvents().Count());
+            XAssert.AreEqual(8, dataStore.GetProcessFingerprintComputationEvents().Count());
+            XAssert.AreEqual(1, dataStore.GetExtraEventDataReportedEvents().Count());
+            XAssert.AreEqual(0, dataStore.GetDependencyViolationReportedEvents().Count());
+            XAssert.AreEqual(42, dataStore.GetPipExecutionStepPerformanceReportedEvents().Count());
+            XAssert.AreEqual(pipCount, dataStore.GetPipCacheMissEvents().Count());
+            XAssert.AreEqual(1, dataStore.GetStatusReportedEvents().Count());
+            XAssert.AreEqual(1, dataStore.GetBXLInvocationEvents().Count());
+            XAssert.AreEqual(4, dataStore.GetPipExecutionDirectoryOutputsEvents().Count());
         }
     }
 }


### PR DESCRIPTION
[AB#1574154](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1574154) 

Creates a unit test to check that the count of events (per event type) that we log is as expected per the data in the .xlg file. Also fixed a bug in our protobuf key since default values are not serialized in protobuf (by design) so if we had a key of value 0, it would not be serialized (and prefixmatch for this would then just match everything). As per @dannyvv we made the default enum value (0) to be invalid for "ExecutionEventId".