### PR TITLE
Stop the build after the first materialization error

### DIFF
--- a/Public/Src/App/Bxl/BuildXLApp.cs
+++ b/Public/Src/App/Bxl/BuildXLApp.cs
@@ -764,6 +764,10 @@ namespace BuildXL
             {
                 return (ExitKind: ExitKind.InfrastructureError, ErrorBucket: BuildXL.Engine.Tracing.LogEventId.DistributionExecutePipFailedNetworkFailure.ToString(), BucketMessage: string.Empty);
             }
+            else if (listener.CountsPerEventId((EventId)SchedulerEventId.ProblematicWorkerExit) >= 1)
+            {
+                return (ExitKind: ExitKind.InfrastructureError, ErrorBucket: SchedulerEventId.ProblematicWorkerExit.ToString(), BucketMessage: string.Empty);
+            }
             else if (listener.InternalErrorDetails.Count > 0)
             {
                 return (ExitKind: ExitKind.InternalError, ErrorBucket: listener.InternalErrorDetails.FirstErrorName, BucketMessage: listener.InternalErrorDetails.FirstErrorMessage);

--- a/Public/Src/App/Bxl/Tracing/Log.cs
+++ b/Public/Src/App/Bxl/Tracing/Log.cs
@@ -735,6 +735,15 @@ namespace BuildXL.App.Tracing
             Keywords = (int)Keywords.UserMessage)]
         public abstract void FrontendIOSlow(LoggingContext context, double factor);
 
+        [GeneratedEvent(
+            (ushort)EventId.ProblematicWorkerExitError,
+            EventGenerators = EventGenerators.LocalOnly,
+            Message = "One worker exited with a connection issue; caused some internal/infrastructure errors in the build: {errorMessage}",
+            EventLevel = Level.Error,
+            EventTask = (ushort)Tasks.Distribution,
+            Keywords = (int)Keywords.UserMessage)]
+        public abstract void ProblematicWorkerExitError(LoggingContext context, string errorMessage);
+
         /// <summary>
         /// Logging DominoCompletion with an extra CloudBuild event
         /// </summary>

--- a/Public/Src/App/UnitTests/Bxl/BuildXLAppTests.cs
+++ b/Public/Src/App/UnitTests/Bxl/BuildXLAppTests.cs
@@ -25,19 +25,19 @@ namespace Test.BuildXL
             using (var listener = new TrackingEventListener(Events.Log))
             {
                 Events.Log.UserErrorEvent("1");
-                var userErrorClassification = BuildXLApp.ClassifyFailureFromLoggedEvents(listener);
+                var userErrorClassification = BuildXLApp.ClassifyFailureFromLoggedEvents(Events.StaticContext, listener);
                 XAssert.AreEqual(ExitKind.UserError, userErrorClassification.ExitKind);
                 XAssert.AreEqual("UserErrorEvent", userErrorClassification.ErrorBucket);
 
                 // Now add an infrasctructure error. This should take prescedence
                 Events.Log.InfrastructureErrorEvent("1");
-                var infrastructureErrorClassification = BuildXLApp.ClassifyFailureFromLoggedEvents(listener);
+                var infrastructureErrorClassification = BuildXLApp.ClassifyFailureFromLoggedEvents(Events.StaticContext, listener);
                 XAssert.AreEqual(ExitKind.InfrastructureError, infrastructureErrorClassification.ExitKind);
                 XAssert.AreEqual("InfrastructureErrorEvent", infrastructureErrorClassification.ErrorBucket);
 
                 // Finally add an internal error. Again, this takes highest prescedence
                 Events.Log.ErrorEvent("1");
-                var internalErrorClassification = BuildXLApp.ClassifyFailureFromLoggedEvents(listener);
+                var internalErrorClassification = BuildXLApp.ClassifyFailureFromLoggedEvents(Events.StaticContext, listener);
                 XAssert.AreEqual(ExitKind.InternalError, internalErrorClassification.ExitKind);
                 XAssert.AreEqual("ErrorEvent", internalErrorClassification.ErrorBucket);
             }
@@ -56,7 +56,7 @@ namespace Test.BuildXL
                 global::BuildXL.Engine.Tracing.Logger.Log.DistributionExecutePipFailedNetworkFailure(loggingContext, "ArbitraryPip", "ArbitraryWorker", "ArbitraryMessage", "ArbitraryStep", "ArbitraryCaller");
                 global::BuildXL.Scheduler.Tracing.Logger.Log.PipMaterializeDependenciesFromCacheFailure(loggingContext, "ArbitraryPip", "ArbitraryMessage");
 
-                var infrastructureErrorClassification = BuildXLApp.ClassifyFailureFromLoggedEvents(listener);
+                var infrastructureErrorClassification = BuildXLApp.ClassifyFailureFromLoggedEvents(Events.StaticContext, listener);
                 XAssert.AreEqual(ExitKind.InfrastructureError, infrastructureErrorClassification.ExitKind);
                 XAssert.AreEqual(global::BuildXL.Engine.Tracing.LogEventId.DistributionExecutePipFailedNetworkFailure.ToString(), infrastructureErrorClassification.ErrorBucket);
             }

--- a/Public/Src/Engine/Dll/Distribution/DistributionHelpers.cs
+++ b/Public/Src/Engine/Dll/Distribution/DistributionHelpers.cs
@@ -174,6 +174,11 @@ namespace BuildXL.Engine.Distribution
                     sb.AppendFormat("ExecutionLogData: Size={0}, SequenceNumber={1}", notificationArgs.ExecutionLogData.Count, notificationArgs.ExecutionLogBlobSequenceNumber);
                 }
 
+                if (notificationArgs.ForwardedEvents?.Count > 0)
+                {
+                    sb.AppendFormat("ForwardedEvents: Count={0}", notificationArgs.ForwardedEvents.Count);
+                }
+
                 return sb.ToString();
             }
         }

--- a/Public/Src/Engine/Dll/Distribution/Grpc/ClientConnectionManager.cs
+++ b/Public/Src/Engine/Dll/Distribution/Grpc/ClientConnectionManager.cs
@@ -154,16 +154,6 @@ namespace BuildXL.Engine.Distribution.Grpc
                     {
                         break;
                     }
-
-                    if (numTry == GrpcSettings.MaxRetry - 1)
-                    {
-                        // If this is the last retry, try to attempt reconnecting. If the connection fails, do not attempt to retry the call.
-                        bool connectionSucceeded = await TryConnectChannelAsync(GrpcSettings.CallTimeout, operation);
-                        if (!connectionSucceeded)
-                        {
-                            break;
-                        }
-                    }
                 }
                 catch (ObjectDisposedException e)
                 {

--- a/Public/Src/Engine/Dll/Distribution/MasterService.cs
+++ b/Public/Src/Engine/Dll/Distribution/MasterService.cs
@@ -175,6 +175,7 @@ namespace BuildXL.Engine.Distribution
                                 EventName = forwardedEvent.EventName,
                                 EventKeywords = forwardedEvent.EventKeywords,
                             });
+                        m_loggingContext.SpecifyErrorWasLogged((ushort)forwardedEvent.EventId);
                         break;
                     case EventLevel.Warning:
                         Logger.Log.DistributionWorkerForwardedWarning(

--- a/Public/Src/Engine/Dll/Distribution/WorkerService.cs
+++ b/Public/Src/Engine/Dll/Distribution/WorkerService.cs
@@ -317,6 +317,9 @@ namespace BuildXL.Engine.Distribution
 
             // Dispose the notify master execution log target to ensure all message are sent to master.
             m_notifyMasterExecutionLogTarget?.Dispose();
+
+            // Dispose the event listener to ensure all events are sent to master.
+            m_forwardingEventListener?.Dispose();
         }
 
 
@@ -825,7 +828,6 @@ namespace BuildXL.Engine.Distribution
             m_workerPipStateManager?.Dispose();
 
             m_workerServer.Dispose();
-            m_forwardingEventListener?.Dispose();
 
 #if !DISABLE_FEATURE_BOND_RPC
             m_bondMasterClient?.Dispose();

--- a/Public/Src/Engine/Dll/Tracing/Log.cs
+++ b/Public/Src/Engine/Dll/Tracing/Log.cs
@@ -466,7 +466,7 @@ namespace BuildXL.Engine.Tracing
             Keywords = (int)Keywords.UserMessage,
             EventTask = (ushort)Tasks.Distribution,
             Message = "Worker {ipAddress}:{port} will get disconnected by {caller}")]
-                public abstract void DistributionWorkerFinish(
+        public abstract void DistributionWorkerFinish(
             LoggingContext context,
             string ipAddress,
             int port,

--- a/Public/Src/Engine/Scheduler/PipQueue.cs
+++ b/Public/Src/Engine/Scheduler/PipQueue.cs
@@ -51,7 +51,7 @@ namespace BuildXL.Scheduler
         /// In distributed builds, new work items can come from external requests after draining is started (i.e., workers get requests from the master)
         /// In single machine builds, after draining is started, new work items are only scheduled from the items that are being executed, not external requests.
         /// </remarks>
-        private bool m_isFinalized;
+        private volatile bool m_isFinalized;
 
         /// <summary>
         /// Whether the queue is cancelled via Ctrl-C

--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -2342,19 +2342,22 @@ namespace BuildXL.Scheduler
                 // This happens before we traverse the dependents of this failed pip; since SchedulePipIfReady
                 // checks m_scheduleTerminating this means that there will not be 'Skipped' pips in this mode
                 // (they remain unscheduled entirely).
-                if (!succeeded && m_scheduleConfiguration.StopOnFirstError)
+                if (!succeeded && !IsDistributedWorker)
                 {
-                    if (!m_scheduleTerminating)
+                    // We stop on the first error only on the master or single-machine builds.
+                    // During cancellation, master coordinates with workers to stop the build.
+
+                    bool hasMaterializationErrorHappened = m_executePhaseLoggingContext.ErrorsLoggedById.Contains((ushort)EventId.PipMaterializeDependenciesFromCacheFailure)
+                        || m_executePhaseLoggingContext.ErrorsLoggedById.Contains((ushort)EventId.PipMaterializeDependenciesFailureUnrelatedToCache);
+
+                    // Early terminate the build if StopOnFirstError is enabled or a materialization error is occurred. 
+                    bool earlyTerminate = m_scheduleConfiguration.StopOnFirstError || hasMaterializationErrorHappened;
+
+                    if (!IsTerminating && earlyTerminate)
                     {
                         Logger.Log.ScheduleTerminatingDueToPipFailure(m_executePhaseLoggingContext, pipDescription);
 
-                        // This flag prevents normally-scheduled pips (i.e., by refcount) from starting (thus m_numPipsQueuedOrRunning should
-                        // reach zero quickly). But we do allow further pips to run inline (see RunPipInline); that's safe from an error
-                        // reporting perspective since m_hasFailures latches to false.
-                        m_scheduleTerminating = true;
-
-                        // A build that has been canceled should return failure
-                        m_hasFailures = true;
+                        RequestTermination();
                     }
 
                     Contract.Assert(m_executePhaseLoggingContext.ErrorWasLogged, I($"Should have logged error for pip: {pipDescription}"));
@@ -2753,7 +2756,7 @@ namespace BuildXL.Scheduler
                 // With a ref count of zero, all pip dependencies (if any) have already executed, and so we have
                 // all needed content hashes (and content on disk) for inputs. This means the pip we can both
                 // compute the content fingerprint and execute it (possibly in a cached manner).
-                if (m_scheduleTerminating)
+                if (IsTerminating)
                 {
                     // We're bringing down the schedule quickly. Even pips which become ready without any dependencies will be skipped.
                     // We return early here to skip OnPipNewlyQueuedOrRunning (which prevents m_numPipsQueuedOrRunning from increasing).
@@ -3662,7 +3665,7 @@ namespace BuildXL.Scheduler
 
         private bool ShouldCancelPip(RunnablePip runnablePip)
         {
-            return m_scheduleTerminating && runnablePip.Step != PipExecutionStep.Start && GetPipRuntimeInfo(runnablePip.PipId).State == PipState.Running && !runnablePip.IsCancelled;
+            return IsTerminating && runnablePip.Step != PipExecutionStep.Start && GetPipRuntimeInfo(runnablePip.PipId).State == PipState.Running && !runnablePip.IsCancelled;
         }
 
         private void FlagSharedOpaqueOutputs(IPipExecutionEnvironment environment, ProcessRunnablePip process)
@@ -6381,7 +6384,9 @@ namespace BuildXL.Scheduler
         /// </summary>
         private void RequestTermination()
         {
-            // Cancellation event has been logged by BuildXLApp before triggering actual cancellation.
+            // This flag prevents normally-scheduled pips (i.e., by refcount) from starting (thus m_numPipsQueuedOrRunning should
+            // reach zero quickly). But we do allow further pips to run inline (see RunPipInline); that's safe from an error
+            // reporting perspective since m_hasFailures latches to false.
             m_scheduleTerminating = true;
 
             // A build that got canceled certainly didn't succeed.

--- a/Public/Src/Engine/Scheduler/Tracing/Log.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/Log.cs
@@ -747,6 +747,15 @@ namespace BuildXL.Scheduler.Tracing
         public abstract void WorkerReleasedEarly(LoggingContext context, string workerName, long drainDurationMs, long disconnectDurationMs, bool isDrainedWithSuccess);
 
         [GeneratedEvent(
+            (ushort)LogEventId.ProblematicWorkerExit,
+            EventGenerators = EventGenerators.LocalOnly,
+            Message = "{workerName} exited with a connection issue. Worker was attached and running during some part of the build.",
+            EventLevel = Level.Warning,
+            EventTask = (ushort)Tasks.Distribution,
+            Keywords = (int)Keywords.UserMessage)]
+        public abstract void ProblematicWorkerExit(LoggingContext context, string workerName);
+
+        [GeneratedEvent(
             (ushort)EventId.StorageCacheGetContentError,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Error,

--- a/Public/Src/Engine/Scheduler/Tracing/LogEventId.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/LogEventId.cs
@@ -138,7 +138,9 @@ namespace BuildXL.Scheduler.Tracing
         InitiateWorkerRelease = 5045,
         WorkerReleasedEarly = 5046, 
         DependencyViolationWriteOnExistingFile = 5047,
-        FailedToLoadPipGraphFragment = 5048
+        FailedToLoadPipGraphFragment = 5048,
+        ProblematicWorkerExit = 5049,
+
         // was DependencyViolationGenericWithRelatedPip_AsError = 25000,
         // was DependencyViolationGeneric_AsError = 25001,
         // was DependencyViolationDoubleWrite_AsError = 25002,

--- a/Public/Src/Utilities/Utilities/Tracing/EventId.cs
+++ b/Public/Src/Utilities/Utilities/Tracing/EventId.cs
@@ -1104,6 +1104,7 @@ namespace BuildXL.Utilities.Tracing
         BuildHasPerfSmells = 14010,
         LogProcessesEnabled = 14011,
         FrontendIOSlow = 14012,
+        ProblematicWorkerExitError = 14013,
 
         // Graph validation.
         InvalidGraphSinceOutputDirectoryContainsSourceFile = 14100,


### PR DESCRIPTION
The motivation is to save the machine hours. After we try 'stop on the first CTMIS' for a week, I will generalize this concept to all internal errors. 