### PR TITLE
Add more information to Disallowed File Access summary messages

### DIFF
--- a/Public/Src/Engine/Scheduler/FileMonitoringViolationAnalyzer.cs
+++ b/Public/Src/Engine/Scheduler/FileMonitoringViolationAnalyzer.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using BuildXL.Pips;
 using BuildXL.Pips.Operations;
 using BuildXL.Processes;
+using BuildXL.Scheduler.Graph;
 using BuildXL.Scheduler.Tracing;
 using BuildXL.Storage;
 using BuildXL.Utilities;
@@ -137,7 +138,7 @@ namespace BuildXL.Scheduler
             /// Detected a write inside a source seal directory
             /// </summary>
             WriteInSourceSealDirectory,
-            
+
             /// <summary>
             /// Detected a write to the same path that is treated as an undeclared source file
             /// </summary>
@@ -295,18 +296,18 @@ namespace BuildXL.Scheduler
                         isWhitelistedViolation: true);
                 }
 
-                var errorPaths = new HashSet<AccessViolationPath>();
-                var warningPaths = new HashSet<AccessViolationPath>();
+                var errorPaths = new HashSet<ReportedViolation>();
+                var warningPaths = new HashSet<ReportedViolation>();
 
                 // For violation analysis results
                 if (reportedDependencyViolations != null)
                 {
-                    Func<ReportedFileAccess, AccessViolationPath?> getAccessViolationPath =
+                    Func<ReportedFileAccess, ReportedViolation?> getAccessViolationPath =
                         a =>
                         {
                             if (TryGetAccessedAndProcessPaths(pip, a, out var path, out var processPath))
                             {
-                                return new AccessViolationPath(path, a.IsWriteViolation, processPath);
+                                return new ReportedViolation(isError: false, a.IsWriteViolation ? DependencyViolationType.UndeclaredOutput : DependencyViolationType.UndeclaredOrderedRead, path: path, violatorPipId: pip.PipId, relatedPipId: null, processPath: processPath);
                             }
 
                             // The failure to parse the accessed path has already been logged in TryParseAbsolutePath.
@@ -315,7 +316,7 @@ namespace BuildXL.Scheduler
 
                     if (violations.Count != reportedDependencyViolations.Length)
                     {
-                        // Populated non-reported violations.
+                        // Populated non-reported violations. Note that this modifies the underlying errorPaths and warningPaths hashet
                         var errorOrWarningPaths = m_unexpectedFileAccessesAsErrors ? errorPaths : warningPaths;
 
                         // If unexpectedFileAccessesAsErrors is false, then (violations - reportedDependencyViolations) are warnings.
@@ -340,8 +341,7 @@ namespace BuildXL.Scheduler
                 if (reportedDependencyViolationsForWhitelisted != null && reportedDependencyViolationsForWhitelisted.Length > 0)
                 {
                     // If /validateDistribution is enabled, we need to log errors from reportedDependencyViolationsForWhitelisted.
-                    var errors = reportedDependencyViolationsForWhitelisted.Where(a => a.IsError)
-                        .Select(a => new AccessViolationPath(a.Path, a.IsWriteViolation, a.ProcessPath));
+                    var errors = reportedDependencyViolationsForWhitelisted.Where(a => a.IsError);
                     errorPaths.UnionWith(errors);
                 }
 
@@ -384,7 +384,7 @@ namespace BuildXL.Scheduler
             foreach (var content in convergedContent)
             {
                 // If the converged content changed, then the allowed double write becomes a true violation
-                if (allowedDoubleWriteViolations.TryGetValue(content.fileArtifact, out var originalContentAndViolation) && 
+                if (allowedDoubleWriteViolations.TryGetValue(content.fileArtifact, out var originalContentAndViolation) &&
                     originalContentAndViolation.fileMaterializationInfo.Hash != content.fileInfo.Hash)
                 {
                     ReportedViolation violation = originalContentAndViolation.reportedViolation;
@@ -392,18 +392,18 @@ namespace BuildXL.Scheduler
 
                     disallowedViolationsOnConvergence.Add(
                         HandleDependencyViolation(
-                            violation.Type, 
-                            AccessLevel.Write, 
-                            violation.Path, 
-                            (Process) m_graph.HydratePip(violation.ViolatorPipId, PipQueryContext.FileMonitoringViolationAnalyzerClassifyAndReportAggregateViolations), 
+                            violation.Type,
+                            AccessLevel.Write,
+                            violation.Path,
+                            (Process)m_graph.HydratePip(violation.ViolatorPipId, PipQueryContext.FileMonitoringViolationAnalyzerClassifyAndReportAggregateViolations),
                             isWhitelistedViolation: false,
                             (Process)m_graph.HydratePip(violation.RelatedPipId.Value, PipQueryContext.FileMonitoringViolationAnalyzerClassifyAndReportAggregateViolations),
                             violation.ProcessPath));
                 }
             }
 
-            var errorPaths = new HashSet<AccessViolationPath>();
-            var warningPaths = new HashSet<AccessViolationPath>();
+            var errorPaths = new HashSet<ReportedViolation>();
+            var warningPaths = new HashSet<ReportedViolation>();
             PopulateErrorsAndWarnings(disallowedViolationsOnConvergence, errorPaths, warningPaths);
 
             LogErrorsAndWarnings(pip, errorPaths, warningPaths);
@@ -440,14 +440,14 @@ namespace BuildXL.Scheduler
 
             using (m_counters.StartStopwatch(FileMonitoringViolationAnalysisCounter.AnalyzeDynamicViolationsDuration))
             {
-                var errorPaths = new HashSet<AccessViolationPath>();
-                var warningPaths = new HashSet<AccessViolationPath>();
+                var errorPaths = new HashSet<ReportedViolation>();
+                var warningPaths = new HashSet<ReportedViolation>();
 
                 List<ReportedViolation> dynamicViolations = ReportDynamicViolations(
-                    pip, 
-                    exclusiveOpaqueDirectoryContent, 
-                    sharedOpaqueDirectoryWriteAccesses, 
-                    allowedUndeclaredReads, 
+                    pip,
+                    exclusiveOpaqueDirectoryContent,
+                    sharedOpaqueDirectoryWriteAccesses,
+                    allowedUndeclaredReads,
                     absentPathProbesUnderOutputDirectories,
                     GetOutputArtifactInfoMap(pip, outputsContent),
                     // We don't need to collect allowed same content double writes here since this is used in the cache replay scenario only, when there is no convergence
@@ -495,15 +495,20 @@ namespace BuildXL.Scheduler
             return dynamicViolations;
         }
 
-        private void LogErrorsAndWarnings(Process pip, HashSet<AccessViolationPath> errorPaths, HashSet<AccessViolationPath> warningPaths)
+        private void LogErrorsAndWarnings(Process pip, HashSet<ReportedViolation> errorPaths, HashSet<ReportedViolation> warningPaths)
         {
+            Func<PipId, string> getDescription = (pipId) =>
+            {
+                return m_graph.HydratePip(pipId, PipQueryContext.FileMonitoringViolationAnalyzerClassifyAndReportAggregateViolations).GetDescription(Context);
+            };
+
             if (errorPaths.Count > 0)
             {
                 Logger.Log.FileMonitoringError(
                     LoggingContext,
                     pip.SemiStableHash,
                     pip.GetDescription(Context),
-                    AggregateAccessViolationPaths(errorPaths, Context.PathTable));
+                    AggregateAccessViolationPaths(errorPaths, Context.PathTable, getDescription));
             }
 
             if (warningPaths.Count > 0)
@@ -512,7 +517,7 @@ namespace BuildXL.Scheduler
                     LoggingContext,
                     pip.SemiStableHash,
                     pip.GetDescription(Context),
-                    AggregateAccessViolationPaths(warningPaths, Context.PathTable));
+                    AggregateAccessViolationPaths(warningPaths, Context.PathTable, getDescription));
             }
         }
 
@@ -523,82 +528,106 @@ namespace BuildXL.Scheduler
                    && AbsolutePath.TryCreate(Context.PathTable, reportedAccess.Process.Path, out processPath);
         }
 
-        private readonly struct AccessViolationPath : IEquatable<AccessViolationPath>
+
+        private void PopulateErrorsAndWarnings(IEnumerable<ReportedViolation> reportedDependencyViolations, ISet<ReportedViolation> errorPaths, ISet<ReportedViolation> warningPaths)
         {
-            public readonly AbsolutePath FilePath;
-            public readonly bool IsWriteViolation;
-            public readonly AbsolutePath ProcessPath;
-
-            public AccessViolationPath(AbsolutePath path, bool writeViolation, AbsolutePath processPath)
-            {
-                FilePath = path;
-                IsWriteViolation = writeViolation;
-                ProcessPath = processPath;
-            }
-
-            public bool Equals(AccessViolationPath other)
-            {
-                return IsWriteViolation == other.IsWriteViolation && FilePath.Value == other.FilePath.Value && ProcessPath == other.ProcessPath;
-            }
-
-            public override bool Equals(object obj)
-            {
-                return StructUtilities.Equals(this, obj);
-            }
-
-            public static bool operator ==(AccessViolationPath left, AccessViolationPath right)
-            {
-                return left.Equals(right);
-            }
-
-            public static bool operator !=(AccessViolationPath left, AccessViolationPath right)
-            {
-                return !left.Equals(right);
-            }
-
-            public override int GetHashCode()
-            {
-                return HashCodeHelper.Combine(FilePath.GetHashCode() , ProcessPath.GetHashCode());
-            }
-        }
-
-        private void PopulateErrorsAndWarnings(IEnumerable<ReportedViolation> reportedDependencyViolations, ISet<AccessViolationPath> errorPaths, ISet<AccessViolationPath> warningPaths)
-        {
-            var errors = reportedDependencyViolations.Where(a => a.IsError).Select(a => new AccessViolationPath(a.Path, a.IsWriteViolation, a.ProcessPath));
-            var warnings = reportedDependencyViolations.Where(a => !a.IsError).Select(a => new AccessViolationPath(a.Path, a.IsWriteViolation, a.ProcessPath));
+            var errors = reportedDependencyViolations.Where(a => a.IsError);
+            var warnings = reportedDependencyViolations.Where(a => !a.IsError);
 
             (m_unexpectedFileAccessesAsErrors ? errorPaths : warningPaths).UnionWith(errors);
             warningPaths.UnionWith(warnings);
         }
 
-        /// <summary>
-        /// Compresses the log message, so it only contains a single line for each path
-        /// </summary>
-        private static string AggregateAccessViolationPaths(HashSet<AccessViolationPath> paths, PathTable pathTable)
+        internal static string AggregateAccessViolationPaths(HashSet<ReportedViolation> paths, PathTable pathTable, Func<PipId, string> getPipDescription)
         {
             using (var wrap = Pools.GetStringBuilder())
             {
                 var builder = wrap.Instance;
-                foreach (var processNameGroup in paths.GroupBy(path => path.ProcessPath))
-                {
-                    var arr = processNameGroup.GroupBy(path => path.FilePath, path => path.IsWriteViolation)
-                        // skip elements with invalid paths
-                        .Where(a => a.Key.IsValid)
-                        // reconstruct the violation descriptions using the same format
-                        // for each file, combine all violation types into a single entry (with Write-type violations taking the precedence)
-                        .Select(a => (a.Any(b => b) ? ReportedFileAccess.WriteDescriptionPrefix : ReportedFileAccess.ReadDescriptionPrefix) + a.Key.ToString(pathTable))
-                        .ToArray();
 
-                    Array.Sort(arr, StringComparer.OrdinalIgnoreCase);
-                    builder.AppendLine($"Disallowed file accesses performed by: {processNameGroup.Key.ToString(pathTable)}");
-                    builder.AppendLine(string.Join(Environment.NewLine, arr));
+                HashSet<PipId> relatedNodes = new HashSet<PipId>();
+                HashSet<string> legendText = new HashSet<string>();
+
+                // Handle each process observed to have file accesses
+                var accessesByProcesses = paths.ToMultiValueDictionary(item => item.ProcessPath, item => item);
+                foreach (var accessByProcess in accessesByProcesses.OrderBy(item => item.Key.ToString(pathTable)))
+                {
+                    var processPath = accessByProcess.Key;
+                    var processAccessesByPath = accessByProcess.Value.ToMultiValueDictionary(item => item.Path, item => item);
+
+                    bool printedProcessHeaderRow = false;
+
+                    // Handle each path accessed by that process
+                    foreach (var pathsAccessed in processAccessesByPath.OrderBy(item => item.Key.ToString(pathTable)))
+                    {
+                        var path = pathsAccessed.Key;
+                        if (!path.IsValid)
+                        {
+                            // skip elements with invalid paths
+                            continue;
+                        }
+
+                        if (!printedProcessHeaderRow)
+                        {
+                            builder.AppendLine($"Disallowed file accesses performed by: {processPath.ToString(pathTable)}");
+                            printedProcessHeaderRow = true;
+                        }
+
+                        // There may be more than one access for the same path under the process. We pick the "worst" access to display
+                        ReportedViolation worstAccess = new ReportedViolation();
+                        for (int i = 0; i < pathsAccessed.Value.Count; i++)
+                        {
+                            var thisAccess = pathsAccessed.Value[i];
+
+                            // Collect any relatedNodes if applicable to display at the end of the message
+                            if (thisAccess.RelatedPipId.HasValue && thisAccess.RelatedPipId.Value.IsValid)
+                            {
+                                relatedNodes.Add(thisAccess.RelatedPipId.Value);
+                            }
+
+                            if (i == 0)
+                            {
+                                worstAccess = thisAccess;
+                            }
+                            else if(thisAccess.ReportingType > worstAccess.ReportingType)
+                            {
+                                worstAccess = thisAccess;
+                            }
+                        }
+
+                        // Write out the access information
+                        builder.AppendLine(worstAccess.RenderForMessage(pathTable));
+                        legendText.Add(worstAccess.LegendText);
+                    }
+
+                    builder.AppendLine();
                 }
+
+                // Display summary information
+                if (legendText.Count > 0)
+                {
+                    foreach (string line in legendText.OrderBy(s => s))
+                    {
+                        builder.AppendLine(line);
+                    }
+
+                    builder.AppendLine();
+                }
+
+                if (relatedNodes.Count > 0)
+                {
+                    builder.AppendLine("Violations related to pip(s):");
+                    foreach (var pipId in relatedNodes)
+                    {
+                        builder.AppendLine(getPipDescription(pipId));
+                    }
+                }
+
                 // cutting the trailing line break
                 return builder.ToString().Trim();
             }
         }
 
-        public readonly struct ReportedViolation
+        public readonly struct ReportedViolation : IEquatable<ReportedViolation>
         {
             public readonly bool IsError;
             public readonly PipId? RelatedPipId;
@@ -619,16 +648,42 @@ namespace BuildXL.Scheduler
                 ViolationMakesPipUncacheable = violationMakesPipUncacheable;
             }
 
-            /// <summary>
-            /// Creates a short description of the operation and path. The following is the summary for writing bar.txt and
-            /// reading bar2.txt:
-            /// 
-            /// W c:\foo\bar.txt
-            /// R c:\foo\bar2.txt
-            /// </summary>
-            public string ShortDescribe(PathTable pathTable)
+            public bool Equals(ReportedViolation other)
             {
-                return (IsWriteViolation ? ReportedFileAccess.WriteDescriptionPrefix : ReportedFileAccess.ReadDescriptionPrefix) + Path.ToString(pathTable);
+                return IsError == other.IsError &&
+                    RelatedPipId.Value == other.RelatedPipId.Value &&
+                    Path == other.Path &&
+                    Type == other.Type &&
+                    ViolatorPipId == other.ViolatorPipId &&
+                    ProcessPath == other.ProcessPath &&
+                    ViolationMakesPipUncacheable == other.ViolationMakesPipUncacheable;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return StructUtilities.Equals(this, obj);
+            }
+
+            public static bool operator ==(ReportedViolation left, ReportedViolation right)
+            {
+                return left.Equals(right);
+            }
+
+            public static bool operator !=(ReportedViolation left, ReportedViolation right)
+            {
+                return !left.Equals(right);
+            }
+
+            public override int GetHashCode()
+            {
+                return HashCodeHelper.Combine(
+                    IsError.GetHashCode(),
+                    RelatedPipId.GetHashCode(),
+                    Path.GetHashCode(),
+                    Type.GetHashCode(),
+                    ViolatorPipId.GetHashCode(),
+                    ProcessPath.GetHashCode(),
+                    ViolationMakesPipUncacheable.GetHashCode());
             }
 
             /// <summary>
@@ -651,6 +706,81 @@ namespace BuildXL.Scheduler
                     }
                 }
             }
+
+            public SimplifiedViolationType ReportingType
+            {
+                get
+                {
+                    switch (Type)
+                    {
+                        case DependencyViolationType.DoubleWrite:
+                            return SimplifiedViolationType.DoubleWrite;
+                        case DependencyViolationType.ReadRace:
+                        case DependencyViolationType.UndeclaredOrderedRead:
+                        case DependencyViolationType.MissingSourceDependency:
+                        case DependencyViolationType.UndeclaredReadCycle:
+                        case DependencyViolationType.ReadUndeclaredOutput:
+                            return SimplifiedViolationType.Read;
+                        case DependencyViolationType.UndeclaredOutput:
+                        case DependencyViolationType.WriteInSourceSealDirectory:
+                        case DependencyViolationType.WriteInUndeclaredSourceRead:
+                        case DependencyViolationType.WriteInExistingFile:
+                        case DependencyViolationType.WriteToTempPathInsideSharedOpaque:
+                        case DependencyViolationType.WriteOnAbsentPathProbe:
+                            return SimplifiedViolationType.Write;
+                        case DependencyViolationType.AbsentPathProbeUnderUndeclaredOpaque:
+                            return SimplifiedViolationType.Probe;
+                        default:
+                            throw new NotImplementedException("Need to implement for: " + Type.ToString());
+                    }   
+                }
+            }
+
+            public string RenderForMessage(PathTable pathTable)
+            {
+                string path = Path.ToString(pathTable);
+                switch (ReportingType)
+                {
+                    case SimplifiedViolationType.Probe:
+                        return " P  " + path;
+                    case SimplifiedViolationType.Read:
+                        return " R  " + path;
+                    case SimplifiedViolationType.Write:
+                        return " W  " + path;
+                    case SimplifiedViolationType.DoubleWrite:
+                        return " DW  " + path;
+                    default:
+                        throw new NotImplementedException("Need to implement for: " + ReportingType.ToString());
+                }
+            }
+
+            public string LegendText
+            {
+                get
+                {
+                    switch (ReportingType)
+                    {
+                        case SimplifiedViolationType.Probe:
+                            return "P = Probe to an absent path";
+                        case SimplifiedViolationType.Read:
+                            return "R = Read";
+                        case SimplifiedViolationType.Write:
+                            return "W = Write";
+                        case SimplifiedViolationType.DoubleWrite:
+                            return "DW = Double Write";
+                        default:
+                            throw new NotImplementedException("Need to implement for: " + ReportingType.ToString());
+                    }
+                }
+            }
+        }
+
+        public enum SimplifiedViolationType
+        {
+            Probe = 1,
+            Read = 2,
+            Write = 3,
+            DoubleWrite = 4,
         }
 
         /// <summary>

--- a/Public/Src/Engine/Scheduler/ReportedViolation.cs
+++ b/Public/Src/Engine/Scheduler/ReportedViolation.cs
@@ -1,0 +1,206 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using BuildXL.Pips;
+using BuildXL.Utilities;
+using static BuildXL.Scheduler.FileMonitoringViolationAnalyzer;
+
+namespace BuildXL.Scheduler
+{
+    /// <summary>
+    /// A file access violation for reporting
+    /// </summary>
+    public readonly struct ReportedViolation : IEquatable<ReportedViolation>
+    {
+        /// <nodoc/>
+        public readonly bool IsError;
+
+        /// <nodoc/>
+        public readonly PipId? RelatedPipId;
+
+        /// <nodoc/>
+        public readonly AbsolutePath Path;
+
+        /// <nodoc/>
+        public readonly DependencyViolationType Type;
+
+        /// <nodoc/>
+        public readonly PipId ViolatorPipId;
+
+        /// <nodoc/>
+        public readonly AbsolutePath ProcessPath;
+
+        /// <nodoc/>
+        public readonly bool ViolationMakesPipUncacheable;
+
+        /// <nodoc/>
+        public ReportedViolation(bool isError, DependencyViolationType type, AbsolutePath path, PipId violatorPipId, PipId? relatedPipId, AbsolutePath processPath, bool violationMakesPipUncacheable = true)
+        {
+            IsError = isError;
+            Type = type;
+            Path = path;
+            ViolatorPipId = violatorPipId;
+            RelatedPipId = relatedPipId;
+            ProcessPath = processPath;
+            ViolationMakesPipUncacheable = violationMakesPipUncacheable;
+        }
+
+        #region MessageRendering
+        /// <summary>
+        /// A simplified violation type for sake of displaying in the DisallowedFileAccess summary message
+        /// </summary>
+        public SimplifiedViolationType ReportingType
+        {
+            get
+            {
+                switch (Type)
+                {
+                    case DependencyViolationType.DoubleWrite:
+                        return SimplifiedViolationType.DoubleWrite;
+                    case DependencyViolationType.ReadRace:
+                    case DependencyViolationType.UndeclaredOrderedRead:
+                    case DependencyViolationType.MissingSourceDependency:
+                    case DependencyViolationType.UndeclaredReadCycle:
+                    case DependencyViolationType.ReadUndeclaredOutput:
+                        return SimplifiedViolationType.Read;
+                    case DependencyViolationType.UndeclaredOutput:
+                    case DependencyViolationType.WriteInSourceSealDirectory:
+                    case DependencyViolationType.WriteInUndeclaredSourceRead:
+                    case DependencyViolationType.WriteInExistingFile:
+                    case DependencyViolationType.WriteToTempPathInsideSharedOpaque:
+                    case DependencyViolationType.WriteOnAbsentPathProbe:
+                        return SimplifiedViolationType.Write;
+                    case DependencyViolationType.AbsentPathProbeUnderUndeclaredOpaque:
+                        return SimplifiedViolationType.Probe;
+                    default:
+                        throw new NotImplementedException("Need to implement for: " + Type.ToString());
+                }
+            }
+        }
+
+        /// <summary>
+        /// Renders the violation for display in the DFA summary
+        /// </summary>
+        public string RenderForDFASummary(PathTable pathTable)
+        {
+            return $" {ReportingType.ToAbbreviation()} {Path.ToString(pathTable)}";
+        }
+
+        /// <summary>
+        /// Legend informaiton to display in the DFA summary
+        /// </summary>
+        public string LegendText
+        {
+            get
+            {
+                switch (ReportingType)
+                {
+                    case SimplifiedViolationType.Probe:
+                        return $"{ReportingType.ToAbbreviation()} = Probe to an absent path";
+                    case SimplifiedViolationType.Read:
+                        return $"{ReportingType.ToAbbreviation()} = Read";
+                    case SimplifiedViolationType.Write:
+                        return $"{ReportingType.ToAbbreviation()} = Write";
+                    case SimplifiedViolationType.DoubleWrite:
+                        return $"{ReportingType.ToAbbreviation()} = Double Write";
+                    default:
+                        throw new NotImplementedException("Need to implement for: " + ReportingType.ToString());
+                }
+            }
+        }
+
+        #endregion
+
+        #region IEquatable
+        /// <nodoc/>
+        public bool Equals(ReportedViolation other)
+        {
+            return IsError == other.IsError &&
+                RelatedPipId.Value == other.RelatedPipId.Value &&
+                Path == other.Path &&
+                Type == other.Type &&
+                ViolatorPipId == other.ViolatorPipId &&
+                ProcessPath == other.ProcessPath &&
+                ViolationMakesPipUncacheable == other.ViolationMakesPipUncacheable;
+        }
+
+        /// <nodoc/>
+        public override bool Equals(object obj)
+        {
+            return StructUtilities.Equals(this, obj);
+        }
+
+        /// <nodoc/>
+        public static bool operator ==(ReportedViolation left, ReportedViolation right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <nodoc/>
+        public static bool operator !=(ReportedViolation left, ReportedViolation right)
+        {
+            return !left.Equals(right);
+        }
+
+        /// <nodoc/>
+        public override int GetHashCode()
+        {
+            return HashCodeHelper.Combine(
+                IsError.GetHashCode(),
+                RelatedPipId.GetHashCode(),
+                Path.GetHashCode(),
+                Type.GetHashCode(),
+                ViolatorPipId.GetHashCode(),
+                ProcessPath.GetHashCode(),
+                ViolationMakesPipUncacheable.GetHashCode());
+        }
+        #endregion
+    }
+
+    /// <summary>
+    /// A simplified summary of the violation that controls what gets rendered in the DFA summary message
+    /// </summary>
+    /// <remarks>
+    /// These need to remain ordered in terms of increasing precedence 
+    /// </remarks>
+    public enum SimplifiedViolationType : byte
+    {
+        /// <nodoc/>
+        Probe = 0,
+
+        /// <nodoc/>
+        Read = 1,
+
+        /// <nodoc/>
+        Write = 2,
+
+        /// <nodoc/>
+        DoubleWrite = 3,
+    }
+
+    /// <nodoc/>
+    public static class SimplifiedViolationTypeExtensions
+    {
+        /// <summary>
+        /// Gets an abbreviation for the violation type. The abbreviation is guarenteed to be a fixed width
+        /// with respect to other abbreviations
+        /// </summary>
+        public static string ToAbbreviation(this SimplifiedViolationType violation)
+        {
+            switch (violation)
+            {
+                case SimplifiedViolationType.Probe:
+                    return "P ";
+                case SimplifiedViolationType.Read:
+                    return "R ";
+                case SimplifiedViolationType.Write:
+                    return "W ";
+                case SimplifiedViolationType.DoubleWrite:
+                    return "DW";
+                default:
+                    throw new NotImplementedException("Need to implement for: " + violation.ToString());
+            }
+        }
+    }
+}

--- a/Public/Src/Engine/UnitTests/Scheduler/FileMonitoringViolationAnalyzerTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/FileMonitoringViolationAnalyzerTests.cs
@@ -4,22 +4,23 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using BuildXL.Cache.ContentStore.Hashing;
 using BuildXL.Pips;
 using BuildXL.Pips.Operations;
 using BuildXL.Processes;
 using BuildXL.Scheduler;
 using BuildXL.Scheduler.Tracing;
+using BuildXL.Storage;
 using BuildXL.Utilities;
+using BuildXL.Utilities.Collections;
+using BuildXL.Utilities.Configuration;
 using BuildXL.Utilities.Instrumentation.Common;
 using BuildXL.Utilities.Tracing;
-using BuildXL.Utilities.Configuration;
 using Test.BuildXL.TestUtilities.Xunit;
 using Xunit;
 using Xunit.Abstractions;
+using static BuildXL.Scheduler.FileMonitoringViolationAnalyzer;
 using static BuildXL.Utilities.FormattableStringEx;
-using BuildXL.Storage;
-using BuildXL.Utilities.Collections;
-using BuildXL.Cache.ContentStore.Hashing;
 
 namespace Test.BuildXL.Scheduler
 {
@@ -636,7 +637,91 @@ namespace Test.BuildXL.Scheduler
             expectedLog.AppendLine(ReportedFileAccess.WriteDescriptionPrefix + undeclaredWrite.ToString(context.PathTable));
 
             var eventLog = OperatingSystemHelper.IsUnixOS ? EventListener.GetLog().Replace("\r", "") : EventListener.GetLog();
-            XAssert.IsTrue(eventLog.EndsWith(expectedLog.ToString()));
+            XAssert.AreEqual(1, CountInstancesOfWord(expectedLog.ToString(), eventLog), eventLog);
+        }
+
+        [Fact]
+        public void AllViolationTypesHandledByReporting()
+        {
+            var testContext = BuildXLContext.CreateInstanceForTesting();
+            var tool = AbsolutePath.Create(testContext.PathTable, X("/X/out/tool.exe"));
+            var path = AbsolutePath.Create(testContext.PathTable, X("/X/out/path.h"));
+
+            foreach (DependencyViolationType violationType in Enum.GetValues(typeof(DependencyViolationType)))
+            {
+                ReportedViolation violation = new ReportedViolation(isError: false, type: violationType, path: path, violatorPipId: new PipId(1), PipId.Invalid, tool);
+
+                // Should not throw
+                Analysis.IgnoreResult(violation.ReportingType);
+                Analysis.IgnoreResult(violation.RenderForMessage(testContext.PathTable));
+                Analysis.IgnoreResult(violation.LegendText);
+            }
+        }
+
+        /// <summary>
+        /// Makes sure that when multiple file operations happen on the same path the appropriate precidence is chosen.
+        /// </summary>
+        [Theory]
+        [InlineData("DW", new DependencyViolationType[] { DependencyViolationType.DoubleWrite, DependencyViolationType.ReadRace })]
+        [InlineData("DW", new DependencyViolationType[] { DependencyViolationType.ReadRace, DependencyViolationType.DoubleWrite })]
+        [InlineData("DW", new DependencyViolationType[] { DependencyViolationType.DoubleWrite })]
+        [InlineData("R", new DependencyViolationType[] { DependencyViolationType.ReadRace, DependencyViolationType.UndeclaredOrderedRead })]
+        [InlineData("R", new DependencyViolationType[] { DependencyViolationType.ReadRace, DependencyViolationType.AbsentPathProbeUnderUndeclaredOpaque })]
+        [InlineData("W", new DependencyViolationType[] { DependencyViolationType.ReadRace, DependencyViolationType.WriteInExistingFile })]
+        public void AnalyzerMessageRenderingOperationPrecedence(string expectedPrefix, DependencyViolationType[] violationTypes)
+        {
+            var testContext = BuildXLContext.CreateInstanceForTesting();
+            var tool = AbsolutePath.Create(testContext.PathTable, X("/X/out/tool.exe"));
+            var path = AbsolutePath.Create(testContext.PathTable, X("/X/out/path.h"));
+
+            HashSet<ReportedViolation> violations = new HashSet<ReportedViolation>();
+            foreach (DependencyViolationType violationType in violationTypes)
+            {
+                violations.Add(new ReportedViolation(isError: false, type: violationType, path: path, violatorPipId: new PipId(1), PipId.Invalid, tool));
+            }
+
+            string result = FileMonitoringViolationAnalyzer.AggregateAccessViolationPaths(violations, testContext.PathTable, (pipId) => "dummy");
+            string accessLine = result.Split(new string [] { Environment.NewLine}, StringSplitOptions.None)[1].TrimStart(' ');
+
+            XAssert.IsTrue(accessLine.StartsWith(expectedPrefix), "Unexpected result: " + result);
+        }
+
+        [Fact]
+        public void AnalyzerMessageRenderingLegendInformation()
+        {
+            var testContext = BuildXLContext.CreateInstanceForTesting();
+            var tool1 = AbsolutePath.Create(testContext.PathTable, X("/X/out/tool1.exe"));
+            var tool2 = AbsolutePath.Create(testContext.PathTable, X("/X/out/tool2.exe"));
+            var pathA = AbsolutePath.Create(testContext.PathTable, X("/X/out/pathA.h"));
+            var pathB = AbsolutePath.Create(testContext.PathTable, X("/X/out/pathB.h"));
+
+            HashSet<ReportedViolation> violations = new HashSet<ReportedViolation>();
+            violations.Add(new ReportedViolation(isError: false, type: DependencyViolationType.DoubleWrite, path: pathA,
+                violatorPipId: new PipId(1), relatedPipId: PipId.Invalid, tool1));
+            violations.Add(new ReportedViolation(isError: false, type: DependencyViolationType.AbsentPathProbeUnderUndeclaredOpaque, path: pathB,
+                violatorPipId: new PipId(1), relatedPipId: new PipId(2), tool1));
+            violations.Add(new ReportedViolation(isError: false, type: DependencyViolationType.WriteInExistingFile, path: pathB,
+                violatorPipId: new PipId(1), relatedPipId: PipId.Invalid, tool2));
+            violations.Add(new ReportedViolation(isError: false, type: DependencyViolationType.WriteInExistingFile, path: pathB,
+                violatorPipId: new PipId(1), relatedPipId: PipId.Invalid, tool2));
+
+            string result = FileMonitoringViolationAnalyzer.AggregateAccessViolationPaths(violations, testContext.PathTable, (pipId) => "PLACEHOLDER PIP DESCRIPTION");
+
+            // Should see a single instance of " W " for the write files legend even though there are 2 write violations
+            XAssert.AreEqual(1, CountInstancesOfWord(" W ", result), result);
+
+            XAssert.AreEqual(1, CountInstancesOfWord(" DW ", result), result);
+            XAssert.AreEqual(1, CountInstancesOfWord(" P ", result), result);
+
+            string[] resultLines = result.Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
+        }
+
+        private int CountInstancesOfWord(string word, string stringToSearch)
+        {
+            int originalLength = stringToSearch.Length;
+            int newLength = stringToSearch.Replace(word, "").Length;
+
+            return (originalLength - newLength) / word.Length;
         }
 
         [Theory]

--- a/Public/Src/Engine/UnitTests/Scheduler/FileMonitoringViolationAnalyzerTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/FileMonitoringViolationAnalyzerTests.cs
@@ -708,12 +708,11 @@ namespace Test.BuildXL.Scheduler
             string result = FileMonitoringViolationAnalyzer.AggregateAccessViolationPaths(violations, testContext.PathTable, (pipId) => "PLACEHOLDER PIP DESCRIPTION");
 
             // Should see a single instance of " W " for the write files legend even though there are 2 write violations
-            XAssert.AreEqual(1, CountInstancesOfWord(" W ", result), result);
+            string legendMarker = " = ";
+            XAssert.AreEqual(1, CountInstancesOfWord(SimplifiedViolationType.Write.ToAbbreviation() + legendMarker, result), result);
 
-            XAssert.AreEqual(1, CountInstancesOfWord(" DW ", result), result);
-            XAssert.AreEqual(1, CountInstancesOfWord(" P ", result), result);
-
-            string[] resultLines = result.Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
+            XAssert.AreEqual(1, CountInstancesOfWord(SimplifiedViolationType.DoubleWrite.ToAbbreviation() + legendMarker, result), result);
+            XAssert.AreEqual(1, CountInstancesOfWord(SimplifiedViolationType.Probe.ToAbbreviation() + legendMarker, result), result);
         }
 
         private int CountInstancesOfWord(string word, string stringToSearch)

--- a/Public/Src/Engine/UnitTests/Scheduler/FileMonitoringViolationAnalyzerTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/FileMonitoringViolationAnalyzerTests.cs
@@ -653,7 +653,7 @@ namespace Test.BuildXL.Scheduler
 
                 // Should not throw
                 Analysis.IgnoreResult(violation.ReportingType);
-                Analysis.IgnoreResult(violation.RenderForMessage(testContext.PathTable));
+                Analysis.IgnoreResult(violation.RenderForDFASummary(testContext.PathTable));
                 Analysis.IgnoreResult(violation.LegendText);
             }
         }


### PR DESCRIPTION
There are verbose messages that go into great detail about DFAs and then there's an error summary that currently just gives the paths. This change adds some more information to the summary message:
- Additional "DW" and "P" abbreviations for double writes and probes
- Legend showing what the abbreviations mean
- Related pips (if any)

This is based on feedback from APEX team

I also removed the AccessViolationPath violation struct and used the already existing ReportedViolation instead of growing AccessViolationPath further.

[AB#1570214](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1570214)