### PR TITLE
More macOS Catalina EndpointSecurity adjustments

### DIFF
--- a/Public/Src/App/Bxl/Args.cs
+++ b/Public/Src/App/Bxl/Args.cs
@@ -784,6 +784,12 @@ namespace BuildXL
                             opt =>
                             {
                                 var parsedOption = CommandLineUtilities.ParseEnumOption<SandboxKind>(opt);
+#if PLATFORM_OSX
+                                if (parsedOption == SandboxKind.MacOsEndpointSecurity && !OperatingSystemHelper.IsMacOSCatalinaOrHigher)
+                                {
+                                    parsedOption = SandboxKind.MacOsKext;
+                                }
+#endif
                                 sandboxConfiguration.UnsafeSandboxConfigurationMutable.SandboxKind = parsedOption;
                                 if ((parsedOption.ToString().StartsWith("Win") && OperatingSystemHelper.IsUnixOS) ||
                                     (parsedOption.ToString().StartsWith("Mac") && !OperatingSystemHelper.IsUnixOS))

--- a/Public/Src/Sandbox/MacOs/Interop/Sandbox/ESSandbox.h
+++ b/Public/Src/Sandbox/MacOs/Interop/Sandbox/ESSandbox.h
@@ -61,7 +61,7 @@ private:
     {
         // Process I/O operations
         
-        // Currently deactivated, done through ES_EVENT_TYPE_NOTIFY_CLOSE
+        // Currently deactivated, done through ES_EVENT_TYPE_NOTIFY_CLOSE to reduce overall event count
         // ES_EVENT_TYPE_NOTIFY_OPEN,
         
         ES_EVENT_TYPE_NOTIFY_CLOSE,

--- a/Public/Src/Sandbox/MacOs/Interop/Sandbox/Handlers/AccessHandler.cpp
+++ b/Public/Src/Sandbox/MacOs/Interop/Sandbox/Handlers/AccessHandler.cpp
@@ -128,6 +128,31 @@ PolicyResult AccessHandler::PolicyForPath(const char *absolutePath)
     return PolicyResult(GetPip()->getFamFlags(), absolutePath, cursor);
 }
 
+static bool is_prefix(const char *s1, const char *s2)
+{
+    int c;
+    while ((c = *s2++) != '\0')
+    {
+        if (c != *s1++)
+        {
+            return false;
+        }
+    }
+    
+    return true;
+}
+
+const char* AccessHandler::IgnoreDataPartitionPrefix(const char* path)
+{
+    const char *marker = path;
+    if (is_prefix(marker, kDataPartitionPrefix))
+    {
+        marker += kAdjustedPrefixLength;
+    }
+
+    return marker;
+}
+
 AccessCheckResult AccessHandler::CheckAndReportInternal(FileOperation operation,
                                                         const char *path,
                                                         CheckFunc checker,
@@ -135,7 +160,7 @@ AccessCheckResult AccessHandler::CheckAndReportInternal(FileOperation operation,
                                                         bool isDir)
 {    
     // 1: check operation against given policy
-    PolicyResult policy = PolicyForPath(path);
+    PolicyResult policy = PolicyForPath(IgnoreDataPartitionPrefix(path));
     AccessCheckResult result = AccessCheckResult::Invalid();
     checker(policy, isDir, &result);
         

--- a/Public/Src/Sandbox/MacOs/Interop/Sandbox/Handlers/AccessHandler.hpp
+++ b/Public/Src/Sandbox/MacOs/Interop/Sandbox/Handlers/AccessHandler.hpp
@@ -24,6 +24,10 @@ struct AccessHandler
 {
 private:
 
+    const char *IgnoreDataPartitionPrefix(const char* path);
+    const char *kDataPartitionPrefix = "/System/Volumes/Data/";
+    const size_t kAdjustedPrefixLength = strlen("/System/Volumes/Data");
+    
     ESSandbox *sandbox_;
 
     SandboxedProcess *process_;

--- a/Public/Src/Tools/SandboxExec/Program.cs
+++ b/Public/Src/Tools/SandboxExec/Program.cs
@@ -173,10 +173,18 @@ namespace BuildXL.SandboxExec
         {
             m_options = options;
             s_crashCollector = OperatingSystemHelper.IsUnixOS ? new CrashCollectorMacOS(new[] { CrashType.SandboxExec, CrashType.Kernel }) : null;
+
+            var useEndpointSecuritySandbox = m_options.UseEndpointSecuritySandbox;
+#if PLATFORM_OSX
+            if (useEndpointSecuritySandbox && !OperatingSystemHelper.IsMacOSCatalinaOrHigher)
+            {
+                useEndpointSecuritySandbox = false;
+            }
+#endif
             m_sandboxConnection = OperatingSystemHelper.IsUnixOS
                 ?
 #if PLATFORM_OSX
-                m_options.UseEndpointSecuritySandbox
+                useEndpointSecuritySandbox
                     ? (ISandboxConnection) new SandboxConnectionES()
                     :
 #endif


### PR DESCRIPTION
Take care of Catalina oddities (system data partition prefix) and add probe emitting piggybacking on the lookup event until we get KAuth callback equivalents for Endpoint Security.