### PR TITLE
Use front end parallelization instead of separately in the pipgraphfragmentmanager 

### DIFF
--- a/Public/Src/Engine/Scheduler/Graph/PipGraphFragmentManager.cs
+++ b/Public/Src/Engine/Scheduler/Graph/PipGraphFragmentManager.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics.ContractsLight;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using BuildXL.Pips;
 using BuildXL.Pips.Operations;
@@ -22,8 +23,6 @@ namespace BuildXL.Scheduler.Graph
     /// </summary>
     public class PipGraphFragmentManager : IPipGraphFragmentManager
     {
-        private readonly ConcurrentDictionary<int, (PipGraphFragmentSerializer, Task<bool>)> m_readFragmentTasks = new ConcurrentDictionary<int, (PipGraphFragmentSerializer, Task<bool>)>();
-
         private readonly IPipGraph m_pipGraph;
 
         private readonly PipExecutionContext m_context;
@@ -54,46 +53,24 @@ namespace BuildXL.Scheduler.Graph
         /// <summary>
         /// Add a single pip graph fragment to the graph.
         /// </summary>
-        public Task<bool> AddFragmentFileToGraph(int id, AbsolutePath filePath, int[] dependencyIds, string description)
+        public bool AddFragmentFileToGraph(int id, AbsolutePath filePath, int[] dependencyIds, string description)
         {
             var deserializer = new PipGraphFragmentSerializer(m_context, new PipGraphFragmentContext());
-
-            Task<bool> readFragmentTask = Task.Run(() =>
+            try
             {
-                Task.WaitAll(dependencyIds.Select(dependencyId => m_readFragmentTasks[dependencyId].Item2).ToArray());
+                var result = deserializer.Deserialize(
+                    filePath,
+                    (fragmentContext, provenance, pipId, pip) => AddPipToGraph(fragmentContext, provenance, pipId, pip),
+                    description);
+                Logger.Log.DeserializationStatsPipGraphFragment(m_loggingContext, deserializer.FragmentDescription, deserializer.Stats.ToString());
 
-                if (dependencyIds.Any(dependencyId => !m_readFragmentTasks[dependencyId].Item2.Result))
-                {
-                    return false;
-                }
-
-                try
-                {
-                    var result = deserializer.Deserialize(
-                        filePath, 
-                        (fragmentContext, provenance, pipId, pip) => AddPipToGraph(fragmentContext, provenance, pipId, pip), 
-                        description);
-                    Logger.Log.DeserializationStatsPipGraphFragment(m_loggingContext, deserializer.FragmentDescription, deserializer.Stats.ToString());
-
-                    return result;
-                }
-                catch (Exception e) when (e is BuildXLException || e is IOException)
-                {
-                    Logger.Log.ExceptionOnDeserializingPipGraphFragment(m_loggingContext, filePath.ToString(m_context.PathTable), e.ToString());
-                    return false;
-                }
-            });
-
-            m_readFragmentTasks[id] = (deserializer, readFragmentTask);
-            return readFragmentTask;
-        }
-
-        /// <summary>
-        /// GetAllFragmentTasks
-        /// </summary>
-        public IReadOnlyCollection<(PipGraphFragmentSerializer, Task<bool>)> GetAllFragmentTasks()
-        {
-            return m_readFragmentTasks.Select(x => x.Value).ToList();
+                return result;
+            }
+            catch (Exception e) when (e is BuildXLException || e is IOException)
+            {
+                Logger.Log.ExceptionOnDeserializingPipGraphFragment(m_loggingContext, filePath.ToString(m_context.PathTable), e.ToString());
+                return false;
+            }
         }
 
         private bool AddPipToGraph(PipGraphFragmentContext fragmentContext, PipGraphFragmentProvenance provenance, PipId pipId, Pip pip)
@@ -215,20 +192,20 @@ namespace BuildXL.Scheduler.Graph
         }
 
         /// <inheritdoc />
-        public bool AddModulePip(ModulePip modulePip) => 
+        public bool AddModulePip(ModulePip modulePip) =>
             m_modulePipUnify.GetOrAdd(
-                modulePip.Module, 
-                false, 
+                modulePip.Module,
+                false,
                 (mid, data) => new Lazy<bool>(() => m_pipGraph.AddModule(modulePip))).Item.Value.Value;
 
         /// <inheritdoc />
-        public bool AddSpecFilePip(SpecFilePip specFilePip) => 
+        public bool AddSpecFilePip(SpecFilePip specFilePip) =>
             m_specFilePipUnify.GetOrAdd(
                 specFilePip.SpecFile,
-                false, 
+                false,
                 (file, data) => new Lazy<bool>(() => m_pipGraph.AddSpecFile(specFilePip))).Item.Value.Value;
 
-        private bool AddValuePip(ValuePip valuePip) => 
+        private bool AddValuePip(ValuePip valuePip) =>
             m_valuePipUnify.GetOrAdd(
                 (valuePip.Symbol, valuePip.Qualifier),
                 false,

--- a/Public/Src/FrontEnd/Core/FrontEndHostController.cs
+++ b/Public/Src/FrontEnd/Core/FrontEndHostController.cs
@@ -1462,7 +1462,7 @@ namespace BuildXL.FrontEnd.Core
                 remaining: remainingMessage);
         }
 
-        private static string ConstructProgressRemainingMessage(TimeSpan elapsed, IReadOnlyCollection<ModuleEvaluationProgress> remainingItems)
+        private string ConstructProgressRemainingMessage(TimeSpan elapsed, IReadOnlyCollection<ModuleEvaluationProgress> remainingItems)
         {
             if (Configuration.Logging.OptimizeConsoleOutputForAzureDevOps)
             {

--- a/Public/Src/Pips/Dll/IPipGraphFragmentManager.cs
+++ b/Public/Src/Pips/Dll/IPipGraphFragmentManager.cs
@@ -23,12 +23,7 @@ namespace BuildXL.Pips
         /// <param name="filePath">Path to the file to read.</param>
         /// <param name="dependencyIds">Name to the pip fragments this fragment depends on.</param>
         /// <param name="description">Description of the fragment for printing on the console</param>
-        Task<bool> AddFragmentFileToGraph(int id, AbsolutePath filePath, int[] dependencyIds, string description);
-
-        /// <summary>
-        /// Get a list of (fragment description, fragment load task)
-        /// </summary>
-        IReadOnlyCollection<(PipGraphFragmentSerializer, Task<bool>)> GetAllFragmentTasks();
+        bool AddFragmentFileToGraph(int id, AbsolutePath filePath, int[] dependencyIds, string description);
 
         /// <summary>
         /// Adds a module pip.


### PR DESCRIPTION
Somehow the task.waitall in pipgraphfragmentmanager creates a 20 minute bottleneck in processing of the graph