### PR TITLE
Create new OperationContext to avoid cancelling Proactive Copy prematurely

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/Sessions/DistributedContentSession.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Sessions/DistributedContentSession.cs
@@ -180,8 +180,11 @@ namespace BuildXL.Cache.ContentStore.Distributed.Sessions
             if (putResult.Succeeded && Settings.EnableProactiveCopy)
             {
                 // Since the rest of the operation is done asynchronously, create new context to stop cancelling operation prematurely.
-                var operationContext = new OperationContext(context.TracingContext);
-                RequestProactiveCopyIfNeededAsync(operationContext, putResult.ContentHash).FireAndForget(context);
+                WithOperationContext(
+                    context,
+                    CancellationToken.None,
+                    operationContext => RequestProactiveCopyIfNeededAsync(operationContext, putResult.ContentHash)
+                ).FireAndForget(context);
             }
 
             return putResult;

--- a/Public/Src/Cache/ContentStore/Distributed/Sessions/DistributedContentSession.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Sessions/DistributedContentSession.cs
@@ -179,7 +179,9 @@ namespace BuildXL.Cache.ContentStore.Distributed.Sessions
 
             if (putResult.Succeeded && Settings.EnableProactiveCopy)
             {
-                RequestProactiveCopyIfNeededAsync(context, putResult.ContentHash).FireAndForget(context);
+                // Since the rest of the operation is done asynchronously, create new context to stop cancelling operation prematurely.
+                var operationContext = new OperationContext(context.TracingContext);
+                RequestProactiveCopyIfNeededAsync(operationContext, putResult.ContentHash).FireAndForget(context);
             }
 
             return putResult;


### PR DESCRIPTION
Operation was being cancelled >99% of the time because operation context was being cancelled while operation ran asynchronously.