### PR TITLE
Introduce external input change list to BuildXL

### DIFF
--- a/Public/Src/App/Bxl/Args.cs
+++ b/Public/Src/App/Bxl/Args.cs
@@ -524,6 +524,9 @@ namespace BuildXL
                         OptionHandlerFactory.CreateOption(
                             "injectCacheMisses",
                             opt => HandleArtificialCacheMissOption(opt, cacheConfiguration)),
+                        OptionHandlerFactory.CreateOption(
+                            "inputChanges",
+                            opt => schedulingConfiguration.InputChanges = CommandLineUtilities.ParsePathOption(opt, pathTable)),
                         OptionHandlerFactory.CreateBoolOption(
                             "interactive",
                             sign => configuration.Interactive = sign),

--- a/Public/Src/App/Bxl/HelpText.cs
+++ b/Public/Src/App/Bxl/HelpText.cs
@@ -1089,6 +1089,10 @@ namespace BuildXL
                 Strings.HelpText_DisplayHelp_SymlinkDefinitionFile);
 
             hw.WriteOption(
+                "/inputChanges:<file>",
+                Strings.HelpText_DisplayHelp_InputChanges);
+
+            hw.WriteOption(
                 "/telemetryTagPrefix:<string>",
                 Strings.HelpText_DisplayHelp_TelemetryTagPrefix);
 

--- a/Public/Src/App/Bxl/Strings.resx
+++ b/Public/Src/App/Bxl/Strings.resx
@@ -1015,4 +1015,7 @@ Example: ad2d42d2ec5d2ca0c0b7ad65402d07c7ef40b91e</value>
   <data name="HelpText_DisplayHelp_Interactive" xml:space="preserve">
     <value>When enabled indicates that {ShortProductName} is allowed to interact with the user either via console or popups. A common use case is to allow front ends like nuget to display authentication prompts in case the user is not authenticated.</value>
   </data>
+  <data name="HelpText_DisplayHelp_InputChanges" xml:space="preserve">
+    <value>Path to file containing a list of input changes</value>
+  </data>
 </root>

--- a/Public/Src/App/Bxl/Strings.resx
+++ b/Public/Src/App/Bxl/Strings.resx
@@ -1016,6 +1016,6 @@ Example: ad2d42d2ec5d2ca0c0b7ad65402d07c7ef40b91e</value>
     <value>When enabled indicates that {ShortProductName} is allowed to interact with the user either via console or popups. A common use case is to allow front ends like nuget to display authentication prompts in case the user is not authenticated.</value>
   </data>
   <data name="HelpText_DisplayHelp_InputChanges" xml:space="preserve">
-    <value>Path to file containing a list of input changes</value>
+    <value>Path to file containing a list of input changes, separated by new lines. The formats of an input change is '&lt;path&gt;|&lt;change kind&gt;' or '&lt;path&gt;', where change kinds are 'DataOrMetadataChanged', 'Removed', 'MembershipChanged', 'NewlyPresentAsFile', 'NewlyPresentAsDirectory'.</value>
   </data>
 </root>

--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -4850,7 +4850,11 @@ namespace BuildXL.Scheduler
 
             if (m_configuration.Schedule.InputChanges.IsValid)
             {
-                inputChangeList = InputChangeList.CreateFromFile(loggingContext, m_configuration.Schedule.InputChanges.ToString(Context.PathTable));
+                inputChangeList = InputChangeList.CreateFromFile(
+                    loggingContext, 
+                    m_configuration.Schedule.InputChanges.ToString(Context.PathTable),
+                    m_configuration.Layout.SourceDirectory.ToString(Context.PathTable),
+                    DirectoryTranslator);
             }
 
             IncrementalSchedulingStateFactory incrementalSchedulingStateFactory = null;

--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -57,6 +57,7 @@ using BuildXL.Interop.MacOS;
 using BuildXL.Processes.Containers;
 using static BuildXL.Scheduler.FileMonitoringViolationAnalyzer;
 using BuildXL.Utilities.VmCommandProxy;
+using BuildXL.Storage.InputChange;
 
 namespace BuildXL.Scheduler
 {
@@ -4845,6 +4846,13 @@ namespace BuildXL.Scheduler
 
         private void ProcessFileChanges(LoggingContext loggingContext, SchedulerState schedulerState)
         {
+            InputChangeList inputChangeList = null;
+
+            if (m_configuration.Schedule.InputChanges.IsValid)
+            {
+                inputChangeList = InputChangeList.CreateFromFile(loggingContext, m_configuration.Schedule.InputChanges.ToString(Context.PathTable));
+            }
+
             IncrementalSchedulingStateFactory incrementalSchedulingStateFactory = null;
 
             if (m_shouldCreateIncrementalSchedulingState)
@@ -4869,7 +4877,7 @@ namespace BuildXL.Scheduler
             }
             else if (m_fileChangeTracker.IsTrackingChanges)
             {
-                var fileChangeProcessor = new FileChangeProcessor(loggingContext, m_fileChangeTracker);
+                var fileChangeProcessor = new FileChangeProcessor(loggingContext, m_fileChangeTracker, inputChangeList);
 
                 // We no longer include file content table (FCT) into file change journal processor because
                 // we don't want FCT to rely on file change tracker (tracker). The underbuild shown by FileChangeTrackerTests.TrackerLoadFailureShouldNotResultInUnderbuild

--- a/Public/Src/Utilities/Configuration/IScheduleConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/IScheduleConfiguration.cs
@@ -306,5 +306,10 @@ namespace BuildXL.Utilities.Configuration
         /// Indicates whether historic cpu information should be used to decide the weight of process pips.
         /// </summary>
         bool UseHistoricalCpuUsageInfo { get; }
+
+        /// <summary>
+        /// Path to file containing input changes.
+        /// </summary>
+        AbsolutePath InputChanges { get; }
     }
 }

--- a/Public/Src/Utilities/Configuration/Mutable/ScheduleConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/ScheduleConfiguration.cs
@@ -71,6 +71,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             SkipHashSourceFile = false;
 
             UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing = false;
+            InputChanges = AbsolutePath.Invalid;
         }
 
         /// <nodoc />
@@ -134,6 +135,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             SkipHashSourceFile = template.SkipHashSourceFile;
 
             UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing = template.UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing;
+            InputChanges = pathRemapper.Remap(template.InputChanges);
         }
 
         /// <inheritdoc />
@@ -314,5 +316,8 @@ namespace BuildXL.Utilities.Configuration.Mutable
 
         /// <inheritdoc />
         public bool UseHistoricalCpuUsageInfo { get; set; }
+
+        /// <inheritdoc />
+        public AbsolutePath InputChanges { get; set; }
     }
 }

--- a/Public/Src/Utilities/Storage/InputChange/InputChangeList.cs
+++ b/Public/Src/Utilities/Storage/InputChange/InputChangeList.cs
@@ -1,0 +1,195 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.ContractsLight;
+using System.IO;
+using System.Linq;
+using BuildXL.Storage.ChangeTracking;
+using BuildXL.Storage.Tracing;
+using BuildXL.Utilities.Instrumentation.Common;
+
+namespace BuildXL.Storage.InputChange
+{
+    /// <summary>
+    /// Class representing input change list.
+    /// </summary>
+    public sealed class InputChangeList : IObservable<ChangedPathInfo>
+    {
+        private readonly List<IObserver<ChangedPathInfo>> m_observers = new List<IObserver<ChangedPathInfo>>(2);
+        private readonly List<ChangedPathInfo> m_changedPaths = new List<ChangedPathInfo>();
+        private static char[] s_inputSeparator = new[] { '|' };
+
+        /// <summary>
+        /// Gets the list of input changes.
+        /// </summary>
+        public IEnumerable<ChangedPathInfo> ChangedPaths => m_changedPaths;
+
+        private InputChangeList()
+        {
+        }
+
+        /// <summary>
+        /// Creates and instance of <see cref="InputChangeList"/> from file.
+        /// </summary>
+        public static InputChangeList CreateFromFile(LoggingContext loggingContext, string path)
+        {
+            Contract.Requires(loggingContext != null);
+            Contract.Requires(!string.IsNullOrEmpty(path));
+
+            try
+            {
+                using (StreamReader reader = new StreamReader(path))
+                {
+                    return CreateFromStream(loggingContext, reader, path);
+                }
+            }
+            catch (IOException ioException)
+            {
+                Logger.Log.ExceptionOnCreatingInputChangeList(loggingContext, path, ioException.ToString());
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Creates an instance of <see cref="InputChangeList"/> from a stream reader.
+        /// </summary>
+        public static InputChangeList CreateFromStream(LoggingContext loggingContext, TextReader reader, string optionalPath = null)
+        {
+            Contract.Requires(loggingContext != null);
+            Contract.Requires(reader != null);
+
+            InputChangeList inputChangeList = new InputChangeList();
+
+            try
+            {   
+                int lineNo = 0;
+
+                while (reader.Peek() >= 0)
+                {
+                    string inputLine = reader.ReadLine();
+                    ++lineNo;
+
+                    if (string.IsNullOrEmpty(inputLine))
+                    {
+                        continue;
+                    }
+
+                    if (!TryParseInput(loggingContext, inputLine, optionalPath ?? string.Empty, lineNo, out var changePathInfo))
+                    {
+                        return null;
+                    }
+
+                    inputChangeList.m_changedPaths.Add(changePathInfo);
+                }
+            }
+            catch (IOException ioException)
+            {
+                Logger.Log.ExceptionOnCreatingInputChangeList(loggingContext, optionalPath ?? string.Empty, ioException.ToString());
+                return null;
+            }
+
+            return inputChangeList;
+        }
+
+        /// <summary>
+        /// Tries to parse input line.
+        /// </summary>
+        /// <remarks>
+        /// Input line must be of the form:
+        ///   full path
+        /// or
+        ///   full path|comma separated <see cref="PathChanges"/>
+        /// The former assumes that changes are <see cref="PathChanges.DataOrMetadataChanged"/>.
+        /// </remarks>
+        private static bool TryParseInput(LoggingContext loggingContext, string input, string filePath, int lineNo, out ChangedPathInfo changedPathInfo)
+        {
+            Contract.Requires(loggingContext != null);
+            Contract.Requires(!string.IsNullOrEmpty(input));
+
+            changedPathInfo = default;
+            string[] splitInput = input.Split(s_inputSeparator);
+
+            if (splitInput.Length > 2)
+            {
+                Logger.Log.InvalidFormatOfInputChange(loggingContext, input, filePath, lineNo);
+                return false;
+            }
+
+            string changedPath = splitInput[0].Trim();
+            string changesStr = null;
+
+            if (splitInput.Length == 2)
+            {
+                changesStr = splitInput[1].Trim();
+            }
+
+            if (!Path.IsPathRooted(changedPath))
+            {
+                Logger.Log.InvalidChangedPathOfInputChange(loggingContext, changedPath, filePath, lineNo);
+                return false;
+            }
+
+            PathChanges changes = PathChanges.None;
+
+            try
+            {
+                changes = !string.IsNullOrEmpty(changesStr)
+                    ? (PathChanges)Enum.Parse(typeof(PathChanges), changesStr)
+                    : PathChanges.DataOrMetadataChanged; // Assume data or metadata change if unspecified.
+            }
+            catch (ArgumentException)
+            {
+                string validKinds = string.Join(", ", ((PathChanges[])Enum.GetValues(typeof(PathChanges))).Select(c => c.ToString()));
+                Logger.Log.InvalidChangeKindsOfInputChange(loggingContext, changesStr, filePath, lineNo, validKinds);
+                return false;
+            }
+
+            changedPathInfo = new ChangedPathInfo(changedPath, changes);
+            return true;
+        }
+        
+        /// <inheritdoc />
+        public IDisposable Subscribe(IObserver<ChangedPathInfo> observer)
+        {
+            Contract.Requires(observer != null);
+
+            if (!m_observers.Contains(observer))
+            {
+                m_observers.Add(observer);
+            }
+
+            return new InputChangeListUnsubscriber(m_observers, observer);
+        }
+
+        /// <summary>
+        /// Process input change list.
+        /// </summary>
+        public void ProcessChanges()
+        {
+            foreach (var changedPath in m_changedPaths)
+            {
+                ReportChanges(changedPath);
+            }
+
+            CompleteChanges();
+        }
+
+        private void ReportChanges(ChangedPathInfo changedPathInfo)
+        {
+            foreach (var observer in m_observers)
+            {
+                observer.OnNext(changedPathInfo);
+            }
+        }
+
+        private void CompleteChanges()
+        {
+            foreach (var observer in m_observers)
+            {
+                observer.OnCompleted();
+            }
+        }
+    }
+}

--- a/Public/Src/Utilities/Storage/InputChange/InputChangeListUnsubscriber.cs
+++ b/Public/Src/Utilities/Storage/InputChange/InputChangeListUnsubscriber.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.ContractsLight;
+using BuildXL.Storage.ChangeTracking;
+
+namespace BuildXL.Storage.InputChange
+{
+    /// <summary>
+    /// Unsubscriber of <see cref="InputChangeList"/>.
+    /// </summary>
+    public sealed class InputChangeListUnsubscriber : IDisposable
+    {
+        /// <summary>
+        /// List of known observers.
+        /// </summary>
+        private readonly List<IObserver<ChangedPathInfo>> m_observers;
+
+        /// <summary>
+        /// The observer.
+        /// </summary>
+        public readonly IObserver<ChangedPathInfo> Observer;
+
+        /// <summary>
+        /// Creates an instance of <see cref="InputChangeListUnsubscriber" />
+        /// </summary>
+        public InputChangeListUnsubscriber(List<IObserver<ChangedPathInfo>> observers, IObserver<ChangedPathInfo> observer)
+        {
+            Contract.Requires(observers != null);
+            Contract.Requires(observer != null);
+
+            m_observers = observers;
+            Observer = observer;
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            m_observers.Remove(Observer);
+        }
+    }
+}

--- a/Public/Src/Utilities/Storage/Tracing/Log.cs
+++ b/Public/Src/Utilities/Storage/Tracing/Log.cs
@@ -120,6 +120,24 @@ namespace BuildXL.Storage.Tracing
         public abstract void InvalidChangeKindsOfInputChange(LoggingContext context, string changeKind, string path, int lineNo, string validChangeKinds);
 
         [GeneratedEvent(
+            (int)LogEventId.InvalidInputChange,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Error,
+            EventTask = (ushort)Tasks.ChangeDetection,
+            Keywords = (int)Keywords.UserMessage,
+            Message = "Invalid input change '{inputChange}' on '{path}:{lineNo}': {message}")]
+        public abstract void InvalidInputChange(LoggingContext context, string inputChange, string path, int lineNo, string message);
+
+        [GeneratedEvent(
+            (int)LogEventId.InputChangeListFileNotFound,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Error,
+            EventTask = (ushort)Tasks.ChangeDetection,
+            Keywords = (int)Keywords.UserMessage,
+            Message = "Input change list file '{path}' does not exist")]
+        public abstract void InputChangeListFileNotFound(LoggingContext context, string path);
+
+        [GeneratedEvent(
             (int)LogEventId.ChangeDetectionFailCreateTrackingSetDueToJournalQueryError,
             EventGenerators = EventGenerators.LocalAndTelemetry,
             EventLevel = Level.Verbose,

--- a/Public/Src/Utilities/Storage/Tracing/Log.cs
+++ b/Public/Src/Utilities/Storage/Tracing/Log.cs
@@ -84,6 +84,42 @@ namespace BuildXL.Storage.Tracing
         public abstract void SavingChangeTracker(LoggingContext context, string path, string token, string state, int trackedVolumeCount, long durationMs);
 
         [GeneratedEvent(
+            (int)LogEventId.ExceptionOnCreatingInputChangeList,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Error,
+            EventTask = (ushort)Tasks.ChangeDetection,
+            Keywords = (int)Keywords.UserMessage,
+            Message = "Exception occured on creating input change list from file '{path}': {message}")]
+        public abstract void ExceptionOnCreatingInputChangeList(LoggingContext context, string path, string message);
+
+        [GeneratedEvent(
+            (int)LogEventId.InvalidFormatOfInputChange,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Error,
+            EventTask = (ushort)Tasks.ChangeDetection,
+            Keywords = (int)Keywords.UserMessage,
+            Message = "Invalid format '{change}' of input change on '{path}:{lineNo}'. Valid format is either 'path' or 'path|changes'.")]
+        public abstract void InvalidFormatOfInputChange(LoggingContext context, string change, string path, int lineNo);
+
+        [GeneratedEvent(
+            (int)LogEventId.InvalidChangedPathOfInputChange,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Error,
+            EventTask = (ushort)Tasks.ChangeDetection,
+            Keywords = (int)Keywords.UserMessage,
+            Message = "Invalid path '{changedPath}' of input change on '{path}:{lineNo}'. Valid path is a full path.")]
+        public abstract void InvalidChangedPathOfInputChange(LoggingContext context, string changedPath, string path, int lineNo);
+
+        [GeneratedEvent(
+            (int)LogEventId.InvalidChangeKindsOfInputChange,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Error,
+            EventTask = (ushort)Tasks.ChangeDetection,
+            Keywords = (int)Keywords.UserMessage,
+            Message = "Invalid change kind '{changeKind}' of input change on '{path}:{lineNo}'. Valid change kinds are '{validChangeKinds}'.")]
+        public abstract void InvalidChangeKindsOfInputChange(LoggingContext context, string changeKind, string path, int lineNo, string validChangeKinds);
+
+        [GeneratedEvent(
             (int)LogEventId.ChangeDetectionFailCreateTrackingSetDueToJournalQueryError,
             EventGenerators = EventGenerators.LocalAndTelemetry,
             EventLevel = Level.Verbose,

--- a/Public/Src/Utilities/Storage/Tracing/LogEventId.cs
+++ b/Public/Src/Utilities/Storage/Tracing/LogEventId.cs
@@ -107,5 +107,10 @@ namespace BuildXL.Storage.Tracing
         StartSavingChangeTracker = 8030,
         EndSavingChangeTracker = 8031,
         SavingChangeTracker = 8032,
+
+        ExceptionOnCreatingInputChangeList = 8201,
+        InvalidFormatOfInputChange = 8202,
+        InvalidChangedPathOfInputChange = 8203,
+        InvalidChangeKindsOfInputChange = 8204,
     }
 }

--- a/Public/Src/Utilities/Storage/Tracing/LogEventId.cs
+++ b/Public/Src/Utilities/Storage/Tracing/LogEventId.cs
@@ -112,5 +112,7 @@ namespace BuildXL.Storage.Tracing
         InvalidFormatOfInputChange = 8202,
         InvalidChangedPathOfInputChange = 8203,
         InvalidChangeKindsOfInputChange = 8204,
+        InvalidInputChange = 8205,
+        InputChangeListFileNotFound = 8206,
     }
 }

--- a/Public/Src/Utilities/UnitTests/Storage/InputChangeListTests.cs
+++ b/Public/Src/Utilities/UnitTests/Storage/InputChangeListTests.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using BuildXL.Storage.ChangeTracking;
+using BuildXL.Storage.InputChange;
+using BuildXL.Utilities.Instrumentation.Common;
+using Test.BuildXL.TestUtilities.Xunit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Test.BuildXL.Storage
+{
+    public sealed class InputChangeListTests : XunitBuildXLTest
+    {
+        public InputChangeListTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        [Fact]
+        public void TestValidInputChangeList()
+        {
+            Verify(new[]
+            {
+                (A("C", new[]{ "D", "E", "f"}), PathChanges.DataOrMetadataChanged.ToString()),
+                (A("C", new[]{ "D", "X", "g"}), (PathChanges.DataOrMetadataChanged | PathChanges.Removed).ToString()),
+                (A("C", new[]{ "D", "X", "h"}), null),
+                (A("C", new[]{ "D", "X", "i"}), PathChanges.NewlyPresent.ToString())
+            },
+            shouldSucceed: true);
+        }
+
+        [Fact]
+        public void TestInvalidPathInInputChangeList()
+        {
+            Verify(new[]
+            {
+                (A("C", new[]{ "D", "E", "f"}), PathChanges.DataOrMetadataChanged.ToString()),
+                (R("X", "Y", "m"), (PathChanges.DataOrMetadataChanged | PathChanges.Removed).ToString()),
+                (A("C", new[]{ "D", "X", "i"}), PathChanges.NewlyPresent.ToString())
+            },
+            shouldSucceed: false);
+        }
+
+        [Fact]
+        public void TestInvalidChangesInChangeList()
+        {
+            Verify(new[]
+            {
+                (A("C", new[]{ "D", "E", "f"}), PathChanges.DataOrMetadataChanged.ToString()),
+                (A("C", new[]{ "D", "X", "g"}), "Foo"),
+                (A("C", new[]{ "D", "X", "i"}), PathChanges.NewlyPresent.ToString())
+            },
+            shouldSucceed: false);
+        }
+
+        private InputChangeList Test((string path, string changes)[] changedPaths)
+        {
+            using (MemoryStream ms = new MemoryStream())
+            {
+                using (StreamWriter writer = new StreamWriter(ms, System.Text.Encoding.UTF8, 4096, true))
+                {
+                    foreach (var changedPath in changedPaths)
+                    {
+                        var changes = !string.IsNullOrEmpty(changedPath.changes) ? "|" + changedPath.changes : string.Empty;
+                        writer.WriteLine(changedPath.path + changes);
+                    }
+                }
+
+                ms.Seek(0, SeekOrigin.Begin);
+
+                using (StreamReader reader = new StreamReader(ms, System.Text.Encoding.UTF8, false, 4096, true))
+                {
+                    return InputChangeList.CreateFromStream(new LoggingContext("Dummy"), reader);
+                }
+            }
+        }
+
+        private void Verify((string path, string changes)[] changedPathsToWrite, bool shouldSucceed)
+        {
+            var inputChangeList = Test(changedPathsToWrite.Select(cp => (cp.path, cp.changes)).ToArray());
+            XAssert.AreEqual(shouldSucceed, inputChangeList != null);
+
+            if (shouldSucceed)
+            {
+                var changedPathsRead = inputChangeList.ChangedPaths.ToArray();
+                XAssert.AreEqual(changedPathsToWrite.Length, changedPathsRead.Length);
+
+                for (int i = 0; i < changedPathsRead.Length; ++i)
+                {
+                    XAssert.AreEqual(changedPathsToWrite[i].path, changedPathsRead[i].Path);
+                    XAssert.AreEqual(
+                        !string.IsNullOrEmpty(changedPathsToWrite[i].changes)
+                        ? (PathChanges)Enum.Parse(typeof(PathChanges), changedPathsToWrite[i].changes)
+                        : PathChanges.DataOrMetadataChanged, 
+                        changedPathsRead[i].PathChanges);
+                }
+            }
+        }
+    }
+}

--- a/Public/Src/Utilities/UnitTests/Storage/InputChangeListTests.cs
+++ b/Public/Src/Utilities/UnitTests/Storage/InputChangeListTests.cs
@@ -57,7 +57,16 @@ namespace Test.BuildXL.Storage
             shouldSucceed: false);
         }
 
-        private InputChangeList Test((string path, string changes)[] changedPaths)
+        [Fact]
+        public void TestFreeString()
+        {
+            XAssert.IsNotNull(Test(new[] { "" }));
+            XAssert.IsNull(Test(new[] { "|" }));
+            XAssert.IsNull(Test(new[] { "?abc|foo" }));
+            XAssert.IsNull(Test(new[] { "?abc|fo|o" }));
+        }
+
+        private InputChangeList Test(string[] changedPaths)
         {
             using (MemoryStream ms = new MemoryStream())
             {
@@ -65,8 +74,7 @@ namespace Test.BuildXL.Storage
                 {
                     foreach (var changedPath in changedPaths)
                     {
-                        var changes = !string.IsNullOrEmpty(changedPath.changes) ? "|" + changedPath.changes : string.Empty;
-                        writer.WriteLine(changedPath.path + changes);
+                        writer.WriteLine(changedPath);
                     }
                 }
 
@@ -81,7 +89,7 @@ namespace Test.BuildXL.Storage
 
         private void Verify((string path, string changes)[] changedPathsToWrite, bool shouldSucceed)
         {
-            var inputChangeList = Test(changedPathsToWrite.Select(cp => (cp.path, cp.changes)).ToArray());
+            var inputChangeList = Test(changedPathsToWrite.Select(cp => CreateInputLine(cp.path, cp.changes)).ToArray());
             XAssert.AreEqual(shouldSucceed, inputChangeList != null);
 
             if (shouldSucceed)
@@ -98,6 +106,12 @@ namespace Test.BuildXL.Storage
                         : PathChanges.DataOrMetadataChanged, 
                         changedPathsRead[i].PathChanges);
                 }
+            }
+
+            string CreateInputLine(string p, string c)
+            {
+                c = !string.IsNullOrEmpty(c) ? "|" + c : string.Empty;
+                return p + c;
             }
         }
     }


### PR DESCRIPTION
Input change list is a list of paths along with kinds of changes applied to those paths. BuildXL infers input change list by scanning USN journal. In this change, BuildXL can take an external input change list that may have been produced by a source control.

[AB#1579479](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1579479)