### PR TITLE
Change default timed compaction setting to disabled

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabaseConfiguration.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabaseConfiguration.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Threading;
 using BuildXL.Cache.ContentStore.Distributed.NuCache.InMemory;
 using BuildXL.Cache.ContentStore.Interfaces.FileSystem;
 
@@ -127,6 +128,6 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         /// Required because of our workload tends to generate a lot of short-lived entries, which clutter the deeper
         /// levels of the RocksDB LSM tree.
         /// </summary>
-        public TimeSpan FullRangeCompactionInterval { get; set; } = TimeSpan.FromHours(6);
+        public TimeSpan FullRangeCompactionInterval { get; set; } = Timeout.InfiniteTimeSpan;
     }
 }

--- a/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
@@ -98,10 +98,9 @@ namespace BuildXL.Cache.Host.Service.Internal
                 ApplyIfNotNull(_distributedSettings.ContentLocationDatabaseCacheMaximumUpdatesPerFlush, v => dbConfig.CacheMaximumUpdatesPerFlush = v);
                 ApplyIfNotNull(_distributedSettings.ContentLocationDatabaseCacheFlushingMaximumInterval, v => dbConfig.CacheFlushingMaximumInterval = v);
 
-                if (_distributedSettings.FullRangeCompactionIntervalMinutes != null)
-                {
-                    dbConfig.FullRangeCompactionInterval = TimeSpan.FromMinutes(_distributedSettings.FullRangeCompactionIntervalMinutes.Value);
-                }
+                ApplyIfNotNull(
+                    _distributedSettings.FullRangeCompactionIntervalMinutes,
+                    v => dbConfig.FullRangeCompactionInterval = TimeSpan.FromMinutes(v));
 
                 ApplySecretSettingsForLlsAsync(redisContentLocationStoreConfiguration, localCacheRoot).GetAwaiter().GetResult();
             }


### PR DESCRIPTION
Since this setting is in minutes, it can't be disabled from config right now. Thus, I'm setting it to disabled by default to avoid an (unwanted) release to prod.