### PR TITLE
Revert "Fix DFA when building BuildXL explorer in CB (#642)"

### DIFF
--- a/Public/Sdk/Experimental/NodeJs/Yarn/yarn.dsc
+++ b/Public/Sdk/Experimental/NodeJs/Yarn/yarn.dsc
@@ -133,8 +133,6 @@ export function install(args: Arguments) : Result {
                         ...(args.privateCache ? [] : [
                             // We don't have a private cache so untrack the appdata cache folder
                             d`${Context.getMount("LocalAppData").path}/yarn`,
-                            // CB creates a junction from %LocalAppData%\yarn to d:\dbs\profile\bxlint\appdata\local\yarn
-                            d`d:/dbs/profile/bxlint/appdata/local/yarn`,
                         ]),
                     ],
                 },


### PR DESCRIPTION
This reverts commit a3429b2fb177a64998b41b53ec21bfd7b132fd87.