### PR TITLE
Add timed full range compaction for RocksDbContentLocationDatabase

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabase.cs
@@ -50,6 +50,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         private NagleQueue<(ShortHash hash, EntryOperation op, OperationReason reason, int modificationCount)> _nagleOperationTracer;
         private readonly ContentLocationDatabaseConfiguration _configuration;
 
+        /// <nodoc />
         protected bool IsDatabaseWriteable;
         private bool _isContentGarbageCollectionEnabled;
         private bool _isMetadataGarbageCollectionEnabled;

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabase.cs
@@ -53,7 +53,9 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
 
         private bool _isContentGarbageCollectionEnabled;
         private bool _isMetadataGarbageCollectionEnabled;
-        private bool IsGarbageCollectionEnabled => _isContentGarbageCollectionEnabled || _isMetadataGarbageCollectionEnabled;
+
+        /// <nodoc />
+        protected bool IsGarbageCollectionEnabled => _isContentGarbageCollectionEnabled || _isMetadataGarbageCollectionEnabled;
 
         /// <summary>
         /// Fine-grained locks that is used for all operations that mutate records.
@@ -121,7 +123,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         /// Prepares the database for read only or read/write mode. This operation assumes no operations are underway
         /// while running. It is the responsibility of the caller to ensure that is so.
         /// </summary>
-        public void SetDatabaseMode(bool isDatabaseWriteable)
+        public virtual void SetDatabaseMode(bool isDatabaseWriteable)
         {
             ConfigureGarbageCollection(isDatabaseWriteable);
             ConfigureInMemoryDatabaseCache(isDatabaseWriteable);

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabaseConfiguration.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabaseConfiguration.cs
@@ -120,5 +120,11 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         /// Gets whether the database is cleared on initialization. (Defaults to true because the standard use case involves restoring from checkpoint after initialization)
         /// </summary>
         public bool CleanOnInitialize { get; set; } = true;
+
+        /// <summary>
+        /// Time between full range compactions. These help keep the size of the DB instance down to a minimum.
+        /// Required because of our workload tends to generate a lot of cruft.
+        /// </summary>
+        public TimeSpan FullRangeCompactionInterval { get; set; } = TimeSpan.FromHours(6);
     }
 }

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabaseConfiguration.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabaseConfiguration.cs
@@ -123,7 +123,9 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
 
         /// <summary>
         /// Time between full range compactions. These help keep the size of the DB instance down to a minimum.
-        /// Required because of our workload tends to generate a lot of cruft.
+        /// 
+        /// Required because of our workload tends to generate a lot of short-lived entries, which clutter the deeper
+        /// levels of the RocksDB LSM tree.
         /// </summary>
         public TimeSpan FullRangeCompactionInterval { get; set; } = TimeSpan.FromHours(6);
     }

--- a/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
@@ -387,7 +387,6 @@ namespace BuildXL.Cache.Host.Configuration
         [DataMember]
         public int? FullRangeCompactionIntervalMinutes { get; set; }
 
-
         // Key Vault Settings
         [DataMember]
         public string KeyVaultSettingsString { get; set; }

--- a/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
@@ -384,6 +384,10 @@ namespace BuildXL.Cache.Host.Configuration
         [DataMember]
         public TimeSpan? ContentLocationDatabaseCacheFlushingMaximumInterval { get; set; }
 
+        [DataMember]
+        public int? FullRangeCompactionIntervalMinutes { get; set; }
+
+
         // Key Vault Settings
         [DataMember]
         public string KeyVaultSettingsString { get; set; }

--- a/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
@@ -98,6 +98,11 @@ namespace BuildXL.Cache.Host.Service.Internal
                 ApplyIfNotNull(_distributedSettings.ContentLocationDatabaseCacheMaximumUpdatesPerFlush, v => dbConfig.CacheMaximumUpdatesPerFlush = v);
                 ApplyIfNotNull(_distributedSettings.ContentLocationDatabaseCacheFlushingMaximumInterval, v => dbConfig.CacheFlushingMaximumInterval = v);
 
+                if (_distributedSettings.FullRangeCompactionIntervalMinutes != null)
+                {
+                    dbConfig.FullRangeCompactionInterval = TimeSpan.FromMinutes(_distributedSettings.FullRangeCompactionIntervalMinutes.Value);
+                }
+
                 ApplySecretSettingsForLlsAsync(redisContentLocationStoreConfiguration, localCacheRoot).GetAwaiter().GetResult();
             }
 

--- a/Public/Src/Utilities/KeyValueStore/IKeyValueStore.cs
+++ b/Public/Src/Utilities/KeyValueStore/IKeyValueStore.cs
@@ -109,5 +109,24 @@ namespace BuildXL.Engine.Cache.KeyValueStores
         /// The column family to use.
         /// </param>
         IEnumerable<KeyValuePair<TKey, TValue>> PrefixSearch(TKey prefix, string columnFamilyName = null);
+
+        /// <summary>
+        /// Forces compaction of a range of keys. What exactly this means depends on the underlying store.
+        /// </summary>
+        /// <param name="start">
+        /// First key in the range (inclusive). If null, the first key in the column family.
+        /// </param>
+        /// <param name="limit">
+        /// Last key in the range (exclusive). If null, a "key" past the end of the column family.
+        /// </param>
+        /// <param name="columnFamilyName">
+        /// The column family to use.
+        /// </param>
+        /// <remarks>
+        /// Set both start and limit to null to force compaction of the entire key space.
+        /// 
+        /// Compaction may happen in parallel with other operations, no exclusive usage is required.
+        /// </remarks>
+        void CompactRange(TKey start, TKey limit, string columnFamilyName = null);
     }
 }

--- a/Public/Src/Utilities/KeyValueStore/RocksDb/RocksDbStore.cs
+++ b/Public/Src/Utilities/KeyValueStore/RocksDb/RocksDbStore.cs
@@ -803,6 +803,21 @@ namespace BuildXL.Engine.Cache.KeyValueStores
 
                 return true;
             }
+
+            /// <inheritdoc />
+            public void CompactRange(string start, string limit, string columnFamilyName = null)
+            {
+                CompactRange(StringToBytes(start), StringToBytes(limit), columnFamilyName);
+            }
+
+            /// <inheritdoc />
+            public void CompactRange(byte[] start, byte[] limit, string columnFamilyName = null)
+            {
+                var columnFamilyInfo = GetColumnFamilyInfo(columnFamilyName);
+
+                // We need to use the instance directly because RocksDbSharp does not handle the case where full range compaction is desired.
+                RocksDbSharp.Native.Instance.rocksdb_compact_range_cf(m_store.Handle, columnFamilyInfo.Handle.Handle, start, start?.GetLongLength(0) ?? 0, limit, limit?.GetLongLength(0) ?? 0);
+            }
         } // RocksDbStore
     } // KeyValueStoreAccessor
 }


### PR DESCRIPTION
We have observed in production that database size grows over time even when the number of keys decrease or stay the same, seeing dramatic effects such as a 2x or 3x size increase. Investigation has shown this to be likely caused to deleted keys/old versions that sink into lower levels of the LSM tree and don't ever get compacted.

This PR adds a timer to the `RocksDbContentLocationDatabase` that runs a full compaction over the entire key range every few hours, thereby forcing the size of the DB to stay relatively small.