### PR TITLE
Split out operations needed by generic memoization stores backed by a database/key-value store.

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabase.cs
@@ -720,7 +720,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         /// <summary>
         /// Gets known selectors for a given weak fingerprint.
         /// </summary>
-        public abstract IReadOnlyCollection<GetSelectorResult> GetSelectors(OperationContext context, Fingerprint weakFingerprint);
+        public abstract Result<IReadOnlyList<Selector>> GetSelectors(OperationContext context, Fingerprint weakFingerprint);
 
         /// <summary>
         /// Enumerates all strong fingerprints currently stored in the cache.

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/InMemory/MemoryContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/InMemory/MemoryContentLocationDatabase.cs
@@ -65,7 +65,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache.InMemory
         }
         
         /// <inheritdoc />
-        public override IReadOnlyCollection<GetSelectorResult> GetSelectors(OperationContext context, Fingerprint weakFingerprint)
+        public override Result<IReadOnlyList<Selector>> GetSelectors(OperationContext context, Fingerprint weakFingerprint)
         {
             throw new NotImplementedException();
         }

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/RocksDbContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/RocksDbContentLocationDatabase.cs
@@ -703,7 +703,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         }
         
         /// <inheritdoc />
-        public override IReadOnlyCollection<GetSelectorResult> GetSelectors(OperationContext context, Fingerprint weakFingerprint)
+        public override Result<IReadOnlyList<Selector>> GetSelectors(OperationContext context, Fingerprint weakFingerprint)
         {
             var selectors = new List<(long TimeUtc, Selector Selector)>();
             var status = _keyValueStore.Use(
@@ -721,15 +721,14 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                     }
                 });
 
-            var result = new List<GetSelectorResult>(selectors
-                .OrderByDescending(entry => entry.TimeUtc)
-                .Select(entry => new GetSelectorResult(entry.Selector)));
             if (!status.Succeeded)
             {
-                result.Add(new GetSelectorResult(status.Failure.CreateException()));
+                return new Result<IReadOnlyList<Selector>>(status.Failure.CreateException());
             }
 
-            return result;
+            return new Result<IReadOnlyList<Selector>>(selectors
+                .OrderByDescending(entry => entry.TimeUtc)
+                .Select(entry => entry.Selector).ToList());
         }
 
         private byte[] SerializeWeakFingerprint(Fingerprint weakFingerprint)

--- a/Public/Src/Cache/ContentStore/Library/Utils/ResultsExtensions.cs
+++ b/Public/Src/Cache/ContentStore/Library/Utils/ResultsExtensions.cs
@@ -7,7 +7,7 @@ using BuildXL.Utilities;
 namespace BuildXL.Cache.ContentStore.Utils
 {
     /// <summary>
-    /// Extension methods for 
+    /// Extension methods for Result classes.
     /// </summary>
     public static class ResultsExtensions
     {

--- a/Public/Src/Cache/ContentStore/Library/Utils/ResultsExtensions.cs
+++ b/Public/Src/Cache/ContentStore/Library/Utils/ResultsExtensions.cs
@@ -6,6 +6,9 @@ using BuildXL.Utilities;
 
 namespace BuildXL.Cache.ContentStore.Utils
 {
+    /// <summary>
+    /// Extension methods for 
+    /// </summary>
     public static class ResultsExtensions
     {
         /// <summary>

--- a/Public/Src/Cache/ContentStore/Library/Utils/ResultsExtensions.cs
+++ b/Public/Src/Cache/ContentStore/Library/Utils/ResultsExtensions.cs
@@ -6,8 +6,23 @@ using BuildXL.Utilities;
 
 namespace BuildXL.Cache.ContentStore.Utils
 {
-    internal static class ResultsExtensions
+    public static class ResultsExtensions
     {
+        /// <summary>
+        /// Converts <see cref="Possible{TResult}"/> to <see cref="Result{T}"/>
+        /// </summary>
+        public static Result<T> ToResult<T>(this Possible<T> possible)
+        {
+            if (possible.Succeeded)
+            {
+                return new Result<T>(possible.Result);
+            }
+            else
+            {
+                return new Result<T>(possible.Failure.DescribeIncludingInnerFailures());
+            }
+        }
+
         /// <summary>
         /// Ensures result exceptions are demystified.
         /// </summary>
@@ -21,7 +36,7 @@ namespace BuildXL.Cache.ContentStore.Utils
         }
 
         /// <nodoc />
-        public static TResult WithLockAcquisitionDuration<TResult, TLockKey>(this TResult result, in LockSet<TLockKey>.LockHandle handle)
+        internal static TResult WithLockAcquisitionDuration<TResult, TLockKey>(this TResult result, in LockSet<TLockKey>.LockHandle handle)
             where TResult : ResultBase
             where TLockKey : IEquatable<TLockKey>
         {

--- a/Public/Src/Cache/MemoizationStore/Interfaces/Results/LevelSelectors.cs
+++ b/Public/Src/Cache/MemoizationStore/Interfaces/Results/LevelSelectors.cs
@@ -8,7 +8,7 @@ using BuildXL.Cache.MemoizationStore.Interfaces.Sessions;
 namespace BuildXL.Cache.MemoizationStore.Interfaces.Results
 {
     /// <summary>
-    /// A list of selectors obtained by calling <see cref="IReadOnlyMemoizationSessionWithLevelSelectors.GetLevelSelectorsAsync"/> call.
+    /// A list of selectors obtained by calling <see cref="ILevelSelectorsProvider.GetLevelSelectorsAsync"/> call.
     /// </summary>
     public class LevelSelectors
     {

--- a/Public/Src/Cache/MemoizationStore/Interfaces/Results/LevelSelectors.cs
+++ b/Public/Src/Cache/MemoizationStore/Interfaces/Results/LevelSelectors.cs
@@ -28,7 +28,8 @@ namespace BuildXL.Cache.MemoizationStore.Interfaces.Results
         }
 
         /// <nodoc />
-        public static Result<LevelSelectors> Single(Result<Selector[]> selectors)
+        public static Result<LevelSelectors> Single<TSelectors>(Result<TSelectors> selectors)
+            where TSelectors : IReadOnlyList<Selector>
         {
             if (selectors)
             {

--- a/Public/Src/Cache/MemoizationStore/Interfaces/Sessions/IReadOnlyMemoizationSession.cs
+++ b/Public/Src/Cache/MemoizationStore/Interfaces/Sessions/IReadOnlyMemoizationSession.cs
@@ -42,7 +42,14 @@ namespace BuildXL.Cache.MemoizationStore.Interfaces.Sessions
     /// <summary>
     /// A related set of read accesses to a cache with support for multi-level GetSelectors.
     /// </summary>
-    public interface IReadOnlyMemoizationSessionWithLevelSelectors : IReadOnlyMemoizationSession
+    public interface IReadOnlyMemoizationSessionWithLevelSelectors : IReadOnlyMemoizationSession, ILevelSelectorsProvider
+    {
+    }
+
+    /// <summary>
+    /// A related set of read accesses to a cache with support for multi-level GetSelectors.
+    /// </summary>
+    public interface ILevelSelectorsProvider
     {
         /// <summary>
         /// Gets known selectors for a given weak fingerprint for a given "level".

--- a/Public/Src/Cache/MemoizationStore/Interfaces/Sessions/ReadOnlyMemoizationSessionExtensions.cs
+++ b/Public/Src/Cache/MemoizationStore/Interfaces/Sessions/ReadOnlyMemoizationSessionExtensions.cs
@@ -25,7 +25,7 @@ namespace BuildXL.Cache.MemoizationStore.Interfaces.Sessions
         /// Returns all the selectors for a given <paramref name="weakFingerprint"/>.
         /// </summary>
         public static async Task<Result<Selector[]>> GetAllSelectorsAsync(
-            this IReadOnlyMemoizationSessionWithLevelSelectors session,
+            this ILevelSelectorsProvider session,
             Context context,
             Fingerprint weakFingerprint,
             CancellationToken cts)
@@ -57,7 +57,7 @@ namespace BuildXL.Cache.MemoizationStore.Interfaces.Sessions
         /// Enumerate known selectors for a given weak fingerprint.
         /// </summary>
         public static Async::System.Collections.Generic.IAsyncEnumerable<GetSelectorResult> GetSelectorsAsAsyncEnumerable(
-            this IReadOnlyMemoizationSessionWithLevelSelectors session,
+            this ILevelSelectorsProvider session,
             Context context,
             Fingerprint weakFingerprint,
             CancellationToken cts,
@@ -121,7 +121,7 @@ namespace BuildXL.Cache.MemoizationStore.Interfaces.Sessions
         }
 
         private static Async::System.Collections.Generic.IAsyncEnumerable<Result<LevelSelectors>> GetLevelSelectorsEnumerableAsync(
-            this IReadOnlyMemoizationSessionWithLevelSelectors session,
+            this ILevelSelectorsProvider session,
             Context context,
             Fingerprint weakFingerprint,
             CancellationToken cts,

--- a/Public/Src/Cache/MemoizationStore/Library/Sessions/DatabaseMemoizationSession.cs
+++ b/Public/Src/Cache/MemoizationStore/Library/Sessions/DatabaseMemoizationSession.cs
@@ -14,7 +14,7 @@ using BuildXL.Cache.MemoizationStore.Stores;
 namespace BuildXL.Cache.MemoizationStore.Sessions
 {
     /// <summary>
-    ///     An IMemoizationSession implemented using a atabase
+    ///     An IMemoizationSession implemented using a database
     /// </summary>
     public class DatabaseMemoizationSession : ReadOnlyDatabaseMemoizationSession, IMemoizationSession
     {

--- a/Public/Src/Cache/MemoizationStore/Library/Sessions/DatabaseMemoizationSession.cs
+++ b/Public/Src/Cache/MemoizationStore/Library/Sessions/DatabaseMemoizationSession.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -14,14 +14,14 @@ using BuildXL.Cache.MemoizationStore.Stores;
 namespace BuildXL.Cache.MemoizationStore.Sessions
 {
     /// <summary>
-    ///     An IMemoizationSession implemented in RocksDb
+    ///     An IMemoizationSession implemented using a atabase
     /// </summary>
-    public class RocksDbMemoizationSession : ReadOnlyRocksDbMemoizationSession, IMemoizationSession
+    public class DatabaseMemoizationSession : ReadOnlyDatabaseMemoizationSession, IMemoizationSession
     {
         private readonly IContentSession _contentSession;
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="RocksDbMemoizationSession" /> class.
+        ///     Initializes a new instance of the <see cref="DatabaseMemoizationSession" /> class.
         /// </summary>
         /// <remarks>
         ///     Allowing contentSession to be null to allow the creation of uncoupled MemoizationSessions.
@@ -29,7 +29,7 @@ namespace BuildXL.Cache.MemoizationStore.Sessions
         ///     to compare to the previous behavior.  With a null content session, metadata will be automatically
         ///     overwritten because we're unable to check whether or not content is missing.
         /// </remarks>
-        public RocksDbMemoizationSession(string name, RocksDbMemoizationStore memoizationStore, IContentSession contentSession = null)
+        public DatabaseMemoizationSession(string name, DatabaseMemoizationStore memoizationStore, IContentSession contentSession = null)
             : base(name, memoizationStore)
         {
             _contentSession = contentSession;

--- a/Public/Src/Cache/MemoizationStore/Library/Sessions/ReadOnlyDatabaseMemoizationSession.cs
+++ b/Public/Src/Cache/MemoizationStore/Library/Sessions/ReadOnlyDatabaseMemoizationSession.cs
@@ -53,9 +53,9 @@ namespace BuildXL.Cache.MemoizationStore.Sessions
         }
 
         /// <inheritdoc />
-        public async Task<Result<LevelSelectors>> GetLevelSelectorsAsync(Context context, Fingerprint weakFingerprint, CancellationToken cts, int level)
+        public Task<Result<LevelSelectors>> GetLevelSelectorsAsync(Context context, Fingerprint weakFingerprint, CancellationToken cts, int level)
         {
-            return await MemoizationStore.GetLevelSelectorsAsync(context, weakFingerprint, cts, level);
+            return MemoizationStore.GetLevelSelectorsAsync(context, weakFingerprint, cts, level);
         }
 
         /// <inheritdoc />

--- a/Public/Src/Cache/MemoizationStore/Library/Sessions/ReadOnlyDatabaseMemoizationSession.cs
+++ b/Public/Src/Cache/MemoizationStore/Library/Sessions/ReadOnlyDatabaseMemoizationSession.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 extern alias Async;
@@ -24,7 +24,7 @@ namespace BuildXL.Cache.MemoizationStore.Sessions
     /// <summary>
     ///     An IReadOnlyMemoizationSession implemented in RocksDb
     /// </summary>
-    public class ReadOnlyRocksDbMemoizationSession : StartupShutdownBase, IReadOnlyMemoizationSessionWithLevelSelectors
+    public class ReadOnlyDatabaseMemoizationSession : StartupShutdownBase, IReadOnlyMemoizationSessionWithLevelSelectors
     {
         /// <inheritdoc />
         public string Name { get; }
@@ -33,10 +33,10 @@ namespace BuildXL.Cache.MemoizationStore.Sessions
         protected override Tracer Tracer { get; }
 
         /// <nodoc />
-        protected readonly RocksDbMemoizationStore MemoizationStore;
+        protected readonly DatabaseMemoizationStore MemoizationStore;
 
         /// <nodoc />
-        public ReadOnlyRocksDbMemoizationSession(string name, RocksDbMemoizationStore memoizationStore)
+        public ReadOnlyDatabaseMemoizationSession(string name, DatabaseMemoizationStore memoizationStore)
         {
             Contract.Requires(name != null);
             Contract.Requires(memoizationStore != null);
@@ -55,7 +55,7 @@ namespace BuildXL.Cache.MemoizationStore.Sessions
         /// <inheritdoc />
         public async Task<Result<LevelSelectors>> GetLevelSelectorsAsync(Context context, Fingerprint weakFingerprint, CancellationToken cts, int level)
         {
-            return LevelSelectors.Single(await MemoizationStore.GetSelectorsCoreAsync(context, weakFingerprint));
+            return await MemoizationStore.GetLevelSelectorsAsync(context, weakFingerprint, cts, level);
         }
 
         /// <inheritdoc />

--- a/Public/Src/Cache/MemoizationStore/Library/Stores/DatabaseMemoizationStore.cs
+++ b/Public/Src/Cache/MemoizationStore/Library/Stores/DatabaseMemoizationStore.cs
@@ -31,7 +31,7 @@ namespace BuildXL.Cache.MemoizationStore.Stores
     /// <summary>
     ///     An IMemoizationStore implementation using RocksDb.
     /// </summary>
-    public abstract class DatabaseMemoizationStore : StartupShutdownBase, IMemoizationStore, ILevelSelectorsProvider
+    public class DatabaseMemoizationStore : StartupShutdownBase, IMemoizationStore
     {
         private MemoizationDatabase _database;
 
@@ -43,6 +43,9 @@ namespace BuildXL.Cache.MemoizationStore.Stores
         /// <inheritdoc />
         protected override Tracer Tracer => _tracer;
 
+        /// <summary>
+        /// The component name
+        /// </summary>
         protected string Component => Tracer.Name;
 
         /// <summary>
@@ -190,7 +193,7 @@ namespace BuildXL.Cache.MemoizationStore.Stores
             });
         }
 
-        public async Task<Result<LevelSelectors>> GetLevelSelectorsAsync(Context context, Fingerprint weakFingerprint, CancellationToken cts, int level)
+        internal async Task<Result<LevelSelectors>> GetLevelSelectorsAsync(Context context, Fingerprint weakFingerprint, CancellationToken cts, int level)
         {
             var ctx = new OperationContext(context);
 

--- a/Public/Src/Cache/MemoizationStore/Library/Stores/DatabaseMemoizationStore.cs
+++ b/Public/Src/Cache/MemoizationStore/Library/Stores/DatabaseMemoizationStore.cs
@@ -1,0 +1,217 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+extern alias Async;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.ContractsLight;
+using System.Threading;
+using System.Threading.Tasks;
+using BuildXL.Cache.ContentStore.Distributed.NuCache;
+using BuildXL.Cache.ContentStore.Interfaces.Extensions;
+using BuildXL.Cache.ContentStore.Interfaces.Logging;
+using BuildXL.Cache.ContentStore.Interfaces.Results;
+using BuildXL.Cache.ContentStore.Interfaces.Sessions;
+using BuildXL.Cache.ContentStore.Interfaces.Time;
+using BuildXL.Cache.ContentStore.Interfaces.Tracing;
+using BuildXL.Cache.ContentStore.Tracing;
+using BuildXL.Cache.ContentStore.Tracing.Internal;
+using BuildXL.Cache.ContentStore.UtilitiesCore;
+using BuildXL.Cache.ContentStore.Utils;
+using BuildXL.Cache.MemoizationStore.Interfaces.Results;
+using BuildXL.Cache.MemoizationStore.Interfaces.Sessions;
+using BuildXL.Cache.MemoizationStore.Interfaces.Stores;
+using BuildXL.Cache.MemoizationStore.Sessions;
+using BuildXL.Cache.MemoizationStore.Tracing;
+
+namespace BuildXL.Cache.MemoizationStore.Stores
+{
+    /// <summary>
+    ///     An IMemoizationStore implementation using RocksDb.
+    /// </summary>
+    public abstract class DatabaseMemoizationStore : StartupShutdownBase, IMemoizationStore, ILevelSelectorsProvider
+    {
+        private MemoizationDatabase _database;
+
+        /// <summary>
+        ///     Store tracer.
+        /// </summary>
+        private readonly MemoizationStoreTracer _tracer;
+
+        /// <inheritdoc />
+        protected override Tracer Tracer => _tracer;
+
+        protected string Component => Tracer.Name;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="DatabaseMemoizationStore"/> class.
+        /// </summary>
+        public DatabaseMemoizationStore(ILogger logger, MemoizationDatabase database)
+        {
+            Contract.Requires(logger != null);
+            Contract.Requires(database != null);
+
+            _tracer = new MemoizationStoreTracer(logger, database.Name);
+            _database = database;
+        }
+
+        /// <inheritdoc />
+        public CreateSessionResult<IReadOnlyMemoizationSession> CreateReadOnlySession(Context context, string name)
+        {
+            var session = new ReadOnlyDatabaseMemoizationSession(name, this);
+            return new CreateSessionResult<IReadOnlyMemoizationSession>(session);
+        }
+
+        /// <inheritdoc />
+        public CreateSessionResult<IMemoizationSession> CreateSession(Context context, string name)
+        {
+            var session = new DatabaseMemoizationSession(name, this);
+            return new CreateSessionResult<IMemoizationSession>(session);
+        }
+
+        /// <inheritdoc />
+        public CreateSessionResult<IMemoizationSession> CreateSession(Context context, string name, IContentSession contentSession)
+        {
+            var session = new DatabaseMemoizationSession(name, this, contentSession);
+            return new CreateSessionResult<IMemoizationSession>(session);
+        }
+
+        /// <inheritdoc />
+        public Task<GetStatsResult> GetStatsAsync(Context context)
+        {
+            return GetStatsCall<MemoizationStoreTracer>.RunAsync(_tracer, new OperationContext(context), () =>
+            {
+                var counters = new CounterSet();
+                counters.Merge(_tracer.GetCounters(), $"{_tracer.Name}.");
+                return Task.FromResult(new GetStatsResult(counters));
+            });
+        }
+
+        /// <inheritdoc />
+        protected override Task<BoolResult> StartupCoreAsync(OperationContext context)
+        {
+            return  _database.StartupAsync(context);
+        }
+
+        /// <inheritdoc />
+        protected override Task<BoolResult> ShutdownCoreAsync(OperationContext context)
+        {
+            return _database.ShutdownAsync(context);
+        }
+
+        /// <inheritdoc />
+        public Async::System.Collections.Generic.IAsyncEnumerable<StructResult<StrongFingerprint>> EnumerateStrongFingerprints(Context context)
+        {
+            var ctx = new OperationContext(context);
+            return AsyncEnumerableExtensions.CreateSingleProducerTaskAsyncEnumerable<StructResult<StrongFingerprint>>(() => _database.EnumerateStrongFingerprintsAsync(ctx));
+        }
+
+        internal Task<GetContentHashListResult> GetContentHashListAsync(Context context, StrongFingerprint strongFingerprint, CancellationToken cts)
+        {
+            var ctx = new OperationContext(context, cts);
+            return GetContentHashListCall.RunAsync(_tracer, ctx, strongFingerprint, async () => {
+                return await _database.GetContentHashListAsync(ctx, strongFingerprint);
+            });
+        }
+
+        internal Task<AddOrGetContentHashListResult> AddOrGetContentHashListAsync(Context context, StrongFingerprint strongFingerprint, ContentHashListWithDeterminism contentHashListWithDeterminism, IContentSession contentSession, CancellationToken cts)
+        {
+            var ctx = new OperationContext(context, cts);
+            return AddOrGetContentHashListCall.RunAsync(_tracer, ctx, strongFingerprint, async () => {
+                return await ctx.PerformOperationAsync(
+               _tracer,
+               async () =>
+               {
+                   // We do multiple attempts here because we have a "CompareExchange" RocksDB in the heart
+                   // of this implementation, and this may fail if the database is heavily contended.
+                   // Unfortunately, there is not much we can do at the time of writing to avoid this
+                   // requirement.
+                   var maxAttempts = 5;
+                   while (maxAttempts-- >= 0)
+                   {
+                       var contentHashList = contentHashListWithDeterminism.ContentHashList;
+                       var determinism = contentHashListWithDeterminism.Determinism;
+
+                       // Load old value. Notice that this get updates the time, regardless of whether we replace the value or not.
+                       var oldContentHashListWithDeterminism = await _database.GetContentHashListAsync(ctx, strongFingerprint);
+                       var oldContentHashList = oldContentHashListWithDeterminism.ContentHashListWithDeterminism.ContentHashList;
+                       var oldDeterminism = oldContentHashListWithDeterminism.ContentHashListWithDeterminism.Determinism;
+
+                       // Make sure we're not mixing SinglePhaseNonDeterminism records
+                       if (!(oldContentHashList is null) &&
+                                  oldDeterminism.IsSinglePhaseNonDeterministic != determinism.IsSinglePhaseNonDeterministic)
+                       {
+                           return AddOrGetContentHashListResult.SinglePhaseMixingError;
+                       }
+
+                       if (oldContentHashList is null || oldDeterminism.ShouldBeReplacedWith(determinism) ||
+                                   !(await contentSession.EnsureContentIsAvailableAsync(ctx, oldContentHashList, ctx.Token).ConfigureAwait(false)))
+                       {
+                           // Replace if incoming has better determinism or some content for the existing
+                           // entry is missing. The entry could have changed since we fetched the old value
+                           // earlier, hence, we need to check it hasn't.
+                           var exchanged = await _database.CompareExchange(
+                              ctx,
+                              strongFingerprint,
+                              oldContentHashListWithDeterminism.ContentHashListWithDeterminism,
+                              contentHashListWithDeterminism).ThrowIfFailureAsync();
+                           if (!exchanged)
+                           {
+                               // Our update lost, need to retry
+                               continue;
+                           }
+
+                           return new AddOrGetContentHashListResult(new ContentHashListWithDeterminism(null, determinism));
+                       }
+
+                       // If we didn't accept the new value because it is the same as before, just with a not
+                       // necessarily better determinism, then let the user know.
+                       if (!(oldContentHashList is null) && oldContentHashList.Equals(contentHashList))
+                       {
+                           return new AddOrGetContentHashListResult(new ContentHashListWithDeterminism(null, oldDeterminism));
+                       }
+
+                       // If we didn't accept a deterministic tool's data, then we're in an inconsistent state
+                       if (determinism.IsDeterministicTool)
+                       {
+                           return new AddOrGetContentHashListResult(
+                               AddOrGetContentHashListResult.ResultCode.InvalidToolDeterminismError,
+                               oldContentHashListWithDeterminism.ContentHashListWithDeterminism);
+                       }
+
+                       // If we did not accept the given value, return the value in the cache
+                       return new AddOrGetContentHashListResult(oldContentHashListWithDeterminism);
+                   }
+
+                   return new AddOrGetContentHashListResult("Hit too many races attempting to add content hash list into the cache");
+               });
+            });
+        }
+
+        public async Task<Result<LevelSelectors>> GetLevelSelectorsAsync(Context context, Fingerprint weakFingerprint, CancellationToken cts, int level)
+        {
+            var ctx = new OperationContext(context);
+
+            var stopwatch = new Stopwatch();
+            try
+            {
+                _tracer.GetSelectorsStart(ctx, weakFingerprint);
+                stopwatch.Start();
+
+                return await _database.GetLevelSelectorsAsync(ctx, weakFingerprint, level);
+            }
+            catch (Exception exception)
+            {
+                _tracer.Debug(ctx, $"{Component}.GetSelectors() error=[{exception}]");
+                return Result.FromException<LevelSelectors>(exception);
+            }
+            finally
+            {
+                stopwatch.Stop();
+                _tracer.GetSelectorsStop(ctx, stopwatch.Elapsed);
+            }
+        }
+    }
+}

--- a/Public/Src/Cache/MemoizationStore/Library/Stores/MemoizationDatabase.cs
+++ b/Public/Src/Cache/MemoizationStore/Library/Stores/MemoizationDatabase.cs
@@ -48,7 +48,7 @@ namespace BuildXL.Cache.MemoizationStore.Stores
         public abstract Task<IEnumerable<StructResult<StrongFingerprint>>> EnumerateStrongFingerprintsAsync(OperationContext context);
 
         /// <summary>
-        /// <see cref="GetLevelSelectorsAsync(Context, Fingerprint, CancellationToken, int)"/>
+        /// <see cref="ILevelSelectorsProvider.GetLevelSelectorsAsync(Context, Fingerprint, CancellationToken, int)"/>
         /// </summary>
         public abstract Task<Result<LevelSelectors>> GetLevelSelectorsAsync(OperationContext context, Fingerprint weakFingerprint, int level);
     }

--- a/Public/Src/Cache/MemoizationStore/Library/Stores/MemoizationDatabase.cs
+++ b/Public/Src/Cache/MemoizationStore/Library/Stores/MemoizationDatabase.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+extern alias Async;
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using BuildXL.Cache.ContentStore.Interfaces.Results;
+using BuildXL.Cache.ContentStore.Interfaces.Sessions;
+using BuildXL.Cache.ContentStore.Interfaces.Stores;
+using BuildXL.Cache.ContentStore.Interfaces.Tracing;
+using BuildXL.Cache.ContentStore.Tracing.Internal;
+using BuildXL.Cache.ContentStore.Utils;
+using BuildXL.Cache.MemoizationStore.Interfaces.Results;
+using BuildXL.Cache.MemoizationStore.Interfaces.Sessions;
+
+namespace BuildXL.Cache.MemoizationStore.Stores
+{
+    /// <summary>
+    /// Defines a database which stores memoization information
+    /// </summary>
+    public abstract class MemoizationDatabase : StartupShutdownSlimBase, IName
+    {
+        /// <summary>
+        /// Gets the name of the component
+        /// </summary>
+        public string Name => Tracer.Name;
+
+        /// <summary>
+        /// Performs a compare exchange operation on metadata, while ensuring all invariants are kept. If the
+        /// fingerprint is not present, then it is inserted.
+        /// </summary>
+        public abstract Task<Result<bool>> CompareExchange(
+            OperationContext context,
+            StrongFingerprint strongFingerprint,
+            ContentHashListWithDeterminism expected,
+            ContentHashListWithDeterminism replacement);
+
+        /// <summary>
+        /// Load a ContentHashList.
+        /// </summary>
+        public abstract Task<GetContentHashListResult> GetContentHashListAsync(OperationContext context, StrongFingerprint strongFingerprint);
+
+        /// <summary>
+        /// Enumerates all strong fingerprints
+        /// </summary>
+        public abstract Task<IEnumerable<StructResult<StrongFingerprint>>> EnumerateStrongFingerprintsAsync(OperationContext context);
+
+        /// <summary>
+        /// <see cref="GetLevelSelectorsAsync(Context, Fingerprint, CancellationToken, int)"/>
+        /// </summary>
+        public abstract Task<Result<LevelSelectors>> GetLevelSelectorsAsync(OperationContext context, Fingerprint weakFingerprint, int level);
+    }
+}

--- a/Public/Src/Cache/MemoizationStore/Library/Stores/RocksDbMemoizationDatabase.cs
+++ b/Public/Src/Cache/MemoizationStore/Library/Stores/RocksDbMemoizationDatabase.cs
@@ -27,6 +27,7 @@ namespace BuildXL.Cache.MemoizationStore.Stores
     {
         internal RocksDbContentLocationDatabase Database { get; }
 
+        /// <inheritdoc />
         protected override Tracer Tracer { get; }
 
         /// <nodoc />

--- a/Public/Src/Cache/MemoizationStore/Library/Stores/RocksDbMemoizationDatabase.cs
+++ b/Public/Src/Cache/MemoizationStore/Library/Stores/RocksDbMemoizationDatabase.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+extern alias Async;
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using BuildXL.Cache.ContentStore.Distributed.NuCache;
+using BuildXL.Cache.ContentStore.Interfaces.Results;
+using BuildXL.Cache.ContentStore.Interfaces.Sessions;
+using BuildXL.Cache.ContentStore.Interfaces.Stores;
+using BuildXL.Cache.ContentStore.Interfaces.Time;
+using BuildXL.Cache.ContentStore.Interfaces.Tracing;
+using BuildXL.Cache.ContentStore.Tracing;
+using BuildXL.Cache.ContentStore.Tracing.Internal;
+using BuildXL.Cache.ContentStore.Utils;
+using BuildXL.Cache.MemoizationStore.Interfaces.Results;
+using BuildXL.Cache.MemoizationStore.Interfaces.Sessions;
+
+namespace BuildXL.Cache.MemoizationStore.Stores
+{
+    /// <summary>
+    /// Defines a database which stores memoization information
+    /// </summary>
+    public class RocksDbMemoizationDatabase : MemoizationDatabase
+    {
+        internal RocksDbContentLocationDatabase Database { get; }
+
+        protected override Tracer Tracer { get; }
+
+        /// <nodoc />
+        public RocksDbMemoizationDatabase(RocksDbMemoizationStoreConfiguration config, IClock clock)
+            : this(new RocksDbContentLocationDatabase(clock, config.Database, () => new MachineId[] { }))
+        {
+        }
+
+        /// <nodoc />
+        public RocksDbMemoizationDatabase(RocksDbContentLocationDatabase database)
+        {
+            Tracer = new Tracer(nameof(RocksDbMemoizationDatabase));
+            Database = database;
+        }
+
+        /// <inheritdoc />
+        public override Task<Result<bool>> CompareExchange(OperationContext context, StrongFingerprint strongFingerprint, ContentHashListWithDeterminism expected, ContentHashListWithDeterminism replacement)
+        {
+            return Task.FromResult(Database.CompareExchange(context, strongFingerprint, expected, replacement).ToResult());
+        }
+
+        /// <inheritdoc />
+        public override Task<IEnumerable<StructResult<StrongFingerprint>>> EnumerateStrongFingerprintsAsync(OperationContext context)
+        {
+            return Task.FromResult(Database.EnumerateStrongFingerprints(context));
+        }
+
+        /// <inheritdoc />
+        public override Task<GetContentHashListResult> GetContentHashListAsync(OperationContext context, StrongFingerprint strongFingerprint)
+        {
+            return Task.FromResult(Database.GetContentHashList(context, strongFingerprint));
+        }
+
+        /// <inheritdoc />
+        public override Task<Result<LevelSelectors>> GetLevelSelectorsAsync(OperationContext context, Fingerprint weakFingerprint, int level)
+        {
+            return Task.FromResult(LevelSelectors.Single(Database.GetSelectors(context, weakFingerprint)));
+        }
+
+        /// <inheritdoc />
+        protected override Task<BoolResult> StartupCoreAsync(OperationContext context)
+        {
+            return Database.StartupAsync(context);
+        }
+
+        /// <inheritdoc />
+        protected override Task<BoolResult> ShutdownCoreAsync(OperationContext context)
+        {
+            return Database.ShutdownAsync(context);
+        }
+    }
+}

--- a/Public/Src/Cache/MemoizationStore/Library/Stores/RocksDbMemoizationStore.cs
+++ b/Public/Src/Cache/MemoizationStore/Library/Stores/RocksDbMemoizationStore.cs
@@ -1,248 +1,47 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 extern alias Async;
 
-using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Diagnostics.ContractsLight;
 using System.Threading;
 using System.Threading.Tasks;
 using BuildXL.Cache.ContentStore.Distributed.NuCache;
-using BuildXL.Cache.ContentStore.Interfaces.Extensions;
 using BuildXL.Cache.ContentStore.Interfaces.Logging;
 using BuildXL.Cache.ContentStore.Interfaces.Results;
 using BuildXL.Cache.ContentStore.Interfaces.Sessions;
+using BuildXL.Cache.ContentStore.Interfaces.Stores;
 using BuildXL.Cache.ContentStore.Interfaces.Time;
 using BuildXL.Cache.ContentStore.Interfaces.Tracing;
 using BuildXL.Cache.ContentStore.Tracing;
 using BuildXL.Cache.ContentStore.Tracing.Internal;
-using BuildXL.Cache.ContentStore.UtilitiesCore;
 using BuildXL.Cache.ContentStore.Utils;
 using BuildXL.Cache.MemoizationStore.Interfaces.Results;
 using BuildXL.Cache.MemoizationStore.Interfaces.Sessions;
-using BuildXL.Cache.MemoizationStore.Interfaces.Stores;
-using BuildXL.Cache.MemoizationStore.Sessions;
-using BuildXL.Cache.MemoizationStore.Tracing;
 
 namespace BuildXL.Cache.MemoizationStore.Stores
 {
     /// <summary>
     ///     An IMemoizationStore implementation using RocksDb.
     /// </summary>
-    public class RocksDbMemoizationStore : StartupShutdownBase, IMemoizationStore
+    public class RocksDbMemoizationStore : DatabaseMemoizationStore
     {
-        private const string Component = nameof(RocksDbMemoizationStore);
-        
-        private IClock _clock;
-        
-        private RocksDbContentLocationDatabase _database;
+        private RocksDbMemoizationDatabase _database;
 
-        internal RocksDbContentLocationDatabase Database => _database;
+        internal RocksDbContentLocationDatabase Database => _database.Database;
 
-        /// <summary>
-        ///     Store tracer.
-        /// </summary>
-        private readonly MemoizationStoreTracer _tracer;
-
-        /// <inheritdoc />
-        protected override Tracer Tracer => _tracer;
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="RocksDbMemoizationStore"/> class.
-        /// </summary>
-        public RocksDbMemoizationStore(ILogger logger, IClock clock, RocksDbMemoizationStoreConfiguration config)
+        /// <nodoc />
+        public RocksDbMemoizationStore(ILogger logger, IClock clock, RocksDbMemoizationStoreConfiguration config) 
+            : this(logger, new RocksDbMemoizationDatabase(config, clock))
         {
-            Contract.Requires(logger != null);
-            Contract.Requires(config != null);
-            Contract.Requires(clock != null);
-
-            _tracer = new MemoizationStoreTracer(logger, Component);
-            _clock = clock;
-            _database = new RocksDbContentLocationDatabase(clock, config.Database, () => new MachineId[] { });
+            // Do nothing. Just delegates to other constructor to allow capturing created database
         }
 
-        /// <inheritdoc />
-        public CreateSessionResult<IReadOnlyMemoizationSession> CreateReadOnlySession(Context context, string name)
+        /// <nodoc />
+        public RocksDbMemoizationStore(ILogger logger, RocksDbMemoizationDatabase database)
+            : base(logger, database)
         {
-            var session = new ReadOnlyRocksDbMemoizationSession(name, this);
-            return new CreateSessionResult<IReadOnlyMemoizationSession>(session);
-        }
-
-        /// <inheritdoc />
-        public CreateSessionResult<IMemoizationSession> CreateSession(Context context, string name)
-        {
-            var session = new RocksDbMemoizationSession(name, this);
-            return new CreateSessionResult<IMemoizationSession>(session);
-        }
-
-        /// <inheritdoc />
-        public CreateSessionResult<IMemoizationSession> CreateSession(Context context, string name, IContentSession contentSession)
-        {
-            var session = new RocksDbMemoizationSession(name, this, contentSession);
-            return new CreateSessionResult<IMemoizationSession>(session);
-        }
-
-        /// <inheritdoc />
-        public Task<GetStatsResult> GetStatsAsync(Context context)
-        {
-            return GetStatsCall<MemoizationStoreTracer>.RunAsync(_tracer, new OperationContext(context), () =>
-            {
-                var counters = new CounterSet();
-                counters.Merge(_tracer.GetCounters(), $"{Component}.");
-                return Task.FromResult(new GetStatsResult(counters));
-            });
-        }
-
-        /// <inheritdoc />
-        protected override async Task<BoolResult> StartupCoreAsync(OperationContext context)
-        {
-            var cldbStartup = await _database.StartupAsync(context);
-            if (!cldbStartup.Succeeded)
-            {
-                return cldbStartup;
-            }
-
-            return BoolResult.Success;
-        }
-
-        /// <inheritdoc />
-        protected override async Task<BoolResult> ShutdownCoreAsync(OperationContext context)
-        {
-            var cldbShutdown = await _database.ShutdownAsync(context);
-            if (!cldbShutdown.Succeeded)
-            {
-                return cldbShutdown;
-            }
-
-            return BoolResult.Success;
-        }
-
-        /// <inheritdoc />
-        public Async::System.Collections.Generic.IAsyncEnumerable<StructResult<StrongFingerprint>> EnumerateStrongFingerprints(Context context)
-        {
-            var ctx = new OperationContext(context);
-            return AsyncEnumerableExtensions.CreateSingleProducerTaskAsyncEnumerable<StructResult<StrongFingerprint>>(() => Task.FromResult(_database.EnumerateStrongFingerprints(ctx)));
-        }
-
-        internal Task<GetContentHashListResult> GetContentHashListAsync(Context context, StrongFingerprint strongFingerprint, CancellationToken cts)
-        {
-            var ctx = new OperationContext(context, cts);
-            return GetContentHashListCall.RunAsync(_tracer, ctx, strongFingerprint, async () => {
-                return await Task.FromResult(_database.GetContentHashList(ctx, strongFingerprint));
-            });
-        }
-
-        internal Task<AddOrGetContentHashListResult> AddOrGetContentHashListAsync(Context context, StrongFingerprint strongFingerprint, ContentHashListWithDeterminism contentHashListWithDeterminism, IContentSession contentSession, CancellationToken cts)
-        {
-            var ctx = new OperationContext(context, cts);
-            return AddOrGetContentHashListCall.RunAsync(_tracer, ctx, strongFingerprint, async () => {
-                return await ctx.PerformOperationAsync(
-               _tracer,
-               async () =>
-               {
-                   // We do multiple attempts here because we have a "CompareExchange" RocksDB in the heart
-                   // of this implementation, and this may fail if the database is heavily contended.
-                   // Unfortunately, there is not much we can do at the time of writing to avoid this
-                   // requirement.
-                   var maxAttempts = 5;
-                   while (maxAttempts-- >= 0)
-                   {
-                       var contentHashList = contentHashListWithDeterminism.ContentHashList;
-                       var determinism = contentHashListWithDeterminism.Determinism;
-
-                       // Load old value. Notice that this get updates the time, regardless of whether we replace the value or not.
-                       var oldContentHashListWithDeterminism = _database.GetContentHashList(ctx, strongFingerprint);
-                       var oldContentHashList = oldContentHashListWithDeterminism.ContentHashListWithDeterminism.ContentHashList;
-                       var oldDeterminism = oldContentHashListWithDeterminism.ContentHashListWithDeterminism.Determinism;
-
-                       // Make sure we're not mixing SinglePhaseNonDeterminism records
-                       if (!(oldContentHashList is null) &&
-                                  oldDeterminism.IsSinglePhaseNonDeterministic != determinism.IsSinglePhaseNonDeterministic)
-                       {
-                           return AddOrGetContentHashListResult.SinglePhaseMixingError;
-                       }
-
-                       if (oldContentHashList is null || oldDeterminism.ShouldBeReplacedWith(determinism) ||
-                                   !(await contentSession.EnsureContentIsAvailableAsync(ctx, oldContentHashList, ctx.Token).ConfigureAwait(false)))
-                       {
-                           // Replace if incoming has better determinism or some content for the existing
-                           // entry is missing. The entry could have changed since we fetched the old value
-                           // earlier, hence, we need to check it hasn't.
-                           var exchanged = _database.CompareExchange(
-                              ctx,
-                              strongFingerprint,
-                              oldContentHashListWithDeterminism.ContentHashListWithDeterminism,
-                              contentHashListWithDeterminism).ThrowOnError();
-                           if (!exchanged)
-                           {
-                               // Our update lost, need to retry
-                               continue;
-                           }
-
-                           return new AddOrGetContentHashListResult(new ContentHashListWithDeterminism(null, determinism));
-                       }
-
-                       // If we didn't accept the new value because it is the same as before, just with a not
-                       // necessarily better determinism, then let the user know.
-                       if (!(oldContentHashList is null) && oldContentHashList.Equals(contentHashList))
-                       {
-                           return new AddOrGetContentHashListResult(new ContentHashListWithDeterminism(null, oldDeterminism));
-                       }
-
-                       // If we didn't accept a deterministic tool's data, then we're in an inconsistent state
-                       if (determinism.IsDeterministicTool)
-                       {
-                           return new AddOrGetContentHashListResult(
-                               AddOrGetContentHashListResult.ResultCode.InvalidToolDeterminismError,
-                               oldContentHashListWithDeterminism.ContentHashListWithDeterminism);
-                       }
-
-                       // If we did not accept the given value, return the value in the cache
-                       return new AddOrGetContentHashListResult(oldContentHashListWithDeterminism);
-                   }
-
-                   return new AddOrGetContentHashListResult("Hit too many races attempting to add content hash list into the cache");
-                   // TODO(jubayard): decouple the counters from the ContentLocationDatabase
-               }, _database.Counters[ContentLocationDatabaseCounters.AddOrGetContentHashList]);
-            });
-        }
-
-        internal Task<Result<Selector[]>> GetSelectorsCoreAsync(Context context, Fingerprint weakFingerprint)
-        {
-            var ctx = new OperationContext(context);
-
-            var stopwatch = new Stopwatch();
-            try
-            {
-                _tracer.GetSelectorsStart(ctx, weakFingerprint);
-                stopwatch.Start();
-
-                var getSelectorsResult = new List<Selector>();
-                foreach (var result in _database.GetSelectors(ctx, weakFingerprint))
-                {
-                    if (!result.Succeeded)
-                    {
-                        return Task.FromResult(Result.FromError<Selector[]>(result));
-                    }
-
-                    getSelectorsResult.Add(result.Selector);
-                }
-
-                _tracer.GetSelectorsCount(ctx, weakFingerprint, getSelectorsResult.Count);
-                return Task.FromResult(Result.Success(getSelectorsResult.ToArray()));
-            }
-            catch (Exception exception)
-            {
-                _tracer.Debug(ctx, $"{Component}.GetSelectors() error=[{exception}]");
-                return Task.FromResult(Result.FromException<Selector[]>(exception));
-            }
-            finally
-            {
-                stopwatch.Stop();
-                _tracer.GetSelectorsStop(ctx, stopwatch.Elapsed);
-            }
+            _database = database;
         }
     }
 }


### PR DESCRIPTION
This is the Part 1 of a series of changes to enable aggregating Redis with RocksDb as a MemoizationStore.
Part 2 - implement generic MemoizationDatabase (KeyValueMemoizationDatabase) which is backed by a binary key value store (i.e. move serialization logic out of RocksDbContentLocationDatabase)
Part 3 - implement RedisMemoizationDatabase which derives from KeyValueMemoizationDatabase.
Part 4 - implement MultiLevelMemoizationDatabase which aggregates two KeyValueMemoizationDatabase (namely for aggregating RocksDbMemoizationDatabase and RedisMemoizationDatabase).