### PR TITLE
Reduce IO used by integration tests

### DIFF
--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -1360,6 +1360,7 @@ namespace BuildXL.Scheduler
                     // create fingerprint store copy in logs.
                     await FingerprintStore.CopyAsync(
                         m_loggingContext,
+                        m_testHooks.FingerprintStoreTestHooks,
                         Context.PathTable,
                         m_configuration,
                         m_fingerprintStoreCounters);

--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -1360,7 +1360,7 @@ namespace BuildXL.Scheduler
                     // create fingerprint store copy in logs.
                     await FingerprintStore.CopyAsync(
                         m_loggingContext,
-                        m_testHooks.FingerprintStoreTestHooks,
+                        m_testHooks?.FingerprintStoreTestHooks,
                         Context.PathTable,
                         m_configuration,
                         m_fingerprintStoreCounters);

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SchedulerIntegrationTestBase.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SchedulerIntegrationTestBase.cs
@@ -20,6 +20,7 @@ using BuildXL.Processes;
 using BuildXL.Scheduler;
 using BuildXL.Scheduler.Filter;
 using BuildXL.Scheduler.Graph;
+using BuildXL.Scheduler.Tracing;
 using BuildXL.Storage;
 using BuildXL.Utilities;
 using BuildXL.Utilities.Collections;
@@ -78,7 +79,7 @@ namespace Test.BuildXL.Scheduler
             XAssert.IsTrue(Args.TryParseArguments(new[] { "/c:" + Path.Combine(TemporaryDirectory, "config.dc") }, Context.PathTable, null, out config), "Failed to construct arguments");
             Configuration = new CommandLineConfiguration(config);
 
-            Cache = OperatingSystemHelper.IsUnixOS ? InMemoryCacheFactory.Create() : MockCacheFactory.Create(CacheRoot);
+            Cache = InMemoryCacheFactory.Create();
 
             FileContentTable = FileContentTable.CreateNew();
 
@@ -402,6 +403,7 @@ namespace Test.BuildXL.Scheduler
             // .....................................................................................
 
             testHooks = testHooks ?? new SchedulerTestHooks();
+            testHooks.FingerprintStoreTestHooks = testHooks.FingerprintStoreTestHooks ?? new FingerprintStoreTestHooks() { MinimalIO = true };
             Contract.Assert(!(config.Engine.CleanTempDirectories && tempCleaner == null));
 
             using (var queue = new PipQueue(config.Schedule))
@@ -444,7 +446,12 @@ namespace Test.BuildXL.Scheduler
                 testScheduler.Start(localLoggingContext);
 
                 bool success = testScheduler.WhenDone().GetAwaiter().GetResult();
-                testScheduler.SaveFileChangeTrackerAsync(localLoggingContext).Wait();
+
+                // Only save file change tracking information for incremental scheduling tests in order to reduce I/O
+                if (Configuration.Schedule.IncrementalScheduling)
+                {
+                    testScheduler.SaveFileChangeTrackerAsync(localLoggingContext).Wait();
+                }
 
                 if (ShouldLogSchedulerStats)
                 {


### PR DESCRIPTION
- Switch to in memory cache for all integration tests
- Introduce test hook to avoid copying RocksDB log file in FingerprintStore tests
- Only save the scheduler's file change tracker when running tests that consume it

These changes yielded a 15% speedup for the Test.BuildXL.FingerprintStore tests (when not I/O constrained).

[AB#1574285](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1574285)