### PR TITLE
Expand conditional compilation in UnixHelpers

### DIFF
--- a/Public/Src/Cache/ContentStore/UtilitiesCore/UnixHelpers.cs
+++ b/Public/Src/Cache/ContentStore/UtilitiesCore/UnixHelpers.cs
@@ -11,6 +11,7 @@ namespace BuildXL.Cache.ContentStore.Interfaces.FileSystem
     /// </summary>
     public static class UnixHelpers
     {
+#if !PLATFORM_WIN
         private static class LibC
         {
             /// <nodoc />
@@ -19,6 +20,7 @@ namespace BuildXL.Cache.ContentStore.Interfaces.FileSystem
 
             public static readonly int AllFilePermssionMask = Convert.ToInt32("777", 8);
         }
+#endif
 
         /// <nodoc />
         public static void OverrideFileAccessMode(bool changePermissions, string path)


### PR DESCRIPTION
To cut out JIT that needs libc. When using cache binaries in another project on Windows we're seeing:

FileSystemContentStore.PlaceFile stop 16ms input=[VSO0:B9FBE4B2985793C492B18BCCCF419EC71334A01FBD3E3888609F2BDDC1E058E100] result=[Error=[TypeLoadException: System.TypeLoadException: Could not load type 'BuildXL.Cache.ContentStore.Interfaces.FileSystem.UnixHelpers' from assembly 'BuildXL.Cache.ContentStore.UtilitiesCore, Version=1.0.0.0, Culture=neutral, PublicKeyToken=6212d9137135ce5d'.
