### PR TITLE
Trace BlobContentSession.PinAsync

### DIFF
--- a/Public/Src/Cache/ContentStore/Vsts/BlobReadOnlyContentSession.cs
+++ b/Public/Src/Cache/ContentStore/Vsts/BlobReadOnlyContentSession.cs
@@ -171,9 +171,6 @@ namespace BuildXL.Cache.ContentStore.Vsts
         protected override void DisposeCore() => TempDirectory.Dispose();
 
         /// <inheritdoc />
-        protected override bool TracePinFinished => false; // Since this implementation calls PinBulk, which has its own tracing, it results in a duplicate stop message.
-
-        /// <inheritdoc />
         protected override async Task<PinResult> PinCoreAsync(
             OperationContext context, ContentHash contentHash, UrgencyHint urgencyHint, Counter retryCounter)
         {


### PR DESCRIPTION
Trace BlobContentSession.PinAsync to be able to better analyze Pin times compared to Dedup.