### PR TITLE
New argument in Transformer.execute.

### DIFF
--- a/Public/Sdk/Public/Transformers/Transformer.Execute.dsc
+++ b/Public/Sdk/Public/Transformers/Transformer.Execute.dsc
@@ -186,6 +186,11 @@ namespace Transformer {
          * Minimum value is 0, maximum value is 99
          */
         priority?: number;
+
+        /**
+         * File to write the change affected input list of the pip before it execute.
+         */
+        changeAffectedInputListWrittenFile?: Path;
     }
 
     @@public

--- a/Public/Src/FrontEnd/Script/Ambients/Transformers/AmbientTransformer.Process.cs
+++ b/Public/Src/FrontEnd/Script/Ambients/Transformers/AmbientTransformer.Process.cs
@@ -135,7 +135,8 @@ namespace BuildXL.FrontEnd.Script.Ambients.Transformers
         private SymbolAtom m_toolPrepareTempDirectory;
         private SymbolAtom m_toolDescription;
         private SymbolAtom m_weight;
-        
+        private SymbolAtom m_changeAffectedInputListWrittenFile;
+
         private SymbolAtom m_runtimeEnvironmentMinimumOSVersion;
         private SymbolAtom m_runtimeEnvironmentMaximumOSVersion;
         private SymbolAtom m_runtimeEnvironmentMinimumClrVersion;
@@ -247,6 +248,7 @@ namespace BuildXL.FrontEnd.Script.Ambients.Transformers
             m_executeDependsOnCurrentHostOSDirectories = Symbol("dependsOnCurrentHostOSDirectories");
             m_weight = Symbol("weight");
             m_priority = Symbol("priority");
+            m_changeAffectedInputListWrittenFile = Symbol("changeAffectedInputListWrittenFile");
 
             m_argN = Symbol("n");
             m_argV = Symbol("v");
@@ -434,6 +436,12 @@ namespace BuildXL.FrontEnd.Script.Ambients.Transformers
             if (consoleErrorOutput.IsValid)
             {
                 processBuilder.SetStandardErrorFile(consoleErrorOutput);
+            }
+
+            var changeAffectedInputListWrittenFile = Converter.ExtractPath(obj, m_changeAffectedInputListWrittenFile, allowUndefined: true);
+            if (changeAffectedInputListWrittenFile.IsValid)
+            {
+                processBuilder.SetChangeAffectedInputListWrittenFile(changeAffectedInputListWrittenFile);
             }
 
             // Environment variables.

--- a/Public/Src/Pips/Dll/Builders/ProcessBuilder.cs
+++ b/Public/Src/Pips/Dll/Builders/ProcessBuilder.cs
@@ -172,6 +172,8 @@ namespace BuildXL.Pips.Builders
         private readonly AbsolutePath m_realUserProfilePath;
         private readonly AbsolutePath m_redirectedUserProfilePath;
 
+        private FileArtifact m_changeAffectedInputListWrittenFile;
+
         /// <nodoc />
         private ProcessBuilder(PathTable pathTable, PooledObjectWrapper<PipDataBuilder> argumentsBuilder)
         {
@@ -394,6 +396,16 @@ namespace BuildXL.Pips.Builders
 
             AddOutputFile(path, FileExistence.Required);
             m_standardErrorFile = FileArtifact.CreateOutputFile(path);
+        }
+
+        /// <nodoc />
+        public void SetChangeAffectedInputListWrittenFile(AbsolutePath path)
+        {
+            Contract.Requires(path.IsValid);
+            Contract.Assert(!m_changeAffectedInputListWrittenFile.IsValid, "Value already set");
+
+            AddOutputFile(path, FileExistence.Optional);
+            m_changeAffectedInputListWrittenFile = FileArtifact.CreateOutputFile(path);
         }
 
         /// <nodoc />


### PR DESCRIPTION
A new argument in Transformer.execute to take the path for BXL to write out the filtered dependencies for code coverage instrumentation.

[AB#1579485](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1579485)
