### PR TITLE
Ignore directory probes for produced files in shared opaques

### DIFF
--- a/Public/Src/Engine/Scheduler/PipExecutor.cs
+++ b/Public/Src/Engine/Scheduler/PipExecutor.cs
@@ -1576,8 +1576,40 @@ namespace BuildXL.Scheduler
             counters.AddToCounter(PipExecutorCounter.ExecuteProcessDuration, executionResult.PrimaryProcessTimes.TotalWallClockTime);
 
             using (operationContext.StartOperation(PipExecutorCounter.ProcessOutputsDuration))
+            using (var excludedPathsWrapper = Pools.GetAbsolutePathSet())
             {
                 ObservedInputProcessingResult observedInputValidationResult;
+
+
+                // ObservedFileAccesses might include various accesses to directories leading to the files inside of shared opaques,
+                // mainly CreateDirectory and ProbeDirectory. To make strong fingerprint computation more stable, we are excluding such
+                // accesses from the list that is passed into the ObservedInputProcessor (as a result, they will not be a part of the path set).
+                //
+                // Given this path: '\sod\dir1\dir2\file.txt', we will exclude accesses to dir1 and dir2 only.
+                var excludedPaths = excludedPathsWrapper.Instance;
+                foreach (var sod in executionResult.SharedDynamicDirectoryWriteAccesses)
+                {
+                    foreach (var file in sod.Value)
+                    {
+                        var pathElement = file.GetParent(pathTable);
+                        while (pathElement.IsValid && pathElement != sod.Key && !excludedPaths.Contains(pathElement))
+                        {
+                            excludedPaths.Add(pathElement);
+                            pathElement = pathElement.GetParent(pathTable);
+                        }
+                    }
+                }
+
+                var filteredAccesses = executionResult.ObservedFileAccesses
+                    .Where(access =>
+                        // if it's an enumeration -> include always
+                        (access.ObservationFlags & ObservationFlags.Enumeration) == ObservationFlags.Enumeration
+                        // otherwise, check whether it's an excluded path 
+                        || !excludedPaths.Contains(access.Path))                        
+                    .ToArray();
+
+                var accessesToProcessAndValidate = SortedReadOnlyArray<ObservedFileAccess, ObservedFileAccessExpandedPathComparer>.FromSortedArrayUnsafe(
+                    ReadOnlyArray<ObservedFileAccess>.FromWithoutCopy(filteredAccesses), executionResult.ObservedFileAccesses.Comparer);
 
                 using (operationContext.StartOperation(PipExecutorCounter.ProcessOutputsObservedInputValidationDuration))
                 {
@@ -1594,7 +1626,7 @@ namespace BuildXL.Scheduler
                             state,
                             state.GetCacheableProcess(pip, environment),
                             fileAccessReportingContext,
-                            executionResult.ObservedFileAccesses,
+                            accessesToProcessAndValidate,
                             trackFileChanges: succeeded);
                 }
 

--- a/Public/Src/Pips/Dll/Builders/ProcessBuilder.cs
+++ b/Public/Src/Pips/Dll/Builders/ProcessBuilder.cs
@@ -61,6 +61,7 @@ namespace BuildXL.Pips.Builders
         private readonly PooledObjectWrapper<HashSet<FileArtifact>> m_inputFiles;
         private readonly PooledObjectWrapper<HashSet<DirectoryArtifact>> m_inputDirectories;
         private readonly PooledObjectWrapper<HashSet<PipId>> m_servicePipDependencies;
+        private readonly PooledObjectWrapper<HashSet<PipId>> m_orderPipDependencies;
 
         // Outputs 
         private readonly PooledObjectWrapper<HashSet<FileArtifactWithAttributes>> m_outputFiles;
@@ -181,6 +182,7 @@ namespace BuildXL.Pips.Builders
             m_inputFiles = Pools.GetFileArtifactSet();
             m_inputDirectories = Pools.GetDirectoryArtifactSet();
             m_servicePipDependencies = PipPools.PipIdSetPool.GetInstance();
+            m_orderPipDependencies = PipPools.PipIdSetPool.GetInstance();
 
             m_outputFiles = Pools.GetFileArtifactWithAttributesSet();
             m_outputDirectories = Pools.GetDirectoryArtifactSet();
@@ -332,6 +334,14 @@ namespace BuildXL.Pips.Builders
             // It is a service client if it has a dependency to a service pip.
             ServiceKind = ServicePipKind.ServiceClient;
             m_servicePipDependencies.Instance.Add(pipId);
+        }
+
+        /// <nodoc />
+        public void AddOrderDependency(PipId pipId)
+        {
+            Contract.Requires(pipId.IsValid);
+
+            m_orderPipDependencies.Instance.Add(pipId);
         }
 
         /// <nodoc />
@@ -617,7 +627,7 @@ namespace BuildXL.Pips.Builders
 
                 dependencies: ReadOnlyArray<FileArtifact>.From(m_inputFiles.Instance),
                 directoryDependencies: ReadOnlyArray<DirectoryArtifact>.From(m_inputDirectories.Instance),
-                orderDependencies: ReadOnlyArray<PipId>.Empty, // There is no code setting this yet.
+                orderDependencies: ReadOnlyArray<PipId>.From(m_orderPipDependencies.Instance),
 
                 outputs: outputFiles,
                 directoryOutputs: directoryOutputs,
@@ -663,6 +673,7 @@ namespace BuildXL.Pips.Builders
             m_inputFiles.Dispose();
             m_inputDirectories.Dispose();
             m_servicePipDependencies.Dispose();
+            m_orderPipDependencies.Dispose();
 
             m_outputFiles.Dispose();
             m_outputDirectories.Dispose();


### PR DESCRIPTION
AB#1584973

Ignore a directory probes if a probe happen on path that contains a file produced by that pip inside of a shared opaque:
.\SharedOpaque\subDir1\subDir2\file.txt
probes to subDir1 and subDir2 to be ignored