### PR TITLE
Implement ToString method for FileArtifact

### DIFF
--- a/Public/Src/Utilities/UnitTests/Utilities/FileArtifactTests.cs
+++ b/Public/Src/Utilities/UnitTests/Utilities/FileArtifactTests.cs
@@ -93,13 +93,17 @@ namespace Test.BuildXL.Utilities
         public void ToStringTest()
         {
             var pt = new PathTable();
-            Assert.Throws<NotImplementedException>(() =>
-            {
-                FileArtifact da1 = FileArtifact.CreateSourceFile(AbsolutePath.Create(pt, A("c")));
-#pragma warning disable 618
-                da1.ToString();
-#pragma warning restore 618
-            });
+            string f = FileArtifact.CreateSourceFile(AbsolutePath.Create(pt, A("F"))).ToString();
+            XAssert.IsTrue(f.Contains("File"), f);
+            XAssert.IsTrue(f.Contains("(source)"), f);
+
+            string g = FileArtifact.CreateOutputFile(AbsolutePath.Create(pt, A("G"))).ToString();
+            XAssert.IsTrue(g.Contains("File"), g);
+            XAssert.IsTrue(g.Contains("(output)"), g);
+
+            string h = FileArtifact.CreateOutputFile(AbsolutePath.Create(pt, A("H"))).CreateNextWrittenVersion().ToString();
+            XAssert.IsTrue(h.Contains("File"), h);
+            XAssert.IsTrue(h.Contains("(rewrite:2)"), h);
         }
     }
 }

--- a/Public/Src/Utilities/UnitTests/Utilities/FileArtifactTests.cs
+++ b/Public/Src/Utilities/UnitTests/Utilities/FileArtifactTests.cs
@@ -104,6 +104,9 @@ namespace Test.BuildXL.Utilities
             string h = FileArtifact.CreateOutputFile(AbsolutePath.Create(pt, A("H"))).CreateNextWrittenVersion().ToString();
             XAssert.IsTrue(h.Contains("File"), h);
             XAssert.IsTrue(h.Contains("(rewrite:2)"), h);
+
+            string i = FileArtifact.Invalid.ToString();
+            XAssert.IsTrue(i.Contains("Invalid"), i);
         }
     }
 }

--- a/Public/Src/Utilities/Utilities/FileArtifact.cs
+++ b/Public/Src/Utilities/Utilities/FileArtifact.cs
@@ -193,13 +193,15 @@ namespace BuildXL.Utilities
 
 #pragma warning disable 809
 
-        /// <summary>
-        /// Not available for FileArtifact, throws an exception
-        /// </summary>
-        [Obsolete("Not suitable for FileArtifact")]
+        /// <inheritdoc />
         public override string ToString()
         {
-            throw new NotImplementedException();
+            if (this == Invalid)
+            {
+                return "{Invalid}";
+            }
+
+            return I($"{{File (id: {Path.Value.Value:x}) ({GetAnnotation()})}}");
         }
 
         /// <summary>
@@ -210,20 +212,6 @@ namespace BuildXL.Utilities
         [ExcludeFromCodeCoverage]
         private string ToDebuggerDisplay()
         {
-            string annotation;
-            switch (m_rewriteCount)
-            {
-                case 0:
-                    annotation = "source";
-                    break;
-                case 1:
-                    annotation = "output";
-                    break;
-                default:
-                    annotation = "rewrite:" + m_rewriteCount.ToString(CultureInfo.InvariantCulture);
-                    break;
-            }
-
             string path;
             if (!Path.IsValid)
             {
@@ -237,8 +225,22 @@ namespace BuildXL.Utilities
                     : Path.ToString(owner);
             }
 
-            return I($"{{{path} ({annotation})}}");
+            return I($"{{{path} ({GetAnnotation()})}}");
         }
+
+        private string GetAnnotation()
+        {
+            switch (m_rewriteCount)
+            {
+                case 0:
+                    return "source";
+                case 1:
+                    return "output";
+                default:
+                    return "rewrite:" + m_rewriteCount.ToString(CultureInfo.InvariantCulture);
+            }
+        }
+
 #pragma warning restore 809
     }
 }

--- a/Public/Src/Utilities/Utilities/FileArtifact.cs
+++ b/Public/Src/Utilities/Utilities/FileArtifact.cs
@@ -237,7 +237,7 @@ namespace BuildXL.Utilities
                 case 1:
                     return "output";
                 default:
-                    return "rewrite:" + m_rewriteCount.ToString(CultureInfo.InvariantCulture);
+                    return I($"rewrite:{m_rewriteCount}");
             }
         }
 


### PR DESCRIPTION
Some methods can innocently call ToString on FileArtifact, and don't expect to get an exception.

[AB#1584874](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1584874)