### PR TITLE
Fix column family logging on FullCompaction for RocksDbContentLocationDatabase

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/RocksDbContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/RocksDbContentLocationDatabase.cs
@@ -154,7 +154,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                         {
                             store.CompactRange((byte[])null, null, columnFamilyName: columnFamilyName);
                             return BoolResult.Success;
-                        }, extraStartMessage: $"ColumnFamily={columnFamilyName}");
+                        }, messageFactory: _ => $"ColumnFamily={columnFamilyName}");
 
                         if (!result.Succeeded)
                         {


### PR DESCRIPTION
Start messages are not getting logged, so the information goes missing. This forces the information to go into the stop message.