### PR TITLE
Add parent to CounterCollection

### DIFF
--- a/Public/Src/Utilities/Utilities/Tracing/CounterCollection.cs
+++ b/Public/Src/Utilities/Utilities/Tracing/CounterCollection.cs
@@ -78,7 +78,7 @@ namespace BuildXL.Utilities.Tracing
         /// Creates a collection with the specified number of counters. Each counter in <c>[0, numberOfCounters - 1]</c>
         /// may be accessed with <see cref="AddToCounterInternal"/> or <see cref="GetCounterValueInternal"/>.
         /// </summary>
-        internal CounterCollection(ushort numberOfCounters, CounterCollection parent)
+        internal CounterCollection(ushort numberOfCounters, CounterCollection parent = null)
         {
             Contract.Requires(numberOfCounters > 0);
 

--- a/Public/Src/Utilities/Utilities/Tracing/CounterCollection.cs
+++ b/Public/Src/Utilities/Utilities/Tracing/CounterCollection.cs
@@ -69,10 +69,16 @@ namespace BuildXL.Utilities.Tracing
         private readonly long[,] m_durations;
 
         /// <summary>
+        /// Parent collection that should be incremented when this counter is.
+        /// We assume that the parent will have the same structure as this counter.
+        /// </summary>
+        private readonly CounterCollection m_parent;
+
+        /// <summary>
         /// Creates a collection with the specified number of counters. Each counter in <c>[0, numberOfCounters - 1]</c>
         /// may be accessed with <see cref="AddToCounterInternal"/> or <see cref="GetCounterValueInternal"/>.
         /// </summary>
-        internal CounterCollection(ushort numberOfCounters)
+        internal CounterCollection(ushort numberOfCounters, CounterCollection parent)
         {
             Contract.Requires(numberOfCounters > 0);
 
@@ -81,6 +87,8 @@ namespace BuildXL.Utilities.Tracing
             int valuesPerProcessor = ((int)numberOfCounters + (ValuesPerCacheLine - 1)) & ~(ValuesPerCacheLine - 1);
             m_counters = new long[AssumedLogicalProcessorCount, valuesPerProcessor];
             m_durations = new long[AssumedLogicalProcessorCount, valuesPerProcessor];
+
+            m_parent = parent;
         }
 
         /// <summary>
@@ -89,6 +97,7 @@ namespace BuildXL.Utilities.Tracing
         internal void AddToCounterInternal(ushort counterId, long add)
         {
             AddToCounter(m_counters, counterId, add);
+            m_parent?.AddToCounterInternal(counterId, add);
         }
 
         /// <summary>
@@ -97,6 +106,7 @@ namespace BuildXL.Utilities.Tracing
         internal void AddToStopwatchInternal(ushort counterId, long add)
         {
             AddToCounter(m_durations, counterId, add);
+            m_parent?.AddToStopwatchInternal(counterId, add);
         }
 
         /// <summary>
@@ -349,8 +359,8 @@ namespace BuildXL.Utilities.Tracing
         /// Creates a collection with a counter for every value of <typeparamref name="TEnum"/>.
         /// Note that the enum should be dense, since this creates <c>MaxEnumValue - MinEnumValue + 1</c> counters.
         /// </summary>
-        public CounterCollection()
-            : base((ushort)s_counterTypes.Length)
+        public CounterCollection(CounterCollection<TEnum> parent = null)
+            : base((ushort)s_counterTypes.Length, parent)
         {
         }
 


### PR DESCRIPTION
Add notion of parent to CounterCollection. 

Since sessions have their own counters, this is a way for stores to keep track of their sessions, while allowing sessions to have counters independent of other sessions.

This PR's scope is only to allow this scenario to be fulfilled, but actual use of parent CounterCollections will be left for future PRs.