### PR TITLE
Fix inconsistency in VSIX naming for marketplace

### DIFF
--- a/Public/Src/IDE/VsCode/client/package-lock.json
+++ b/Public/Src/IDE/VsCode/client/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "buildxldscript",
+  "name": "dscript",
   "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/Public/Src/IDE/VsCode/client/package.json
+++ b/Public/Src/IDE/VsCode/client/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "buildxldscript",
+  "name": "dscript",
   "displayName": "BuildXL",
   "description": "Visual Studio Code Extension for BuildXL",
   "icon": "BuildXL.png",

--- a/Public/Src/IDE/VsCode/client/src/update.ts
+++ b/Public/Src/IDE/VsCode/client/src/update.ts
@@ -65,7 +65,7 @@ export function checkForUpdates() {
         };
     
         // Our build version is in the form of "date.index.minor"
-        const thisExtension = extensions.getExtension("Microsoft.buildxldscript");
+        const thisExtension = extensions.getExtension("Microsoft.dscript");
         const thisVersion : string = thisExtension.packageJSON.version;
         const splitVersion = thisVersion.split('.');
         if (splitVersion.length === 3) {

--- a/Public/Src/IDE/VsCode/pluginTemplate/extension/out/src/update.js
+++ b/Public/Src/IDE/VsCode/pluginTemplate/extension/out/src/update.js
@@ -45,7 +45,7 @@ function checkForUpdates() {
             minor: 0
         };
         // Our build version is in the form of "date.index.minor"
-        const thisExtension = vscode_1.extensions.getExtension("Microsoft.buildxldscript");
+        const thisExtension = vscode_1.extensions.getExtension("Microsoft.dscript");
         const thisVersion = thisExtension.packageJSON.version;
         const splitVersion = thisVersion.split('.');
         if (splitVersion.length === 3) {


### PR DESCRIPTION
This is the last step that will allow us to programatically publish the vscode plugin to the marketplace in our CI pipeline.