### PR TITLE
Fix logging for cache

### DIFF
--- a/Public/Src/Cache/ContentStore/Library/Logging/FileLog.cs
+++ b/Public/Src/Cache/ContentStore/Library/Logging/FileLog.cs
@@ -179,7 +179,7 @@ namespace BuildXL.Cache.ContentStore.Logging
                     message
                 );
 
-            WriteLineInternal(severity, line);
+            WriteLine(severity, severity.ToString(), line);
         }
 
         /// <summary>

--- a/Public/Src/Cache/ContentStore/Library/Logging/FileLog.cs
+++ b/Public/Src/Cache/ContentStore/Library/Logging/FileLog.cs
@@ -179,7 +179,8 @@ namespace BuildXL.Cache.ContentStore.Logging
                     message
                 );
 
-            WriteLine(severity, severity.ToString(), line);
+            // Important to call WriteLine and not WriteLineInternal as subclasses might override behavior.
+            WriteLine(severity, severityName, line);
         }
 
         /// <summary>


### PR DESCRIPTION
The implementation of EtwFileLog overrides WriteLine.

Not calling WriteLine meant that EtwFileLog implementation, on which cache telemetry depends on would never be called.