### PR TITLE
[WIP] New macOS sandbox based on EndpointSecurity APIs

### DIFF
--- a/Private/macOS/publish-buildxl-runtime.sh
+++ b/Private/macOS/publish-buildxl-runtime.sh
@@ -99,20 +99,20 @@ function updateKextVersionSourceFile() {
 function updateBuildXLConfigDscFile() {
     local _newVersion=$1
 
-    updateSingleLineInFile          \
-        ${buildxlDir}/config.microsoftInternal.dsc    \
-        "runtime.osx-x64.BuildXL"   \
-        'version: ".*"'             \
+    updateSingleLineInFile                         \
+        ${buildxlDir}/config.microsoftInternal.dsc \
+        "runtime.osx-x64.BuildXL"                  \
+        'version: ".*"'                            \
         'version: "'$_newVersion'"'
 }
 
 function updateRequiredKextVersion() {
     local _newVersion=$1
 
-    updateSingleLineInFile                                                   \
-        ${buildxlDir}/Public/Src/Engine/Processes/SandboxedKextConnection.cs \
-        "public const string RequiredKextVersionNumber = "                   \
-        ' = ".*"'                                                            \
+    updateSingleLineInFile                                                 \
+        ${buildxlDir}/Public/Src/Engine/Processes/SandboxConnectionKext.cs \
+        "public const string RequiredKextVersionNumber = "                 \
+        ' = ".*"'                                                          \
         ' = "'$_newVersion'"'
 }
 

--- a/Private/macOS/sandbox.entitlements
+++ b/Private/macOS/sandbox.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.endpoint-security.client</key>
+	<true/>
+</dict>
+</plist>

--- a/Public/Src/Demos/BlockAccesses/BlockingEnumerator.cs
+++ b/Public/Src/Demos/BlockAccesses/BlockingEnumerator.cs
@@ -62,7 +62,7 @@ namespace BuildXL.Demo
                 WorkingDirectory = directoryToEnumerateAsString,
                 PipSemiStableHash = 0,
                 PipDescription = "EnumerateWithBlockedDirectories",
-                SandboxedKextConnection = OperatingSystemHelper.IsUnixOS ? new KextConnection() : null
+                SandboxConnection = OperatingSystemHelper.IsUnixOS ? new SandboxConnectionKext() : null
             };
 
             var process = SandboxedProcessFactory.StartAsync(info, forceSandboxing: true).GetAwaiter().GetResult();

--- a/Public/Src/Demos/Demos.md
+++ b/Public/Src/Demos/Demos.md
@@ -55,7 +55,7 @@ var info =
         WorkingDirectory = workingDirectory,
         PipSemiStableHash = 0,
         PipDescription = "Simple sandbox demo",
-        SandboxedKextConnection = OperatingSystemHelper.IsUnixOS ? new SandboxedKextConnection(numberOfKextConnections: 2) : null
+        SandboxConnection = OperatingSystemHelper.IsUnixOS ? new SandboxConnectionKext() : null
     };
 ``` 
 

--- a/Public/Src/Demos/ReportAccesses/FileAccessReporter.cs
+++ b/Public/Src/Demos/ReportAccesses/FileAccessReporter.cs
@@ -47,7 +47,7 @@ namespace BuildXL.Demo
                 WorkingDirectory = Directory.GetCurrentDirectory(),
                 PipSemiStableHash = 0,
                 PipDescription = "Simple sandbox demo",
-                SandboxedKextConnection = OperatingSystemHelper.IsUnixOS ? new KextConnection() : null
+                SandboxConnection = OperatingSystemHelper.IsUnixOS ? new SandboxConnectionKext() : null
             };
 
             var process = SandboxedProcessFactory.StartAsync(info, forceSandboxing: true).GetAwaiter().GetResult();

--- a/Public/Src/Demos/ReportProcesses/ProcessReporter.cs
+++ b/Public/Src/Demos/ReportProcesses/ProcessReporter.cs
@@ -57,7 +57,7 @@ namespace BuildXL.Demo
                 WorkingDirectory = Directory.GetCurrentDirectory(),
                 PipSemiStableHash = 0,
                 PipDescription = "Process list demo",
-                SandboxedKextConnection = OperatingSystemHelper.IsUnixOS ? new KextConnection() : null
+                SandboxConnection = OperatingSystemHelper.IsUnixOS ? new SandboxConnectionKext() : null
             };
 
             var process = SandboxedProcessFactory.StartAsync(info, forceSandboxing: true).GetAwaiter().GetResult();

--- a/Public/Src/Engine/Processes/ISandboxConnection.cs
+++ b/Public/Src/Engine/Processes/ISandboxConnection.cs
@@ -6,10 +6,10 @@ using System;
 namespace BuildXL.Processes
 {
     /// <summary>
-    /// Interface for <see cref="KextConnection"/> used to establish a sandbox kernel extension connection
-    /// and manage communication between BuildXL and the macOS kernel extension.
+    /// Interface for sandbox connections, used to establish a connection
+    /// and manage communication between BuildXL and the macOS sandbox implementation.
     /// </summary>
-    public interface IKextConnection : IDisposable
+    public interface ISandboxConnection : IDisposable
     {
         /// <summary>
         /// Whether to measure CPU times (user/system) of sandboxed processes.  Default: false.
@@ -21,7 +21,7 @@ namespace BuildXL.Processes
         bool MeasureCpuTimes { get; }
 
         /// <summary>
-        /// Reports the earliest (minimum) enqueue time received from all the sandbox kernel report queues available
+        /// Reports the earliest (minimum) enqueue time received from all the sandbox report queues available
         /// </summary>
         ulong MinReportQueueEnqueueTime { get; }
 
@@ -31,49 +31,48 @@ namespace BuildXL.Processes
         TimeSpan CurrentDrought { get; }
 
         /// <summary>
-        /// Notifies the kernel extension of:
+        /// Notifies the sandbox of:
         ///   (1) the current CPU usage (in basis points), and
         ///   (2) amount of available physical memory (in megabytes).
         /// CPU usage is normalized across all cores (i.e., this number should be between 0 and 10000,
         /// which corresponds to 0% and 100%).
         /// </summary>
         /// <remarks>
-        /// This method wouldn't be necessary if the kernel extension could obtain 'host_statistics' on its own;
-        /// with the current kernel (High Sierra), unfortunately, it appears that there is no way for it to do so.
+        /// This method wouldn't be necessary if the sandbox could obtain 'host_statistics' on its own;
+        /// with the current implementation, unfortunately, it appears that there is no way for it to do so.
         /// </remarks>
         bool NotifyUsage(uint cpuUsageBasisPoints, uint availableRamMB);
 
         /// <summary>
-        /// Notifies the kernel extension that a new pip is about to start. Since the kernel extension expects to receive the
+        /// Notifies the sandbox that a new pip is about to start. Since the sandbox expects to receive the
         /// process ID of the pip, this method requires that the supplied <paramref name="process"/> has already been started,
         /// and hence already has an ID assigned to it. To ensure that the process is not going to request file accesses before the
-        /// kernel extension is notified about it being started, the process should be started in some kind of suspended mode, and
-        /// resumed only after the kernel extension has been notified.
+        /// sandbox is notified about it being started, the process should be started in some kind of suspended mode, and
+        /// resumed only after the sandbox has been notified.
         /// </summary>
-        bool NotifyKextPipStarted(FileAccessManifest fam, SandboxedProcessMacKext process);
+        bool NotifyPipStarted(FileAccessManifest fam, SandboxedProcessMac process);
 
         /// <summary>
-        /// Notifies the sandbox kernel extension that <paramref name="process"/> is done processing access reports
+        /// Notifies the sandbox that <paramref name="process"/> is done processing access reports
         /// for Pip <paramref name="pipId"/> so that resources can be freed up.
-        /// Returns whether the sandbox kernel extension was successfully notified and cleaned up all resources
+        /// Returns whether the sandbox was successfully notified and cleaned up all resources
         /// for the pip with <paramref name="pipId"/>d.
         /// </summary>
-        bool NotifyKextProcessFinished(long pipId, SandboxedProcessMacKext process);
+        bool NotifyProcessFinished(long pipId, SandboxedProcessMac process);
 
         /// <summary>
         /// Notification that a pip process was forcefully terminated.
         /// </summary>
-        void NotifyKextPipProcessTerminated(long pipId, int processId);
+        void NotifyPipProcessTerminated(long pipId, int processId);
 
         /// <summary>
-        /// Releases all resources held by the sandbox kernel extension connection including all unmanaged references too. This is only for unit testing and should not
-        /// be called directly at any time! Unit tests need this as they reference a static sandbox kernel extension connection instance that is torn down on process exit.
-        /// This is done to not overburden the host system and kernel extension with connection spam.
+        /// Releases all resources held by the sandbox connection including all unmanaged references too. This is only for unit testing and should not
+        /// be called directly at any time! Unit tests need this as they reference a static sandbox connection instance that is torn down on process exit.
         /// </summary>
         void ReleaseResources();
 
         /// <summary>
-        /// Indicates if the SandboxKextConnection is running for unit-test mode.
+        /// Indicates if the SandboxConnection is running for unit-test mode.
         /// </summary>
         bool IsInTestMode { get; }
     }

--- a/Public/Src/Engine/Processes/SandboxConnectionES.cs
+++ b/Public/Src/Engine/Processes/SandboxConnectionES.cs
@@ -1,0 +1,214 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.ContractsLight;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using BuildXL.Interop.MacOS;
+using BuildXL.Native.Processes;
+using BuildXL.Utilities;
+
+namespace BuildXL.Processes
+{
+    /// <summary>
+    /// A class that manages the connection to the macOS EndpointSecurity subsystem
+    /// </summary>
+    public sealed class SandboxConnectionES : ISandboxConnection
+    {
+        /// <inheritdoc />
+        public bool MeasureCpuTimes { get; }
+
+        /// <inheritdoc />
+        public ulong MinReportQueueEnqueueTime => Volatile.Read(ref m_reportQueueLastEnqueueTime);
+
+        /// <inheritdoc />
+        public bool IsInTestMode { get; }
+
+        private readonly ConcurrentDictionary<long, SandboxedProcessMac> m_pipProcesses = new ConcurrentDictionary<long, SandboxedProcessMac>();
+
+        private Sandbox.KextConnectionInfo m_fakeKextConnectionInfo = new Sandbox.KextConnectionInfo();
+        private Sandbox.ESConnectionInfo m_esConnectionInfo;
+        private readonly Thread m_workerThread;
+
+        /// <summary>
+        /// Enqueue time of the last received report (or 0 if no reports have been received)
+        /// </summary>
+        private ulong m_reportQueueLastEnqueueTime;
+
+        /// <summary>
+        /// The time (in ticks) when the last report was received.
+        /// </summary>
+        private long m_lastReportReceivedTimestampTicks = DateTime.UtcNow.Ticks;
+
+        private long LastReportReceivedTimestampTicks => Volatile.Read(ref m_lastReportReceivedTimestampTicks);
+
+        /// <inheritdoc />
+        public TimeSpan CurrentDrought => DateTime.UtcNow.Subtract(new DateTime(ticks: LastReportReceivedTimestampTicks));
+
+        /// <summary>
+        /// Initializes the ES sandbox
+        /// </summary>
+        public SandboxConnectionES()
+        {
+            m_reportQueueLastEnqueueTime = 0;
+            m_esConnectionInfo = new Sandbox.ESConnectionInfo() { Error = Sandbox.SandboxSuccess };
+
+            MeasureCpuTimes = false;
+            IsInTestMode = false;
+
+            var process = System.Diagnostics.Process.GetCurrentProcess();
+
+            Sandbox.InitializeEndpointSecuritySandbox(ref m_esConnectionInfo, process.Id);
+            if (m_esConnectionInfo.Error != Sandbox.SandboxSuccess)
+            {
+                throw new BuildXLException($@"Unable to connect to EndpointSecurity sandbox (Code: {m_esConnectionInfo.Error})");
+            }
+
+#if DEBUG
+            ProcessUtilities.SetNativeConfiguration(true);
+#else
+            ProcessUtilities.SetNativeConfiguration(false);
+            
+#endif
+
+            m_workerThread = new Thread(() => StartReceivingAccessReports());
+            m_workerThread.IsBackground = true;
+            m_workerThread.Priority = ThreadPriority.Highest;
+            m_workerThread.Start();
+        }
+
+        /// <summary>
+        /// Disposes the sandbox connection and release the resources in the interop layer, when running tests this can be skipped
+        /// </summary>
+        public void Dispose()
+        {
+            if (!IsInTestMode)
+            {
+                ReleaseResources();
+            }
+        }
+
+        /// <summary>
+        /// Releases all resources and cleans up the interop instance too
+        /// </summary>
+        public void ReleaseResources()
+        {
+            Sandbox.DeinitializeEndpointSecuritySandbox(m_esConnectionInfo);
+            m_workerThread.Join();
+        }
+
+        /// <summary>
+        /// Starts listening for reports from the EndpointSecurity sandbox
+        /// </summary>
+        private void StartReceivingAccessReports()
+        {
+            Sandbox.AccessReportCallback callback = (Sandbox.AccessReport report, int code) =>
+            {   
+                if (code != Sandbox.ReportQueueSuccessCode)
+                {
+                    var message = "EndpointSecurity event delivery failed with error: " + code;
+                    throw new BuildXLException(message, ExceptionRootCause.MissingRuntimeDependency);
+                }
+                
+                // Stamp the access report as it has been dequeued at this point
+                report.Statistics.DequeueTime = Sandbox.GetMachAbsoluteTime();
+
+                // Update last received timestamp
+                Volatile.Write(ref m_lastReportReceivedTimestampTicks, DateTime.UtcNow.Ticks);
+
+                // Remember the latest enqueue time
+                Volatile.Write(ref m_reportQueueLastEnqueueTime, report.Statistics.EnqueueTime);
+
+                // The only way it can happen that no process is found for 'report.PipId' is when that pip is
+                // explicitly terminated (e.g., because it timed out or Ctrl-c was pressed)
+                if (m_pipProcesses.TryGetValue(report.PipId, out var process))
+                {
+                    // if the process is found, its ProcessId must match the RootPid of the report.
+                    if (process.ProcessId != report.RootPid)
+                    {
+                        throw new BuildXLException("The process id from the lookup did not match the file access report process id", ExceptionRootCause.FailFast);
+                    }
+                    else
+                    {
+                        process.PostAccessReport(report);
+                    }
+                }
+            };
+
+            Sandbox.ObserverFileAccessReports(ref m_esConnectionInfo, callback, Marshal.SizeOf<Sandbox.AccessReport>());
+        }
+
+        /// <inheritdoc />
+        public bool NotifyUsage(uint cpuUsage, uint availableRamMB)
+        {
+            // TODO: Will we need this?
+            return true;
+        }
+
+        /// <inheritdoc />
+        public bool NotifyPipStarted(FileAccessManifest fam, SandboxedProcessMac process)
+        {
+            Contract.Requires(process.Started);
+            Contract.Requires(fam.PipId != 0);
+
+            if (!m_pipProcesses.TryAdd(fam.PipId, process))
+            {
+                throw new BuildXLException($"Process with PidId {fam.PipId} already exists");
+            }
+
+            var setup = new FileAccessSetup()
+            {
+                DllNameX64 = string.Empty,
+                DllNameX86 = string.Empty,
+                ReportPath = process.ExecutableAbsolutePath, // piggybacking on ReportPath to pass full executable path
+            };
+
+            using (var wrapper = Pools.MemoryStreamPool.GetInstance())
+            {
+                var debugFlags = true;
+                ArraySegment<byte> manifestBytes = fam.GetPayloadBytes(
+                    setup,
+                    wrapper.Instance,
+                    timeoutMins: 10, // don't care because on Mac we don't kill the process from the sandbox once it times out
+                    debugFlagsMatch: ref debugFlags);
+
+                Contract.Assert(manifestBytes.Offset == 0);
+
+                var result = Sandbox.SendPipStarted(
+                    processId: process.ProcessId,
+                    pipId: fam.PipId,
+                    famBytes: manifestBytes.Array,
+                    famBytesLength: manifestBytes.Count,
+                    type: Sandbox.ConnectionType.EndpointSecurity,
+                    info: ref m_fakeKextConnectionInfo);
+
+                return result;
+            }
+        }
+
+        /// <inheritdoc />
+        public void NotifyPipProcessTerminated(long pipId, int processId)
+        {
+            Sandbox.SendPipProcessTerminated(pipId, processId, type: Sandbox.ConnectionType.EndpointSecurity, info: ref m_fakeKextConnectionInfo);
+        }
+
+        /// <inheritdoc />
+        public bool NotifyProcessFinished(long pipId, SandboxedProcessMac process)
+        {
+            if (m_pipProcesses.TryRemove(pipId, out var proc))
+            {
+                Contract.Assert(process == proc);
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/Public/Src/Engine/Processes/SandboxConnectionKext.cs
+++ b/Public/Src/Engine/Processes/SandboxConnectionKext.cs
@@ -18,10 +18,10 @@ namespace BuildXL.Processes
     /// <summary>
     /// A class that manages the connection to the macOS kernel extension and provides utilities to communicate with the sandbox kernel extension
     /// </summary>
-    public sealed class KextConnection : IKextConnection
+    public sealed class SandboxConnectionKext : ISandboxConnection
     {
         /// <summary>
-        /// Configuration for <see cref="KextConnection"/>.
+        /// Configuration for <see cref="SandboxConnectionKext"/>.
         /// </summary>
         public sealed class Config
         {
@@ -74,9 +74,9 @@ Use the the following command to load/reload the sandbox kernel extension and fi
         /// </summary>
         private const int MaxVersionNumberLength = 17;
 
-        private readonly ConcurrentDictionary<long, SandboxedProcessMacKext> m_pipProcesses = new ConcurrentDictionary<long, SandboxedProcessMacKext>();
+        private readonly ConcurrentDictionary<long, SandboxedProcessMac> m_pipProcesses = new ConcurrentDictionary<long, SandboxedProcessMac>();
 
-        private readonly Sandbox.KextConnectionInfo m_kextConnectionInfo;
+        private Sandbox.KextConnectionInfo m_kextConnectionInfo;
         private readonly Sandbox.KextSharedMemoryInfo m_sharedMemoryInfo;
         private readonly Sandbox.ManagedFailureCallback m_failureCallback;
         private readonly Thread m_workerThread;
@@ -100,18 +100,18 @@ Use the the following command to load/reload the sandbox kernel extension and fi
         /// Initializes the sandbox kernel extension connection manager, setting up the kernel extension connection and workers that drain the
         /// kernel event queue and report file accesses
         /// </summary>
-        public KextConnection(Config config = null, bool skipDisposingForTests = false)
+        public SandboxConnectionKext(Config config = null, bool skipDisposingForTests = false)
         {
             m_reportQueueLastEnqueueTime = 0;
-            m_kextConnectionInfo = new Sandbox.KextConnectionInfo() { Error = Sandbox.KextSuccess };
-            m_sharedMemoryInfo = new Sandbox.KextSharedMemoryInfo() { Error = Sandbox.KextSuccess };
+            m_kextConnectionInfo = new Sandbox.KextConnectionInfo() { Error = Sandbox.SandboxSuccess };
+            m_sharedMemoryInfo = new Sandbox.KextSharedMemoryInfo() { Error = Sandbox.SandboxSuccess };
 
             MeasureCpuTimes = config.MeasureCpuTimes;
             IsInTestMode = skipDisposingForTests;
 
             // initialize kext connection
             Sandbox.InitializeKextConnection(ref m_kextConnectionInfo);
-            if (m_kextConnectionInfo.Error != Sandbox.KextSuccess)
+            if (m_kextConnectionInfo.Error != Sandbox.SandboxSuccess)
             {
                 throw new BuildXLException($@"Unable to connect to sandbox kernel extension (Code: {m_kextConnectionInfo.Error}) - make sure it is loaded and retry! {KextInstallHelper}");
             }
@@ -152,7 +152,7 @@ Use the the following command to load/reload the sandbox kernel extension and fi
 
             // Initialize the shared memory region
             Sandbox.InitializeKextSharedMemory(m_kextConnectionInfo, ref m_sharedMemoryInfo);
-            if (m_sharedMemoryInfo.Error != Sandbox.KextSuccess)
+            if (m_sharedMemoryInfo.Error != Sandbox.SandboxSuccess)
             {
                 throw new BuildXLException($"Unable to allocate shared memory region for worker (Code:{m_sharedMemoryInfo.Error})");
             }
@@ -246,7 +246,7 @@ Use the the following command to load/reload the sandbox kernel extension and fi
         }
 
         /// <inheritdoc />
-        public bool NotifyKextPipStarted(FileAccessManifest fam, SandboxedProcessMacKext process)
+        public bool NotifyPipStarted(FileAccessManifest fam, SandboxedProcessMac process)
         {
             Contract.Requires(process.Started);
             Contract.Requires(fam.PipId != 0);
@@ -279,20 +279,21 @@ Use the the following command to load/reload the sandbox kernel extension and fi
                     pipId: fam.PipId,
                     famBytes: manifestBytes.Array,
                     famBytesLength: manifestBytes.Count,
-                    info: m_kextConnectionInfo);
+                    type: Sandbox.ConnectionType.Kext,
+                    info: ref m_kextConnectionInfo);
 
                 return result;
             }
         }
 
         /// <inheritdoc />
-        public void NotifyKextPipProcessTerminated(long pipId, int processId)
+        public void NotifyPipProcessTerminated(long pipId, int processId)
         {
-            Sandbox.SendPipProcessTerminated(pipId, processId, m_kextConnectionInfo);
+            Sandbox.SendPipProcessTerminated(pipId, processId, type: Sandbox.ConnectionType.Kext, info: ref m_kextConnectionInfo);
         }
 
         /// <inheritdoc />
-        public bool NotifyKextProcessFinished(long pipId, SandboxedProcessMacKext process)
+        public bool NotifyProcessFinished(long pipId, SandboxedProcessMac process)
         {
             if (m_pipProcesses.TryRemove(pipId, out var proc))
             {

--- a/Public/Src/Engine/Processes/SandboxedProcessFactory.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessFactory.cs
@@ -15,7 +15,7 @@ namespace BuildXL.Processes
     /// <summary>
     /// Factory for creating and spawning processes.
     /// 
-    /// Currently, if <see cref="FileAccessManifest.DisableDetours"/> is set, an instance of <see cref="UnSandboxedProcess"/>
+    /// Currently, if <see cref="FileAccessManifest.DisableDetours"/> is set, an instance of <see cref="UnsandboxedProcess"/>
     /// is returned; otherwise, <see cref="SandboxedProcess"/> is used.
     /// </summary>
     public static class SandboxedProcessFactory
@@ -138,11 +138,11 @@ namespace BuildXL.Processes
 
             if (sandboxKind == SandboxKind.None)
             {
-                return new UnSandboxedProcess(sandboxedProcessInfo);
+                return new UnsandboxedProcess(sandboxedProcessInfo);
             }
             else if (OperatingSystemHelper.IsUnixOS)
             {
-                return new SandboxedProcessMacKext(sandboxedProcessInfo, ignoreReportedAccesses: sandboxKind == SandboxKind.MacOsKextIgnoreFileAccesses);
+                return new SandboxedProcessMac(sandboxedProcessInfo, ignoreReportedAccesses: sandboxKind == SandboxKind.MacOsKextIgnoreFileAccesses);
             }
             else
             {

--- a/Public/Src/Engine/Processes/SandboxedProcessInfo.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessInfo.cs
@@ -64,7 +64,7 @@ namespace BuildXL.Processes
         /// <summary>
         /// A macOS kernel extension connection.
         /// </summary>
-        public IKextConnection SandboxedKextConnection;
+        public ISandboxConnection SandboxConnection;
 
         /// <summary>
         /// Holds the path remapping information for a process that needs to run in a container
@@ -81,8 +81,8 @@ namespace BuildXL.Processes
             bool testRetries = false,
             LoggingContext loggingContext = null,
             IDetoursEventListener detoursEventListener = null,
-            IKextConnection sandboxedKextConnection = null)
-            : this(new PathTable(), fileStorage, fileName, disableConHostSharing, testRetries, loggingContext, detoursEventListener, sandboxedKextConnection)
+            ISandboxConnection sandboxConnection = null)
+            : this(new PathTable(), fileStorage, fileName, disableConHostSharing, testRetries, loggingContext, detoursEventListener, sandboxConnection)
         {
         }
 
@@ -99,7 +99,7 @@ namespace BuildXL.Processes
             bool testRetries = false,
             LoggingContext loggingContext = null,
             IDetoursEventListener detoursEventListener = null,
-            IKextConnection sandboxedKextConnection = null)
+            ISandboxConnection sandboxConnection = null)
         {
             Contract.Requires(pathTable != null);
             Contract.Requires(fileStorage != null);
@@ -117,7 +117,7 @@ namespace BuildXL.Processes
             NestedProcessTerminationTimeout = DefaultNestedProcessTerminationTimeout;
             LoggingContext = loggingContext;
             DetoursEventListener = detoursEventListener;
-            SandboxedKextConnection = sandboxedKextConnection;
+            SandboxConnection = sandboxConnection;
             ContainerConfiguration = containerConfiguration;
         }
 
@@ -132,7 +132,7 @@ namespace BuildXL.Processes
             bool testRetries = false,
             LoggingContext loggingContext = null,
             IDetoursEventListener detoursEventListener = null,
-            IKextConnection sandboxedKextConnection = null,
+            ISandboxConnection sandboxConnection = null,
             ContainerConfiguration containerConfiguration = null,
             FileAccessManifest fileAccessManifest = null)
             : this(
@@ -145,7 +145,7 @@ namespace BuildXL.Processes
                   testRetries,
                   loggingContext,
                   detoursEventListener,
-                  sandboxedKextConnection)
+                  sandboxConnection)
         {
             Contract.Requires(pathTable != null);
             Contract.Requires(fileStorage != null);

--- a/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
@@ -588,7 +588,7 @@ namespace BuildXL.Processes
         /// <summary>
         /// Runs the process pip (uncached).
         /// </summary>
-        public async Task<SandboxedProcessPipExecutionResult> RunAsync(CancellationToken cancellationToken = default, IKextConnection sandboxedKextConnection = null)
+        public async Task<SandboxedProcessPipExecutionResult> RunAsync(CancellationToken cancellationToken = default, ISandboxConnection sandboxConnection = null)
         {
             try
             {
@@ -650,7 +650,7 @@ namespace BuildXL.Processes
                         m_containerConfiguration,
                         m_pip.TestRetries,
                         m_loggingContext,
-                        sandboxedKextConnection: sandboxedKextConnection)
+                        sandboxConnection: sandboxConnection)
                     {
                         Arguments = arguments,
                         WorkingDirectory = m_workingDirectory,

--- a/Public/Src/Engine/Processes/UnSandboxedProcess.cs
+++ b/Public/Src/Engine/Processes/UnSandboxedProcess.cs
@@ -27,7 +27,7 @@ namespace BuildXL.Processes
     /// <summary>
     /// An implementation of <see cref="ISandboxedProcess"/> that doesn't perform any sandboxing.
     /// </summary>
-    public class UnSandboxedProcess : ISandboxedProcess
+    public class UnsandboxedProcess : ISandboxedProcess
     {
         private static readonly ISet<ReportedFileAccess> s_emptyFileAccessesSet = new HashSet<ReportedFileAccess>();
         private static readonly TimeSpan DefaultProcessTimeout = TimeSpan.FromMinutes(SandboxConfiguration.DefaultProcessTimeoutInMinutes);
@@ -92,7 +92,7 @@ namespace BuildXL.Processes
         protected virtual bool HasSandboxFailures => false;
 
         /// <nodoc />
-        public UnSandboxedProcess(SandboxedProcessInfo info)
+        public UnsandboxedProcess(SandboxedProcessInfo info)
         {
             Contract.Requires(info != null);
 
@@ -270,7 +270,7 @@ namespace BuildXL.Processes
 
             ProcessDumper.TryDumpProcessAndChildren(ProcessId, ProcessInfo.TimeoutDumpDirectory, out m_dumpCreationException);
 
-            LogProcessState($"UnSandboxedProcess::KillAsync()");
+            LogProcessState($"UnsandboxedProcess::KillAsync()");
             return m_processExecutor.KillAsync();
         }
 

--- a/Public/Src/Engine/Scheduler/Fingerprints/ExtraFingerprintSalts.cs
+++ b/Public/Src/Engine/Scheduler/Fingerprints/ExtraFingerprintSalts.cs
@@ -19,9 +19,9 @@ namespace BuildXL.Scheduler.Fingerprints
     public struct ExtraFingerprintSalts : IEquatable<ExtraFingerprintSalts>
     {
         // For non-Unix platforms, this is an arbitrary fixed value
-        private static readonly string s_requiredKextVersionNumber = OperatingSystemHelper.IsUnixOS ?
-                            Processes.KextConnection.RequiredKextVersionNumber :
-                            "0";
+        private static readonly string s_requiredKextVersionNumber = OperatingSystemHelper.IsUnixOS 
+            ? Processes.SandboxConnectionKext.RequiredKextVersionNumber
+            : "0";
 
         private static readonly ExtraFingerprintSalts s_defaultValue = new ExtraFingerprintSalts(
                         ignoreSetFileInformationByHandle: false,

--- a/Public/Src/Engine/Scheduler/IPipExecutionEnvironment.cs
+++ b/Public/Src/Engine/Scheduler/IPipExecutionEnvironment.cs
@@ -163,7 +163,7 @@ namespace BuildXL.Scheduler
         /// <summary>
         /// Kernel connection, needed to instrument sandboxed processes / pips on macOS
         /// </summary>
-        BuildXL.Processes.IKextConnection SandboxedKextConnection { get; }
+        BuildXL.Processes.ISandboxConnection SandboxConnection { get; }
 
         /// <summary>
         /// Sets the maximum number of external processes run concurrently so far.

--- a/Public/Src/Engine/Scheduler/IPipScheduler.cs
+++ b/Public/Src/Engine/Scheduler/IPipScheduler.cs
@@ -21,7 +21,7 @@ namespace BuildXL.Scheduler
         /// Initialize runtime state, optionally apply a filter and schedule all ready pips.
         /// Do not start the actual execution.
         /// </summary>
-        bool InitForMaster([NotNull]LoggingContext loggingContext, RootFilter filter = null, SchedulerState state = null, IKextConnection kextConnection = null);
+        bool InitForMaster([NotNull]LoggingContext loggingContext, RootFilter filter = null, SchedulerState state = null, ISandboxConnection SandboxConnectionKext = null);
 
         /// <summary>
         /// Start running.

--- a/Public/Src/Engine/Scheduler/PipExecutor.cs
+++ b/Public/Src/Engine/Scheduler/PipExecutor.cs
@@ -1384,7 +1384,7 @@ namespace BuildXL.Scheduler
                                     environment.SetMaxExternalProcessRan();
                                 }
 
-                                result = await executor.RunAsync(innerResourceLimitCancellationTokenSource.Token, sandboxedKextConnection: environment.SandboxedKextConnection);
+                                result = await executor.RunAsync(innerResourceLimitCancellationTokenSource.Token, sandboxConnection: environment.SandboxConnection);
 
                                 ++retryCount;
 

--- a/Public/Src/Engine/UnitTests/Processes.Detours/PipExecutorDetoursTest.cs
+++ b/Public/Src/Engine/UnitTests/Processes.Detours/PipExecutorDetoursTest.cs
@@ -150,7 +150,7 @@ namespace Test.BuildXL.Processes.Detours
                 buildEngineDirectory: binDirectory,
                 directoryTranslator: directoryTranslator,
                 isQbuildIntegrated: isQuickBuildIntegrated,
-                tempDirectoryCleaner: MoveDeleteCleaner).RunAsync(sandboxedKextConnection: GetSandboxedKextConnection());
+                tempDirectoryCleaner: MoveDeleteCleaner).RunAsync(SandboxConnection: GetSandboxConnection());
         }
 
         [Fact]

--- a/Public/Src/Engine/UnitTests/Processes.Detours/SandboxedProcessPipExecutorTest.cs
+++ b/Public/Src/Engine/UnitTests/Processes.Detours/SandboxedProcessPipExecutorTest.cs
@@ -2116,7 +2116,7 @@ namespace Test.BuildXL.Processes.Detours
                 new PipEnvironment(),
                 validateDistribution: false,
                 directoryArtifactContext: directoryArtifactContext ?? TestDirectoryArtifactContext.Empty,
-                tempDirectoryCleaner: MoveDeleteCleaner).RunAsync(sandboxedKextConnection: GetSandboxedKextConnection());
+                tempDirectoryCleaner: MoveDeleteCleaner).RunAsync(SandboxConnection: GetSandboxConnection());
         }
 
         private static void VerifyExitCode(BuildXLContext context, SandboxedProcessPipExecutionResult result, int expectedExitCode)

--- a/Public/Src/Engine/UnitTests/Processes/SandboxedProcessTest.cs
+++ b/Public/Src/Engine/UnitTests/Processes/SandboxedProcessTest.cs
@@ -1051,7 +1051,7 @@ namespace Test.BuildXL.Processes
             {
                 PipSemiStableHash = 0,
                 PipDescription = DiscoverCurrentlyExecutingXunitTestMethodFQN(),
-                SandboxedKextConnection = GetSandboxedKextConnection()
+                SandboxConnection = GetSandboxConnection()
             };
 
             try
@@ -1131,7 +1131,7 @@ namespace Test.BuildXL.Processes
                 info.FileAccessManifest.PipId = GetNextPipId();
                 info.FileAccessManifest.ReportFileAccesses = true;
                 info.FileAccessManifest.FailUnexpectedFileAccesses = false;
-                info.SandboxedKextConnection = GetSandboxedKextConnection();
+                info.SandboxConnection = GetSandboxConnection();
 
                 var result = await RunProcess(info);
                 XAssert.AreEqual(0, result.ExitCode);

--- a/Public/Src/Engine/UnitTests/Processes/SandboxedProcessTestBase.cs
+++ b/Public/Src/Engine/UnitTests/Processes/SandboxedProcessTestBase.cs
@@ -44,7 +44,7 @@ namespace Test.BuildXL.Processes
                 this,
                 process.Executable.Path.ToString(Context.PathTable),
                 detoursEventListener: detoursListener,
-                sandboxedKextConnection: GetSandboxedKextConnection(),
+                sandboxConnection: GetSandboxConnection(),
                 disableConHostSharing: disableConHostSharing,
                 fileAccessManifest: fileAccessManifest)
             {

--- a/Public/Src/Engine/UnitTests/Scheduler/FileContentManagerTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/FileContentManagerTests.cs
@@ -458,7 +458,7 @@ namespace Test.BuildXL.Scheduler
                     return;
                 }
 
-                Environment = new DummyPipExecutionEnvironment(CreateLoggingContextForTest(), m_context, Configuration, sandboxedKextConnection: GetSandboxedKextConnection());
+                Environment = new DummyPipExecutionEnvironment(CreateLoggingContextForTest(), m_context, Configuration, SandboxConnection: GetSandboxConnection());
                 FileContentManager = new FileContentManager(Environment, new NullOperationTracker());
                 UntrackedOpContext = OperationContext.CreateUntracked(Environment.LoggingContext);
 

--- a/Public/Src/Engine/UnitTests/Scheduler/ObservedInputProcessorTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/ObservedInputProcessorTests.cs
@@ -1129,7 +1129,7 @@ namespace Test.BuildXL.Scheduler
                 context.PathTable,
                 AbsolutePath.Create(context.PathTable, Path.Combine(TestOutputDirectory, "config.dc")));
 
-            DummyPipExecutionEnvironment dummy = new DummyPipExecutionEnvironment(LoggingContext, context, config, sandboxedKextConnection: GetSandboxedKextConnection());
+            DummyPipExecutionEnvironment dummy = new DummyPipExecutionEnvironment(LoggingContext, context, config, SandboxConnection: GetSandboxConnection());
             DirectoryMembershipFingerprinter fingerprinter = new DirectoryMembershipFingerprinter(LoggingContext, context);
 
             DirectoryMembershipFingerprinterRule excludeFiles =

--- a/Public/Src/Engine/UnitTests/Scheduler/PipExecutorTest.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/PipExecutorTest.cs
@@ -2447,7 +2447,7 @@ EXIT /b 3
                 semanticPathExpander: mountExpander,
                 fileAccessWhitelist: fileAccessWhitelist,
                 allowUnspecifiedSealedDirectories: false,
-                sandboxedKextConnection: GetSandboxedKextConnection());
+                SandboxConnection: GetSandboxConnection());
             env.ContentFingerprinter.FingerprintTextEnabled = true;
             return env;
         }
@@ -2479,7 +2479,7 @@ EXIT /b 3
                 fileAccessWhitelist: fileAccessWhitelist,
                 allowUnspecifiedSealedDirectories: false,
                 ipcProvider: ipcProvider,
-                sandboxedKextConnection: GetSandboxedKextConnection());
+                SandboxConnection: GetSandboxConnection());
             env.ContentFingerprinter.FingerprintTextEnabled = true;
 
             // A bit of a hack for tests that validate things that get logged to the Static context

--- a/Public/Src/Engine/UnitTests/Scheduler/PipFileSystemViewTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/PipFileSystemViewTests.cs
@@ -125,7 +125,7 @@ namespace Test.BuildXL.Scheduler
             {
                 Context = BuildXLContext.CreateInstanceForTesting();
                 var config = ConfigurationHelpers.GetDefaultForTesting(Context.PathTable, AbsolutePath.Create(Context.PathTable, System.IO.Path.Combine(testOutputDirectory, "config.dc")));
-                m_env = new DummyPipExecutionEnvironment(CreateLoggingContextForTest(), Context, config, sandboxedKextConnection: GetSandboxedKextConnection());
+                m_env = new DummyPipExecutionEnvironment(CreateLoggingContextForTest(), Context, config, SandboxConnection: GetSandboxConnection());
                 var sealContentsCache = new ConcurrentBigMap<DirectoryArtifact, int[]>();
 
                 Table = Context.PathTable;

--- a/Public/Src/Engine/UnitTests/Scheduler/PipQueueTest.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/PipQueueTest.cs
@@ -43,7 +43,7 @@ using Xunit.Abstractions;
 using System.Diagnostics.CodeAnalysis;
 using BuildXL.Scheduler.FileSystem;
 using Test.BuildXL.Scheduler.Utils;
-using KextConnection = BuildXL.Processes.KextConnection;
+using SandboxConnectionKext = BuildXL.Processes.SandboxConnectionKext;
 using BuildXL.Processes.Containers;
 using BuildXL.Utilities.VmCommandProxy;
 
@@ -97,7 +97,7 @@ namespace Test.BuildXL.Scheduler
                     maxDegreeOfParallelism: (Environment.ProcessorCount + 2) / 3,
                     debug: false))
                 {
-                    var executionEnvironment = new PipQueueTestExecutionEnvironment(context, config, pipTable, Path.Combine(TestOutputDirectory, "temp"), GetSandboxedKextConnection());
+                    var executionEnvironment = new PipQueueTestExecutionEnvironment(context, config, pipTable, Path.Combine(TestOutputDirectory, "temp"), GetSandboxConnection());
 
                     Func<RunnablePip, Task<PipResult>> taskFactory = async (runnablePip) =>
                         {
@@ -288,11 +288,11 @@ namespace Test.BuildXL.Scheduler
 
             private readonly TestPipGraphFilesystemView m_filesystemView;
             private readonly ConcurrentBigMap<DirectoryArtifact, int[]> m_sealContentsById;
-            private readonly IKextConnection m_sandboxedKextConnection;
+            private readonly ISandboxConnection m_sandboxConnectionKext;
 
             private readonly IFileMonitoringViolationAnalyzer m_disabledFileMonitoringViolationAnalyzer = new DisabledFileMonitoringViolationAnalyzer();
             
-            public PipQueueTestExecutionEnvironment(BuildXLContext context, IConfiguration configuration, PipTable pipTable, string tempDirectory, IKextConnection sandboxedKextConnection = null)
+            public PipQueueTestExecutionEnvironment(BuildXLContext context, IConfiguration configuration, PipTable pipTable, string tempDirectory, ISandboxConnection SandboxConnection = null)
             {
                 Contract.Requires(context != null);
                 Contract.Requires(configuration != null);
@@ -313,7 +313,7 @@ namespace Test.BuildXL.Scheduler
                 Cache = InMemoryCacheFactory.Create();
                 LocalDiskContentStore = new LocalDiskContentStore(LoggingContext, context.PathTable, FileContentTable, tracker);
 
-                m_sandboxedKextConnection = sandboxedKextConnection;
+                m_sandboxConnectionKext = SandboxConnection;
                 m_expectedWrittenContent = new ConcurrentDictionary<FileArtifact, ContentHash>();
                 m_wellKnownFiles = new ConcurrentDictionary<FileArtifact, ContentHash>();
                 m_producers = new ConcurrentDictionary<FileArtifact, Pip>();
@@ -588,7 +588,7 @@ namespace Test.BuildXL.Scheduler
 
             SemanticPathExpander IFileContentManagerHost.SemanticPathExpander => PathExpander;
 
-            public IKextConnection SandboxedKextConnection => m_sandboxedKextConnection;
+            public ISandboxConnection SandboxConnection => m_sandboxConnectionKext;
 
             public ProcessInContainerManager ProcessInContainerManager { get; }
 

--- a/Public/Src/Engine/UnitTests/Scheduler/SchedulerTest.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/SchedulerTest.cs
@@ -385,7 +385,7 @@ namespace Test.BuildXL.Scheduler
                 Contract.Assert(cacheLayer != null);
 
                 Contract.Assume(scheduler != null);
-                scheduler.InitForMaster(LoggingContext, kextConnection: GetSandboxedKextConnection());
+                scheduler.InitForMaster(LoggingContext, sandboxConnectionKext: GetSandboxConnection());
                 scheduler.Start(LoggingContext);
 
                 bool success = scheduler.WhenDone().Result;

--- a/Public/Src/Engine/UnitTests/Scheduler/TestScheduler.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/TestScheduler.cs
@@ -35,11 +35,11 @@ namespace Test.BuildXL.Scheduler
 
         protected override bool SandboxingWithKextEnabled => OperatingSystemHelper.IsUnixOS;
 
-        protected override bool InitSandboxedKextConnection(LoggingContext loggingContext, IKextConnection kextConnection = null)
+        protected override bool InitSandboxConnectionKext(LoggingContext loggingContext, ISandboxConnection SandboxConnectionKext = null)
         {
             if (SandboxingWithKextEnabled)
             {
-                SandboxedKextConnection = kextConnection ?? XunitBuildXLTest.GetSandboxedKextConnection();
+                SandboxConnection = SandboxConnectionKext ?? XunitBuildXLTest.GetSandboxConnection();
             }
 
             return false;

--- a/Public/Src/Engine/UnitTests/Scheduler/Utils/DummyPipExecutionEnvironment.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/Utils/DummyPipExecutionEnvironment.cs
@@ -35,7 +35,7 @@ using BuildXL.Utilities.Instrumentation.Common;
 using BuildXL.Utilities.Tasks;
 using BuildXL.Utilities.Tracing;
 using BuildXL.Utilities.Configuration;
-using KextConnection = BuildXL.Processes.KextConnection;
+using SandboxConnectionKext = BuildXL.Processes.SandboxConnectionKext;
 using BuildXL.Utilities.VmCommandProxy;
 using Test.BuildXL.TestUtilities;
 
@@ -65,7 +65,7 @@ namespace Test.BuildXL.Scheduler.Utils
         private readonly bool m_allowUnspecifiedSealedDirectories;
         private IReadOnlyDictionary<PipId, IReadOnlyCollection<Pip>> m_servicePipToClientProcesses;
         private readonly IFileMonitoringViolationAnalyzer m_disabledFileMonitoringViolationAnalyzer = new DisabledFileMonitoringViolationAnalyzer();
-        private readonly IKextConnection m_sandboxedKextConnection;
+        private readonly ISandboxConnection m_sandboxConnectionKext;
 
         public Dictionary<FileArtifact, string> HostMaterializedFileContents = new Dictionary<FileArtifact, string>();
 
@@ -105,7 +105,7 @@ namespace Test.BuildXL.Scheduler.Utils
             bool allowUnspecifiedSealedDirectories = false,
             PipTable pipTable = null,
             IIpcProvider ipcProvider = null,
-            IKextConnection sandboxedKextConnection = null)
+            ISandboxConnection SandboxConnection = null)
         {
             Contract.Requires(context != null);
             Contract.Requires(config != null);
@@ -131,7 +131,7 @@ namespace Test.BuildXL.Scheduler.Utils
             Cache = pipCache;
             FileAccessWhitelist = fileAccessWhitelist;
             m_allowUnspecifiedSealedDirectories = allowUnspecifiedSealedDirectories;
-            m_sandboxedKextConnection = sandboxedKextConnection;
+            m_sandboxConnectionKext = SandboxConnection;
 
             if (Cache == null)
             {
@@ -578,7 +578,7 @@ namespace Test.BuildXL.Scheduler.Utils
 
         SemanticPathExpander IFileContentManagerHost.SemanticPathExpander => PathExpander;
 
-        public IKextConnection SandboxedKextConnection => m_sandboxedKextConnection;
+        public ISandboxConnection SandboxConnection => m_sandboxConnectionKext;
 
         public ProcessInContainerManager ProcessInContainerManager { get; }
 

--- a/Public/Src/FrontEnd/Nuget/WorkspaceNugetModuleResolver.cs
+++ b/Public/Src/FrontEnd/Nuget/WorkspaceNugetModuleResolver.cs
@@ -1249,7 +1249,7 @@ namespace BuildXL.FrontEnd.Nuget
                         disableConHostSharing: true,
                         ContainerConfiguration.DisabledIsolation,
                         loggingContext: m_context.LoggingContext,
-                        sandboxedKextConnection: m_useMonoBasedNuGet ? new FakeKextConnection() : null)
+                        sandboxConnection: m_useMonoBasedNuGet ? new SandboxConnectionFake() : null)
                     {
                         Arguments = arguments,
                         WorkingDirectory = layout.TempDirectory.ToString(PathTable),
@@ -1354,7 +1354,7 @@ namespace BuildXL.FrontEnd.Nuget
             }
         }
 
-        private class FakeKextConnection : IKextConnection
+        private class SandboxConnectionFake : ISandboxConnection
         {
             public int NumberOfKextConnections => 1;
 
@@ -1378,11 +1378,11 @@ namespace BuildXL.FrontEnd.Nuget
 
             public bool NotifyUsage(uint cpuUsage, uint availableRamMB) { return true; }
 
-            public bool NotifyKextPipStarted(FileAccessManifest fam, SandboxedProcessMacKext process) { return true; }
+            public bool NotifyPipStarted(FileAccessManifest fam, SandboxedProcessMac process) { return true; }
 
-            public void NotifyKextPipProcessTerminated(long pipId, int processId) { }
+            public void NotifyPipProcessTerminated(long pipId, int processId) { }
 
-            public bool NotifyKextProcessFinished(long pipId, SandboxedProcessMacKext process) { return true; }
+            public bool NotifyProcessFinished(long pipId, SandboxedProcessMac process) { return true; }
 
             public void ReleaseResources() { }
         }

--- a/Public/Src/Sandbox/MacOs/Interop/Interop.xcodeproj/project.pbxproj
+++ b/Public/Src/Sandbox/MacOs/Interop/Interop.xcodeproj/project.pbxproj
@@ -18,6 +18,22 @@
 		3C245100219C565400EBC811 /* CoreDumpTester.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C2450FF219C565400EBC811 /* CoreDumpTester.c */; };
 		3C245106219C576C00EBC811 /* libBuildXLInterop.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C1D7C8220C025F10069CF65 /* libBuildXLInterop.dylib */; };
 		3C245108219C741400EBC811 /* libcurses.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C245107219C741400EBC811 /* libcurses.tbd */; };
+		3C3B60B922F1DC6600130AB3 /* SandboxedProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3CF74D9522F1C1A50018A1AF /* SandboxedProcess.cpp */; };
+		3C3B60BA22F1DC6600130AB3 /* SandboxedProcess.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3CF74D9622F1C1A50018A1AF /* SandboxedProcess.hpp */; };
+		3C3B60BB22F1DC9E00130AB3 /* SandboxedPip.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3C5A969022F1A9CC00C56F4C /* SandboxedPip.cpp */; };
+		3C3B60BC22F1DC9E00130AB3 /* SandboxedPip.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3C5A969122F1A9CC00C56F4C /* SandboxedPip.hpp */; };
+		3C3B60C122F1DE8D00130AB3 /* Trie.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3C5A969422F1B3F800C56F4C /* Trie.cpp */; };
+		3C3B60C222F1DE9000130AB3 /* Trie.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3C5A969522F1B3F800C56F4C /* Trie.hpp */; };
+		3C3B60C322F1DEB200130AB3 /* KextSandbox.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CF3733F20C1897400D14240 /* KextSandbox.h */; };
+		3C3B60C422F1DEB400130AB3 /* KextSandbox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3CF3733E20C1897400D14240 /* KextSandbox.cpp */; };
+		3C3B60C722F1E12C00130AB3 /* ESSandbox.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C85C76D22F04DAC00BC3989 /* ESSandbox.h */; };
+		3C3B60C822F1E14B00130AB3 /* ESSandbox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3C85C76C22F04DAC00BC3989 /* ESSandbox.cpp */; };
+		3C3B60C922F1E2B400130AB3 /* Common.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C85C77122F04DEB00BC3989 /* Common.h */; };
+		3C3B60CA22F1E2BC00130AB3 /* Common.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3C85C77022F04DEB00BC3989 /* Common.cpp */; };
+		3C4C636822F386AE0014D9AA /* Checkers.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3C4C636422F386AE0014D9AA /* Checkers.hpp */; };
+		3C4C636922F386AE0014D9AA /* OpNames.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3C4C636522F386AE0014D9AA /* OpNames.cpp */; };
+		3C4C636A22F386AE0014D9AA /* Checkers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3C4C636622F386AE0014D9AA /* Checkers.cpp */; };
+		3C4C636B22F386AE0014D9AA /* OpNames.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3C4C636722F386AE0014D9AA /* OpNames.hpp */; };
 		3C5C178E212EF6E900F4100F /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C5C178D212EF6E900F4100F /* CoreFoundation.framework */; };
 		3C6495C221A6E2E20083FD3A /* AriaLogger.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3C6495C121A6E2E20083FD3A /* AriaLogger.hpp */; };
 		3C6495C621A6E2E20083FD3A /* AriaLogger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3C6495C521A6E2E20083FD3A /* AriaLogger.cpp */; };
@@ -25,8 +41,12 @@
 		3C6495E421A6E3E70083FD3A /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C6495E321A6E3E60083FD3A /* libz.tbd */; };
 		3C80E70821347B9700ECBD6E /* io.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C80E70621347B9700ECBD6E /* io.h */; };
 		3C80E70921347B9700ECBD6E /* io.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C80E70721347B9700ECBD6E /* io.c */; };
-		3CF3734020C1897400D14240 /* Sandbox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3CF3733E20C1897400D14240 /* Sandbox.cpp */; };
-		3CF3734120C1897400D14240 /* Sandbox.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CF3733F20C1897400D14240 /* Sandbox.h */; };
+		3C85C77522F0595500BC3989 /* libbsm.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C85C77422F0594800BC3989 /* libbsm.tbd */; settings = {ATTRIBUTES = (Weak, ); }; };
+		3C85C77722F0595900BC3989 /* libEndpointSecurity.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C85C77622F0595900BC3989 /* libEndpointSecurity.tbd */; settings = {ATTRIBUTES = (Weak, ); }; };
+		3CD0BB4022F2E035008C0AC9 /* AccessHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3C44208122F1F5B1000E1003 /* AccessHandler.cpp */; };
+		3CD0BB4122F2E035008C0AC9 /* AccessHandler.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3C44208822F1F5B2000E1003 /* AccessHandler.hpp */; };
+		3CD0BB4222F2E84A008C0AC9 /* IOHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3C44208022F1F5B1000E1003 /* IOHandler.cpp */; };
+		3CD0BB4322F2E84A008C0AC9 /* IOHandler.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3C44208422F1F5B1000E1003 /* IOHandler.hpp */; };
 		F588040520D03EB7006CF533 /* PolicyResult.h in Headers */ = {isa = PBXBuildFile; fileRef = F588040320D03EB7006CF533 /* PolicyResult.h */; };
 		F588040720D042FB006CF533 /* PolicyResult_common.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F588040620D042FB006CF533 /* PolicyResult_common.cpp */; };
 		F58E9207220B5B3D0083C57E /* utf8proc.c in Sources */ = {isa = PBXBuildFile; fileRef = F58E9204220B5B3C0083C57E /* utf8proc.c */; };
@@ -70,6 +90,18 @@
 		3C2450FD219C565400EBC811 /* CoreDumpTester */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = CoreDumpTester; sourceTree = BUILT_PRODUCTS_DIR; };
 		3C2450FF219C565400EBC811 /* CoreDumpTester.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = CoreDumpTester.c; sourceTree = "<group>"; };
 		3C245107219C741400EBC811 /* libcurses.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libcurses.tbd; path = usr/lib/libcurses.tbd; sourceTree = SDKROOT; };
+		3C44208022F1F5B1000E1003 /* IOHandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IOHandler.cpp; sourceTree = "<group>"; };
+		3C44208122F1F5B1000E1003 /* AccessHandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AccessHandler.cpp; sourceTree = "<group>"; };
+		3C44208422F1F5B1000E1003 /* IOHandler.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = IOHandler.hpp; sourceTree = "<group>"; };
+		3C44208822F1F5B2000E1003 /* AccessHandler.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = AccessHandler.hpp; sourceTree = "<group>"; };
+		3C4C636422F386AE0014D9AA /* Checkers.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = Checkers.hpp; path = ../Sandbox/Src/Kauth/Checkers.hpp; sourceTree = "<group>"; };
+		3C4C636522F386AE0014D9AA /* OpNames.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = OpNames.cpp; path = ../Sandbox/Src/Kauth/OpNames.cpp; sourceTree = "<group>"; };
+		3C4C636622F386AE0014D9AA /* Checkers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Checkers.cpp; path = ../Sandbox/Src/Kauth/Checkers.cpp; sourceTree = "<group>"; };
+		3C4C636722F386AE0014D9AA /* OpNames.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = OpNames.hpp; path = ../Sandbox/Src/Kauth/OpNames.hpp; sourceTree = "<group>"; };
+		3C5A969022F1A9CC00C56F4C /* SandboxedPip.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SandboxedPip.cpp; path = ../Data/SandboxedPip.cpp; sourceTree = "<group>"; };
+		3C5A969122F1A9CC00C56F4C /* SandboxedPip.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = SandboxedPip.hpp; path = ../Data/SandboxedPip.hpp; sourceTree = "<group>"; };
+		3C5A969422F1B3F800C56F4C /* Trie.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Trie.cpp; sourceTree = "<group>"; };
+		3C5A969522F1B3F800C56F4C /* Trie.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Trie.hpp; sourceTree = "<group>"; };
 		3C5C178D212EF6E900F4100F /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
 		3C6495BF21A6E2E20083FD3A /* libBuildXLAria.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libBuildXLAria.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		3C6495C121A6E2E20083FD3A /* AriaLogger.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = AriaLogger.hpp; sourceTree = "<group>"; };
@@ -80,8 +112,16 @@
 		3C6495E321A6E3E60083FD3A /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		3C80E70621347B9700ECBD6E /* io.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = io.h; sourceTree = "<group>"; };
 		3C80E70721347B9700ECBD6E /* io.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = io.c; sourceTree = "<group>"; };
-		3CF3733E20C1897400D14240 /* Sandbox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Sandbox.cpp; sourceTree = "<group>"; };
-		3CF3733F20C1897400D14240 /* Sandbox.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Sandbox.h; sourceTree = "<group>"; };
+		3C85C76C22F04DAC00BC3989 /* ESSandbox.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ESSandbox.cpp; sourceTree = "<group>"; };
+		3C85C76D22F04DAC00BC3989 /* ESSandbox.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ESSandbox.h; sourceTree = "<group>"; };
+		3C85C77022F04DEB00BC3989 /* Common.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Common.cpp; sourceTree = "<group>"; };
+		3C85C77122F04DEB00BC3989 /* Common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Common.h; sourceTree = "<group>"; };
+		3C85C77422F0594800BC3989 /* libbsm.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libbsm.tbd; path = usr/lib/libbsm.tbd; sourceTree = SDKROOT; };
+		3C85C77622F0595900BC3989 /* libEndpointSecurity.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libEndpointSecurity.tbd; path = usr/lib/libEndpointSecurity.tbd; sourceTree = SDKROOT; };
+		3CF3733E20C1897400D14240 /* KextSandbox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = KextSandbox.cpp; sourceTree = "<group>"; };
+		3CF3733F20C1897400D14240 /* KextSandbox.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KextSandbox.h; sourceTree = "<group>"; };
+		3CF74D9522F1C1A50018A1AF /* SandboxedProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SandboxedProcess.cpp; sourceTree = "<group>"; };
+		3CF74D9622F1C1A50018A1AF /* SandboxedProcess.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = SandboxedProcess.hpp; sourceTree = "<group>"; };
 		F588040320D03EB7006CF533 /* PolicyResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PolicyResult.h; path = ../../Windows/DetoursServices/PolicyResult.h; sourceTree = "<group>"; };
 		F588040620D042FB006CF533 /* PolicyResult_common.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PolicyResult_common.cpp; path = ../../Windows/DetoursServices/PolicyResult_common.cpp; sourceTree = "<group>"; };
 		F58E9204220B5B3C0083C57E /* utf8proc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = utf8proc.c; sourceTree = "<group>"; };
@@ -105,6 +145,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3C85C77722F0595900BC3989 /* libEndpointSecurity.tbd in Frameworks */,
+				3C85C77522F0595500BC3989 /* libbsm.tbd in Frameworks */,
 				3C5C178E212EF6E900F4100F /* CoreFoundation.framework in Frameworks */,
 				3C05DAEA20E3740100488EF5 /* IOKit.framework in Frameworks */,
 			);
@@ -134,6 +176,8 @@
 		3C05DAE820E3740100488EF5 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				3C85C77622F0595900BC3989 /* libEndpointSecurity.tbd */,
+				3C85C77422F0594800BC3989 /* libbsm.tbd */,
 				3C6495E321A6E3E60083FD3A /* libz.tbd */,
 				3C6495E121A6E3C30083FD3A /* libcompression.tbd */,
 				3C6495DF21A6E3AA0083FD3A /* libsqlite3.tbd */,
@@ -194,6 +238,30 @@
 			path = CoreDumpTester;
 			sourceTree = "<group>";
 		};
+		3C3B60AC22F1D83400130AB3 /* Handlers */ = {
+			isa = PBXGroup;
+			children = (
+				3C44208122F1F5B1000E1003 /* AccessHandler.cpp */,
+				3C44208822F1F5B2000E1003 /* AccessHandler.hpp */,
+				3C44208022F1F5B1000E1003 /* IOHandler.cpp */,
+				3C44208422F1F5B1000E1003 /* IOHandler.hpp */,
+			);
+			path = Handlers;
+			sourceTree = "<group>";
+		};
+		3C5A968F22F1A9A500C56F4C /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				3CF74D9522F1C1A50018A1AF /* SandboxedProcess.cpp */,
+				3CF74D9622F1C1A50018A1AF /* SandboxedProcess.hpp */,
+				3C5A969422F1B3F800C56F4C /* Trie.cpp */,
+				3C5A969522F1B3F800C56F4C /* Trie.hpp */,
+				3C5A969022F1A9CC00C56F4C /* SandboxedPip.cpp */,
+				3C5A969122F1A9CC00C56F4C /* SandboxedPip.hpp */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
 		3C6495C021A6E2E20083FD3A /* Aria */ = {
 			isa = PBXGroup;
 			children = (
@@ -216,8 +284,14 @@
 		3CF3733D20C1897400D14240 /* Sandbox */ = {
 			isa = PBXGroup;
 			children = (
-				3CF3733E20C1897400D14240 /* Sandbox.cpp */,
-				3CF3733F20C1897400D14240 /* Sandbox.h */,
+				3C5A968F22F1A9A500C56F4C /* Data */,
+				3C3B60AC22F1D83400130AB3 /* Handlers */,
+				3C85C77022F04DEB00BC3989 /* Common.cpp */,
+				3C85C77122F04DEB00BC3989 /* Common.h */,
+				3C85C76C22F04DAC00BC3989 /* ESSandbox.cpp */,
+				3C85C76D22F04DAC00BC3989 /* ESSandbox.h */,
+				3CF3733E20C1897400D14240 /* KextSandbox.cpp */,
+				3CF3733F20C1897400D14240 /* KextSandbox.h */,
 			);
 			path = Sandbox;
 			sourceTree = "<group>";
@@ -260,8 +334,12 @@
 			isa = PBXGroup;
 			children = (
 				F5CF3B0C20C1E3DC00DC1B2E /* BuildXLSandboxShared.hpp */,
+				3C4C636622F386AE0014D9AA /* Checkers.cpp */,
+				3C4C636422F386AE0014D9AA /* Checkers.hpp */,
 				F5CF3B0820C1E3C500DC1B2E /* FileAccessManifestParser.cpp */,
 				F5CF3B0920C1E3C500DC1B2E /* FileAccessManifestParser.hpp */,
+				3C4C636522F386AE0014D9AA /* OpNames.cpp */,
+				3C4C636722F386AE0014D9AA /* OpNames.hpp */,
 			);
 			name = BuildXLSandbox;
 			sourceTree = "<group>";
@@ -275,16 +353,25 @@
 			files = (
 				3C80E70821347B9700ECBD6E /* io.h in Headers */,
 				F5CF3B1320C1E40C00DC1B2E /* PolicySearch.h in Headers */,
+				3C3B60C222F1DE9000130AB3 /* Trie.hpp in Headers */,
+				3CD0BB4322F2E84A008C0AC9 /* IOHandler.hpp in Headers */,
+				3C4C636B22F386AE0014D9AA /* OpNames.hpp in Headers */,
 				F5CF3B0B20C1E3C500DC1B2E /* FileAccessManifestParser.hpp in Headers */,
 				3C1D7C8C20C0262B0069CF65 /* cpu.h in Headers */,
+				3C4C636822F386AE0014D9AA /* Checkers.hpp in Headers */,
 				F5CF3B1420C1E40C00DC1B2E /* StringOperations.h in Headers */,
+				3CD0BB4122F2E035008C0AC9 /* AccessHandler.hpp in Headers */,
 				F5CF3B1D20C1F0F200DC1B2E /* FileAccessHelpers.h in Headers */,
 				3C1FD6D420D3F766007A0C1A /* process.h in Headers */,
+				3C3B60BA22F1DC6600130AB3 /* SandboxedProcess.hpp in Headers */,
+				3C3B60C922F1E2B400130AB3 /* Common.h in Headers */,
 				3C1D7C9320C03E830069CF65 /* Dependencies.h in Headers */,
+				3C3B60C322F1DEB200130AB3 /* KextSandbox.h in Headers */,
 				F588040520D03EB7006CF533 /* PolicyResult.h in Headers */,
 				F5CF3B1520C1E40C00DC1B2E /* DataTypes.h in Headers */,
-				3CF3734120C1897400D14240 /* Sandbox.h in Headers */,
+				3C3B60BC22F1DC9E00130AB3 /* SandboxedPip.hpp in Headers */,
 				3C1D7C9020C036850069CF65 /* memory.h in Headers */,
+				3C3B60C722F1E12C00130AB3 /* ESSandbox.h in Headers */,
 				F5CF3B0D20C1E3DC00DC1B2E /* BuildXLSandboxShared.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -399,17 +486,26 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3CD0BB4022F2E035008C0AC9 /* AccessHandler.cpp in Sources */,
+				3C4C636A22F386AE0014D9AA /* Checkers.cpp in Sources */,
+				3C4C636922F386AE0014D9AA /* OpNames.cpp in Sources */,
+				3C3B60B922F1DC6600130AB3 /* SandboxedProcess.cpp in Sources */,
+				3C3B60C422F1DEB400130AB3 /* KextSandbox.cpp in Sources */,
 				F58E920A220B5B750083C57E /* utf8proc.c in Sources */,
 				F58E920B220B5B750083C57E /* utf8proc_data.c in Sources */,
 				3C1D7C9120C036850069CF65 /* memory.c in Sources */,
-				3CF3734020C1897400D14240 /* Sandbox.cpp in Sources */,
+				3CD0BB4222F2E84A008C0AC9 /* IOHandler.cpp in Sources */,
+				3C3B60C822F1E14B00130AB3 /* ESSandbox.cpp in Sources */,
 				F5CF3B1720C1E40C00DC1B2E /* StringOperations.cpp in Sources */,
 				3C1D7C8D20C0262B0069CF65 /* cpu.c in Sources */,
 				3C80E70921347B9700ECBD6E /* io.c in Sources */,
 				3C1FD6D520D3F766007A0C1A /* process.c in Sources */,
+				3C3B60CA22F1E2BC00130AB3 /* Common.cpp in Sources */,
 				F5CF3B1620C1E40C00DC1B2E /* PolicySearch.cpp in Sources */,
+				3C3B60BB22F1DC9E00130AB3 /* SandboxedPip.cpp in Sources */,
 				F5CF3B0A20C1E3C500DC1B2E /* FileAccessManifestParser.cpp in Sources */,
 				F588040720D042FB006CF533 /* PolicyResult_common.cpp in Sources */,
+				3C3B60C122F1DE8D00130AB3 /* Trie.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -478,6 +574,7 @@
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
+					"_DEBUG=1",
 					"BUILDXL_BUNDLE_IDENTIFIER=$(BUILDXL_BUNDLE_IDENTIFIER)",
 					"BUILDXL_CLASS_PREFIX=$(BUILDXL_CLASS_PREFIX)",
 				);
@@ -535,8 +632,8 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
-					"NDEBUG=1",
 					"RELEASE=1",
+					"NDEBUG=1",
 					"BUILDXL_BUNDLE_IDENTIFIER=$(BUILDXL_BUNDLE_IDENTIFIER)",
 					"BUILDXL_CLASS_PREFIX=$(BUILDXL_CLASS_PREFIX)",
 				);
@@ -559,8 +656,11 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				EXECUTABLE_PREFIX = lib;
-				GCC_PREPROCESSOR_DEFINITIONS_NOT_USED_IN_PRECOMPS = (
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
 					"_DEBUG=1",
+					"BUILDXL_BUNDLE_IDENTIFIER=$(BUILDXL_BUNDLE_IDENTIFIER)",
+					"BUILDXL_CLASS_PREFIX=$(BUILDXL_CLASS_PREFIX)",
 					"MAC_OS_LIBRARY=1",
 				);
 				HEADER_SEARCH_PATHS = "";
@@ -578,7 +678,13 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				EXECUTABLE_PREFIX = lib;
-				GCC_PREPROCESSOR_DEFINITIONS_NOT_USED_IN_PRECOMPS = "MAC_OS_LIBRARY=1";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"RELEASE=1",
+					"NDEBUG=1",
+					"BUILDXL_BUNDLE_IDENTIFIER=$(BUILDXL_BUNDLE_IDENTIFIER)",
+					"BUILDXL_CLASS_PREFIX=$(BUILDXL_CLASS_PREFIX)",
+					"MAC_OS_LIBRARY=1",
+				);
 				HEADER_SEARCH_PATHS = "";
 				INSTALL_PATH = "@executable_path";
 				PRODUCT_NAME = BuildXLInterop;

--- a/Public/Src/Sandbox/MacOs/Interop/Sandbox/Common.cpp
+++ b/Public/Src/Sandbox/MacOs/Interop/Sandbox/Common.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "Common.h"
+
+#if !SB_MONITOR
+#include "KextSandbox.h"
+#include "ESSandbox.h"
+#endif
+
+os_log_t logger = os_log_create(kBuildXLBundleIdentifier, "Logger");
+
+extern "C"
+{
+    void SetLogger(os_log_t newLogger)
+    {
+        logger = newLogger;
+    }
+
+#pragma mark Pip status functions
+#if !SB_MONITOR
+    bool SendPipStarted(const pid_t processId, pipid_t pipId, const char *const famBytes, int famBytesLength, ConnectionType type, void *connection)
+    {
+        switch (type)
+        {
+            case Kext:
+            {
+                KextConnectionInfo *context = (KextConnectionInfo *) connection;
+                return KEXT_SendPipStarted(processId, pipId, famBytes, famBytesLength, *context);
+            }
+            case EndpointSecurity:
+                return ES_SendPipStarted(processId, pipId, famBytes, famBytesLength);
+        }
+    
+        return false;
+    }
+
+    bool SendPipProcessTerminated(pipid_t pipId, pid_t processId, ConnectionType type, void *connection)
+    {
+        switch (type)
+        {
+            case Kext:
+            {
+                KextConnectionInfo *context = (KextConnectionInfo *) connection;
+                return KEXT_SendPipProcessTerminated(pipId, processId, *context);
+            }
+            case EndpointSecurity:
+                return ES_SendPipProcessTerminated(pipId, processId);
+        }
+    
+        return false;
+    }
+#endif
+#pragma mark Exported interop functions
+
+    int NormalizePathAndReturnHash(const BYTE *path, BYTE *buffer, int bufferSize)
+    {
+        return NormalizeAndHashPath((PCPathChar)path, buffer, bufferSize);
+    }
+}

--- a/Public/Src/Sandbox/MacOs/Interop/Sandbox/Common.h
+++ b/Public/Src/Sandbox/MacOs/Interop/Sandbox/Common.h
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef Common_hpp
+#define Common_hpp
+
+#include "BuildXLSandboxShared.hpp"
+
+#define REPORT_QUEUE_SUCCESS                      0x1000
+#define REPORT_QUEUE_CONNECTION_ERROR             0x1001
+#define REPORT_QUEUE_DEQUEUE_ERROR                0x1002
+
+typedef enum {
+    Kext,
+    EndpointSecurity
+} ConnectionType;
+
+extern "C"
+{
+    void SetLogger(os_log_t newLogger);
+
+    /*!
+     * Normalized path is stored in 'buffer'.  That buffer must be 'bufferSize' bytes long.
+     *
+     * @param path Path to normalize and hash.
+     * @param buffer Buffer where the normalized path is stored.
+     * @param bufferSize The size of 'buffer' in bytes.
+     * @result Hash of the normalized path.
+     */
+    int NormalizePathAndReturnHash(const char *path, char *buffer, int bufferSize);
+
+    typedef void (__cdecl *AccessReportCallback)(AccessReport, int);
+
+    bool SendPipStarted(const pid_t processId, pipid_t pipId, const char *const famBytes, int famBytesLength, ConnectionType type, void *connection);
+    bool SendPipProcessTerminated(pipid_t pipId, pid_t processId, ConnectionType type, void *connection);
+};
+
+#endif /* Common_hpp */

--- a/Public/Src/Sandbox/MacOs/Interop/Sandbox/Data/SandboxedPip.cpp
+++ b/Public/Src/Sandbox/MacOs/Interop/Sandbox/Data/SandboxedPip.cpp
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "SandboxedPip.hpp"
+
+SandboxedPip::SandboxedPip(pid_t pid, const char *payload, size_t length)
+{
+    payload_ = (char *) malloc(length);
+    if (payload == NULL)
+    {
+        throw "Could not allocate memory for payload storage!";
+    }
+    
+    processId_ = pid;
+    processTreeCount_ = 1;
+    memcpy(payload_, payload, length);
+    fam_.init((BYTE*)payload_, length);
+    if (fam_.HasErrors())
+    {
+        throw "FileAccessManifest parsing exception";
+    }
+}
+
+SandboxedPip::~SandboxedPip()
+{
+    free(payload_);
+}
+

--- a/Public/Src/Sandbox/MacOs/Interop/Sandbox/Data/SandboxedPip.hpp
+++ b/Public/Src/Sandbox/MacOs/Interop/Sandbox/Data/SandboxedPip.hpp
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef SandboxedPip_hpp
+#define SandboxedPip_hpp
+
+#include "BuildXLSandboxShared.hpp"
+#include "FileAccessManifestParser.hpp"
+
+/*!
+ * Represents the root of the process tree being tracked.
+ *
+ * The 'Pip' name comes from the BuildXL terminology, where 'pip' is a generic build task
+ * that may spawn arbitrary number of child processes.
+ *
+ * Every pip comes with a 'FileAccessManifest' (FAM).  A FAM contains all the policies relevant
+ * for sandboxing a pip, e.g., which file accesses are permitted, which are not, which should
+ * be reported back, etc.
+ */
+class SandboxedPip
+{
+
+private:
+
+    /*! Process id of the root process of this pip. */
+    pid_t processId_;
+
+    /*! File access manifest payload bytes */
+    char *payload_;
+
+    /*! File access manifest (contains pointers into the 'payload_' byte array */
+    FileAccessManifestParseResult fam_;
+
+    /*! Number of processses in this pip's process tree */
+    _Atomic int processTreeCount_;
+
+public:
+
+    SandboxedPip() = delete;
+    SandboxedPip(pid_t pid, const char *payload, size_t length);
+    ~SandboxedPip();
+
+    /*! Process id of the root process of this pip. */
+    pid_t getProcessId() const { return processId_; }
+
+    /*! A unique identifier of this pip. */
+    pipid_t getPipId() const   { return fam_.GetPipId()->PipId; }
+
+    /*! File access manifest record for this pip (to be used for checking file accesses) */
+    PCManifestRecord getManifestRecord() const    { return fam_.GetUnixRootNode(); }
+
+    /*! File access manifest flags */
+    FileAccessManifestFlag getFamFlags() const    { return fam_.GetFamFlags(); }
+
+    /*!
+     * Returns the full path of the root process of this pip.
+     * The lenght of the path is stored in the 'length' argument because the path is not necessarily 0-terminated.
+     */
+    const char* getProcessPath(int *length) const { return fam_.GetProcessPath(length); }
+
+#pragma mark Process Tree Tracking
+
+    /*! Number of currently active processes in this pip's process tree */
+    int getTreeSize() const          { return processTreeCount_; }
+
+    /*! Atomically increments this pip's process tree size and returns the size before increment. */
+    int incrementProcessTreeCount() { return ++processTreeCount_; }
+
+    /*! Atomically dencrements this pip's process tree size and returns the size before decrement. */
+    int decrementProcessTreeCount() { return --processTreeCount_; }
+};
+
+#endif /* SandboxedPip_hpp */

--- a/Public/Src/Sandbox/MacOs/Interop/Sandbox/Data/SandboxedProcess.cpp
+++ b/Public/Src/Sandbox/MacOs/Interop/Sandbox/Data/SandboxedProcess.cpp
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "SandboxedProcess.hpp"
+#include <execinfo.h>
+#include <errno.h>
+
+static void full_write(int fd, const char *buf, size_t len)
+{
+        while (len > 0) {
+                ssize_t ret = write(fd, buf, len);
+
+                if ((ret == -1) && (errno != EINTR))
+                        break;
+
+                buf += (size_t) ret;
+                len -= (size_t) ret;
+        }
+}
+
+void print_backtrace(void)
+{
+        static const char start[] = "BACKTRACE ------------\n";
+        static const char end[] = "----------------------\n";
+
+        void *bt[1024];
+        int bt_size;
+        char **bt_syms;
+        int i;
+
+        bt_size = backtrace(bt, 1024);
+        bt_syms = backtrace_symbols(bt, bt_size);
+        full_write(STDERR_FILENO, start, strlen(start));
+        for (i = 1; i < bt_size; i++) {
+                size_t len = strlen(bt_syms[i]);
+                full_write(STDERR_FILENO, bt_syms[i], len);
+                full_write(STDERR_FILENO, "\n", 1);
+        }
+        full_write(STDERR_FILENO, end, strlen(end));
+    free(bt_syms);
+}
+
+SandboxedProcess::SandboxedProcess(pid_t processId, SandboxedPip *pip)
+{
+    assert(pip != nullptr);
+    pip_ = pip;
+    id_  = processId;
+
+    bzero(path_, sizeof(path_));
+    pathLength_ = 0;
+
+    if (pip_ == nullptr)
+    {
+        throw "No valid SandboxedPip provided on SandboxedProcess construction!";
+    }
+}
+
+SandboxedProcess::~SandboxedProcess()
+{
+    print_backtrace();
+    log("Releasing process object %d (%#llX) - freed from %{public}s", id_, pip_->getPipId(),  __FUNCTION__);
+    if (pip_ != nullptr) delete pip_;
+}

--- a/Public/Src/Sandbox/MacOs/Interop/Sandbox/Data/SandboxedProcess.hpp
+++ b/Public/Src/Sandbox/MacOs/Interop/Sandbox/Data/SandboxedProcess.hpp
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef SandboxedProcess_hpp
+#define SandboxedProcess_hpp
+
+#include "SandboxedPip.hpp"
+
+/*!
+ * Represents a process being tracked.
+ *
+ * A process always has a pointer to a pip it belongs to.  Additionally, it stores
+ * its Process ID as well as the full path to its executable.
+ *
+ * Process path is updated every time the process performs the 'exec' system call.
+ * When a process forks, the child process inherits the path from its parent.
+ */
+class SandboxedProcess
+{
+private:
+
+    /*! The pip this process belongs to. */
+    SandboxedPip *pip_;
+
+    /*! PID */
+    pid_t id_;
+
+    /*! Full path to this process' executable */
+    char path_[PATH_MAX];
+
+    /*! The length of the path stored in 'path_' */
+    int pathLength_;
+
+public:
+    
+    SandboxedProcess() = delete;
+    SandboxedProcess(pid_t processId, SandboxedPip *pip);
+    ~SandboxedProcess();
+
+    /*! The pip this process belongs to */
+    SandboxedPip* getPip() const                                { return pip_; }
+
+    /*! Process ID of this process */
+    inline pid_t getPid() const                                 { return id_; }
+
+    /*! Returns whether a full path has been set */
+    inline bool hasPath() const                                 { return path_[0] == '/'; }
+
+    /*! 0-terminated full path to the executable file of this process */
+    inline const char* getPath() const                          { return path_; }
+
+    /*! Copies the 0-terminated string in 'path' to its own path buffer. */
+    inline void setPath(const char *path, size_t len = PATH_MAX)   { strlcpy(path_, path, len); }
+
+    /*! An alternative to 'setPath': returns a buffer to which the caller can set the path. */
+    inline char* getPathBuffer()                                { return path_; }
+};
+
+#endif /* SandboxedProcess_hpp */

--- a/Public/Src/Sandbox/MacOs/Interop/Sandbox/Data/Trie.cpp
+++ b/Public/Src/Sandbox/MacOs/Interop/Sandbox/Data/Trie.cpp
@@ -1,0 +1,657 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "Trie.hpp"
+
+_Atomic uint Node::s_numUintNodes = 0;
+_Atomic uint Node::s_numPathNodes = 0;
+
+Node::Node(uint numChildren)
+{
+    if (numChildren == s_uintNodeChildrenCount) ++s_numUintNodes;
+    else if (numChildren == s_pathNodeChildrenCount) ++s_numPathNodes;
+
+    record_ = nullptr;
+    childrenLength_ = numChildren;
+    
+    children_ = (Node **) malloc(numChildren * sizeof(Node *));
+
+    for (int i = 0; i < childrenLength_; i++)
+    {
+        children_[i] = nullptr;
+    }
+}
+
+Node::~Node()
+{
+    for (int i = 0; i < childrenLength_; i++)
+    {
+        children_[i] = nullptr;
+    }
+
+    free(children_);
+    children_ = nullptr;
+
+    if (record_ != nullptr) delete record_;
+
+    if (length() == s_uintNodeChildrenCount) --s_numUintNodes;
+    else if (length() == s_pathNodeChildrenCount) --s_numPathNodes;
+}
+
+// ================================== class Trie ==================================
+
+Trie::Trie(TrieKind kind)
+{
+    kind_ = kind;
+    root_ = createNode();
+    if (root_ == nullptr)
+    {
+        throw "Trie creation failed as no root node could be allocated!";
+    }
+}
+
+Trie::~Trie()
+{
+    traverse(/*computeKey*/ false, /*callbackArgs*/ nullptr, [](Trie*, void*, uint64_t, Node *node)
+    {
+        delete node;
+    });
+
+    root_ = nullptr;
+    size_ = 0;
+}
+
+bool Trie::findChildNode(Node *node, int idx, bool createIfMissing)
+{
+    if (idx < 0 || idx >= node->length())
+    {
+        return false;
+    }
+
+    bool childNodeExists = node->children()[idx] != nullptr;
+
+    if (childNodeExists)
+    {
+        return true;
+    }
+
+    // child is missing
+    if (!createIfMissing)
+    {
+        return false;
+    }
+
+    Node* newNode = createNode();
+
+    // This should never happen except if we run out of memory.
+    if (newNode == nullptr)
+    {
+        return false;
+    }
+    
+    // TODO: Make thread safe!
+    node->children()[idx] = newNode;
+
+    return true;
+}
+
+Trie::TrieResult Trie::makeSentinel(Node *node, SandboxedProcess *record)
+{
+    // if this is a sentinel node --> nothing to do
+    if (node->record_ != nullptr)
+    {
+        return kTrieResultAlreadyExists;
+    }
+
+    SandboxedProcess *newRecord = record;
+    if (newRecord == nullptr)
+    {
+        return kTrieResultAlreadyExists;
+    }
+    
+    if (node->record_ != nullptr)
+    {
+//        delete newRecord;
+        return kTrieResultAlreadyExists;
+    }
+    
+    // TODO: Make thread safe!
+    node->record_ = newRecord;
+    int oldCount = (++size_);
+    triggerOnChange(oldCount, oldCount + 1);
+    
+    return kTrieResultInserted;
+}
+
+SandboxedProcess* Trie::get(Node *node)
+{
+    return node != nullptr ? node->record_ : nullptr;
+}
+
+SandboxedProcess* Trie::getOrAdd(Node *node, SandboxedProcess *record, TrieResult *result)
+{
+    if (node == nullptr) return nullptr;
+    auto sentinelResult = makeSentinel(node, record);
+    if (result) *result = sentinelResult;
+ 
+    return node->record_;
+}
+
+Trie::TrieResult Trie::replace(Node *node, const SandboxedProcess *value)
+{
+    if (node == nullptr || value == nullptr)
+    {
+        return kTrieResultFailure;
+    }
+
+    SandboxedProcess *previousValue = node->record_;
+    
+    if (previousValue != nullptr)
+    {
+        node->record_ = (SandboxedProcess *) value;
+//        delete previousValue;
+        
+        return kTrieResultReplaced;
+    }
+    else
+    {
+        node->record_ = (SandboxedProcess *) value;
+        
+        int oldCount = (++size_);
+        triggerOnChange(oldCount, oldCount + 1);
+        
+        return kTrieResultInserted;
+    }
+}
+
+Trie::TrieResult Trie::insert(Node *node, const SandboxedProcess *value)
+{
+    if (node == nullptr || value == nullptr)
+    {
+        return kTrieResultFailure;
+    }
+    
+    if (node->record_ != nullptr) return kTrieResultAlreadyExists;
+    
+    node->record_ = (SandboxedProcess *) value;
+    int oldCount = (++size_);
+    triggerOnChange(oldCount, oldCount + 1);
+    
+    return kTrieResultInserted;
+}
+
+Trie::TrieResult Trie::remove(Node *node)
+{
+    if (node == nullptr || node->record_ == nullptr)
+    {
+        return kTrieResultAlreadyEmpty;
+    }
+
+    SandboxedProcess *previousValue = node->record_;
+    
+    if (previousValue != nullptr)
+    {
+        node->record_ = nullptr;
+//        delete previousValue;
+        
+        int oldCount = (--size_);
+        triggerOnChange(oldCount, oldCount - 1);
+        
+        return kTrieResultRemoved;
+    }
+    
+    return kTrieResultFailure;
+}
+
+/*
+ * Code used to generate this array:
+
+ printf("static int s_char2idx[] = \n");
+ printf("{\n");
+ for (int ch = 0; ch < 256; ch++)
+ {
+     int idx = toupper(ch) - 32;
+     if (idx < 0 || idx >= 65) idx = -1;
+     printf("    %2d, // '%c' (\\%2d)\n", idx, ch < 32 || ch > 126 ? 0 : ch, ch);
+ }
+ printf("};\n");
+ */
+static int s_char2idx[256] =
+{
+    -1, // '' (\0)
+    -1, // '' (\1)
+    -1, // '' (\2)
+    -1, // '' (\3)
+    -1, // '' (\4)
+    -1, // '' (\5)
+    -1, // '' (\6)
+    -1, // '' (\7)
+    -1, // '' (\8)
+    -1, // '' (\9)
+    -1, // '' (\10)
+    -1, // '' (\11)
+    -1, // '' (\12)
+    -1, // '' (\13)
+    -1, // '' (\14)
+    -1, // '' (\15)
+    -1, // '' (\16)
+    -1, // '' (\17)
+    -1, // '' (\18)
+    -1, // '' (\19)
+    -1, // '' (\20)
+    -1, // '' (\21)
+    -1, // '' (\22)
+    -1, // '' (\23)
+    -1, // '' (\24)
+    -1, // '' (\25)
+    -1, // '' (\26)
+    -1, // '' (\27)
+    -1, // '' (\28)
+    -1, // '' (\29)
+    -1, // '' (\30)
+    -1, // '' (\31)
+    0, // ' ' (\32)
+    1, // '!' (\33)
+    2, // '"' (\34)
+    3, // '#' (\35)
+    4, // '$' (\36)
+    5, // '%' (\37)
+    6, // '&' (\38)
+    7, // ''' (\39)
+    8, // '(' (\40)
+    9, // ')' (\41)
+    10, // '*' (\42)
+    11, // '+' (\43)
+    12, // ',' (\44)
+    13, // '-' (\45)
+    14, // '.' (\46)
+    15, // '/' (\47)
+    16, // '0' (\48)
+    17, // '1' (\49)
+    18, // '2' (\50)
+    19, // '3' (\51)
+    20, // '4' (\52)
+    21, // '5' (\53)
+    22, // '6' (\54)
+    23, // '7' (\55)
+    24, // '8' (\56)
+    25, // '9' (\57)
+    26, // ':' (\58)
+    27, // ';' (\59)
+    28, // '<' (\60)
+    29, // '=' (\61)
+    30, // '>' (\62)
+    31, // '?' (\63)
+    32, // '@' (\64)
+    33, // 'A' (\65)
+    34, // 'B' (\66)
+    35, // 'C' (\67)
+    36, // 'D' (\68)
+    37, // 'E' (\69)
+    38, // 'F' (\70)
+    39, // 'G' (\71)
+    40, // 'H' (\72)
+    41, // 'I' (\73)
+    42, // 'J' (\74)
+    43, // 'K' (\75)
+    44, // 'L' (\76)
+    45, // 'M' (\77)
+    46, // 'N' (\78)
+    47, // 'O' (\79)
+    48, // 'P' (\80)
+    49, // 'Q' (\81)
+    50, // 'R' (\82)
+    51, // 'S' (\83)
+    52, // 'T' (\84)
+    53, // 'U' (\85)
+    54, // 'V' (\86)
+    55, // 'W' (\87)
+    56, // 'X' (\88)
+    57, // 'Y' (\89)
+    58, // 'Z' (\90)
+    59, // '[' (\91)
+    60, // '\' (\92)
+    61, // ']' (\93)
+    62, // '^' (\94)
+    63, // '_' (\95)
+    64, // '`' (\96)
+    33, // 'a' (\97)
+    34, // 'b' (\98)
+    35, // 'c' (\99)
+    36, // 'd' (\100)
+    37, // 'e' (\101)
+    38, // 'f' (\102)
+    39, // 'g' (\103)
+    40, // 'h' (\104)
+    41, // 'i' (\105)
+    42, // 'j' (\106)
+    43, // 'k' (\107)
+    44, // 'l' (\108)
+    45, // 'm' (\109)
+    46, // 'n' (\110)
+    47, // 'o' (\111)
+    48, // 'p' (\112)
+    49, // 'q' (\113)
+    50, // 'r' (\114)
+    51, // 's' (\115)
+    52, // 't' (\116)
+    53, // 'u' (\117)
+    54, // 'v' (\118)
+    55, // 'w' (\119)
+    56, // 'x' (\120)
+    57, // 'y' (\121)
+    58, // 'z' (\122)
+    -1, // '{' (\123)
+    -1, // '|' (\124)
+    -1, // '}' (\125)
+    -1, // '~' (\126)
+    -1, // '' (\127)
+    -1, // '' (\128)
+    -1, // '' (\129)
+    -1, // '' (\130)
+    -1, // '' (\131)
+    -1, // '' (\132)
+    -1, // '' (\133)
+    -1, // '' (\134)
+    -1, // '' (\135)
+    -1, // '' (\136)
+    -1, // '' (\137)
+    -1, // '' (\138)
+    -1, // '' (\139)
+    -1, // '' (\140)
+    -1, // '' (\141)
+    -1, // '' (\142)
+    -1, // '' (\143)
+    -1, // '' (\144)
+    -1, // '' (\145)
+    -1, // '' (\146)
+    -1, // '' (\147)
+    -1, // '' (\148)
+    -1, // '' (\149)
+    -1, // '' (\150)
+    -1, // '' (\151)
+    -1, // '' (\152)
+    -1, // '' (\153)
+    -1, // '' (\154)
+    -1, // '' (\155)
+    -1, // '' (\156)
+    -1, // '' (\157)
+    -1, // '' (\158)
+    -1, // '' (\159)
+    -1, // '' (\160)
+    -1, // '' (\161)
+    -1, // '' (\162)
+    -1, // '' (\163)
+    -1, // '' (\164)
+    -1, // '' (\165)
+    -1, // '' (\166)
+    -1, // '' (\167)
+    -1, // '' (\168)
+    -1, // '' (\169)
+    -1, // '' (\170)
+    -1, // '' (\171)
+    -1, // '' (\172)
+    -1, // '' (\173)
+    -1, // '' (\174)
+    -1, // '' (\175)
+    -1, // '' (\176)
+    -1, // '' (\177)
+    -1, // '' (\178)
+    -1, // '' (\179)
+    -1, // '' (\180)
+    -1, // '' (\181)
+    -1, // '' (\182)
+    -1, // '' (\183)
+    -1, // '' (\184)
+    -1, // '' (\185)
+    -1, // '' (\186)
+    -1, // '' (\187)
+    -1, // '' (\188)
+    -1, // '' (\189)
+    -1, // '' (\190)
+    -1, // '' (\191)
+    -1, // '' (\192)
+    -1, // '' (\193)
+    -1, // '' (\194)
+    -1, // '' (\195)
+    -1, // '' (\196)
+    -1, // '' (\197)
+    -1, // '' (\198)
+    -1, // '' (\199)
+    -1, // '' (\200)
+    -1, // '' (\201)
+    -1, // '' (\202)
+    -1, // '' (\203)
+    -1, // '' (\204)
+    -1, // '' (\205)
+    -1, // '' (\206)
+    -1, // '' (\207)
+    -1, // '' (\208)
+    -1, // '' (\209)
+    -1, // '' (\210)
+    -1, // '' (\211)
+    -1, // '' (\212)
+    -1, // '' (\213)
+    -1, // '' (\214)
+    -1, // '' (\215)
+    -1, // '' (\216)
+    -1, // '' (\217)
+    -1, // '' (\218)
+    -1, // '' (\219)
+    -1, // '' (\220)
+    -1, // '' (\221)
+    -1, // '' (\222)
+    -1, // '' (\223)
+    -1, // '' (\224)
+    -1, // '' (\225)
+    -1, // '' (\226)
+    -1, // '' (\227)
+    -1, // '' (\228)
+    -1, // '' (\229)
+    -1, // '' (\230)
+    -1, // '' (\231)
+    -1, // '' (\232)
+    -1, // '' (\233)
+    -1, // '' (\234)
+    -1, // '' (\235)
+    -1, // '' (\236)
+    -1, // '' (\237)
+    -1, // '' (\238)
+    -1, // '' (\239)
+    -1, // '' (\240)
+    -1, // '' (\241)
+    -1, // '' (\242)
+    -1, // '' (\243)
+    -1, // '' (\244)
+    -1, // '' (\245)
+    -1, // '' (\246)
+    -1, // '' (\247)
+    -1, // '' (\248)
+    -1, // '' (\249)
+    -1, // '' (\250)
+    -1, // '' (\251)
+    -1, // '' (\252)
+    -1, // '' (\253)
+    -1, // '' (\254)
+    -1, // '' (\255)
+};
+
+static_assert(CHAR_BIT == 8, "char is not 8 bits long");
+static_assert(UCHAR_MAX == 255, "max unsigned char is not 255");
+
+Node* Trie::findPathNode(const char *path, bool createIfMissing)
+{
+    Node *currNode = root_;
+    unsigned char ch;
+    while ((ch = *path++) != '\0')
+    {
+        int idx = s_char2idx[ch];
+        if (!findChildNode(currNode, idx, createIfMissing))
+        {
+            return nullptr;
+        }
+        currNode = currNode->children()[idx];
+    }
+
+    return currNode;
+}
+
+Node* Trie::findUintNode(uint64_t key, bool createIfMissing)
+{
+    Node *currNode = root_;
+    
+    while (true)
+    {
+        assert(currNode->length() == 10);
+
+        int lsd = key % 10;
+
+        if (!findChildNode(currNode, lsd, createIfMissing))
+        {
+            return nullptr;
+        }
+
+        currNode = currNode->children()[lsd];
+
+        if (key < 10)
+        {
+            break;
+        }
+
+        key = key / 10;
+    }
+
+    return currNode;
+}
+
+bool Trie::onChange(void *callbackArgs, on_change_fn callback)
+{
+    if (onChangeCallback_) return false;
+    
+    onChangeData_ = callbackArgs;
+    onChangeCallback_ = callback;
+    return true;
+}
+
+void Trie::triggerOnChange(int oldCount, int newCount) const
+{
+    if (onChangeCallback_) return;
+    
+    if (onChangeCallback_ && oldCount != newCount)
+    {
+        onChangeCallback_(onChangeData_, oldCount, newCount);
+    }
+}
+
+void Trie::forEach(void *callbackArgs, for_each_fn callback)
+{
+    typedef struct { for_each_fn callback; void *args; } State;
+    State state = { .callback = callback, .args = callbackArgs };
+    traverse(/*computeKey*/ kind_ == kUintTrie, /*callbackArgs*/ &state, [](Trie *me, void *s, uint64_t key, Node *node)
+             {
+                 State *state = (State*)s;
+                 SandboxedProcess *record = node->record_;
+                 if (record)
+                 {
+//                     record->retain();
+                     state->callback(state->args, key, record);
+//                     record->release();
+                 }
+             });
+}
+
+void Trie::removeMatching(void *filterArgs, filter_fn filter)
+{
+    typedef struct { filter_fn filter; void *args; } State;
+    State state = { .filter = filter, .args = filterArgs };
+    traverse(/*computeKey*/ false, /*callbackArgs*/ &state, [](Trie *me, void *s, uint64_t, Node *node)
+    {
+        State *state = (State*)s;
+        SandboxedProcess *record = node->record_;
+        if (record)
+        {
+//            record->retain();
+            if (state->filter(state->args, record))
+            {
+                me->remove(node);
+            }
+//            record->release();
+        }
+    });
+}
+
+typedef struct Stack {
+    Node *node;
+    Stack *next;
+    uint32_t depth;
+    uint64_t key;
+} Stack;
+
+static void push(Stack **stack, Node *node, uint64_t path, uint32_t depth)
+{
+    if (node == nullptr) return;
+
+    Stack *top = new Stack();
+    top->node  = node;
+    top->next  = *stack;
+    top->key   = path;
+    top->depth = depth;
+
+    *stack = top;
+}
+
+static Node* pop(Stack **stack)
+{
+    Stack *top = *stack;
+    *stack = top->next;
+    Node *node = top->node;
+    delete top;
+    return node;
+}
+
+static uint64_t s_pow10[] =
+{
+    1,
+    10,
+    100,
+    1000,
+    10000,
+    100000,
+    1000000,
+    10000000,
+    100000000,
+    1000000000,
+    10000000000,
+    100000000000,
+    1000000000000
+};
+
+static int s_powLen = sizeof(s_pow10)/sizeof(s_pow10[0]);
+
+static uint64_t pow10(int exp)
+{
+    if (exp < s_powLen) return s_pow10[exp];
+    uint64_t result = 1;
+    while (--exp >= 0) result *= 10;
+    return result;
+}
+
+void Trie::traverse(bool computeKey, void *callbackArgs, traverse_fn callback)
+{
+    Stack *stack = nullptr;
+    push(&stack, root_, /*key*/ 0, /*depth*/ 0);
+    while (stack != nullptr)
+    {
+        uint64_t key = stack->key;
+        uint32_t depth = stack->depth;
+
+        Node *curr = pop(&stack);
+        for (int i = 0; i < curr->length(); ++i)
+        {
+            push(&stack, curr->children()[i], computeKey ? (i * pow10(depth) + key) : 0, depth + 1);
+        }
+
+        // the callback may deallocate 'curr' node, hence this must be the last statement in this loop
+        callback(this, callbackArgs, key, curr);
+    }
+}

--- a/Public/Src/Sandbox/MacOs/Interop/Sandbox/Data/Trie.hpp
+++ b/Public/Src/Sandbox/MacOs/Interop/Sandbox/Data/Trie.hpp
@@ -1,0 +1,366 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef Trie_hpp
+#define Trie_hpp
+
+#include "SandboxedProcess.hpp"
+
+/*!
+ * A node in a Trie.
+ * Only accessible to its friend class Trie.
+ */
+class Node
+{
+private:
+
+    friend class Trie;
+
+    _Atomic static uint s_numUintNodes;
+    _Atomic static uint s_numPathNodes;
+
+    /*!
+     * The value 65 is chosen so that all ASCII characters between 32 (' ') and 122 ('z')
+     * get a unique entry in the 'children_' array.  The formula for mapping a character
+     * ch to an array index is:
+     *
+     *   toupper(ch) - 32
+     */
+    static const uint s_pathNodeChildrenCount = 65;
+
+    /*! For 10 digits */
+    static const uint s_uintNodeChildrenCount = 10;
+
+    /*! Arbitrary value */
+    SandboxedProcess *record_;
+
+    /*! The length of the 'children_' array (i.e., the the number of allocated nodes) */
+    uint childrenLength_;
+
+    /*! Pre-allocated pointers to all possible children nodes. */
+    Node **children_;
+
+    uint length()     const { return childrenLength_; }
+    Node** children() const { return children_; }
+    
+    static Node* createUintNode() { return new Node(s_uintNodeChildrenCount); }
+    static Node* createPathNode() { return new Node(s_pathNodeChildrenCount); }
+    
+public:
+    
+    Node() = delete;
+    Node(uint numChildren);
+    ~Node();
+};
+
+// ================================== class Trie ==================================
+
+/*!
+ * A thread-safe, lock-free, dictionary implementation.
+ *
+ * Only 2 types of keys are allowed: (1) an unsigned integer, and (2) an ascii path.
+ *
+ * A value must be a pointer to an arbitrary OSObject.  Once an OSObject is added
+ * to this trie, it is automatically retained by this trie; once it is removed, it is
+ * automatically released by this trie; this is analogous to how OSDictionary works.
+ *
+ * Paths are considered case-insensitive.  Attempting to add a path with a non-ascii
+ * character will fail gracefully by returning 'kTrieResultFailure'.
+ *
+ * Thread-safe.  Non-blocking.
+ */
+class Trie
+{
+public:
+
+    typedef void (*on_change_fn)(void *data, const int oldCount, const int newCount);
+    typedef void (*for_each_fn)(void *data, uint64_t key, const SandboxedProcess *value);
+    typedef bool (*filter_fn)(void *data, const SandboxedProcess *value);
+
+    typedef enum {
+        kTrieResultInserted,
+        kTrieResultReplaced,
+        kTrieResultRemoved,
+        kTrieResultAlreadyEmpty,
+        kTrieResultAlreadyExists,
+        kTrieResultRace,
+        kTrieResultFailure,
+    } TrieResult;
+
+    static void getUintNodeCounts(uint *count, double *sizeMB)
+    {
+        getNodeCounts(Node::s_numUintNodes, Node::s_uintNodeChildrenCount, count, sizeMB);
+    }
+
+    static void getPathNodeCounts(uint *count, double *sizeMB)
+    {
+        getNodeCounts(Node::s_numPathNodes, Node::s_pathNodeChildrenCount, count, sizeMB);
+    }
+
+private:
+
+    static const uint BytesInAMegabyte = 1 << 20;
+
+    static void getNodeCounts(uint count, uint numChildren, uint *outCount, double *outSizeMB)
+    {
+        *outCount = count;
+        *outSizeMB = (1.0 * count * (sizeof(Node) + numChildren * sizeof(Node*))) / BytesInAMegabyte;
+    }
+
+    typedef enum { kUintTrie, kPathTrie } TrieKind;
+    typedef void (*traverse_fn)(Trie*, void*, uint64_t key, Node*);
+
+    /*! The root of the tree. */
+    Node *root_;
+
+    /*! The kind of keys this tree accepts */
+    TrieKind kind_;
+
+    /*! This is the size of the tree (i.e., number of values stored) and not the number of nodes in the tree. */
+    _Atomic uint size_;
+
+    /*! Callback function (and associated payload) to call whenever count changes. */
+    on_change_fn onChangeCallback_;
+
+    /*! Payload for the 'onChangeCallback_' function */
+    void *onChangeData_;
+
+    /*! Invokes the 'onChangeCallback_' if it's set and 'newCount' is different from 'oldCount' */
+    void triggerOnChange(int oldCount, int newCount) const;
+
+    /*!
+     * Checks if a child node of 'node' exists at position 'idx'.
+     * If no such child node exists and 'createIfMissing' is true,
+     * a new child node is created and saved at position 'idx'.
+     *
+     * @param node The parent node.  Must not be null.
+     * @param idx Must be between 0 (inclusive) and 'node.length()' (exclusive); otherwise this method returns false.
+     * @param createIfMissing When true, this method creates a new child node at position 'idx' if one doesn't already exist.
+     * @result True IFF 'node' contains a child node at position 'idx' after this method returns.
+     */
+    bool findChildNode(Node *node, int idx, bool createIfMissing);
+
+    /*!
+     * Ensures that 'node' has its 'record_' field set to a non-null value.
+     * If not already set, uses the 'factory' function to create a new value and assign it to the 'record_' field.
+     *
+     * @param node The node that must become sentinel.
+     * @param record The object to use to set the sentinel record to
+     * @result
+     *    - kTrieResultAlreadyExists : if 'node' already has a record
+     *    - kTrieResultInserted      : if a new record was created and assigned to 'node'.
+     */
+    TrieResult makeSentinel(Node *node, SandboxedProcess *record);
+
+    /*!
+     * Returns the record already assigned to 'node' or, if no record is assigned to it, creates a new one by invoking
+     * 'factory', assigns it to 'node', and returns it.
+     *
+     * IMPORTANT: The caller must not assume that 'factory' is invoked IFF its return value is assigned to 'node'.
+     *            It is possible that 'factory' is invoked, but due to a race some other record gets assigned to this
+     *            node first; in that case, the OSObject returned by 'factory' is released and simply ignored.
+     *
+     * @result The record associated with 'node' or NULL if 'node' is NULL.
+     */
+    SandboxedProcess* getOrAdd(Node *node, SandboxedProcess *records, TrieResult *result);
+
+    /*!
+     * Returns the record associated with 'node' or NULL if either 'node' is NULL or no record is associated with it.
+     */
+    SandboxedProcess* get(Node *node);
+
+    /*!
+     * Attempts to associate 'value' with 'node', even if there is already a value associated with 'node'.
+     *
+     * If either 'node' or 'value' is NULL, the result is 'kTrieResultFailure'.
+     *
+     * If 'value' has been associated with 'node' and there wasn't a record previously associated with 'node':
+     * retains 'value', increments size, and returns 'kTrieResultInserted'.
+     *
+     * If 'value' has been associated with 'node' and there was a record previously associated with 'node':
+     * retains 'value', releases the previous record, and returns 'kTrieResultReplaced'.
+     *
+     * If 'value' has not beed associated with 'node' because there was a race (i.e., someone else associated a
+     * different record first), it does nothing and returns 'kTrieResultRace'.  The caller should decide whether to
+     * retry or accept the existing outcome.
+     *
+     * @result kTrieResultInserted, kTrieResultReplaced, kTrieResultRace, or kTrieResultFailure
+     */
+    TrieResult replace(Node *node, const SandboxedProcess *value);
+
+    /*!
+     * Attempts to associate 'value' with 'node', ONLY if no value is already associated with 'node'.
+     *
+     * If either 'node' or 'value' is NULL, the result is 'kTrieResultFailure'.
+     *
+     * @result kTrieResultInserted, kTrieResultAlreadyExists, or kTrieResultFailure
+     */
+    TrieResult insert(Node *node, const SandboxedProcess *value);
+
+    /*!
+     * Attempts to remove any record currently associated with 'node'.
+     *
+     * If 'node' is NULL, returns 'kTrieResultFailure'.
+     *
+     * If no record is currently associated with 'node', returns 'kTrieResultAlreadyEmpty'.
+     *
+     * If there is a record currently associated with 'node', it releases that record, decrements the size, and
+     * returns 'kTrieResultRemoved'.
+     *
+     * If there is a record currently associated with 'node' but it gets changed in the middle of this method,
+     * this method simply returns 'kTrieResultRace'; the caller should decide whether to retry the operation or accept
+     * the existing outcome.
+     */
+    TrieResult remove(Node *node);
+
+    /*! Calls 'callback' for every node in the trie during a pre-order traversal. */
+    void traverse(bool computeKey, void *callbackArgs, traverse_fn callback);
+
+    /*!
+     * When 'createIfMissing' is true:
+     *   traverses the trie until it gets to the node corresponding to the given 'key', creating new nodes as necessary
+     * else:
+     *   returns the node corresponding to the given 'key' IFF such node already exists, or NULL otherwise.
+     */
+    Node* findUintNode(uint64_t key, bool createIfMissing);
+
+    /*! Calls 'findUintNode' with 'createIfMissing' set to true. */
+    Node* findOrCreateNodeForUint(uint64_t key) { return findUintNode(key, true); }
+
+    /*! Calls 'findUintNode' with 'createIfMissing' set to false. */
+    Node* findExistingNodeForUint(uint64_t key) { return findUintNode(key, false); }
+
+    /*!
+     * When 'createIfMissing' is true:
+     *   traverses the trie until it gets to the node corresponding to the given 'key', creating new nodes as necessary
+     * else:
+     *   returns the node corresponding to the given 'key' IFF such node already exists, or NULL otherwise.
+     *
+     * NULL is also returned when the key is invalid (contains non-ascii characters) or the system is out of memory.
+     */
+    Node* findPathNode(const char *key, bool createIfMissing);
+
+    /*! Calls 'findPathNode' with 'createIfMissing' set to true. */
+    Node* findOrCreateNodeForPath(const char *key) { return findPathNode(key, true); }
+
+    /*! Calls 'findPathNode' with 'createIfMissing' set to false. */
+    Node* findExistingNodeForPath(const char *key) { return findPathNode(key, false); }
+
+    /*! Creates either a Uint or a Path node, based on the kind of this trie. */
+    Node* createNode()
+    {
+        return kind_ == kUintTrie ? Node::createUintNode() :
+               kind_ == kPathTrie ? Node::createPathNode() :
+               nullptr;
+    }
+
+public:
+
+    Trie() = delete;
+    Trie(TrieKind kind);
+    ~Trie();
+    
+    /*!
+     * Returns the size of the tree (i.e., the number of values stored).
+     */
+    inline uint getCount() { return size_; }
+
+    /*!
+     * Callback to be invoked every time the size of this tree changes.
+     */
+    bool onChange(void *callbackArgs, on_change_fn callback);
+
+    /*!
+     * Invokes a given callback for every entry in this dictionary.
+     *
+     * @param callbackArgs Arbitrary pointer passed to 'callback'
+     * @param callback Callback function to call for each entry in this dictionary
+     */
+    void forEach(void *callbackArgs, for_each_fn callback);
+
+    /*!
+     * Removes all the entries matching a given filter.
+     */
+    void removeMatching(void *filterArgs, filter_fn filter);
+
+#pragma mark Methods for 'path' keys
+
+    SandboxedProcess* get(const char *path)
+    {
+        if (kind_ != kPathTrie) return nullptr;
+        return get(findExistingNodeForPath(path));
+    }
+
+    /*!
+     * If 'path' hasn't been seen before: creates a new value (using the supplied factory function),
+     * associates it with 'path', and returns it; otherwise, returns the 'OSObject' object previously
+     * associated with 'path'.
+     *
+     * Paths are considered case-insensitive.
+     *
+     * NOTE: The current implementation only paths containig only ASCII characters; for all other paths
+     *       nullptr is returned indicating that the path couldn't be added.
+     */
+    SandboxedProcess* getOrAdd(const char *path, SandboxedProcess *record, TrieResult *result = nullptr)
+    {
+        if (kind_ != kPathTrie) return nullptr;
+        return getOrAdd(findOrCreateNodeForPath(path), record, result);
+    }
+
+    TrieResult replace(const char *path, const SandboxedProcess *value)
+    {
+        if (kind_ != kPathTrie) return kTrieResultFailure;
+        return replace(findOrCreateNodeForPath(path), value);
+    }
+
+    TrieResult insert(const char *path, const SandboxedProcess *value)
+    {
+        if (kind_ != kPathTrie) return kTrieResultFailure;
+        return insert(findOrCreateNodeForPath(path), value);
+    }
+
+    TrieResult remove(const char *key)
+    {
+        if (kind_ != kPathTrie) return kTrieResultFailure;
+        return remove(findExistingNodeForPath(key));
+    }
+
+#pragma mark Methods for 'uint' keys
+
+    SandboxedProcess* get(uint64_t key)
+    {
+        if (kind_ != kUintTrie) return nullptr;
+        return get(findExistingNodeForUint(key));
+    }
+
+    SandboxedProcess* getOrAdd(uint64_t key, SandboxedProcess *record, TrieResult *result = nullptr)
+    {
+        if (kind_ != kUintTrie) return nullptr;
+        return getOrAdd(findOrCreateNodeForUint(key), record, result);
+    }
+
+    TrieResult replace(uint64_t key, const SandboxedProcess *value)
+    {
+        if (kind_ != kUintTrie) return kTrieResultFailure;
+        return replace(findOrCreateNodeForUint(key), value);
+    }
+
+    TrieResult insert(uint64_t key, const SandboxedProcess *value)
+    {
+        if (kind_ != kUintTrie) return kTrieResultFailure;
+        return insert(findOrCreateNodeForUint(key), value);
+    }
+
+    TrieResult remove(uint64_t key)
+    {
+        if (kind_ != kUintTrie) return kTrieResultFailure;
+        return remove(findExistingNodeForUint(key));
+    }
+
+#pragma mark Static factory methods
+
+    static Trie* createUintTrie() { return new Trie(kUintTrie); }
+    static Trie* createPathTrie() { return  new Trie(kPathTrie); }
+};
+
+#endif /* Trie_hpp */

--- a/Public/Src/Sandbox/MacOs/Interop/Sandbox/ESSandbox.cpp
+++ b/Public/Src/Sandbox/MacOs/Interop/Sandbox/ESSandbox.cpp
@@ -1,0 +1,354 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include <signal.h>
+#include "ESSandbox.h"
+#include "BuildXLSandboxShared.hpp"
+
+#include "IOHandler.hpp"
+
+static ESSandbox *sandbox;
+
+dispatch_queue_t serialQueue = dispatch_queue_create("com.blah.queue", DISPATCH_QUEUE_SERIAL);
+
+void processEndpointSecurityEvent(es_client_t *client, const es_message_t *msg, pid_t host)
+{
+    pid_t pid = audit_token_to_pid(msg->process->audit_token);
+    
+    // Mute all events comming from BuildXL itself
+    if (pid == host)
+    {
+        es_mute_process(client, &msg->process->audit_token);
+        return;
+    }
+    
+    IOHandler handler = IOHandler(sandbox);
+    
+    if (handler.TryInitializeWithTrackedProcess(pid))
+    {
+        switch (msg->event_type)
+        {
+            case ES_EVENT_TYPE_NOTIFY_EXEC:
+                return handler.HandleProcessExec(msg);
+                
+            case ES_EVENT_TYPE_NOTIFY_FORK:
+                return handler.HandleProcessFork(msg);
+                
+            case ES_EVENT_TYPE_NOTIFY_EXIT:
+                return handler.HandleProcessExit(msg);
+                
+            case ES_EVENT_TYPE_NOTIFY_LOOKUP:
+                return handler.HandleLookup(msg);
+                
+            case ES_EVENT_TYPE_NOTIFY_OPEN:
+                return handler.HandleOpen(msg);
+                
+            case ES_EVENT_TYPE_NOTIFY_CLOSE:
+                return handler.HandleClose(msg);
+
+            case ES_EVENT_TYPE_NOTIFY_CREATE:
+                return handler.HandleCreate(msg);
+
+            // TODO: Decide what to do, tools touch source files too
+            case ES_EVENT_TYPE_NOTIFY_SETATTRLIST:
+            case ES_EVENT_TYPE_NOTIFY_SETEXTATTR:
+            case ES_EVENT_TYPE_NOTIFY_SETFLAGS:
+            case ES_EVENT_TYPE_NOTIFY_SETMODE:
+            case ES_EVENT_TYPE_NOTIFY_WRITE:
+                return handler.HandleWrite(msg);
+
+            case ES_EVENT_TYPE_NOTIFY_EXCHANGEDATA:
+                return handler.HandleExchange(msg);
+
+            case ES_EVENT_TYPE_NOTIFY_RENAME:
+                return handler.HandleRename(msg);
+                
+            case ES_EVENT_TYPE_NOTIFY_READLINK:
+                return handler.HandleReadlink(msg);
+                
+            case ES_EVENT_TYPE_NOTIFY_LINK:
+                return handler.HandleLink(msg);
+                    
+            case ES_EVENT_TYPE_NOTIFY_UNLINK:
+                return handler.HandleUnlink(msg);
+        }
+    }
+}
+
+extern "C"
+{
+#pragma mark Exported interop methods
+
+    void InitializeEndpointSecuritySandbox(ESConnectionInfo *info, pid_t host)
+    {
+        sandbox = new ESSandbox(^(es_client_t *client, const es_message_t *msg)
+        {
+            processEndpointSecurityEvent(client, msg, host);
+        });
+        
+        es_client_t *client;
+        es_new_client_result_t result = es_new_client(&client, sandbox->GetObservationHandler());
+        if (result != ES_NEW_CLIENT_RESULT_SUCCESS)
+        {
+            log_error("Failed creating EndpointSecurity client with error code: (%d)\n", result);
+            info->error = ES_CLIENT_CREATION_FAILED;
+            return;
+        }
+        
+        sandbox->SetESClient(client);
+        
+        es_clear_cache_result_t clearResult = es_clear_cache(client);
+        if (clearResult != ES_CLEAR_CACHE_RESULT_SUCCESS)
+        {
+            log_error("%s", "Failed resetting result cache on EndpointSecurity client initialization!\n");
+            info->error = ES_CLIENT_CACHE_RESET_FAILED;
+            return;
+        }
+    
+        info->client = (uintptr_t) client;
+        info->source = (uintptr_t) CFRunLoopSourceCreate(NULL, 0, sandbox->GetRunLoopSourceContext());
+    }
+    
+    void DeinitializeEndpointSecuritySandbox(ESConnectionInfo info)
+    {
+        es_client_t *client = (es_client_t *) info.client;
+        
+        es_return_t result = es_unsubscribe_all(client);
+        if (result != ES_RETURN_SUCCESS)
+        {
+            log_error("%s", "Failed unsubscribing from all EndpointSecurity events on client tear-down!\n");
+        }
+        
+        result = es_delete_client(client);
+        if (result != ES_RETURN_SUCCESS)
+        {
+            log_error("%s", "Failed deleting the EndpointSecurity client!\n");
+        }
+        
+        CFRunLoopRef runLoop = (CFRunLoopRef) info.runLoop;
+        CFRunLoopSourceRef source = (CFRunLoopSourceRef) info.source;
+        
+        CFRunLoopRemoveSource(runLoop, source, kCFRunLoopDefaultMode);
+        CFRunLoopSourceInvalidate(source);
+        CFRelease(source);
+        
+        CFRunLoopStop(runLoop);
+        delete sandbox;
+        log_debug("%s", "Successfully shut down EndpointSecurity subystem...");
+    }
+
+    __cdecl void ObserverFileAccessReports(ESConnectionInfo *info, AccessReportCallback callback, long accessReportSize)
+    {
+        if (sizeof(AccessReport) != accessReportSize)
+        {
+            log_error("Wrong size of the AccessReport buffer: expected %ld, received %ld", sizeof(AccessReport), accessReportSize);
+            if (callback != NULL) callback(AccessReport{}, ES_WRONG_BUFFER_SIZE);
+            return;
+        }
+
+        if (callback == NULL)
+        {
+            log_error("%s", "No callback has been supplied for EndpointSecurity file observation!");
+            return;
+        }
+        
+        sandbox->SetAccessReportCallback(callback);
+        es_client_t *client = (es_client_t *) info->client;
+        
+        // Subsribe and activate the ES client
+        
+        es_return_t status = es_subscribe(client, sandbox->GetSubscibedESEvents(), sandbox->GetSubscribedESEventsCount());
+        if (status != ES_RETURN_SUCCESS)
+        {
+            log_error("%s", "Failed subscribing to EndpointSecurity events, please check the sandbox configuration!");
+            if (callback != NULL) callback(AccessReport{}, ES_CLIENT_SUBSCRIBE_FAILED);
+            return;
+        }
+        
+        log_debug("Listening for reports of the EndpointSecurity sub system from process: %d", getpid());
+        
+        info->runLoop = (uintptr_t) CFRunLoopGetCurrent();
+        
+        // Use a dedicated run-loop for the thread so we can continously observe ES events
+        CFRunLoopAddSource((CFRunLoopRef) info->runLoop, (CFRunLoopSourceRef) info->source, kCFRunLoopDefaultMode);
+        CFRunLoopRun();
+    }
+}
+
+#pragma mark EndpointSecurity stubs
+
+bool ES_SendPipStarted(const pid_t pid, pipid_t pipId, const char *const famBytes, int famBytesLength)
+{
+    log_debug("Pip with PipId = %#llX, PID = %d launching", pipId, pid);
+    SandboxedPip *entry = new SandboxedPip(pid, famBytes, famBytesLength);
+    return sandbox->TrackRootProcess(entry);
+}
+
+bool ES_SendPipProcessTerminated(pipid_t pipId, pid_t pid)
+{
+    log_debug("Pip with PipId = %#llX, PID = %d terminated", pipId, pid);
+    
+    IOHandler handler = IOHandler(sandbox);
+    if (handler.TryInitializeWithTrackedProcess(pid) && handler.GetPipId() == pipId)
+    {
+        log_debug("Killing process (%d)", pid);
+        handler.HandleProcessUntracked(pid);
+        kill(pid, SIGTERM);
+    }
+
+    return true;
+}
+
+#pragma mark ESSandbox implementation
+
+ESSandbox::~ESSandbox()
+{
+    Block_release(esObservationHandler_);
+    esObservationHandler_ = nullptr;
+    client = nullptr;
+    
+    if (trackedProcesses_ != nullptr)
+    {
+        delete trackedProcesses_;
+    }
+}
+
+SandboxedProcess* ESSandbox::FindTrackedProcess(pid_t pid)
+{
+    // NOTE: this has to be very fast when we are not tracking any processes (i.e., trackedProcesses_ is empty)
+    //       because this is called on every single file access any process makes
+    return trackedProcesses_->get(pid);
+}
+
+bool ESSandbox::TrackRootProcess(SandboxedPip *pip)
+{
+    pid_t pid = pip->getProcessId();
+    SandboxedProcess *process = new SandboxedProcess(pid, pip);
+
+    if (process == nullptr)
+    {
+        return false;
+    }
+
+    int len = MAXPATHLEN;
+    process->setPath(pip->getProcessPath(&len), len);
+    
+    int numAttempts = 0;
+    while (++numAttempts <= 3)
+    {
+        Trie::TrieResult result = trackedProcesses_->insert(pid, process);
+        if (result == Trie::TrieResult::kTrieResultAlreadyExists)
+        {
+            // if mapping for 'pid' exists (this can happen only if clients are nested) --> remove it and retry
+            IOHandler handler = IOHandler(this);
+            if (handler.TryInitializeWithTrackedProcess(pid))
+            {
+                log_debug("EARLY untracking PID(%d); Previous :: RootPID: %d, PipId: %#llX, tree size: %d)",
+                          pid, handler.GetProcessId(), handler.GetPipId(), handler.GetProcessTreeSize());
+                          handler.HandleProcessUntracked(pid); // consider: handler.HandleProcessExit(pid);
+            }
+
+            continue;
+        }
+        else
+        {
+            bool insertedNew = result == Trie::TrieResult::kTrieResultInserted;
+            log_debug("Tracking root process PID(%d), PipId: %#llX, tree size: %d, path: %{public}s, code: %d",
+                      pid, pip->getPipId(), pip->getTreeSize(), process->getPath(), result);
+            
+            return insertedNew;
+        }
+    }
+
+    log_debug("Exceeded max number of attempts: %d", numAttempts);
+    return false;
+}
+
+bool ESSandbox::TrackChildProcess(pid_t childPid, SandboxedProcess *parentProcess)
+{
+    SandboxedPip *pip = parentProcess->getPip();
+    SandboxedProcess *childProcess = new SandboxedProcess(childPid, pip);
+
+    if (childProcess == nullptr)
+    {
+        return false;
+    }
+
+    Trie::TrieResult getOrAddResult;
+    SandboxedProcess *newValue = trackedProcesses_->getOrAdd(childPid, childProcess, &getOrAddResult);
+    
+    // Operation getOrAdd failed:
+    //   -> skip everything and return error (should not happen under normal circumstances)
+    if (newValue == nullptr)
+    {
+        goto error;
+    }
+
+    // There was already a process associated with this 'childPid':
+    //   -> log an appropriate message and return false to indicate that no new process has been tracked
+    if (getOrAddResult == Trie::TrieResult::kTrieResultAlreadyExists)
+    {
+        if (newValue->getPip() == pip)
+        {
+            log_debug("Child process PID(%d) already tracked by the same Root PID(%d)", childPid, pip->getProcessId());
+        }
+        else if (newValue->getPip()->getProcessId() == childPid)
+        {
+            log_debug("Child process PID(%d) cannot be added to Root PID(%d) because it has already been promoted to root itself",
+                      childPid, pip->getProcessId());
+        }
+        else
+        {
+            log_debug("Child process PID(%d) already tracked by a different Root PID(%d); intended new: Root PID(%d) (Code: %d)",
+                      childPid, newValue->getPip()->getProcessId(), pip->getProcessId(), getOrAddResult);
+        }
+        return false;
+    }
+
+    // We associated 'process' with 'childPid' -> increment process tree and return true to indicate that a new process is being tracked
+    if (getOrAddResult == Trie::TrieResult::kTrieResultInserted)
+    {
+        // copy the path from the parent process (because the child process always starts out as a fork of the parent)
+        childProcess->setPath(parentProcess->getPath());
+        pip->incrementProcessTreeCount();
+        
+        log_debug("Track entry %d -> %d, PipId: %#llX, New tree size: %d", childPid, pip->getProcessId(), pip->getPipId(), pip->getTreeSize());
+        
+        return true;
+    }
+
+error:
+
+    log_debug("Track entry %d -> %d FAILED, PipId: %#llX, Tree size: %d, Code: %d",
+              childPid, pip->getProcessId(), pip->getPipId(), pip->getTreeSize(), getOrAddResult);
+    
+    return false;
+}
+
+bool ESSandbox::UntrackProcess(pid_t pid, SandboxedProcess *process)
+{
+    // remove the mapping for 'pid'
+    auto removeResult = trackedProcesses_->remove(pid);
+    bool removedExisting = removeResult == Trie::TrieResult::kTrieResultRemoved;
+    if (removedExisting)
+    {
+        process->getPip()->decrementProcessTreeCount();
+    }
+    
+    SandboxedPip *pip = process->getPip();
+    
+    log_debug("Untrack entry %d (%{public}s) -> %d, PipId: %#llX, New tree size: %d, Code: %d",
+              pid, process->getPathBuffer(), pip->getProcessId(), pip->getPipId(), pip->getTreeSize(), removeResult);
+    
+    return removedExisting;
+}
+
+void const ESSandbox::SendAccessReport(AccessReport &report, SandboxedPip *pip)
+{
+    report.stats.enqueueTime = mach_absolute_time();
+
+    this->GetAccessReportCallback()(report, REPORT_QUEUE_SUCCESS);
+
+    log_debug("Enqueued PID(%d), Root PID(%d), PIP(%#llX), Operation: %{public}s, Path: %{public}s, Status: %d",
+              report.pid, report.rootPid, report.pipId, OpNames[report.operation], report.path, report.status);
+}

--- a/Public/Src/Sandbox/MacOs/Interop/Sandbox/ESSandbox.h
+++ b/Public/Src/Sandbox/MacOs/Interop/Sandbox/ESSandbox.h
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef ESSandbox_h
+#define ESSandbox_h
+
+#include <EndpointSecurity/EndpointSecurity.h>
+#include <bsm/libbsm.h>
+
+#include "Common.h"
+#include "Trie.hpp"
+
+#define ES_CLIENT_CREATION_FAILED       0x1
+#define ES_CLIENT_CACHE_RESET_FAILED    0x2
+#define ES_CLIENT_SUBSCRIBE_FAILED      0x4
+#define ES_WRONG_BUFFER_SIZE            0x8
+
+typedef struct {
+    int error;
+    uintptr_t client;
+    uintptr_t source;
+    uintptr_t runLoop;
+} ESConnectionInfo;
+
+extern "C"
+{
+    void InitializeEndpointSecuritySandbox(ESConnectionInfo *info, pid_t host);
+    void DeinitializeEndpointSecuritySandbox(ESConnectionInfo info);
+    
+    __cdecl void ObserverFileAccessReports(ESConnectionInfo *info, AccessReportCallback callback, long accessReportSize);
+};
+
+bool ES_SendPipStarted(const pid_t pid, pipid_t pipId, const char *const famBytes, int famBytesLength);
+bool ES_SendPipProcessTerminated(pipid_t pipId, pid_t pid);
+
+class ESSandbox
+{
+private:
+    
+    Trie *trackedProcesses_;
+    
+    /*! This is the number of observed ES events, keep this up to date with the active events in observed_events_ otherwise ES behaves very odd! */
+    static const int numberOfSubscribedEvents_ = 18;
+    
+    const es_event_type_t observed_events_[numberOfSubscribedEvents_] =
+    {
+        // Process life cycle
+        ES_EVENT_TYPE_NOTIFY_EXEC,
+        ES_EVENT_TYPE_NOTIFY_FORK,
+        ES_EVENT_TYPE_NOTIFY_EXIT,
+
+        // Process file operations
+        ES_EVENT_TYPE_NOTIFY_OPEN,
+        ES_EVENT_TYPE_NOTIFY_CLOSE,
+        ES_EVENT_TYPE_NOTIFY_CREATE,
+        ES_EVENT_TYPE_NOTIFY_EXCHANGEDATA,
+        ES_EVENT_TYPE_NOTIFY_RENAME,
+        ES_EVENT_TYPE_NOTIFY_LINK,
+        ES_EVENT_TYPE_NOTIFY_UNLINK,
+        ES_EVENT_TYPE_NOTIFY_READLINK,
+        
+        ES_EVENT_TYPE_NOTIFY_WRITE,
+        ES_EVENT_TYPE_NOTIFY_SETATTRLIST,
+        ES_EVENT_TYPE_NOTIFY_SETEXTATTR,
+        ES_EVENT_TYPE_NOTIFY_SETFLAGS,
+        ES_EVENT_TYPE_NOTIFY_SETMODE,
+        ES_EVENT_TYPE_NOTIFY_SETOWNER,
+        
+          // Crashes with segmentation faults and assert violations frequently with serious workload (radar created)
+        ES_EVENT_TYPE_NOTIFY_LOOKUP
+    };
+
+    CFRunLoopSourceContext sourceContext_ = {
+        .version         = 0,
+        .info            = NULL,
+        .retain          = NULL,
+        .release         = NULL,
+        .copyDescription = NULL,
+        .equal           = NULL,
+        .hash            = NULL,
+        .schedule        = NULL,
+        .cancel          = NULL,
+        .perform         = NULL
+    };
+    
+    es_client_t *client;
+    es_handler_block_t esObservationHandler_;
+    AccessReportCallback accessReportCallback_;
+    
+public:
+    
+    ESSandbox() = delete;
+    ESSandbox(es_handler_block_t handler)
+    {
+        _Block_copy(handler);
+        esObservationHandler_ = handler;
+        accessReportCallback_ = nullptr;
+        
+        trackedProcesses_ = Trie::createUintTrie();
+        if (!trackedProcesses_)
+        {
+            throw "Could not create Trie for process tracking!";
+        }
+    }
+    
+    ~ESSandbox();
+    
+    inline CFRunLoopSourceContext* GetRunLoopSourceContext() { return &sourceContext_; }
+    
+    inline es_event_type_t* GetSubscibedESEvents() { return (es_event_type_t*) observed_events_; }
+    inline int GetSubscribedESEventsCount() { return numberOfSubscribedEvents_; }
+    
+    inline es_handler_block_t GetObservationHandler() { return esObservationHandler_; }
+    
+    inline const AccessReportCallback GetAccessReportCallback() { return accessReportCallback_; }
+    inline const void SetAccessReportCallback(AccessReportCallback callback) { accessReportCallback_ = callback; }
+    
+    inline const es_client_t* GetESClient() { return client; }
+    inline const void SetESClient(es_client_t *c) { client = c; }
+    
+    SandboxedProcess* FindTrackedProcess(pid_t pid);
+    bool TrackRootProcess(SandboxedPip *pip);
+    bool TrackChildProcess(pid_t childPid, SandboxedProcess *parentProcess);
+    bool UntrackProcess(pid_t pid, SandboxedProcess *process);
+    
+    void const SendAccessReport(AccessReport &report, SandboxedPip *pip);
+};
+
+#endif /* ESSandbox_h */
+

--- a/Public/Src/Sandbox/MacOs/Interop/Sandbox/Handlers/AccessHandler.cpp
+++ b/Public/Src/Sandbox/MacOs/Interop/Sandbox/Handlers/AccessHandler.cpp
@@ -1,0 +1,148 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "AccessHandler.hpp"
+#include "OpNames.hpp"
+
+bool AccessHandler::TryInitializeWithTrackedProcess(pid_t pid)
+{
+    SandboxedProcess *process = sandbox_->FindTrackedProcess(pid);
+    if (process == nullptr || CheckDisableDetours(process->getPip()->getFamFlags()))
+    {
+        return false;
+    }
+    
+    SetProcess(process);
+    return true;
+}
+
+PolicySearchCursor AccessHandler::FindManifestRecord(const char *absolutePath, size_t pathLength)
+{
+    assert(absolutePath[0] == '/');
+    const char *pathWithoutRootSentinel = absolutePath + 1;
+
+    size_t len = pathLength == -1 ? strlen(pathWithoutRootSentinel) : pathLength;
+    return FindFileAccessPolicyInTreeEx(GetPip()->getManifestRecord(), pathWithoutRootSentinel, len);
+}
+
+void AccessHandler::SetProcessPath(AccessReport *report)
+{
+    const char *procName = process_->hasPath()
+        ? process_->getPath()
+        : "/unknown-process"; // should never happen
+    
+    strlcpy(report->path, procName, sizeof(report->path));
+}
+
+ReportResult AccessHandler::ReportFileOpAccess(FileOperation operation,
+                                               PolicyResult policyResult,
+                                               AccessCheckResult checkResult,
+                                               pid_t processID)
+{
+    AccessReport report =
+    {
+        .operation          = operation,
+        .pid                = processID,
+        .rootPid            = GetProcessId(),
+        .requestedAccess    = (DWORD)checkResult.RequestedAccess,
+        .status             = checkResult.GetFileAccessStatus(),
+        .reportExplicitly   = checkResult.ReportLevel == ReportLevel::ReportExplicit,
+        .error              = 0,
+        .pipId              = GetPipId(),
+        .path               = {0},
+        .stats              = { .creationTime = creationTimestamp_ }
+    };
+
+    strlcpy(report.path, policyResult.Path(), sizeof(report.path));
+    sandbox_->SendAccessReport(report, GetPip());
+
+    return kReported;
+}
+
+bool AccessHandler::ReportProcessTreeCompleted(pid_t processId)
+{
+    AccessReport report =
+    {
+        .operation = kOpProcessTreeCompleted,
+        .pid       = processId,
+        .rootPid   = GetProcessId(),
+        .pipId     = GetPipId(),
+        .stats     = { .creationTime = creationTimestamp_ }
+    };
+
+    sandbox_->SendAccessReport(report, GetPip());
+    return true;
+}
+
+bool AccessHandler::ReportProcessExited(pid_t childPid)
+{
+    AccessReport report =
+    {
+        .operation        = kOpProcessExit,
+        .pid              = childPid,
+        .rootPid          = GetProcessId(),
+        .pipId            = GetPipId(),
+        .status           = FileAccessStatus::FileAccessStatus_Allowed,
+        .reportExplicitly = 0,
+        .error            = 0,
+        .stats            = { .creationTime = creationTimestamp_ }
+    };
+
+    SetProcessPath(&report);
+    sandbox_->SendAccessReport(report, GetPip());
+    return true;
+}
+
+bool AccessHandler::ReportChildProcessSpawned(pid_t childPid)
+{
+    AccessReport report =
+    {
+        .operation          = kOpProcessStart,
+        .pid                = childPid,
+        .rootPid            = GetProcessId(),
+        .requestedAccess    = (int)RequestedAccess::Read,
+        .status             = FileAccessStatus::FileAccessStatus_Allowed,
+        .reportExplicitly   = 0,
+        .error              = 0,
+        .pipId              = GetPipId(),
+        .path               = {0},
+        .stats              = { .creationTime = creationTimestamp_ }
+    };
+
+    SetProcessPath(&report);
+    sandbox_->SendAccessReport(report, GetPip());
+    
+    return true;
+}
+
+PolicyResult AccessHandler::PolicyForPath(const char *absolutePath)
+{
+    PolicySearchCursor cursor = FindManifestRecord(absolutePath);
+    if (!cursor.IsValid())
+    {
+        log_error("Invalid policy cursor for path '%s'", absolutePath);
+    }
+
+    return PolicyResult(GetPip()->getFamFlags(), absolutePath, cursor);
+}
+
+AccessCheckResult AccessHandler::CheckAndReportInternal(FileOperation operation,
+                                                        const char *path,
+                                                        CheckFunc checker,
+                                                        const es_message_t *msg,
+                                                        bool isDir)
+{    
+    // 1: check operation against given policy
+    PolicyResult policy = PolicyForPath(path);
+    AccessCheckResult result = AccessCheckResult::Invalid();
+    checker(policy, isDir, &result);
+        
+    // 2: skip if this access should not be reported
+    if (!result.ShouldReport())
+    {
+        return result;
+    }
+
+    ReportFileOpAccess(operation, policy, result, audit_token_to_pid(msg->process->audit_token));
+    return result;
+}

--- a/Public/Src/Sandbox/MacOs/Interop/Sandbox/Handlers/AccessHandler.hpp
+++ b/Public/Src/Sandbox/MacOs/Interop/Sandbox/Handlers/AccessHandler.hpp
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef AccessHandler_hpp
+#define AccessHandler_hpp
+
+#include "ESSandbox.h"
+#include "SandboxedPip.hpp"
+#include "Checkers.hpp"
+#include "OpNames.hpp"
+
+enum ReportResult
+{
+    kReported,
+    kSkipped,
+    kFailed
+};
+
+typedef bool (Handler)(void *data);
+
+struct AccessHandler
+{
+private:
+
+    ESSandbox *sandbox_;
+
+    SandboxedProcess *process_;
+
+    uint64_t creationTimestamp_;
+
+    ReportResult ReportFileOpAccess(FileOperation operation,
+                                    PolicyResult policy,
+                                    AccessCheckResult accessCheckResult,
+                                    pid_t processID);
+
+    inline void SetProcess(SandboxedProcess *process) { process_ = process; }
+
+protected:
+
+    ESSandbox* GetSandbox()   const { return sandbox_; }
+    SandboxedProcess* GetProcess() const { return process_; }
+    SandboxedPip* GetPip()         const { return process_->getPip(); }
+
+    PolicySearchCursor FindManifestRecord(const char *absolutePath, size_t pathLength = -1);
+    
+    /*!
+     * Copies 'process_->getPath()' into 'report->path'.
+     */
+    void SetProcessPath(AccessReport *report);
+
+    /*!
+     * Template for checking and reporting file accesses.
+     *
+     * Adds caching around the existing checking ('CheckAccess') and reporting ('ReportFileOpAccess') methods.
+     *
+     * The key used for looking up if the operation was already reported is "<operation>,<path>".
+     *
+     * If the operation has already been reported (cache hit w.r.t. the aforementioned key), an AccessCheckResult
+     * object is returned that indicates that the operation is allowed (@result.ShouldDenyAccess() returns false)
+     * and that it should not be reported (@result.ShouldReport() returns false).
+     *
+     * If the operation has not been reported, 'CheckAccess' and 'ReportFileOpAccess' are called and the result
+     * is added to the cache if the returned AccessCheckResult object indicates that the operation should not be denied.
+     *
+     * @param operation Operation to be executed
+     * @param path Absolute path against which the operation is to be executed
+     * @param checker Checker function to apply to policy
+     * @param msg The EndpointSecurity message containing all necessary details about the observed event
+     * @param isDir Indicates if the report is being generated for a directory or file
+     */
+    AccessCheckResult CheckAndReportInternal(FileOperation operation,
+                                     const char *path,
+                                     CheckFunc checker,
+                                     const es_message_t *msg,
+                                     bool isDir);
+
+    AccessCheckResult CheckAndReport(FileOperation operation, const char *path, CheckFunc checker, const es_message_t *msg)
+    {
+        return CheckAndReportInternal(operation, path, checker, msg, false);
+    }
+
+    AccessCheckResult CheckAndReport(FileOperation operation, const char *path, CheckFunc checker, const es_message_t *msg, bool isDir)
+    {
+        return CheckAndReportInternal(operation, path, checker, msg, isDir);
+    }
+
+public:
+
+    AccessHandler(ESSandbox *sandbox)
+    {
+        creationTimestamp_ = mach_absolute_time();
+        sandbox_           = sandbox;
+        process_           = nullptr;
+    }
+
+    ~AccessHandler()
+    {
+        sandbox_ = nullptr;
+        process_ = nullptr;
+    }
+
+    /*!
+     * Attempts to find a tracked ProcessObject instance that corresponds to a given 'pid'.
+     * If successful, initializes this object with the found ProcessObject.
+     *
+     * IMPORTANT: This should be the first method to call after upon constructor this object.
+     *            Whenever the initialization fails, this object should not be used futher.
+     *
+     * @param pid Process ID to try to find.
+     * @result Indicates whether the initialization was successful.
+     */
+    bool TryInitializeWithTrackedProcess(pid_t pid);
+
+    inline bool HasTrackedProcess()             const { return process_ != nullptr; }
+    inline pid_t GetProcessId()                 const { return GetPip()->getProcessId(); }
+    inline pipid_t GetPipId()                   const { return GetPip()->getPipId(); }
+    inline int GetProcessTreeSize()             const { return GetPip()->getTreeSize(); }
+    inline FileAccessManifestFlag GetFamFlags() const { return GetPip()->getFamFlags(); }
+
+    PolicyResult PolicyForPath(const char *absolutePath);
+
+    bool ReportProcessTreeCompleted(pid_t processId);
+    bool ReportProcessExited(pid_t childPid);
+    bool ReportChildProcessSpawned(pid_t childPid);
+};
+
+#endif /* AccessHandler_hpp */

--- a/Public/Src/Sandbox/MacOs/Interop/Sandbox/Handlers/IOHandler.cpp
+++ b/Public/Src/Sandbox/MacOs/Interop/Sandbox/Handlers/IOHandler.cpp
@@ -1,0 +1,290 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include <assert.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "IOHandler.hpp"
+#include "OpNames.hpp"
+
+class PathExtractor
+{
+private:
+    
+    typedef struct { char data[PATH_MAX]; size_t length; } Buffer;
+    Buffer buffer_;
+    
+    
+public:
+    
+    PathExtractor(const char *buffer, size_t length)
+    {
+        assert(length <= PATH_MAX);
+        char *end = (char *) memccpy(buffer_.data, buffer, '\0', length);
+        if (end == NULL) buffer_.data[length] = '\0';
+        buffer_.length = strlen(buffer_.data);
+    }
+
+    ~PathExtractor() { }
+
+    inline const char *Path() { return buffer_.data; }
+    inline const size_t PathLength() { return buffer_.length; }
+};
+
+static bool exists(const char *path)
+{
+    struct stat path_stat;
+    return lstat(path, &path_stat) == 0;
+}
+
+static mode_t get_mode(const char *path)
+{
+    struct stat path_stat;
+    // Do not follow symlinks
+    lstat(path, &path_stat);
+    return path_stat.st_mode;
+}
+
+#pragma mark Process life cycle
+
+void IOHandler::HandleProcessFork(const es_message_t *msg)
+{
+    es_event_fork_t fork = msg->event.fork;
+    pid_t childPorcessPid = audit_token_to_pid(fork.child->audit_token);
+    
+    if (GetSandbox()->TrackChildProcess(childPorcessPid, GetProcess()))
+    {
+        ReportChildProcessSpawned(childPorcessPid);
+    }
+}
+
+void IOHandler::HandleProcessExec(const es_message_t *msg)
+{
+    es_event_exec_t exec = msg->event.exec;
+    PathExtractor ext = PathExtractor(exec.target->executable->path.data, exec.target->executable->path.size);
+    GetProcess()->setPath(ext.Path());
+    
+    // report child process to clients only (tracking happens on 'fork's not 'exec's)
+    ReportChildProcessSpawned(GetProcess()->getPid());
+}
+
+void IOHandler::HandleProcessExit(const es_message_t *msg)
+{
+    id_t pid = audit_token_to_pid(msg->process->audit_token);
+    
+    ReportProcessExited(pid);
+    HandleProcessUntracked(pid);
+}
+
+void IOHandler::HandleProcessUntracked(const pid_t pid)
+{
+    GetSandbox()->UntrackProcess(pid, GetProcess());
+    if (GetPip()->getTreeSize() == 0)
+    {
+        ReportProcessTreeCompleted(pid);
+    }
+}
+
+#pragma mark Process I/O observation
+
+void IOHandler::HandleLookup(const es_message_t *msg)
+{
+    es_event_lookup_t lookup = msg->event.lookup;
+    
+    PathExtractor srcExt = PathExtractor(lookup.source_dir->path.data, lookup.source_dir->path.size);
+    PathExtractor relExt = PathExtractor(lookup.relative_target.data, lookup.relative_target.size);
+    
+    char path[PATH_MAX];
+    size_t length = srcExt.PathLength() + relExt.PathLength() + 1;
+    assert(length < PATH_MAX);
+    
+    int index = snprintf(path, PATH_MAX, "%.*s%s%.*s",
+                         (int) srcExt.PathLength(), srcExt.Path(),
+                         // Handle the case where source dir has no trailing /
+                         (srcExt.PathLength() == 1) ? "" : "/",
+                         (int) relExt.PathLength(), relExt.Path());
+    
+    path[index] = '\0';
+    
+    bool doesExist = exists(path);
+    FileOperation operation = doesExist ? kOpKAuthVNodeProbe : kOpMacLookup;
+    CheckFunc checker = doesExist ? Checkers::CheckProbe : Checkers::CheckLookup;
+    
+    // Check, report, but never deny lookups
+    CheckAndReport(operation, path, checker, msg, false);
+}
+
+void IOHandler::HandleOpen(const es_message_t *msg)
+{
+    es_event_open_t open = msg->event.open;
+    PathExtractor ext = PathExtractor(open.file->path.data, open.file->path.size);
+    
+    mode_t mode = get_mode(ext.Path());
+    bool isDir = !S_ISREG(mode);
+    
+    CheckFunc checker = isDir ? Checkers::CheckEnumerateDir : Checkers::CheckRead;
+    FileOperation op  = isDir ? kOpKAuthOpenDir : kOpKAuthReadFile;
+    
+    CheckAndReport(op, ext.Path(), checker, msg, isDir);
+}
+
+void IOHandler::HandleClose(const es_message_t *msg)
+{
+    es_event_close_t close = msg->event.close;
+    PathExtractor ext = PathExtractor(close.target->path.data, close.target->path.size);
+    
+    if (close.modified)
+    {
+        CheckAndReport(kOpKAuthCloseModified, ext.Path(), Checkers::CheckWrite, msg);
+        return;
+    }
+    
+    // TODO: Should this be reported?
+    // CheckAndReport(kOpKAuthClose, close.target->path.data, Checkers::CheckRead, msg);
+}
+
+void IOHandler::HandleLink(const es_message_t *msg)
+{
+    es_event_link_t link = msg->event.link;
+    
+    PathExtractor dirExt = PathExtractor(link.target_dir->path.data, link.target_dir->path.size);
+    PathExtractor fileExt = PathExtractor(link.target_filename.data, link.target_filename.size);
+    
+    char path[PATH_MAX];
+    size_t length = dirExt.PathLength() + fileExt.PathLength() + 1;
+    assert(length < PATH_MAX);
+    
+    int index = snprintf(path, PATH_MAX, "%.*s%.*s", (int) strlen(dirExt.Path()), dirExt.Path(), (int) fileExt.PathLength(), fileExt.Path());
+    path[index] = '\0';
+    
+    CheckAndReport(kOpKAuthCreateHardlinkSource, link.source->path.data, Checkers::CheckRead, msg);
+    CheckAndReport(kOpKAuthCreateHardlinkDest, path, Checkers::CheckWrite, msg);
+}
+
+void IOHandler::HandleUnlink(const es_message_t *msg)
+{
+    es_event_unlink_t unlink = msg->event.unlink;
+    mode_t mode = get_mode(unlink.target->path.data);
+    bool isDir = !S_ISREG(mode);
+    
+    FileOperation operation = isDir ? kOpKAuthDeleteDir : kOpKAuthDeleteFile;
+    
+    PathExtractor ext = PathExtractor(unlink.target->path.data, unlink.target->path.size);
+    CheckAndReport(operation, ext.Path(), Checkers::CheckWrite, msg);
+}
+
+void IOHandler::HandleReadlink(const es_message_t *msg)
+{
+    es_event_readlink_t readlink = msg->event.readlink;
+    
+    PathExtractor ext = PathExtractor(readlink.source->path.data, readlink.source->path.size);
+    AccessCheckResult checkResult = CheckAndReport(kOpMacReadlink, ext.Path(), Checkers::CheckRead, msg, false);
+    
+    if (checkResult.ShouldDenyAccess())
+    {
+        // TODO: Deny access
+    }
+}
+
+void IOHandler::HandleRename(const es_message_t *msg)
+{
+    es_event_rename_t rename = msg->event.rename;
+    PathExtractor srcExt = PathExtractor(rename.source->path.data, rename.source->path.size);
+    CheckAndReport(kOpKAuthMoveSource, srcExt.Path(), Checkers::CheckRead, msg);
+    
+    switch (rename.destination_type)
+    {
+        case ES_DESTINATION_TYPE_EXISTING_FILE:
+        {
+            PathExtractor dstExt = PathExtractor(rename.destination.existing_file->path.data, rename.destination.existing_file->path.size);
+            CheckAndReport(kOpKAuthMoveDest, dstExt.Path(), Checkers::CheckWrite, msg);
+            break;
+        }
+        case ES_DESTINATION_TYPE_NEW_PATH:
+        {
+            PathExtractor dstExt = PathExtractor(rename.destination.new_path.dir->path.data, rename.destination.new_path.dir->path.size);
+            CheckAndReport(kOpKAuthMoveDest, dstExt.Path(), Checkers::CheckWrite, msg);
+            break;
+        }
+    }
+}
+
+void IOHandler::HandleExchange(const es_message_t *msg)
+{
+    es_event_exchangedata_t exchange = msg->event.exchangedata;
+    
+    PathExtractor f1Ext = PathExtractor(exchange.file1->path.data, exchange.file1->path.size);
+    PathExtractor f2Ext = PathExtractor(exchange.file2->path.data, exchange.file2->path.size);
+    
+    CheckAndReport(kOpKAuthCopySource, f1Ext.Path(), Checkers::CheckReadWrite, msg);
+    CheckAndReport(kOpKAuthCopyDest, f2Ext.Path(), Checkers::CheckReadWrite, msg);
+}
+
+void IOHandler::HandleCreate(const es_message_t *msg)
+{
+    es_event_create_t create = msg->event.create;
+    
+    PathExtractor ext = PathExtractor(create.target->path.data, create.target->path.size);
+    mode_t mode = get_mode(ext.Path());
+    
+    bool enforceDirectoryCreation = CheckDirectoryCreationAccessEnforcement(GetFamFlags());
+    CheckFunc checker =
+        S_ISLNK(mode) ? Checkers::CheckCreateSymlink :
+        S_ISREG(mode) ? Checkers::CheckWrite :
+        enforceDirectoryCreation ? Checkers::CheckCreateDirectory :
+                                   Checkers::CheckProbe;
+    
+    AccessCheckResult result = CheckAndReport(kOpMacVNodeCreate, ext.Path(), checker, msg, !S_ISREG(mode));
+
+    if (result.ShouldDenyAccess())
+    {
+        // TODO: Deny access
+    }
+}
+
+void IOHandler::HandleWrite(const es_message_t *msg)
+{
+    const char *path = nullptr;
+    
+    switch (msg->event_type) {
+        case ES_EVENT_TYPE_NOTIFY_SETATTRLIST:
+        {
+            es_event_setattrlist_t setattrlist = msg->event.setattrlist;
+            PathExtractor ext = PathExtractor(setattrlist.target->path.data, setattrlist.target->path.size);
+            path = ext.Path();
+            break;
+        }
+        case ES_EVENT_TYPE_NOTIFY_SETEXTATTR:
+        {
+            es_event_setextattr_t setextattr = msg->event.setextattr;
+            PathExtractor ext = PathExtractor(setextattr.target->path.data, setextattr.target->path.size);
+            path = ext.Path();
+            break;
+        }
+        case ES_EVENT_TYPE_NOTIFY_SETFLAGS:
+        {
+            es_event_setflags_t flags = msg->event.setflags;
+            PathExtractor ext = PathExtractor(flags.target->path.data, flags.target->path.size);
+            path = ext.Path();
+            break;
+        }
+        case ES_EVENT_TYPE_NOTIFY_SETMODE:
+        {
+            es_event_setmode_t setmode = msg->event.setmode;
+            PathExtractor ext = PathExtractor(setmode.target->path.data, setmode.target->path.size);
+            path = ext.Path();
+            break;
+        }
+        case ES_EVENT_TYPE_NOTIFY_WRITE:
+        {
+            es_event_write_t write = msg->event.write;
+            PathExtractor ext = PathExtractor(write.target->path.data, write.target->path.size);
+            path = ext.Path();
+            break;
+        }
+    }
+    
+    if (path != nullptr) CheckAndReport(kOpKAuthVNodeWrite, path, Checkers::CheckWrite, msg);
+}

--- a/Public/Src/Sandbox/MacOs/Interop/Sandbox/Handlers/IOHandler.hpp
+++ b/Public/Src/Sandbox/MacOs/Interop/Sandbox/Handlers/IOHandler.hpp
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef IOHandler_hpp
+#define IOHandler_hpp
+
+#include "AccessHandler.hpp"
+
+struct IOHandler : public AccessHandler
+{
+public:
+
+    IOHandler(ESSandbox *sandbox) : AccessHandler(sandbox) { }
+
+#pragma mark Process life cycle
+    
+    void HandleProcessFork(const es_message_t *msg);
+
+    void HandleProcessExec(const es_message_t *msg);
+
+    void HandleProcessExit(const es_message_t *msg);
+
+    void HandleProcessUntracked(const pid_t pid);
+    
+#pragma mark Process I/O observation
+    
+    void HandleLookup(const es_message_t *msg);
+    
+    void HandleOpen(const es_message_t *msg);
+    
+    void HandleClose(const es_message_t *msg);
+    
+    void HandleLink(const es_message_t *msg);
+    
+    void HandleUnlink(const es_message_t *msg);
+    
+    void HandleReadlink(const es_message_t *msg);
+    
+    void HandleRename(const es_message_t *msg);
+    
+    void HandleExchange(const es_message_t *msg);
+    
+    void HandleCreate(const es_message_t *msg);
+    
+    void HandleWrite(const es_message_t *msg);
+};
+
+#endif /* IOHandler_hpp */

--- a/Public/Src/Sandbox/MacOs/Sandbox/Sandbox.xcodeproj/project.pbxproj
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Sandbox.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		3C2614AE20D7E85E00488B0B /* DataTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C2614A620D7E85E00488B0B /* DataTypes.h */; };
 		3C2614AF20D7E85E00488B0B /* PolicySearch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3C2614A720D7E85E00488B0B /* PolicySearch.cpp */; };
 		3C2614B020D7E85E00488B0B /* StringOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3C2614A820D7E85E00488B0B /* StringOperations.cpp */; };
+		3C44209B22F1F796000E1003 /* Common.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3C44209922F1F782000E1003 /* Common.cpp */; };
 		3C73ADD22135A37700035B21 /* ClientInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3C73ADD02135A37700035B21 /* ClientInfo.cpp */; };
 		3C73ADD32135A37700035B21 /* ClientInfo.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3C73ADD12135A37700035B21 /* ClientInfo.hpp */; };
 		3C8327D42146927500EE8022 /* FileAccessManifestParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3C8327D22146927500EE8022 /* FileAccessManifestParser.cpp */; };
@@ -54,7 +55,7 @@
 		F54B6ADA21D3E37A00069515 /* ResourceManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F54B6AD821D3E37A00069515 /* ResourceManager.cpp */; };
 		F54B6ADB21D3E37A00069515 /* ResourceManager.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F54B6AD921D3E37A00069515 /* ResourceManager.hpp */; };
 		F557784D219217E60006B275 /* arg_parse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F557784B219217E60006B275 /* arg_parse.cpp */; };
-		F57355F0224444A400264A6C /* Sandbox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F57355EF224444A400264A6C /* Sandbox.cpp */; };
+		F57355F0224444A400264A6C /* KextSandbox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F57355EF224444A400264A6C /* KextSandbox.cpp */; };
 		F57355F22244450600264A6C /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F57355F12244450600264A6C /* CoreFoundation.framework */; };
 		F57355F32244456B00264A6C /* StringOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3C2614A820D7E85E00488B0B /* StringOperations.cpp */; };
 		F57355F42244458E00264A6C /* utf8proc.c in Sources */ = {isa = PBXBuildFile; fileRef = F58E91FD220B595B0083C57E /* utf8proc.c */; };
@@ -191,6 +192,7 @@
 		3C2614A620D7E85E00488B0B /* DataTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DataTypes.h; path = ../../../Windows/DetoursServices/DataTypes.h; sourceTree = "<group>"; };
 		3C2614A720D7E85E00488B0B /* PolicySearch.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PolicySearch.cpp; path = ../../../Windows/DetoursServices/PolicySearch.cpp; sourceTree = "<group>"; };
 		3C2614A820D7E85E00488B0B /* StringOperations.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = StringOperations.cpp; path = ../../../Windows/DetoursServices/StringOperations.cpp; sourceTree = "<group>"; };
+		3C44209922F1F782000E1003 /* Common.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Common.cpp; path = ../../../../Interop/Sandbox/Common.cpp; sourceTree = "<group>"; };
 		3C48422220D290BD002760DE /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
 		3C73ADD02135A37700035B21 /* ClientInfo.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ClientInfo.cpp; sourceTree = "<group>"; };
 		3C73ADD12135A37700035B21 /* ClientInfo.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ClientInfo.hpp; sourceTree = "<group>"; };
@@ -240,7 +242,7 @@
 		F557784C219217E60006B275 /* arg_parse.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = arg_parse.hpp; sourceTree = "<group>"; };
 		F557784E21921BA20006B275 /* args.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = args.hpp; sourceTree = "<group>"; };
 		F5577851219367F70006B275 /* lambda.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = lambda.hpp; sourceTree = "<group>"; };
-		F57355EF224444A400264A6C /* Sandbox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Sandbox.cpp; path = ../../../../Interop/Sandbox/Sandbox.cpp; sourceTree = "<group>"; };
+		F57355EF224444A400264A6C /* KextSandbox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = KextSandbox.cpp; path = ../../../../Interop/Sandbox/KextSandbox.cpp; sourceTree = "<group>"; };
 		F57355F12244450600264A6C /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
 		F577F04E21BEE0270066F2EF /* Trie.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Trie.cpp; sourceTree = "<group>"; };
 		F577F04F21BEE0270066F2EF /* Trie.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Trie.hpp; sourceTree = "<group>"; };
@@ -508,12 +510,13 @@
 				F557784B219217E60006B275 /* arg_parse.cpp */,
 				F557784C219217E60006B275 /* arg_parse.hpp */,
 				F557784E21921BA20006B275 /* args.hpp */,
+				3C44209922F1F782000E1003 /* Common.cpp */,
 				F5577851219367F70006B275 /* lambda.hpp */,
 				F51A2BFB2190C67500880752 /* main.cpp */,
 				F5490C072196345F0036B941 /* ps.cpp */,
 				F5490C082196345F0036B941 /* ps.hpp */,
 				F5490C052195F0C60036B941 /* render.hpp */,
-				F57355EF224444A400264A6C /* Sandbox.cpp */,
+				F57355EF224444A400264A6C /* KextSandbox.cpp */,
 			);
 			path = SandboxMonitor;
 			sourceTree = "<group>";
@@ -1066,8 +1069,9 @@
 				F57355F42244458E00264A6C /* utf8proc.c in Sources */,
 				F57355F32244456B00264A6C /* StringOperations.cpp in Sources */,
 				F557784D219217E60006B275 /* arg_parse.cpp in Sources */,
-				F57355F0224444A400264A6C /* Sandbox.cpp in Sources */,
+				F57355F0224444A400264A6C /* KextSandbox.cpp in Sources */,
 				F51A2BFC2190C67500880752 /* main.cpp in Sources */,
+				3C44209B22F1F796000E1003 /* Common.cpp in Sources */,
 				F5490C092196345F0036B941 /* ps.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1243,6 +1247,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"MAC_OS_LIBRARY=1",
+					"SB_MONITOR=1",
 				);
 				HEADER_SEARCH_PATHS = "$(SOURCE_ROOT)/../Interop/Sandbox";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
@@ -1262,6 +1267,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"MAC_OS_LIBRARY=1",
+					"SB_MONITOR=1",
 				);
 				HEADER_SEARCH_PATHS = "$(SOURCE_ROOT)/../Interop/Sandbox";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/BuildXLSandboxShared.hpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/BuildXLSandboxShared.hpp
@@ -10,6 +10,10 @@
 #if MAC_OS_SANDBOX
 #include <IOKit/IOLib.h>
 #include "SysCtl.hpp"
+#elif MAC_OS_LIBRARY
+#include <IOKit/IOKitLib.h>
+#include <IOKit/IODataQueueClient.h>
+#include <mach/mach_time.h>
 #endif
 
 #include "stdafx.h"
@@ -84,8 +88,7 @@ public:
     void operator++ (int)
     {
 #if MAC_OS_SANDBOX
-        if (g_bxl_enable_counters)
-            OSIncrementAtomic(&count_);
+       if (g_bxl_enable_counters) OSIncrementAtomic(&count_);
 #else
         ++count_;
 #endif
@@ -94,8 +97,7 @@ public:
     void operator-- (int)
     {
 #if MAC_OS_SANDBOX
-        if (g_bxl_enable_counters)
-            OSDecrementAtomic(&count_);
+       if (g_bxl_enable_counters) OSDecrementAtomic(&count_);
 #else
         --count_;
 #endif
@@ -119,11 +121,11 @@ private:
     void AddMicroseconds(uint64_t durationUs)
     {
 #if MAC_OS_SANDBOX
-        if (g_bxl_enable_counters)
-        {
-            OSIncrementAtomic(&count_);
-            OSAddAtomic64(durationUs, &durationUs_);
-        }
+       if (g_bxl_enable_counters)
+       {
+           OSIncrementAtomic(&count_);
+           OSAddAtomic64(durationUs, &durationUs_);
+       }
 #else
         ++count_;
         durationUs_ += durationUs;

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/CLI/SandboxMonitor/Common.cpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/CLI/SandboxMonitor/Common.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "Common.h"
+#include "Sandbox.h"
+#include "ESSandbox.h"
+
+void SetLogger(os_log_t newLogger)
+{
+    logger = newLogger;
+}
+
+extern "C"
+{
+#pragma mark Pip status functions
+
+    bool SendPipStarted(const pid_t processId, pipid_t pipId, const char *const famBytes, int famBytesLength, ConnectionType type, void *connection)
+    {
+        switch (type)
+        {
+            case Kext:
+            {
+                KextConnectionInfo *context = (KextConnectionInfo *) connection;
+                return KEXT_SendPipStarted(processId, pipId, famBytes, famBytesLength, *context);
+            }
+            case EndpointSecurity:
+                return ES_SendPipStarted(processId, pipId, famBytes, famBytesLength);
+        }
+    
+        return false;
+    }
+
+    bool SendPipProcessTerminated(pipid_t pipId, pid_t processId, ConnectionType type, void *connection)
+    {
+        switch (type)
+        {
+            case Kext:
+            {
+                KextConnectionInfo *context = (KextConnectionInfo *) connection;
+                return KEXT_SendPipProcessTerminated(pipId, processId, *context);
+            }
+            case EndpointSecurity:
+                return ES_SendPipProcessTerminated(pipId, processId);
+        }
+    
+        return false;
+    }
+
+#pragma mark Exported interop functions
+
+    int NormalizePathAndReturnHash(const BYTE *path, BYTE *buffer, int bufferSize)
+    {
+        return NormalizeAndHashPath((PCPathChar)path, buffer, bufferSize);
+    }
+}

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/CLI/SandboxMonitor/main.cpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/CLI/SandboxMonitor/main.cpp
@@ -17,7 +17,8 @@
 #import "ps.hpp"
 #import "lambda.hpp"
 #import "render.hpp"
-#import "Sandbox.h"
+#import "Common.h"
+#import "KextSandbox.h"
 
 using namespace std;
 

--- a/Public/Src/Sandbox/Windows/DetoursServices/stdafx-mac-interop.h
+++ b/Public/Src/Sandbox/Windows/DetoursServices/stdafx-mac-interop.h
@@ -5,5 +5,6 @@
 
 #pragma once
 
-#include <assert.h>
 #include <stdio.h>
+#include <assert.h>
+#include <string.h>

--- a/Public/Src/Sandbox/Windows/DetoursServices/targetver.h
+++ b/Public/Src/Sandbox/Windows/DetoursServices/targetver.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#if !defined(MAC_OS_SANDBOX)
+#if !defined(MAC_OS_SANDBOX) && !defined(MAC_OS_LIBRARY)
 // BuildXL should run on Win7+.
 #include <WinSDKVer.h>
 #define _WIN32_WINNT _WIN32_WINNT_WIN7

--- a/Public/Src/Tools/SandboxExec/Program.cs
+++ b/Public/Src/Tools/SandboxExec/Program.cs
@@ -142,16 +142,16 @@ namespace BuildXL.SandboxExec
         }
 
         private readonly Options m_options;
-        private readonly IKextConnection m_kextConnection;
+        private readonly ISandboxConnection m_sandboxConnection;
         private PathTable m_pathTable;
 
         /// <summary>
         /// For unit tests only.
         /// </summary>
-        public SandboxExecRunner(IKextConnection connection)
+        public SandboxExecRunner(ISandboxConnection connection)
         {
             m_options = Options.Defaults;
-            m_kextConnection = connection;
+            m_sandboxConnection = connection;
         }
 
         /// <nodoc />
@@ -162,25 +162,30 @@ namespace BuildXL.SandboxExec
         {
             m_options = options;
             s_crashCollector = OperatingSystemHelper.IsUnixOS ? new CrashCollectorMacOS(new[] { CrashType.SandboxExec, CrashType.Kernel }) : null;
-
-            m_kextConnection = OperatingSystemHelper.IsUnixOS
-                ? new KextConnection(
-                    new KextConnection.Config
-                    {
-                        FailureCallback = (int status, string description) =>
-                        {
-                            m_kextConnection.Dispose();
-                            throw new SystemException($"Received unrecoverable error from the sandbox (Code: {status.ToString("X")}, Description: {description}), please reload the extension and retry.");
-                        },
-                        KextConfig = new Sandbox.KextConfig
-                        {
-                            ReportQueueSizeMB = m_options.ReportQueueSizeMB,
-                            EnableReportBatching = m_options.EnableReportBatching,
+            m_sandboxConnection = OperatingSystemHelper.IsUnixOS
+                ? 
 #if PLATFORM_OSX
-                            EnableCatalinaDataPartitionFiltering = OperatingSystemHelper.IsMacOSCatalinaOrHigher
+                OperatingSystemHelper.IsMacOSCatalinaOrHigher 
+                    ? (ISandboxConnection) new SandboxConnectionES() 
+                    : 
+#endif                
+                    (ISandboxConnection) new SandboxConnectionKext(
+                        new SandboxConnectionKext.Config
+                        {
+                            FailureCallback = (int status, string description) =>
+                            {
+                                m_sandboxConnection.Dispose();
+                                throw new SystemException($"Received unrecoverable error from the sandbox (Code: {status.ToString("X")}, Description: {description}), please reload the extension and retry.");
+                            },
+                            KextConfig = new Sandbox.KextConfig
+                            {
+                                ReportQueueSizeMB = m_options.ReportQueueSizeMB,
+                                EnableReportBatching = m_options.EnableReportBatching,
+#if PLATFORM_OSX
+                                EnableCatalinaDataPartitionFiltering = OperatingSystemHelper.IsMacOSCatalinaOrHigher
 #endif
-                        },
-                    })
+                            },
+                        })
                 : null;
         }
 
@@ -290,10 +295,10 @@ namespace BuildXL.SandboxExec
             outputTime.Stop();
 
             var disposeTime = Stopwatch.StartNew();
-            if (instance.m_kextConnection != null)
+            if (instance.m_sandboxConnection != null)
             {
                 // Take care of releasing sandbox kernel extension resources on macOS
-                instance.m_kextConnection.Dispose();
+                instance.m_sandboxConnection.Dispose();
             }
             disposeTime.Stop();
 
@@ -352,7 +357,7 @@ namespace BuildXL.SandboxExec
         {
             var sandboxProcessInfo = new SandboxedProcessInfo(fileStorage: instance, fileName: processFileName, disableConHostSharing: true);
             sandboxProcessInfo.PipDescription = processFileName;
-            sandboxProcessInfo.SandboxedKextConnection = instance.m_kextConnection;
+            sandboxProcessInfo.SandboxConnection = instance.m_sandboxConnection;
 
             sandboxProcessInfo.StandardOutputEncoding = Encoding.UTF8;
             sandboxProcessInfo.StandardOutputObserver = PrintToStdout;

--- a/Public/Src/Tools/UnitTests/SandboxExec/SandboxExecTests.cs
+++ b/Public/Src/Tools/UnitTests/SandboxExec/SandboxExecTests.cs
@@ -182,7 +182,7 @@ namespace Test.Tool.SandboxExec
 
         private SandboxExecRunner CreateSandboxExecRunner()
         {
-            return new SandboxExecRunner(GetSandboxedKextConnection());
+            return new SandboxExecRunner(GetSandboxConnection());
         }
     }
 }

--- a/Public/Src/Utilities/Interop/MacOS/Sandbox.cs
+++ b/Public/Src/Utilities/Interop/MacOS/Sandbox.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -15,12 +16,44 @@ namespace BuildXL.Interop.MacOS
         public static readonly int ReportQueueSuccessCode = 0x1000;
 
         /// <nodoc />
-        public static readonly int KextSuccess = 0x0;
+        public static readonly int SandboxSuccess = 0x0;
 
         /// <nodoc />
         [DllImport(Libraries.BuildXLInteropLibMacOS)]
         public static extern unsafe int NormalizePathAndReturnHash(byte[] pPath, byte* buffer, int bufferLength);
 
+        /// <nodoc />
+        [StructLayout(LayoutKind.Sequential)]
+        public struct ESConnectionInfo
+        {
+            /// <nodoc />
+            public int Error;
+
+            /// <nodoc />
+            public ulong Client;
+
+            /// <nodoc />
+            public ulong Source;
+
+            /// <nodoc />
+            public ulong RunLoop;
+        }
+
+        /// <nodoc />
+        [DllImport(Libraries.BuildXLInteropLibMacOS, SetLastError = true)]
+        public static extern void InitializeEndpointSecuritySandbox(ref ESConnectionInfo info, int host);
+
+        /// <nodoc />
+        [DllImport(Libraries.BuildXLInteropLibMacOS, SetLastError = true)]
+        public static extern void DeinitializeEndpointSecuritySandbox(ESConnectionInfo info);
+
+        /// <nodoc />
+        [DllImport(Libraries.BuildXLInteropLibMacOS, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern void ObserverFileAccessReports(
+            ref ESConnectionInfo info,
+            [MarshalAs(UnmanagedType.FunctionPtr)] AccessReportCallback callbackPointer,
+            long accessReportSize);
+            
         /// <nodoc />
         [StructLayout(LayoutKind.Sequential)]
         public struct KextConnectionInfo
@@ -80,14 +113,25 @@ namespace BuildXL.Interop.MacOS
         public static extern void KextVersionString(StringBuilder s, int size);
 
         /// <nodoc />
+        [Flags]
+        public enum ConnectionType
+        {
+            /// <nodoc />
+            Kext,
+            
+            /// <nodoc />
+            EndpointSecurity
+        }
+
+        /// <nodoc />
         [DllImport(Libraries.BuildXLInteropLibMacOS, EntryPoint = "SendPipStarted")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool SendPipStarted(int processId, long pipId, byte[] famBytes, int famBytesLength, KextConnectionInfo info);
+        public static extern bool SendPipStarted(int processId, long pipId, byte[] famBytes, int famBytesLength, ConnectionType type, ref KextConnectionInfo info);
 
         /// <nodoc />
         [DllImport(Libraries.BuildXLInteropLibMacOS, EntryPoint = "SendPipProcessTerminated")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool SendPipProcessTerminated(long pipId, int processId, KextConnectionInfo info);
+        public static extern bool SendPipProcessTerminated(long pipId, int processId, ConnectionType type, ref KextConnectionInfo info);
 
         /// <nodoc />
         [DllImport(Libraries.BuildXLInteropLibMacOS, EntryPoint = "CheckForDebugMode")]
@@ -233,7 +277,7 @@ namespace BuildXL.Interop.MacOS
         public unsafe delegate void NativeFailureCallback(void *refCon, int status);
 
         /// <summary>
-        /// Callback the SandboxedKextConnection uses to report any unrecoverable failure back to
+        /// Callback the SandboxConnection uses to report any unrecoverable failure back to
         /// the scheduler (which, in response, should then terminate the build).
         /// </summary>
         /// <param name="status">Error code indicating what failure happened</param>


### PR DESCRIPTION
Initial draft for EndpointSecurity based sandbox support on macOS Catalina and higher. This is here to test and prototype a new sandbox for the upcoming OS release as kernel extensions are deprecated and will soon be forbidden.

**Important**

This currently only runs on systems with SIP disabled, using super user privileges and signing the bxl binary with a valid developer certificate before executing!

```codesign --entitlements Private/macOS/sandbox.entitlements Out/Bin/Debug/osx-x64/bxl -s XYZ```

A valid signing key (replace XYZ) can be obtained by using a registered MS developer account connected with an AppleID.

Running ```security find-identity -v -p codesigning``` will list those if any are available on the system.