### PR TITLE
Add statistics to ContentLocationDatabase's cache

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabase.cs
@@ -598,14 +598,15 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                         Interlocked.Exchange(ref _cacheUpdatesSinceLastFlush, 0);
                         ResetFlushTimer();
                     }
-                }, extraEndMessage: maybeStatistics => {
+                }, extraEndMessage: maybeStatistics =>
+                {
                     if (!maybeStatistics.Succeeded)
                     {
                         return string.Empty;
                     }
 
                     var statistics = maybeStatistics.Value;
-                    return $"Persisted={statistics.Persisted} Leftover={statistics.Leftover} Growth={statistics.Growth} FlushingTimeMs={statistics.FlushingTime.TotalMilliseconds} CleanupTimeMs={statistics.CleanupTime.TotalMilliseconds}";
+                    return $"Persisted={statistics.Persisted} Leftover={statistics.Leftover} Growth={statistics.Growth} FlushingTime={statistics.FlushingTime.TotalMilliseconds}ms CleanupTime={statistics.CleanupTime.TotalMilliseconds}ms";
                 }).ThrowIfFailure();
         }
 

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabase.cs
@@ -598,15 +598,15 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                         Interlocked.Exchange(ref _cacheUpdatesSinceLastFlush, 0);
                         ResetFlushTimer();
                     }
-                }, extraEndMessage: maybeStatistics =>
+                }, extraEndMessage: maybeCounters =>
                 {
-                    if (!maybeStatistics.Succeeded)
+                    if (!maybeCounters.Succeeded)
                     {
                         return string.Empty;
                     }
 
-                    var statistics = maybeStatistics.Value;
-                    return $"Persisted={statistics.Persisted} Leftover={statistics.Leftover} Growth={statistics.Growth} FlushingTime={statistics.FlushingTime.TotalMilliseconds}ms CleanupTime={statistics.CleanupTime.TotalMilliseconds}ms";
+                    var counters = maybeCounters.Value;
+                    return $"Persisted={counters[FlushableCache.FlushableCacheCounters.Persisted].Value} Leftover={counters[FlushableCache.FlushableCacheCounters.Leftover].Value} Growth={counters[FlushableCache.FlushableCacheCounters.Growth].Value} FlushingTime={counters[FlushableCache.FlushableCacheCounters.FlushingTime].Duration.TotalMilliseconds}ms CleanupTime={counters[FlushableCache.FlushableCacheCounters.CleanupTime].Duration.TotalMilliseconds}ms";
                 }).ThrowIfFailure();
         }
 

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/FlushableCache.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/FlushableCache.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -107,10 +105,8 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         /// </summary>
         private CounterCollection<FlushableCacheCounters> PerformFlush(OperationContext context)
         {
-            var counters = new CounterCollection<FlushableCacheCounters>();
-            var stopwatch = new Stopwatch();
-
             _database.Counters[ContentLocationDatabaseCounters.TotalNumberOfCacheFlushes].Increment();
+            var counters = new CounterCollection<FlushableCacheCounters>();
 
             using (_database.Counters[ContentLocationDatabaseCounters.CacheFlush].Start())
             {
@@ -119,8 +115,6 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                     _flushingCache = _cache;
                     _cache = new ConcurrentBigMap<ShortHash, ContentLocationEntry>();
                 }
-
-                stopwatch.Start();
 
                 using (counters[FlushableCacheCounters.FlushingTime].Start()) {
                     if (_configuration.FlushSingleTransaction)
@@ -148,7 +142,6 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                 }
 
                 counters[FlushableCacheCounters.Persisted].Add(_flushingCache.Count);
-                stopwatch.Restart();
 
                 _database.Counters[ContentLocationDatabaseCounters.NumberOfPersistedEntries].Add(_flushingCache.Count);
 

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/FlushableCache.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/FlushableCache.cs
@@ -100,15 +100,6 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             }
         }
 
-        public struct FlushStatistics
-        {
-            public long Persisted;
-            public long Leftover;
-            public long Growth;
-            public TimeSpan FlushingTime;
-            public TimeSpan CleanupTime;
-        }
-
         /// <summary>
         /// Needs to take the flushing lock. Called only from <see cref="FlushAsync(OperationContext)"/>. Refactored
         /// out for clarity.
@@ -186,6 +177,15 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             statistics.Growth = _cache.Count;
 
             return statistics;
+        }
+
+        public struct FlushStatistics
+        {
+            public long Persisted;
+            public long Leftover;
+            public long Growth;
+            public TimeSpan FlushingTime;
+            public TimeSpan CleanupTime;
         }
     }
 }


### PR DESCRIPTION
Adds some statistics over how flushing went to the logging. The counter reporting granularity is way too large vs how many times flushing actually happens.