### PR TITLE
[MsBuild] Upgrade to 16.3.0-preview-19415-01

### DIFF
--- a/Public/Sdk/SelfHost/Libraries/MSBuild/msbuild.dsc
+++ b/Public/Sdk/SelfHost/Libraries/MSBuild/msbuild.dsc
@@ -17,8 +17,11 @@ export const msbuildReferences: Managed.ManagedNugetPackage[] = [
 /** Runtime content for tests */
 @@public
 export const msbuildRuntimeContent = [
-    importFrom("System.Numerics.Vectors").pkg,
     importFrom("Microsoft.Build.Runtime").pkg,
+    importFrom("SystemMemoryForMSBuild").withQualifier({targetFramework: "netstandard2.0"}).pkg,
+    importFrom("SystemNumericsVectorsForMSBuild").pkg,
+    importFrom("SystemRuntimeCompilerServicesUnsafeForMSBuild").withQualifier({targetFramework: "netstandard2.0"}).pkg,
+    
     ...BuildXLSdk.isDotNetCoreBuild ? [
         importFrom("Microsoft.NETCore.App.210").pkg,
         importFrom("System.Text.Encoding.CodePages").withQualifier({targetFramework: "netstandard2.0"}).pkg,

--- a/config.dsc
+++ b/config.dsc
@@ -420,27 +420,31 @@ config({
                 { id: "Microsoft.TeamFoundation.DistributedTask.Common.Contracts", version: "16.137.0-preview"},
 
                 // MSBuild. These should be used for compile references only, as at runtime one can only practically use MSBuilds from Visual Studio / dotnet CLI
-                { id: "Microsoft.Build.Runtime", version: "16.1.0-preview.42",
+                { id: "Microsoft.Build", version: "16.3.0-preview-19415-01",
+                    dependentPackageIdsToSkip: ["System.Threading.Tasks.Dataflow", "System.Memory"], // These are overwritten in the deployment by DataflowForMSBuild and SystemMemoryForMSBuild since it doesn't work with the versions we use in larger buildxl.
+                    dependentPackageIdsToIgnore: ["System.Threading.Tasks.Dataflow", "System.Memory"],
+                },
+                { id: "Microsoft.Build.Runtime", version: "16.3.0-preview-19415-01",
                     dependentPackageIdsToSkip: ["System.Threading.Tasks.Dataflow"],
                     dependentPackageIdsToIgnore: ["System.Threading.Tasks.Dataflow"],
                 },
-                { id: "Microsoft.Build.Tasks.Core", version: "16.1.0-preview.42",
+                { id: "Microsoft.Build.Tasks.Core", version: "16.3.0-preview-19415-01",
                     dependentPackageIdsToSkip: ["System.Threading.Tasks.Dataflow"],
                     dependentPackageIdsToIgnore: ["System.Threading.Tasks.Dataflow"],
                 },
-                { id: "Microsoft.Build.Utilities.Core", version: "16.1.0-preview.42"},
-                { id: "Microsoft.Build", version: "16.1.0-preview.42",
-                    dependentPackageIdsToSkip: ["System.Threading.Tasks.Dataflow"],
-                    dependentPackageIdsToIgnore: ["System.Threading.Tasks.Dataflow"],
-                },
-
-                { id: "Microsoft.Build.Framework", version: "16.1.0-preview.42"},
+                { id: "Microsoft.Build.Utilities.Core", version: "16.3.0-preview-19415-01"},
+                { id: "Microsoft.Build.Framework", version: "16.3.0-preview-19415-01"},
+                { id: "System.Resources.Extensions", version: "4.6.0-preview9.19411.4", dependentPackageIdsToIgnore: ["System.Memory"], dependentPackageIdsToSkip: ["System.Memory"]},
 
                 // Extra dependencies to make MSBuild work
                 { id: "Microsoft.VisualStudio.Setup.Configuration.Interop", version: "1.16.30"},
                 { id: "System.CodeDom", version: "4.4.0"},
                 { id: "System.Text.Encoding.CodePages", version: "4.5.1", dependentPackageIdsToSkip: ["System.Runtime.CompilerServices.Unsafe"]},
                 { id: "System.Threading.Tasks.Dataflow", version: "4.5.24", alias: "DataflowForMSBuild" },
+                { id: "System.Memory", version: "4.5.3", alias: "SystemMemoryForMSBuild", dependentPackageIdsToIgnore: ["*"], dependentPackageIdsToSkip: ["*"]},
+                { id: "System.Numerics.Vectors", version: "4.4.0", alias: "SystemNumericsVectorsForMSBuild"},
+                { id: "System.Runtime.CompilerServices.Unsafe", version: "4.5.2", alias: "SystemRuntimeCompilerServicesUnsafeForMSBuild"},
+
                 { id: "Microsoft.NETCore.App", version: "2.1.0", alias: "Microsoft.NETCore.App.210" },
 
                 // Used for MSBuild input/output prediction


### PR DESCRIPTION
This updates the MsBuild version used by BuildXL to the latest preview build.