### PR TITLE
More error-tolerant during worker re-connection

### DIFF
--- a/Public/Src/Engine/Dll/Distribution/Grpc/ClientConnectionManager.cs
+++ b/Public/Src/Engine/Dll/Distribution/Grpc/ClientConnectionManager.cs
@@ -72,8 +72,10 @@ namespace BuildXL.Engine.Distribution.Grpc
                     // Try connecting with timeout (default 5min) 
                     // If it does not succeed, disconnect the worker. 
                     bool connectionSucceeded = await TryConnectChannelAsync(GrpcSettings.CallTimeout, nameof(MonitorConnectionAsync));
-                    if (!connectionSucceeded)
+                    if (!connectionSucceeded && IsNonRecoverableState(Channel.State))
                     {
+                        // If re-connection attempt does not succeed; but the state is one of the recoverable states (Connecting, Ready, Transient)
+                        // Then, there is still a chance for the reconnection. 
                         OnConnectionTimeOutAsync?.Invoke(this, EventArgs.Empty);
                         break;
                     }
@@ -204,6 +206,18 @@ namespace BuildXL.Engine.Distribution.Grpc
             }
 
             return true;
+        }
+
+        private static bool IsNonRecoverableState(ChannelState state)
+        {
+            switch (state)
+            {
+                case ChannelState.Idle:
+                case ChannelState.Shutdown:
+                    return true;
+                default:
+                    return false;
+            }
         }
     }
 }


### PR DESCRIPTION
Bug: Worker dropped out of build with "Failure Reached deadline.." when machine was still available

[AB#1583652](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1583652)