### PR TITLE
Reduce sizes of BuildXL's NuGet packages

### DIFF
--- a/Public/Sdk/Public/Managed/Tools/NuGet/pack.dsc
+++ b/Public/Sdk/Public/Managed/Tools/NuGet/pack.dsc
@@ -26,6 +26,9 @@ export interface Arguments extends Transformer.RunnerArguments {
     /** Deployed files. */
     deployment?: Deployment.Definition;
 
+    /** Options to use during the deployment. i.e. to not deploy the pdb or xml docs */
+    deploymentOptions?: Managed.Deployment.FlattenOptions,
+
     /** The metadata for the package we generate */
     metadata: PackageMetadata;
 
@@ -123,7 +126,7 @@ export function pack(args: Arguments): PackResult {
     const nupkgPath = p`${outDir}/${packName + ".nupkg"}`;
 
     // Due to nuspec file not supporting renaming files, we have to compute the dependencies on the fly since we need to copy renames to a temp location with the same name.
-    const nuspecData = createNuSpecFile(args.metadata, args.deployment, nuspecPath);
+    const nuspecData = createNuSpecFile(args.metadata, args.deployment, nuspecPath, args.deploymentOptions);
 
     const arguments: Argument[] = [
         Cmd.argument("pack"),
@@ -160,7 +163,12 @@ export function pack(args: Arguments): PackResult {
     };
 }
 
-function createNuSpecFile(metaData: PackageMetadata, deployment: Deployment.Definition, nuSpecOutput: Path) : { nuspec: File, dependencies: (File|OpaqueDirectory)[] } {
+function createNuSpecFile(
+    metaData: PackageMetadata, 
+    deployment: Deployment.Definition, 
+    nuSpecOutput: Path,
+    deploymentOptions: Managed.Deployment.FlattenOptions) : { nuspec: File, dependencies: (File|OpaqueDirectory)[] } {
+
     let optionalElement = (element:string, value: string) => String.isUndefinedOrEmpty(value)
         ? undefined
         : Xml.elem(element, value);
@@ -168,7 +176,7 @@ function createNuSpecFile(metaData: PackageMetadata, deployment: Deployment.Defi
     let dependencies : (File|OpaqueDirectory)[] = [];
     let fileElements : Xml.Element[] = [];
 
-    let flattened = Deployment.flatten(deployment);
+    let flattened = Deployment.flatten(deployment, undefined, deploymentOptions);
 
     // Process the flattened files with one quirck where we have to handle nuspec not supporting renamed files
     for (let flattenedFile of flattened.flattenedFiles.toArray())

--- a/Public/Sdk/SelfHost/BuildXL/BuildXLSdk.dsc
+++ b/Public/Sdk/SelfHost/BuildXL/BuildXLSdk.dsc
@@ -158,12 +158,6 @@ namespace Flags {
      */
     @@public
     export const buildRequiredAdminPrivilegeTestInVm = Environment.getFlag("[Sdk.BuildXL]BuildRequiredAdminPrivilegeTestInVm");
-
-    /**
-     * Whether we deploy experimental tools.
-     */
-    @@public
-    export const deployExperimentalTools = Environment.getFlag("[Sdk.BuildXL]deployExperimentalTools");
 }
 
 @@public

--- a/Public/Src/Deployment/NugetPackages.dsc
+++ b/Public/Src/Deployment/NugetPackages.dsc
@@ -20,6 +20,11 @@ namespace NugetPackages {
         ? r`${qualifier.configuration}/pkgs`
         : r`${qualifier.configuration}/public/pkgs`;
 
+    const reducedDeploymentOptions: Managed.Deployment.FlattenOptions = {
+        skipPdb: true,
+        skipXml: true,
+    };
+
     const net472 = !canBuildAllPackagesOnThisHost ? undefined : pack({
         id: `${packageNamePrefix}.net472`,
         deployment: BuildXL.withQualifier({
@@ -27,6 +32,7 @@ namespace NugetPackages {
             targetFramework: "net472",
             targetRuntime: "win-x64"
         }).deployment,
+        deploymentOptions: reducedDeploymentOptions
     });
 
     const winX64 = !canBuildAllPackagesOnThisHost ? undefined : pack({
@@ -36,6 +42,7 @@ namespace NugetPackages {
             targetFramework: "netcoreapp3.0",
             targetRuntime: "win-x64"
         }).deployment,
+        deploymentOptions: reducedDeploymentOptions
     });
 
     const osxX64 = pack({
@@ -45,6 +52,7 @@ namespace NugetPackages {
             targetFramework: "netcoreapp3.0",
             targetRuntime: "osx-x64"
         }).deployment,
+        deploymentOptions: reducedDeploymentOptions
     });
 
     const sdks = pack({
@@ -139,7 +147,14 @@ namespace NugetPackages {
         targetLocation: packageTargetFolder,
     });
 
-    export function pack(args: {id: string, deployment: Deployment.Definition, copyContentFiles?: boolean, dependencies?: (Nuget.Dependency | Managed.ManagedNugetPackage)[]}) : File {
+    export function pack(args: {
+        id: string, 
+        deployment: Deployment.Definition, 
+        deploymentOptions?: Managed.Deployment.FlattenOptions,
+        copyContentFiles?: boolean, 
+        dependencies?: (Nuget.Dependency | Managed.ManagedNugetPackage)[]
+    }) : File {
+
         const dependencies : Nuget.Dependency[] = (args.dependencies || [])
             .map(dep => {
                 if (isManagedPackage(dep)) {
@@ -148,7 +163,7 @@ namespace NugetPackages {
                     return dep;
                 }
             });
-
+        
         return Nuget.pack({
             metadata:  {
                 id: args.id,
@@ -168,6 +183,7 @@ namespace NugetPackages {
                     : undefined,
             },
             deployment: args.deployment,
+            deploymentOptions: args.deploymentOptions,
             noPackageAnalysis: true,
             noDefaultExcludes: true,
         }).nuPkg;

--- a/Public/Src/Deployment/buildXL.dsc
+++ b/Public/Src/Deployment/buildXL.dsc
@@ -23,6 +23,10 @@ namespace BuildXL {
             importFrom("BuildXL.Tools").BxlScriptAnalyzer.exe,
             importFrom("BuildXL.Cache.VerticalStore").Analyzer.exe,
 
+            ...addIfLazy(qualifier.targetRuntime !== "osx-x64", () => [
+                importFrom("BuildXL.Tools").SandboxedProcessExecutor.exe,
+            ]),
+
             // tools
             ...addIfLazy(qualifier.targetRuntime !== "osx-x64", () => [{
                 subfolder: r`tools`,
@@ -62,37 +66,14 @@ namespace BuildXL {
                             }).exe
                         ]
                     },
-                    ...(BuildXLSdk.Flags.deployExperimentalTools
-                        ? [
-                            {
-                                subfolder: r`NinjaGraphBuilder`,
-                                contents: [
-                                    importFrom("BuildXL.Tools").NinjaGraphBuilder.exe,
-                                    importFrom("BuildXL.Tools.Ninjson").pkg.contents
-                                ]
-                            },
-                            {
-                                subfolder: r`CMakeRunner`,
-                                contents: [
-                                    importFrom("BuildXL.Tools").CMakeRunner.exe,
-                                ]
-                            }
-                          ]
-                        : []),
                     {
-                        subfolder: r`SandboxedProcessExecutor`,
+                        subfolder: r`CMakeNinja`,
                         contents: [
-                            importFrom("BuildXL.Tools").SandboxedProcessExecutor.exe,
+                            importFrom("BuildXL.Tools").CMakeRunner.exe,
+                            importFrom("BuildXL.Tools").NinjaGraphBuilder.exe,
+                            importFrom("BuildXL.Tools.Ninjson").pkg.contents
                         ]
                     },
-                    ...addIfLazy(BuildXLSdk.Flags.isMicrosoftInternal && !BuildXLSdk.isTargetRuntimeOsx,
-                        () =>
-                        [{
-                            subfolder: r`VmCommandProxy`,
-                            contents: [
-                                importFrom("CloudBuild.VmCommandProxy").pkg.contents
-                            ]
-                        }]),
                 ]
             }])
         ]

--- a/Public/Src/Engine/Dll/EngineSchedule.cs
+++ b/Public/Src/Engine/Dll/EngineSchedule.cs
@@ -284,6 +284,7 @@ namespace BuildXL.Engine
                     buildEngineFingerprint: buildEngineFingerprint,
                     vmInitializer: VmInitializer.CreateFromEngine(
                         configuration.Layout.BuildEngineDirectory.ToString(context.PathTable),
+                        vmCommandProxyAlternate: EngineEnvironmentSettings.VmCommandProxyPath,
                         message => Logger.Log.StartInitializingVm(loggingContext, message),
                         message => Logger.Log.EndInitializingVm(loggingContext, message),
                         message => Logger.Log.InitializingVm(loggingContext, message)));
@@ -1661,6 +1662,7 @@ namespace BuildXL.Engine
                         buildEngineFingerprint: buildEngineFingerprint,
                         vmInitializer: VmInitializer.CreateFromEngine(
                             newConfiguration.Layout.BuildEngineDirectory.ToString(newContext.PathTable),
+                            vmCommandProxyAlternate: EngineEnvironmentSettings.VmCommandProxyPath,
                             message => Logger.Log.StartInitializingVm(loggingContext, message),
                             message => Logger.Log.EndInitializingVm(loggingContext, message),
                             message => Logger.Log.InitializingVm(loggingContext, message)));

--- a/Public/Src/Engine/Processes/ExternalToolSandboxedProcessExecutor.cs
+++ b/Public/Src/Engine/Processes/ExternalToolSandboxedProcessExecutor.cs
@@ -16,7 +16,7 @@ namespace BuildXL.Processes
         /// <summary>
         /// Relative path to the default tool.
         /// </summary>
-        public const string DefaultToolRelativePath = @"tools\SandboxedProcessExecutor\SandboxedProcessExecutor.exe";
+        public const string DefaultToolRelativePath = @"SandboxedProcessExecutor.exe";
 
         /// <summary>
         /// Tool path.

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/IntegrationTest.BuildXL.Scheduler.dsc
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/IntegrationTest.BuildXL.Scheduler.dsc
@@ -55,17 +55,8 @@ namespace Scheduler.IntegrationTest {
         ],
         runtimeContent: [
             importFrom("BuildXL.Utilities.UnitTests").TestProcess.deploymentDefinition,
-            {
-                subfolder: a`tools`,
-                contents: [
-                    {
-                        subfolder: a`SandboxedProcessExecutor`,
-                        contents: [
-                            importFrom("BuildXL.Tools").SandboxedProcessExecutor.exe
-                        ]
-                    }
-                ]
-            },
+            importFrom("BuildXL.Tools").SandboxedProcessExecutor.exe,
+            // TODO: Move it to the root when we can access the real VmCommandProxy in CB.
             {
                 subfolder: r`tools/VmCommandProxy/tools`,
                 contents: [

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SchedulerIntegrationTestBase.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SchedulerIntegrationTestBase.cs
@@ -424,7 +424,7 @@ namespace Test.BuildXL.Scheduler
                 failedPips: null,
                 ipcProvider: null,
                 directoryTranslator: DirectoryTranslator,
-                vmInitializer: VmInitializer.CreateFromEngine(config.Layout.BuildEngineDirectory.ToString(Context.PathTable)),
+                vmInitializer: VmInitializer.CreateFromEngine(config.Layout.BuildEngineDirectory.ToString(Context.PathTable)), // VM command proxy for unit tests comes from engine.
                 testHooks: testHooks))
             {
                 MountPathExpander mountPathExpander = null;

--- a/Public/Src/FrontEnd/CMake/CMakeWorkspaceResolver.cs
+++ b/Public/Src/FrontEnd/CMake/CMakeWorkspaceResolver.cs
@@ -60,7 +60,7 @@ namespace BuildXL.FrontEnd.CMake
         /// <summary>
         /// Keep in sync with the BuildXL deployment spec that places the tool (\Public\Src\Deployment\buildXL.dsc)
         /// </summary>
-        private const string CMakeRunnerRelativePath = @"tools\CMakeRunner\CMakeRunner.exe";
+        private const string CMakeRunnerRelativePath = @"tools\CMakeNinja\CMakeRunner.exe";
         private AbsolutePath m_pathToTool;
 
         internal readonly NinjaWorkspaceResolver EmbeddedNinjaWorkspaceResolver;

--- a/Public/Src/FrontEnd/Ninja/NinjaWorkspaceResolver.cs
+++ b/Public/Src/FrontEnd/Ninja/NinjaWorkspaceResolver.cs
@@ -66,7 +66,7 @@ namespace BuildXL.FrontEnd.Ninja
         /// <summary>
         /// Keep in sync with the BuildXL deployment spec that places the tool (\Public\Src\Deployment\buildXL.dsc)
         /// </summary>
-        private const string NinjaGraphBuilderRelativePath = @"tools\NinjaGraphBuilder\NinjaGraphBuilder.exe";
+        private const string NinjaGraphBuilderRelativePath = @"tools\CMakeNinja\NinjaGraphBuilder.exe";
 
         /// <inheritdoc/>
         public NinjaWorkspaceResolver()

--- a/Public/Src/FrontEnd/UnitTests/Ninja/Test.BuildXL.FrontEnd.Ninja.dsc
+++ b/Public/Src/FrontEnd/UnitTests/Ninja/Test.BuildXL.FrontEnd.Ninja.dsc
@@ -45,10 +45,10 @@ namespace Test.Ninja {
                 subfolder: a`tools`,
                 contents: [
                     {
-                        subfolder: a`NinjaGraphBuilder`,
+                        subfolder: a`CMakeNinja`,
                         contents: [
-                        importFrom("BuildXL.Tools").NinjaGraphBuilder.exe,
-                        importFrom("BuildXL.Tools.Ninjson").pkg.contents 
+                            importFrom("BuildXL.Tools").NinjaGraphBuilder.exe,
+                            importFrom("BuildXL.Tools.Ninjson").pkg.contents 
                         ]
                     }
                 ]

--- a/Public/Src/Utilities/Configuration/EngineEnvironmentSettings.cs
+++ b/Public/Src/Utilities/Configuration/EngineEnvironmentSettings.cs
@@ -52,6 +52,11 @@ namespace BuildXL.Utilities.Configuration
         public static readonly Setting<string> DebugGraphFingerprintSalt = CreateSetting("BUILDXL_GRAPH_FINGERPRINT_SALT", value => ProcessFingerprintSalt(value));
 
         /// <summary>
+        /// Path pointing to VM command proxy needed for build in VM feature.
+        /// </summary>
+        public static readonly Setting<string> VmCommandProxyPath = CreateSetting("BUILDXL_VMCOMMANDPROXY_PATH", value => value);
+
+        /// <summary>
         /// Bypass NuGet up to date checks
         /// </summary>
         public static readonly Setting<bool> BypassNugetDownload = CreateSetting("BuildXLBypassNugetDownload", value => value == "1");

--- a/config.microsoftInternal.dsc
+++ b/config.microsoftInternal.dsc
@@ -18,7 +18,6 @@ export const pkgs = isMicrosoftInternal ? [
     { id: "Aria.Cpp.SDK", version: "8.5.6" },
 
     { id: "CB.QTest", version: "19.7.18.221046" },
-    { id: "CloudBuild.VmCommandProxy", version: "19.7.10.150722" },
 
     { id: "BuildXL.Tracing.AriaTenantToken", version: "1.0.0" },
 


### PR DESCRIPTION
We take a number of approaches to reduce the sizes of NuGet packages:

- Move `SandboxedProcessExecutor` to the root.
- Collapse CMake and Ninja runners into the same root.
- Remove `VmCommandProxy` from bin folder in favor of the one provided by CB.
- Remove PDB and XML files.

Resulting packages:
net472: 471M -> 391M
win-x64: 583M -> 451M

[AB#1579686](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1579686)
[AB#1574487](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1574487)