### PR TITLE
Include runtime framework name as part of DominoInvocation message

### DIFF
--- a/Public/Src/App/Bxl/BuildXLApp.cs
+++ b/Public/Src/App/Bxl/BuildXLApp.cs
@@ -924,7 +924,9 @@ namespace BuildXL
                         translatedLogDirectory,
                         m_configuration.InCloudBuild(),
                         Directory.GetCurrentDirectory(),
-                        m_initialConfiguration.Startup.ConfigFile.ToString(m_pathTable));
+                        m_initialConfiguration.Startup.ConfigFile.ToString(m_pathTable),
+                        OperatingSystemHelper.IsDotNetCore
+                        );
 
                     // "o" means it is round-trippable. It happens to be ISO-8601.
                     Logger.Log.StartupTimestamp(

--- a/Public/Src/App/Bxl/BuildXLApp.cs
+++ b/Public/Src/App/Bxl/BuildXLApp.cs
@@ -924,9 +924,7 @@ namespace BuildXL
                         translatedLogDirectory,
                         m_configuration.InCloudBuild(),
                         Directory.GetCurrentDirectory(),
-                        m_initialConfiguration.Startup.ConfigFile.ToString(m_pathTable),
-                        OperatingSystemHelper.IsDotNetCore
-                        );
+                        m_initialConfiguration.Startup.ConfigFile.ToString(m_pathTable));
 
                     // "o" means it is round-trippable. It happens to be ISO-8601.
                     Logger.Log.StartupTimestamp(

--- a/Public/Src/App/Bxl/MachineInfo.cs
+++ b/Public/Src/App/Bxl/MachineInfo.cs
@@ -59,6 +59,12 @@ namespace BuildXL
         public string DotNetFrameworkVersion { get; private set; }
 
         /// <summary>
+        /// Returns the runtime on which this process is currently running
+        /// (<see cref="OperatingSystemHelper.GetRuntimeFrameworkNameAndVersion"/>)
+        /// </summary>
+        public string RuntimeFrameworkName { get; private set; }
+
+        /// <summary>
         /// Creates a MachineInfo describing the current machine
         /// </summary>
         public static MachineInfo CreateForCurrentMachine()
@@ -89,6 +95,7 @@ namespace BuildXL
                 : false;
             mi.CurrentDriveHasSeekPenalty = seekPenalty ?? false;
             mi.DotNetFrameworkVersion = OperatingSystemHelper.GetInstalledDotNetFrameworkVersion();
+            mi.RuntimeFrameworkName = OperatingSystemHelper.GetRuntimeFrameworkNameAndVersion();
             return mi;
         }
     }

--- a/Public/Src/App/Bxl/Tracing/Log.cs
+++ b/Public/Src/App/Bxl/Tracing/Log.cs
@@ -37,7 +37,7 @@ namespace BuildXL.App.Tracing
         public static Logger Log => m_log;
 
         [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields")]
-        private const string AppInvocationMessage = "{ShortProductName} Startup Command Line Arguments: '{commandLine}' \r\n{ShortProductName} version:{buildInfo.CommitId}, Build: {buildInfo.Build}, Session ID:{sessionIdentifier}, Related Session:{relatedSessionIdentifier}, MachineInfo: CPU count: {machineInfo.ProcessorCount}, Physical Memory: {machineInfo.InstalledMemoryMB}MB, Current Drive seek penalty: {machineInfo.CurrentDriveHasSeekPenalty}, OS: {machineInfo.OsVersion}, .NETFramework: {machineInfo.DotNetFrameworkVersion}, Processor:{machineInfo.ProcessorIdentifier} - {machineInfo.ProcessorName}, CLR Version: {machineInfo.EnvironmentVersion}, Starup directory: {startupDirectory}, Main configuration file: {mainConfig}";
+        private const string AppInvocationMessage = "{ShortProductName} Startup Command Line Arguments: '{commandLine}' \r\n{ShortProductName} version:{buildInfo.CommitId}, Build: {buildInfo.Build}, Session ID:{sessionIdentifier}, Related Session:{relatedSessionIdentifier}, MachineInfo: CPU count: {machineInfo.ProcessorCount}, Physical Memory: {machineInfo.InstalledMemoryMB}MB, Current Drive seek penalty: {machineInfo.CurrentDriveHasSeekPenalty}, OS: {machineInfo.OsVersion}, .NETFramework: {machineInfo.DotNetFrameworkVersion}, Processor:{machineInfo.ProcessorIdentifier} - {machineInfo.ProcessorName}, CLR Version: {machineInfo.EnvironmentVersion}, Starup directory: {startupDirectory}, Main configuration file: {mainConfig}, Running on .NET Core: {isDotNetCore}";
 
         /// <summary>
         /// CAUTION!!
@@ -791,7 +791,7 @@ namespace BuildXL.App.Tracing
                     // Truncate the command line that gets to the CB event to avoid exceeding the max event payload of 64kb
                     CommandLineArgs = commandLine?.Substring(0, Math.Min(commandLine.Length, 4 * 1024)),
                     DominoVersion = buildInfo.CommitId,
-                    Environment = isDotNetCore ? "[.NETCore] " + environment : environment,
+                    Environment = environment,
                     LogDirectory = logDirectory,
                 });
             }

--- a/Public/Src/App/Bxl/Tracing/Log.cs
+++ b/Public/Src/App/Bxl/Tracing/Log.cs
@@ -37,7 +37,7 @@ namespace BuildXL.App.Tracing
         public static Logger Log => m_log;
 
         [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields")]
-        private const string AppInvocationMessage = "{ShortProductName} Startup Command Line Arguments: '{commandLine}' \r\n{ShortProductName} version:{buildInfo.CommitId}, Build: {buildInfo.Build}, Session ID:{sessionIdentifier}, Related Session:{relatedSessionIdentifier}, MachineInfo: CPU count: {machineInfo.ProcessorCount}, Physical Memory: {machineInfo.InstalledMemoryMB}MB, Current Drive seek penalty: {machineInfo.CurrentDriveHasSeekPenalty}, OS: {machineInfo.OsVersion}, .NETFramework: {machineInfo.DotNetFrameworkVersion}, Processor:{machineInfo.ProcessorIdentifier} - {machineInfo.ProcessorName}, CLR Version: {machineInfo.EnvironmentVersion}, Starup directory: {startupDirectory}, Main configuration file: {mainConfig}, Running on .NET Core: {isDotNetCore}";
+        private const string AppInvocationMessage = "{ShortProductName} Startup Command Line Arguments: '{commandLine}' \r\n{ShortProductName} version:{buildInfo.CommitId}, Build: {buildInfo.Build}, Session ID:{sessionIdentifier}, Related Session:{relatedSessionIdentifier}, MachineInfo: CPU count: {machineInfo.ProcessorCount}, Physical Memory: {machineInfo.InstalledMemoryMB}MB, Current Drive seek penalty: {machineInfo.CurrentDriveHasSeekPenalty}, OS: {machineInfo.OsVersion}, .NETFramework: {machineInfo.DotNetFrameworkVersion}, Processor:{machineInfo.ProcessorIdentifier} - {machineInfo.ProcessorName}, CLR Version: {machineInfo.EnvironmentVersion}, Runtime Framework: '{machineInfo.RuntimeFrameworkName}', Starup directory: {startupDirectory}, Main configuration file: {mainConfig}";
 
         /// <summary>
         /// CAUTION!!
@@ -54,7 +54,7 @@ namespace BuildXL.App.Tracing
             // Prevent this from going to the log. It is only for ETW and telemetry. DominoInvocationForLocalLog is for the log.
             Keywords = (int)Keywords.SelectivelyEnabled,
             Message = AppInvocationMessage)]
-        public abstract void DominoInvocation(LoggingContext context, string commandLine, BuildInfo buildInfo, MachineInfo machineInfo, string sessionIdentifier, string relatedSessionIdentifier, string startupDirectory, string mainConfig, bool isDotNetCore);
+        public abstract void DominoInvocation(LoggingContext context, string commandLine, BuildInfo buildInfo, MachineInfo machineInfo, string sessionIdentifier, string relatedSessionIdentifier, string startupDirectory, string mainConfig);
 
         /// <summary>
         /// This is the event that populates the local log file. It differs from DominoInvocation in that it contains the raw commandline without any truncation
@@ -65,7 +65,7 @@ namespace BuildXL.App.Tracing
             EventLevel = Level.Verbose,
             EventOpcode = (byte)EventOpcode.Start,
             Message = AppInvocationMessage)]
-        public abstract void DominoInvocationForLocalLog(LoggingContext context, string commandLine, BuildInfo buildInfo, MachineInfo machineInfo, string sessionIdentifier, string relatedSessionIdentifier, string startupDirectory, string mainConfig, bool isDotNetCore);
+        public abstract void DominoInvocationForLocalLog(LoggingContext context, string commandLine, BuildInfo buildInfo, MachineInfo machineInfo, string sessionIdentifier, string relatedSessionIdentifier, string startupDirectory, string mainConfig);
 
         [GeneratedEvent(
             (ushort)EventId.StartupTimestamp,
@@ -775,11 +775,10 @@ namespace BuildXL.App.Tracing
             string logDirectory,
             bool inCloudBuild,
             string startupDirectory,
-            string mainConfigurationFile,
-            bool isDotNetCore)
+            string mainConfigurationFile)
         {
-            Log.DominoInvocation(context, ScrubCommandLine(commandLine, 100000, 100000), buildInfo, machineInfo, sessionIdentifier, relatedSessionIdentifier, startupDirectory, mainConfigurationFile, isDotNetCore);
-            Log.DominoInvocationForLocalLog(context, commandLine, buildInfo, machineInfo, sessionIdentifier, relatedSessionIdentifier, startupDirectory, mainConfigurationFile, isDotNetCore);
+            Log.DominoInvocation(context, ScrubCommandLine(commandLine, 100000, 100000), buildInfo, machineInfo, sessionIdentifier, relatedSessionIdentifier, startupDirectory, mainConfigurationFile);
+            Log.DominoInvocationForLocalLog(context, commandLine, buildInfo, machineInfo, sessionIdentifier, relatedSessionIdentifier, startupDirectory, mainConfigurationFile);
 
             if (inCloudBuild)
             {

--- a/Public/Src/Utilities/Utilities/OperatingSystemHelper.cs
+++ b/Public/Src/Utilities/Utilities/OperatingSystemHelper.cs
@@ -54,6 +54,13 @@ namespace BuildXL.Utilities
             false;
 #endif
 
+        public static readonly bool IsDotNetCore =
+#if NET_CORE
+            true;
+#else
+            false;
+#endif
+
         /// <summary>
         /// Indicates if BuildXL is running on a Unix based operating system
         /// </summary>
@@ -325,7 +332,7 @@ namespace BuildXL.Utilities
             }
         }
 
-        #region macOS Helpers
+#region macOS Helpers
 
         private static Version GetOSVersionMacOS()
         {
@@ -415,6 +422,6 @@ namespace BuildXL.Utilities
             return new FileSize(physicalPages * pageSize);
         }
 
-        #endregion
+#endregion
     }
 }

--- a/Public/Src/Utilities/Utilities/OperatingSystemHelper.cs
+++ b/Public/Src/Utilities/Utilities/OperatingSystemHelper.cs
@@ -263,7 +263,7 @@ namespace BuildXL.Utilities
         public static string GetRuntimeFrameworkNameAndVersion()
         {
             return IsDotNetCore
-                ? Assembly.GetEntryAssembly()?.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkName ?? ".NETCore"
+                ? Assembly.GetEntryAssembly()?.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkName ?? ".NETCoreApp"
                 : AppDomain.CurrentDomain.SetupInformation.TargetFrameworkName;
         }
 

--- a/Public/Src/Utilities/Utilities/OperatingSystemHelper.cs
+++ b/Public/Src/Utilities/Utilities/OperatingSystemHelper.cs
@@ -54,6 +54,9 @@ namespace BuildXL.Utilities
             false;
 #endif
 
+        /// <summary>
+        /// Indicates if BuildXL is running on .NET Core
+        /// </summary>
         public static readonly bool IsDotNetCore =
 #if NET_CORE
             true;

--- a/Public/Src/Utilities/Utilities/OperatingSystemHelper.cs
+++ b/Public/Src/Utilities/Utilities/OperatingSystemHelper.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Xml.Linq;
 using Microsoft.Win32;
 using static BuildXL.Interop.Windows.Memory;
@@ -249,6 +251,20 @@ namespace BuildXL.Utilities
             }
 
             return "No .NET Framework is detected";
+        }
+
+        /// <summary>
+        /// Returns the current runtime version.
+        /// 
+        /// On .NET Core, the return string is something like ".NETCoreApp, Version=v2.0"
+        /// 
+        /// On .NET Framework, the return string is something like ".NETFramework, Version = v4.7.2".
+        /// </summary>
+        public static string GetRuntimeFrameworkNameAndVersion()
+        {
+            return IsDotNetCore
+                ? Assembly.GetEntryAssembly()?.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkName ?? "unknown"
+                : AppDomain.CurrentDomain.SetupInformation.TargetFrameworkName;
         }
 
         /// <summary>

--- a/Public/Src/Utilities/Utilities/OperatingSystemHelper.cs
+++ b/Public/Src/Utilities/Utilities/OperatingSystemHelper.cs
@@ -263,7 +263,7 @@ namespace BuildXL.Utilities
         public static string GetRuntimeFrameworkNameAndVersion()
         {
             return IsDotNetCore
-                ? Assembly.GetEntryAssembly()?.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkName ?? "unknown"
+                ? Assembly.GetEntryAssembly()?.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkName ?? ".NETCore"
                 : AppDomain.CurrentDomain.SetupInformation.TargetFrameworkName;
         }
 


### PR DESCRIPTION
Without this, it's is hard to know if a build was running on .NET Core or .NET Framework.