### PR TITLE
Add support for BuildXL to emit a summary page for AzureDevOps UI

### DIFF
--- a/Public/Src/App/Bxl/AzureDevOpsListener.cs
+++ b/Public/Src/App/Bxl/AzureDevOpsListener.cs
@@ -1,0 +1,215 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.ObjectModel;
+using System.Diagnostics.ContractsLight;
+using System.Diagnostics.Tracing;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using BuildXL.Utilities.Collections;
+using BuildXL.Utilities.Instrumentation.Common;
+using BuildXL.Utilities.Tracing;
+using BuildXL.ViewModel;
+
+namespace BuildXL
+{
+    /// <summary>
+    /// This event listener should only be hooked up when AzureDevOps optimzied UI is requested by
+    /// the user via the /ado commandline flag.
+    /// </summary>
+    /// <remarks>
+    /// Capturing the information for the build summary in azure devops is best done in the code
+    /// where the values are computed. Unfortunately this is not always possible, for example in the 
+    /// Cache miss analyzer case, there is would be prohibitive to pass through the BuildSummary class
+    /// through all the abstraction layers and passing it down through many levels. Therefore this is
+    /// a way to still collect the information.
+    /// </remarks>
+    public sealed class AzureDevOpsListener : FormattingEventListener
+    {
+        private static readonly char[] s_newLineCharArray = Environment.NewLine.ToCharArray();
+
+        private readonly IConsole m_console;
+
+        /// <summary>
+        /// The last reported percentage. To avoid double reporting the same percentage over and over
+        /// </summary>
+        private int m_lastReportedProgress = -1;
+
+        private readonly BuildViewModel m_buildViewModel;
+
+        /// <nodoc />
+        public AzureDevOpsListener(
+            Events eventSource,
+            IConsole console,
+            DateTime baseTime,
+            BuildViewModel buildViewModel)
+            : base(eventSource, baseTime, warningMapper: null, level: EventLevel.Verbose, captureAllDiagnosticMessages: false, timeDisplay: TimeDisplay.Seconds)
+        {
+            Contract.Requires(console != null);
+            Contract.Requires(buildViewModel != null);
+
+            m_console = console;
+            m_buildViewModel = buildViewModel;
+        }
+
+
+        /// <inheritdoc />
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1063:ImplementIDisposableCorrectly")]
+        public override void Dispose()
+        {
+            m_console.Dispose();
+            base.Dispose();
+        }
+
+        /// <inheritdoc />
+        protected override void OnInformational(EventWrittenEventArgs eventData)
+        {
+            switch (eventData.EventId)
+            {
+                case (int)EventId.PipStatus:
+                case (int)BuildXL.Scheduler.Tracing.LogEventId.PipStatusNonOverwriteable:
+                    {
+                        var payload = eventData.Payload;
+
+                        var executing = (long)payload[10];
+                        var succeeded = (long)payload[11];
+                        var failed = (long)payload[12];
+                        var skipped = (long)payload[13];
+                        var pending = (long)payload[14];
+                        var waiting = (long)payload[15];
+
+                        var done = succeeded + failed + skipped;
+                        var total = done + pending + waiting + executing;
+
+                        var processPercent = (100.0 * done) / (total * 1.0);
+                        var currentProgress = Convert.ToInt32(Math.Floor(processPercent));
+
+                        if (currentProgress > m_lastReportedProgress)
+                        {
+                            m_lastReportedProgress = currentProgress;
+                            m_console.WriteOutputLine(MessageLevel.Info, $"##vso[task.setprogress value={currentProgress};]Pip Execution phase");
+                        }
+
+                        break;
+                    }
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void OnAlways(EventWrittenEventArgs eventData)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override void OnVerbose(EventWrittenEventArgs eventData)
+        {
+            switch (eventData.EventId)
+            {
+                case (int)EventId.CacheMissAnalysis:
+                    {
+                        var payload = eventData.Payload;
+
+                        m_buildViewModel.BuildSummary.CacheSummary.Entries.Add(
+                            new CacheMissSummaryEntry
+                            {
+                                PipDescription = (string)payload[0],
+                                Reason = (string)payload[1],
+                                FromCacheLookup = (bool)payload[2],
+
+                            }
+                        );
+                    }
+                    break;
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void OnCritical(EventWrittenEventArgs eventData)
+        {
+            LogAzureDevOpsIssue(eventData, "error");
+        }
+
+        /// <inheritdoc />
+        protected override void OnError(EventWrittenEventArgs eventData)
+        {
+            LogAzureDevOpsIssue(eventData, "error");
+
+            switch (eventData.EventId)
+            {
+                case (int)EventId.PipProcessError:
+                    {
+                        var payload = eventData.Payload;
+
+                        m_buildViewModel.BuildSummary.PipErrors.Add(new BuildSummaryPipDiagnostic
+                        {
+                            SemiStablePipId = $"Pip{((long)eventData.Payload[0]):X16}",
+                            PipDescription = (string)eventData.Payload[1],
+                            SpecPath = (string)eventData.Payload[2],
+                            ToolName = (string)eventData.Payload[4],
+                            ExitCode = (int)eventData.Payload[7],
+                            Output = (string)eventData.Payload[5],
+                        }); 
+                    }
+                    break;
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void OnWarning(EventWrittenEventArgs eventData)
+        {
+            LogAzureDevOpsIssue(eventData, "warning");
+        }
+
+        /// <inheritdoc />
+        protected override void Output(EventLevel level, int id, string eventName, EventKeywords eventKeywords, string text, bool doNotTranslatePaths = false)
+        {
+        }
+
+        private void LogAzureDevOpsIssue(EventWrittenEventArgs eventData, string eventType)
+        {
+            var builder = new StringBuilder();
+            builder.Append("##vso[task.logIssue type=");
+            builder.Append(eventType);
+
+            var message = eventData.Message;
+            var args = eventData.Payload == null ? CollectionUtilities.EmptyArray<object>() : eventData.Payload.ToArray();
+            string body;
+
+            // see if this event provides provenance info
+            if (message.StartsWith(EventConstants.ProvenancePrefix, StringComparison.Ordinal))
+            {
+                Contract.Assume(args.Length >= 3, "Provenance prefix contains 3 formatting tokens.");
+
+                // file
+                builder.Append(";sourcepath=");
+                builder.Append(args[0]);
+
+                //line
+                builder.Append(";linenumber=");
+                builder.Append(args[1]);
+
+                //column
+                builder.Append(";columnnumber=");
+                builder.Append(args[2]);
+
+                //code
+                builder.Append(";code=DX");
+                builder.Append(eventData.EventId.ToString("D4"));
+            }
+
+            // report the entire message since Azure DevOps does not yet provide actionalbe information from the metadata.
+            body = string.Format(CultureInfo.CurrentCulture, message, args);
+
+            builder.Append(";]");
+
+            // substitute newlines in the message
+
+            var encodedBody = body.Replace("\r", "%0D").Replace("\n", "%0A");
+            builder.Append(encodedBody);
+
+            m_console.WriteOutputLine(MessageLevel.Info, builder.ToString());
+        }
+    }
+}

--- a/Public/Src/App/Bxl/Strings.resx
+++ b/Public/Src/App/Bxl/Strings.resx
@@ -240,6 +240,9 @@
   <data name="App_Main_Logs" xml:space="preserve">
     <value>Logs</value>
   </data>
+  <data name="App_Main_FailedToWriteSummary" xml:space="preserve">
+    <value>Error writing AzureDevOps summary file: {0}</value>
+  </data>
   <data name="HelpText_DisplayHelp_CacheDirectory" xml:space="preserve">
     <value>Specifies the root directory for the incremental artifact cache (short form: /cd)</value>
   </data>

--- a/Public/Src/Engine/Dll/Engine.cs
+++ b/Public/Src/Engine/Dll/Engine.cs
@@ -318,9 +318,18 @@ namespace BuildXL.Engine
             m_rootTranslator = new RootTranslator(m_directoryTranslator.GetReverseTranslator());
 
             m_collector = collector;
-            m_buildViewModel = buildViewModel;
             m_commitId = commitId;
             m_buildVersion = buildVersion;
+            m_buildViewModel = buildViewModel;
+
+            var loggingConfig = Configuration.Logging;
+            if (loggingConfig.OptimizeConsoleOutputForAzureDevOps)
+            {
+                var filePath = Path.Combine(loggingConfig.LogsDirectory.ToString(Context.PathTable), loggingConfig.LogPrefix + ".Summary.md");
+                
+                // Tell the build viewmodel to collect a builder summary which we report to azure devops.
+                m_buildViewModel.BuildSummary = new BuildSummary(filePath);
+            }
 
             // Designate a temp directory under ObjectDirectory for FileUtilities to move files to during deletion attempts
             m_moveDeleteTempDirectory = Path.Combine(configuration.Layout.ObjectDirectory.ToString(context.PathTable), MoveDeleteTempDirectoryName);
@@ -2985,7 +2994,7 @@ namespace BuildXL.Engine
                 && constructScheduleResult != ConstructScheduleResult.Failure
                 && constructScheduleResult != ConstructScheduleResult.None)
             {
-                m_enginePerformanceInfo.SchedulerPerformanceInfo = schedule.LogStats(loggingContext);
+                m_enginePerformanceInfo.SchedulerPerformanceInfo = schedule.LogStats(loggingContext, m_buildViewModel.BuildSummary);
             }
 
             foreach (var type in BuildXLWriterStats.Types.OrderByDescending(type => BuildXLWriterStats.GetBytes(type)))

--- a/Public/Src/Engine/Dll/EngineSchedule.cs
+++ b/Public/Src/Engine/Dll/EngineSchedule.cs
@@ -35,6 +35,7 @@ using BuildXL.Utilities.Qualifier;
 using BuildXL.Utilities.Tasks;
 using BuildXL.Utilities.Tracing;
 using BuildXL.Utilities.VmCommandProxy;
+using BuildXL.ViewModel;
 using JetBrains.Annotations;
 using static BuildXL.Utilities.FormattableStringEx;
 using Logger = BuildXL.Engine.Tracing.Logger;
@@ -1421,7 +1422,7 @@ namespace BuildXL.Engine
         /// <summary>
         /// At the end of the build this logs some important stats about the build
         /// </summary>
-        public SchedulerPerformanceInfo LogStats(LoggingContext loggingContext)
+        public SchedulerPerformanceInfo LogStats(LoggingContext loggingContext, [CanBeNull] BuildSummary buildSummary)
         {
 #pragma warning disable SA1114 // Parameter list must follow declaration
 
@@ -1446,7 +1447,7 @@ namespace BuildXL.Engine
 #pragma warning restore SA1114 // Parameter list must follow declaration
             }
 
-            var schedulerPerformance = Scheduler.LogStats(loggingContext);
+            var schedulerPerformance = Scheduler.LogStats(loggingContext, buildSummary);
 
             // Log whitelist file statistics
             if (m_configFileState.FileAccessWhitelist != null && m_configFileState.FileAccessWhitelist.MatchedEntryCounts.Count > 0)

--- a/Public/Src/Engine/Scheduler/BuildXL.Scheduler.dsc
+++ b/Public/Src/Engine/Scheduler/BuildXL.Scheduler.dsc
@@ -18,6 +18,7 @@ namespace Scheduler {
             Cache.dll,
             Processes.dll,
             Distribution.Grpc.dll,
+            ViewModel.dll,
             importFrom("BuildXL.Cache.ContentStore").Hashing.dll,
             importFrom("BuildXL.Cache.ContentStore").UtilitiesCore.dll,
             importFrom("BuildXL.Cache.ContentStore").Interfaces.dll,

--- a/Public/Src/Engine/Scheduler/SchedulerTestHooks.cs
+++ b/Public/Src/Engine/Scheduler/SchedulerTestHooks.cs
@@ -18,11 +18,6 @@ namespace BuildXL.Scheduler
     public class SchedulerTestHooks
     {
         /// <summary>
-        /// File change tracker owned by the scheduler.
-        /// </summary>
-        public FileChangeTracker FileChangeTracker { get; set; }
-
-        /// <summary>
         /// Incremental scheduling state owned by the scheduler.
         /// </summary>
         public IIncrementalSchedulingState IncrementalSchedulingState { get; set; }
@@ -45,11 +40,5 @@ namespace BuildXL.Scheduler
         /// Test hooks for the <see cref="FingerprintStore"/>.
         /// </summary>
         public FingerprintStoreTestHooks FingerprintStoreTestHooks { get; set; }
-
-        /// <summary>
-        /// Whether <see cref="Scheduler.LogStats(Utilities.Instrumentation.Common.LoggingContext)"/> should be called after the
-        /// scheduler run is completed.
-        /// </summary>
-        public bool LogSchedulerStats = false;
     }
 }

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/IntegrationTest.BuildXL.Scheduler.dsc
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/IntegrationTest.BuildXL.Scheduler.dsc
@@ -42,6 +42,7 @@ namespace Scheduler.IntegrationTest {
             importFrom("BuildXL.Engine").Engine.dll,
             importFrom("BuildXL.Engine").Processes.dll,
             importFrom("BuildXL.Engine").Scheduler.dll,
+            importFrom("BuildXL.Engine").ViewModel.dll,
             importFrom("BuildXL.Pips").dll,
             importFrom("BuildXL.Utilities").dll,
             importFrom("BuildXL.Utilities").Collections.dll,

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SchedulerIntegrationTestBase.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SchedulerIntegrationTestBase.cs
@@ -459,7 +459,7 @@ namespace Test.BuildXL.Scheduler
                     // to write out the stats perf JSON file
                     var logsDir = config.Logging.LogsDirectory.ToString(Context.PathTable);
                     Directory.CreateDirectory(logsDir);
-                    testScheduler.LogStats(localLoggingContext);
+                    testScheduler.LogStats(localLoggingContext, null);
                 }
 
                 var runResult = new ScheduleRunResult

--- a/Public/Src/Engine/ViewModel/BuildSummary.cs
+++ b/Public/Src/Engine/ViewModel/BuildSummary.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.ContractsLight;
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+namespace BuildXL.ViewModel
+{
+    /// <summary>
+    /// This class collects build information during the build to be displayed in Azure DevOps extensions page as a MarkDown
+    /// </summary>
+    /// <remarks>
+    /// This class is only expected to be instantiated when the users passes /ado on the commandline
+    /// to enable Azure DevOps optimized UI
+    /// </remarks>
+    public class BuildSummary
+    {
+        /// <summary>
+        /// The path where to store the summary
+        /// </summary>
+        private string m_filePath;
+
+        /// <summary>
+        /// This is a model of the tree rendering of the perf regions
+        /// </summary>
+        public PerfTree DurationTree { get; set; }
+
+        /// <nodoc />
+        public CriticalPathSummary CriticalPathSummary { get; } = new CriticalPathSummary();
+
+        /// <nodoc />
+        public CacheSummary CacheSummary { get; } = new CacheSummary();
+
+        /// <nodoc />
+        public List<BuildSummaryPipDiagnostic> PipErrors { get; } = new List<BuildSummaryPipDiagnostic>();
+
+        /// <nodoc />
+        public BuildSummary(string filePath)
+        {
+            Contract.Requires(!string.IsNullOrEmpty(filePath));
+            m_filePath = filePath;
+        }
+
+        /// <summary>
+        /// This will render the markdown to the predetermined file.
+        /// </summary>
+        /// <remarks>
+        /// Caller is responsible for exception handling
+        /// </remarks>
+        public string RenderMarkdown()
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(m_filePath));
+            using (var writer = new MarkDownWriter(m_filePath))
+            {
+                writer.WriteHeader("Stats");
+
+                writer.StartTable();
+
+                if (DurationTree != null)
+                {
+                    writer.StartDetailedTableSummary("Build Duration", DurationTree.Duration.MakeFriendly());
+                    var builder = new StringBuilder();
+                    DurationTree.Write(builder, 0, DurationTree.Duration);
+                    writer.WritePre(builder.ToString());
+                    writer.EndDetailedTableSummary();
+                }
+
+                CacheSummary.RenderMarkdown(writer);
+
+                CriticalPathSummary.RenderMarkdown(writer);
+
+                writer.EndTable();
+
+                if (PipErrors.Count >0)
+                {
+                    writer.WriteHeader("Pip Errors");
+                    foreach (var error in PipErrors)
+                    {
+                        writer.WriteLineRaw("");
+                        error.RenderMarkDown(writer);
+                    }
+                }
+            }
+
+            return m_filePath;
+        }
+        
+        private string ExtractDuration(TimeSpan timespan)
+        {
+            return timespan.TotalMilliseconds.ToString(CultureInfo.InvariantCulture) + "ms";
+        }
+    }
+}

--- a/Public/Src/Engine/ViewModel/BuildSummaryPipDiagnostic.cs
+++ b/Public/Src/Engine/ViewModel/BuildSummaryPipDiagnostic.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+
+namespace BuildXL.ViewModel
+{
+    /// <nodoc />
+    public class BuildSummaryPipDiagnostic
+    {
+        /// <nodoc />
+        public string SemiStablePipId { get; set; }
+
+        /// <nodoc />
+        public string PipDescription { get; set; }
+
+        /// <nodoc />
+        public string SpecPath { get; set; }
+
+        /// <nodoc />
+        public string ToolName { get; set; }
+
+        /// <nodoc />
+        public int ExitCode { get; set; }
+
+        /// <nodoc />
+        public string Output { get; set; }
+
+        /// <nodoc />
+        internal void RenderMarkDown(MarkDownWriter writer)
+        {
+            writer.WriteRaw("### <span style=\"font - family:consolas; monospace\">");
+            writer.WriteText(PipDescription);
+            writer.WriteRaw("</span> failed with exit code ");
+            writer.WriteLineRaw(ExitCode.ToString(CultureInfo.InvariantCulture));
+
+            writer.StartDetails("Pip Details");
+            writer.StartTable();
+            WriteKeyValuePair(writer, "PipHash:", SemiStablePipId, true);
+            WriteKeyValuePair(writer, "Pip:", PipDescription, true);
+            WriteKeyValuePair(writer, "Spec:", SpecPath, true);
+            WriteKeyValuePair(writer, "Tool:", ToolName, true);
+            WriteKeyValuePair(writer, "Exit Code:", ExitCode.ToString(CultureInfo.InvariantCulture), true);
+            writer.EndTable();
+            writer.EndDetails();
+
+            if (!string.IsNullOrEmpty(Output))
+            {
+                writer.WritePre(Output);
+            }
+        }
+
+        private void WriteKeyValuePair(MarkDownWriter writer, string key, string value, bool fixedFont)
+        {
+            writer.StartElement("tr");
+
+            writer.StartElement("td", "text-align:left;vertical-align: text-top;min-width:5em");
+            writer.WriteText(key);
+            writer.EndElement("td");
+
+            writer.StartElement("td");
+            if (fixedFont)
+            {
+                writer.StartElement("span", "font-family:consolas;monospace");
+            }
+
+            writer.WriteText(value);
+            if (fixedFont)
+            {
+                writer.EndElement("span");
+            }
+            writer.EndElement("td");
+            writer.EndElement("tr");
+        }
+    }
+}

--- a/Public/Src/Engine/ViewModel/BuildViewModel.cs
+++ b/Public/Src/Engine/ViewModel/BuildViewModel.cs
@@ -21,6 +21,11 @@ namespace BuildXL.ViewModel
         public PipExecutionContext Context { get; private set; }
 
         /// <summary>
+        /// Optional field to collect a build summary page
+        /// </summary>
+        public BuildSummary BuildSummary { get; set; }
+
+        /// <summary>
         /// Gets the currently execution pips
         /// </summary>
         /// <returns></returns>

--- a/Public/Src/Engine/ViewModel/CacheMissSummaryEntry.cs
+++ b/Public/Src/Engine/ViewModel/CacheMissSummaryEntry.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace BuildXL.ViewModel
+{
+    /// <summary>
+    /// Cache miss details
+    /// </summary>
+    public class CacheMissSummaryEntry
+    {
+        /// <nodoc />
+        public string PipDescription { get; set; }
+
+        /// <nodoc />
+        public string Reason { get; set; }
+
+        /// <nodoc />
+        public bool FromCacheLookup { get; set; }
+    }
+}

--- a/Public/Src/Engine/ViewModel/CacheSummary.cs
+++ b/Public/Src/Engine/ViewModel/CacheSummary.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace BuildXL.ViewModel
+{
+    /// <nodoc />
+    public class CacheSummary
+    {
+        /// <nodoc />
+        public long TotalProcessPips { get; set; }
+
+        /// <nodoc />
+        public long ProcessPipCacheHit { get; set; }
+
+        /// <nodoc />
+        public List<CacheMissSummaryEntry> Entries { get; } = new List<CacheMissSummaryEntry>();
+
+        /// <nodoc />
+        internal void RenderMarkdown(MarkDownWriter writer)
+        {
+            int cacheHitRate = 0;
+            if (TotalProcessPips > 0)
+            {
+                cacheHitRate = (int)(100.0 * ProcessPipCacheHit / TotalProcessPips);
+            }
+
+            var caseRateMessage = $"Process pip cache hits: {cacheHitRate}% ({ProcessPipCacheHit}/{TotalProcessPips}";
+
+            if (Entries.Count == 0) 
+            {
+                writer.WriteDetailedTableEntry("Cache rages", caseRateMessage);
+            }
+            else
+            {
+                writer.StartDetailedTableSummary(
+                    "Cache rates & Misses",
+                    caseRateMessage
+                    );
+
+                foreach (var entry in Entries)
+                {
+                    writer.WritePreDetails(
+                        entry.PipDescription + (entry.FromCacheLookup ? " (From Cachelookup)" : null), 
+                        entry.Reason,
+                        25);
+                }
+
+                writer.EndDetailedTableSummary();
+            }
+        }
+    }
+}

--- a/Public/Src/Engine/ViewModel/CriticalPathSummary.cs
+++ b/Public/Src/Engine/ViewModel/CriticalPathSummary.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace BuildXL.ViewModel
+{
+    /// <summary>
+    /// Critical path summary view model
+    /// </summary>
+    public class CriticalPathSummary
+    {
+        /// <nodoc />
+        public List<CriticalPathSummaryLine> Lines { get; } = new List<CriticalPathSummaryLine>();
+
+        /// <nodoc />
+        public TimeSpan TotalCriticalPathRuntime { get; set; }
+
+        /// <nodoc />
+        public TimeSpan ExeDurationCriticalPath { get; set; }
+
+        /// <nodoc />
+        public TimeSpan TotalMasterQueueTime { get; set; }
+
+        /// <nodoc />
+        internal void RenderMarkdown(MarkDownWriter writer)
+        {
+            writer.StartDetailedTableSummary(
+                "Critical path",
+                $"Pip Duration: {TotalCriticalPathRuntime.MakeFriendly()}, Exe Duration: {ExeDurationCriticalPath.MakeFriendly()}");
+            writer.StartTable(
+                "Pip Duration",
+                "Exe Duration",
+                "Queue Duration",
+                "Pip Result",
+                "Scheduled Time",
+                "Completed Time",
+                "Pip");
+            writer.WriteTableRow(
+                TotalCriticalPathRuntime.MakeFriendly(),
+                ExeDurationCriticalPath.MakeFriendly(),
+                TotalMasterQueueTime.MakeFriendly(),
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                "*Total");
+            writer.WriteTableRow(
+                "-",
+                "-",
+                "-",
+                "-",
+                "-",
+                "-",
+                "-");
+            foreach (var line in Lines)
+            {
+                writer.WriteTableRow(
+                    line.PipDuration.MakeFriendly(),
+                    line.ProcessExecuteTime.MakeFriendly(),
+                    line.PipQueueDuration.MakeFriendly(),
+                    line.Result,
+                    line.ScheduleTime.MakeFriendly(),
+                    line.Completed.MakeFriendly(),
+                    line.PipDescription
+                );
+            }
+
+            writer.EndTable();
+            writer.EndDetailedTableSummary();
+        }
+
+    }
+}

--- a/Public/Src/Engine/ViewModel/CriticalPathSummaryLine.cs
+++ b/Public/Src/Engine/ViewModel/CriticalPathSummaryLine.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace BuildXL.ViewModel
+{
+    /// <summary>
+    /// A line item in the critical path summary
+    /// </summary>
+    public class CriticalPathSummaryLine
+    {
+        /// <nodoc />
+        public TimeSpan PipDuration { get; set; }
+
+        /// <nodoc />
+        public TimeSpan ProcessExecuteTime { get; set; }
+
+        /// <nodoc />
+        public TimeSpan PipQueueDuration { get; set; }
+
+        /// <nodoc />
+        public string Result { get; set; }
+
+        /// <nodoc />
+        public TimeSpan ScheduleTime { get; set; }
+
+        /// <nodoc />
+        public TimeSpan Completed { get; set; }
+
+        /// <nodoc />
+        public string PipDescription { get; set; }
+    }
+}

--- a/Public/Src/Engine/ViewModel/FriendlyTextHelpers.cs
+++ b/Public/Src/Engine/ViewModel/FriendlyTextHelpers.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace BuildXL.ViewModel
+{
+    /// <summary>
+    /// Helper to print view model objects in a user friendly way.
+    /// </summary>
+    public static class FriendlyTextHelpers
+    {
+        /// <summary>
+        /// Prints a timespan duration in human friendly form
+        /// </summary>
+        public static string MakeFriendly(this TimeSpan duration)
+        {
+            if (duration.TotalHours >= 3)
+            {
+                // over 3 hours, no need for seconds
+                return $"{duration.Hours + duration.Days * 24}h {duration.Minutes}m";
+            }
+
+            if (duration.TotalHours >= 1)
+            {
+                return $"{duration.Hours + duration.Days * 24}h {duration.Minutes}m {duration.Seconds}s";
+            }
+
+            if (duration.TotalMinutes >= 5)
+            {
+                // over 5 minutes, no need for milliseconds
+                return $"{duration.Minutes}m {duration.Seconds}s";
+            }
+
+            if (duration.TotalMinutes >= 1)
+            {
+                return $"{duration.Minutes}m {duration.Seconds}s {duration.Milliseconds}ms";
+            }
+
+            if (duration.TotalSeconds >= 1)
+            {
+                return $"{duration.Seconds}s {duration.Milliseconds}ms";
+            }
+
+            return $"{duration.Milliseconds}ms";
+        }
+    }
+}

--- a/Public/Src/Engine/ViewModel/MarkdownWriter.cs
+++ b/Public/Src/Engine/ViewModel/MarkdownWriter.cs
@@ -1,0 +1,205 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Net;
+
+namespace BuildXL.ViewModel
+{
+    /// <nodoc />
+    internal class MarkDownWriter : IDisposable
+    {
+        private TextWriter m_writer;
+
+        /// <nodoc />
+        public MarkDownWriter(string filePath)
+        {
+            m_writer = new StreamWriter(filePath);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            m_writer.Dispose();
+        }
+
+        /// <nodoc />
+        public void WriteHeader(string header)
+        {
+            m_writer.WriteLine();
+            m_writer.Write("## ");
+            m_writer.WriteLine(header);
+        }
+
+        //
+        // Detailed table entries
+        //
+
+        /// <nodoc />
+        public void WriteDetailedTableEntry(string key, string value)
+        {
+            StartDetailedTableEntry(key);
+            m_writer.WriteLine(HtmlEscape(value));
+            EndDetailedTableEntry();
+        }
+
+        /// <nodoc />
+        private void StartDetailedTableEntry(string key)
+        {
+            m_writer.WriteLine("<tr>");
+            m_writer.WriteLine("<th  style='text-align:left;vertical-align: text-top;width:12em;'>");
+            m_writer.WriteLine(HtmlEscape(key));
+            m_writer.WriteLine("</th>");
+            m_writer.WriteLine("<td>");
+        }
+
+        /// <nodoc />
+        private void EndDetailedTableEntry()
+        {
+            m_writer.WriteLine("</td>");
+            m_writer.WriteLine("</tr>");
+        }
+        
+        /// <nodoc />
+        public void StartDetailedTableSummary(string key, string summary)
+        {
+            StartDetailedTableEntry(key);
+            StartDetails(summary);
+        }
+
+        /// <nodoc />
+        public void StartDetails(string summary)
+        {
+            m_writer.WriteLine("<details>");
+            m_writer.WriteLine("<summary>");
+            m_writer.WriteLine(HtmlEscape(summary));
+            m_writer.WriteLine("</summary>");
+        }
+
+        /// <nodoc />
+        public void EndDetails()
+        {
+            m_writer.WriteLine("</details>");
+        }
+
+        /// <nodoc />
+        public void EndDetailedTableSummary()
+        {
+            EndDetails();
+            EndDetailedTableEntry();
+        }
+
+        /// <nodoc />
+        public void WritePreDetails(string summary, string details, int indentPixels = 0)
+        {
+            m_writer.Write("<details");
+            if (indentPixels > 0)
+            {
+                m_writer.Write($" style='margin-left:{indentPixels}px'");
+            }
+            m_writer.WriteLine(">");
+
+            m_writer.WriteLine("<summary>");
+            m_writer.WriteLine(HtmlEscape(summary));
+            m_writer.WriteLine("</summary>");
+            m_writer.WriteLine("<pre>");
+            m_writer.WriteLine(HtmlEscape(details));
+            m_writer.WriteLine("</pre>");
+            m_writer.WriteLine("</summary>");
+
+            m_writer.WriteLine("</details>");
+        }
+
+        /// <nodoc />
+        public void WritePre(string contents)
+        {
+            m_writer.WriteLine("<pre>");
+            m_writer.WriteLine(HtmlEscape(contents));
+            m_writer.WriteLine("</pre>");
+        }
+
+
+        //
+        // Generic table writers
+        //
+
+        /// <nodoc />
+        public void StartTable(params object[] headers)
+        {
+            m_writer.WriteLine("<table>");
+            if (headers?.Length > 0)
+            {
+                WriteRow(headers, true);
+            }
+        }
+
+        /// <nodoc />
+        public void WriteTableRow(params object[] columns)
+        {
+            WriteRow(columns, false);
+        }
+
+        private void WriteRow(object[] columns, bool isHeader)
+        {
+            var rowChar = isHeader ? 'h' : 'd';
+
+            m_writer.WriteLine("<tr>");
+            foreach (var column in columns)
+            {
+                m_writer.Write($"<t{rowChar}>");
+                m_writer.Write(HtmlEscape(Convert.ToString(column, CultureInfo.InvariantCulture)));
+                m_writer.Write($"</t{rowChar}>");
+            }
+            m_writer.WriteLine("</tr>");
+
+        }
+
+        /// <nodoc />
+        public void EndTable()
+        {
+            m_writer.WriteLine("</table>");
+        }
+
+        //
+        // Basic helpers
+        //
+
+        /// <nodoc />
+        public void StartElement(string element, string style = null)
+        {
+            m_writer.WriteLine("<" + element +  (style == null ? null : " style=\"" + style + "\"") + ">");
+        }
+
+        /// <nodoc />
+        public void EndElement(string element)
+        {
+            m_writer.WriteLine("</" + element + ">");
+        }
+
+        /// <nodoc />
+        public void WriteRaw(string text)
+        {
+            m_writer.Write(text);
+        }
+
+        /// <nodoc />
+        public void WriteText(string text)
+        {
+            m_writer.Write(HtmlEscape(text));
+        }
+
+        /// <nodoc />
+        public void WriteLineRaw(string text)
+        {
+            m_writer.WriteLine(text);
+        }
+
+        /// <nodoc />
+        private string HtmlEscape(string value)
+        {
+            return WebUtility.HtmlEncode(value);
+        }
+    }
+}

--- a/Public/Src/Engine/ViewModel/PerfTree.cs
+++ b/Public/Src/Engine/ViewModel/PerfTree.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BuildXL.ViewModel
+{
+    /// <summary>
+    /// Stores a recursive structure of perf measurements
+    /// </summary>
+    /// <remarks>
+    /// This class has an Add method and implements IEnumerable so that we can use object literal construction of PerfTree's.
+    /// </remarks>
+    public class PerfTree : IEnumerable<PerfTree>
+    {
+        /// <nodoc />
+        public PerfTree(string title, TimeSpan duration)
+        {
+            Title = title;
+            Duration = duration;
+        }
+
+        /// <nodoc />
+        public PerfTree(string title, long durationMs)
+            : this(title, TimeSpan.FromMilliseconds(durationMs))
+        {
+        }
+
+        /// <summary>
+        /// The duration of the current step
+        /// </summary>
+        public TimeSpan Duration { get; }
+
+        /// <summary>
+        /// The title of the current step
+        /// </summary>
+        public string Title { get; }
+
+        /// <summary>
+        /// The nested child pref trees
+        /// </summary>
+        public List<PerfTree> NestedItems { get; } = new List<PerfTree>();
+
+        /// <summary>
+        /// Add method for overload literal support
+        /// </summary>
+        public void Add(PerfTree item)
+        {
+            NestedItems.Add(item);
+        }
+
+        /// <inheritdoc />
+        public IEnumerator<PerfTree> GetEnumerator()
+        {
+            return NestedItems.GetEnumerator();
+        }
+
+        /// <inheritdoc />
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        /// <summary>
+        /// Prints indented tree view
+        /// </summary>
+        public void Write(StringBuilder builder, int indent, TimeSpan outer)
+        {
+            AddLine(builder, indent, Title, Duration, outer);
+
+            indent++;
+
+            var remaining = Duration;
+            if (NestedItems.Count > 0)
+            {
+                foreach (var item in NestedItems)
+                {
+                    item.Write(builder, indent, Duration);
+                    remaining -= item.Duration;
+                }
+
+                if (remaining.TotalMilliseconds > 0)
+                {
+                    AddLine(builder, indent, "Other", remaining, outer);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Helper to print a single line with fixed spacing, the time it took to run and the relative percentage compared to the parent
+        /// </summary>
+        private void AddLine(StringBuilder builder, int indent, string title, TimeSpan duration, TimeSpan parentDuration)
+        {
+            int percent = 0;
+            if (parentDuration.TotalMilliseconds > 0)
+            {
+                percent = (int)(100.0 * duration.TotalMilliseconds / parentDuration.TotalMilliseconds);
+            }
+
+            builder.AppendLine($"{new string(' ', indent * 4)}{title,-40} {duration.MakeFriendly(),-20} {percent,3}%");
+        }
+    }
+}

--- a/Public/Src/Utilities/UnitTests/Utilities/PathTranslatorTests.cs
+++ b/Public/Src/Utilities/UnitTests/Utilities/PathTranslatorTests.cs
@@ -13,41 +13,85 @@ namespace Test.BuildXL.Utilities
         [Fact]
         public void BasicTest()
         {
-            PathTranslator pt = new PathTranslator(PathGeneratorUtilities.GetAbsolutePath("b", "foo"), PathGeneratorUtilities.GetAbsolutePath("d","src","123"));
-            XAssert.AreEqual(PathGeneratorUtilities.GetAbsolutePath(" d", "src","123","bar"), pt.Translate(PathGeneratorUtilities.GetAbsolutePath(" b", "foo","bar")));
-            XAssert.AreEqual(PathGeneratorUtilities.GetAbsolutePath("d", "src","123","bar"), pt.Translate(PathGeneratorUtilities.GetAbsolutePath("b", "foo","bar")));
+            var pt = GetPathTranslator();
 
-            XAssert.AreEqual(PathGeneratorUtilities.GetAbsolutePath("d", "src", "123", "bar  '")
-                + PathGeneratorUtilities.GetAbsolutePath("d", "src", "123", "BAR"),
-                pt.Translate(PathGeneratorUtilities.GetAbsolutePath("b", "foo", "bar  '")
-                + PathGeneratorUtilities.GetAbsolutePath("B", "FOO", "BAR")));
+            XAssert.AreEqual(
+                PathGeneratorUtilities.GetAbsolutePath(" d", "src", "123", "bar"),
+                pt.Translate(PathGeneratorUtilities.GetAbsolutePath(" b", "foo", "bar")));
+            XAssert.AreEqual(
+                PathGeneratorUtilities.GetAbsolutePath("d", "src", "123", "bar"),
+                pt.Translate(PathGeneratorUtilities.GetAbsolutePath("b", "foo", "bar")));
 
-            XAssert.AreEqual(PathGeneratorUtilities.GetAbsolutePath(" d", "src", "123", "bar  '")
-                + PathGeneratorUtilities.GetAbsolutePath("d", "src", "123", "BAR"),
-                pt.Translate(PathGeneratorUtilities.GetAbsolutePath(" b", "foo", "bar  '")
-                + PathGeneratorUtilities.GetAbsolutePath("B", "FOO", "BAR")));
+            XAssert.AreEqual(
+                PathGeneratorUtilities.GetAbsolutePath("d", "src", "123", "bar  '") +
+                PathGeneratorUtilities.GetAbsolutePath("d", "src", "123", "BAR"),
+                pt.Translate(PathGeneratorUtilities.GetAbsolutePath("b", "foo", "bar  '") + PathGeneratorUtilities.GetAbsolutePath("B", "FOO", "BAR")));
 
-            XAssert.AreEqual(PathGeneratorUtilities.GetAbsolutePath("where is my head", "src", "foo", "bar  '")
-                + PathGeneratorUtilities.GetAbsolutePath("d", "src", "123", "BAR"),
-                pt.Translate(PathGeneratorUtilities.GetAbsolutePath("where is my head", "src", "foo", "bar  '")
-                + PathGeneratorUtilities.GetAbsolutePath("B", "FOO", "BAR")));
+            XAssert.AreEqual(
+                PathGeneratorUtilities.GetAbsolutePath(" d", "src", "123", "bar  '") +
+                PathGeneratorUtilities.GetAbsolutePath("d", "src", "123", "BAR"),
+                pt.Translate(PathGeneratorUtilities.GetAbsolutePath(" b", "foo", "bar  '") + PathGeneratorUtilities.GetAbsolutePath("B", "FOO", "BAR")));
 
-            XAssert.AreEqual(PathGeneratorUtilities.GetAbsolutePath(@"logging a path: [d", "src", "123", "bar]"), pt.Translate(PathGeneratorUtilities.GetAbsolutePath(@"logging a path: [b", "foo", "bar]")));
-            XAssert.AreEqual(PathGeneratorUtilities.GetAbsolutePath(@" \\?\d", "src", "123", "bar"), pt.Translate(PathGeneratorUtilities.GetAbsolutePath(@" \\?\b", "foo", "bar")));
-            XAssert.AreEqual(PathGeneratorUtilities.GetAbsolutePath(@"\\?\d", "src", "123", "bar"), pt.Translate(PathGeneratorUtilities.GetAbsolutePath(@"\\?\b", "foo", "bar")));
-            XAssert.AreEqual(PathGeneratorUtilities.GetAbsolutePath(@"\??\d", "src", "123", "bar"), pt.Translate(PathGeneratorUtilities.GetAbsolutePath(@"\??\b", "foo", "bar")));
+            XAssert.AreEqual(
+                PathGeneratorUtilities.GetAbsolutePath("where is my head", "src", "foo", "bar  '") +
+                PathGeneratorUtilities.GetAbsolutePath("d", "src", "123", "BAR"),
+                pt.Translate(PathGeneratorUtilities.GetAbsolutePath("where is my head", "src", "foo", "bar  '") + PathGeneratorUtilities.GetAbsolutePath("B", "FOO", "BAR")));
+        }
+
+        [Fact]
+        public void PathsInMarkers()
+        {
+            var pt = GetPathTranslator();
+
+            XAssert.AreEqual(
+                PathGeneratorUtilities.GetAbsolutePath(@"logging a path: [d", "src", "123", "bar]"),
+                pt.Translate(PathGeneratorUtilities.GetAbsolutePath(@"logging a path: [b", "foo", "bar]")));
+            XAssert.AreEqual(
+                PathGeneratorUtilities.GetAbsolutePath(@"##vso[task.uploadsummary]d", "src", "123", "bar"),
+                pt.Translate(PathGeneratorUtilities.GetAbsolutePath(@"##vso[task.uploadsummary]b", "foo", "bar")));
+            XAssert.AreEqual(
+                PathGeneratorUtilities.GetAbsolutePath(@" \\?\d", "src", "123", "bar"),
+                pt.Translate(PathGeneratorUtilities.GetAbsolutePath(@" \\?\b", "foo", "bar")));
+            XAssert.AreEqual(
+                PathGeneratorUtilities.GetAbsolutePath(@"\\?\d", "src", "123", "bar"),
+                pt.Translate(PathGeneratorUtilities.GetAbsolutePath(@"\\?\b", "foo", "bar")));
+            XAssert.AreEqual(
+                PathGeneratorUtilities.GetAbsolutePath(@"\??\d", "src", "123", "bar"),
+                pt.Translate(PathGeneratorUtilities.GetAbsolutePath(@"\??\b", "foo", "bar")));
+        }
+
+        [Fact]
+        public void CheckForFalsePositives()
+        {
+            var pt = GetPathTranslator();
 
             // Don't match the patterns. Validate for off by one errors & false positives
             if (OperatingSystemHelper.IsUnixOS)
             {
-                XAssert.AreEqual(PathGeneratorUtilities.GetAbsolutePath(null, @"\\?b", "foo", "bar"), pt.Translate(PathGeneratorUtilities.GetAbsolutePath(null, @"\\?b", "foo", "bar")));
-                XAssert.AreEqual(PathGeneratorUtilities.GetAbsolutePath(null, @"comb", "foo", "bar"), pt.Translate(PathGeneratorUtilities.GetAbsolutePath(null, @"comb", "foo", "bar")));
+                XAssert.AreEqual(
+                    PathGeneratorUtilities.GetAbsolutePath(null, @"\\?b", "foo", "bar"),
+                    pt.Translate(PathGeneratorUtilities.GetAbsolutePath(null, @"\\?b", "foo", "bar")));
+                XAssert.AreEqual(
+                    PathGeneratorUtilities.GetAbsolutePath(null, @"comb", "foo", "bar"),
+                    pt.Translate(PathGeneratorUtilities.GetAbsolutePath(null, @"comb", "foo", "bar")));
             }
             else
             {
-                XAssert.AreEqual(PathGeneratorUtilities.GetAbsolutePath(@"\\?b", "foo", "bar"), pt.Translate(PathGeneratorUtilities.GetAbsolutePath(@"\\?b", "foo", "bar")));
-                XAssert.AreEqual(PathGeneratorUtilities.GetAbsolutePath(@"comb", "foo", "bar"), pt.Translate(PathGeneratorUtilities.GetAbsolutePath(@"comb", "foo", "bar")));
+                XAssert.AreEqual(
+                    PathGeneratorUtilities.GetAbsolutePath(@"\\?b", "foo", "bar"),
+                    pt.Translate(PathGeneratorUtilities.GetAbsolutePath(@"\\?b", "foo", "bar")));
+                XAssert.AreEqual(
+                    PathGeneratorUtilities.GetAbsolutePath(@"comb", "foo", "bar"),
+                    pt.Translate(PathGeneratorUtilities.GetAbsolutePath(@"comb", "foo", "bar")));
             }
+        }
+
+        private PathTranslator GetPathTranslator()
+        {
+            return new PathTranslator(
+                PathGeneratorUtilities.GetAbsolutePath("b", "foo"),
+                PathGeneratorUtilities.GetAbsolutePath("d", "src", "123")
+            );
         }
     }
 }

--- a/Public/Src/Utilities/Utilities/Tracing/PathTranslator.cs
+++ b/Public/Src/Utilities/Utilities/Tracing/PathTranslator.cs
@@ -35,7 +35,7 @@ namespace BuildXL.Utilities.Tracing
 
         // Set of characters to allow as prefixes to denote a path. A sequence matching fromPath must be preceded
         // by one of these characters or be at the beginning of the string in order to be translated.
-        private static readonly char[] s_prefixCharacters = { ':', '\'', '"', '[' };
+        private static readonly char[] s_prefixCharacters = { ':', '\'', '"', '[', ']' };
         private static readonly string[] s_prefixPatterns = { @"\\?\", @"\??\" };
 
         public static bool CreateIfEnabled(AbsolutePath target, AbsolutePath source, PathTable pathTable, out PathTranslator translator)


### PR DESCRIPTION
Azure DevOps UI now has a summary page:
![image](https://user-images.githubusercontent.com/11037542/63536345-457f8880-c4c8-11e9-8d28-4486892a289f.png)

It contains expandable information like the build duration tree:
![image](https://user-images.githubusercontent.com/11037542/63536035-a35fa080-c4c7-11e9-8c16-a9fb773d3091.png)
Critical path:
![image](https://user-images.githubusercontent.com/11037542/63536111-becaab80-c4c7-11e9-959c-d4486883ecc5.png)
as well as cache miss analysis when available

The summary will also contain the information of failed pips.
This can be extended with other information pretty easily. So please give feedback on missing information. And anything renderable in markdown is possible to display.

It now also displays progress and warning counts:
![image](https://user-images.githubusercontent.com/11037542/63535840-4106a000-c4c7-11e9-8e53-c1cea9efbe2a.png)

And renders errors/warnings in clearly identifyable colors:
![image](https://user-images.githubusercontent.com/11037542/63535891-609dc880-c4c7-11e9-86d7-b84edd9d6678.png)



