### PR TITLE
Fix undefined problem

### DIFF
--- a/Public/Src/Deployment/tools.dsc
+++ b/Public/Src/Deployment/tools.dsc
@@ -74,8 +74,10 @@ namespace Tools {
         };
 
         export const deployment : Deployment.Definition = {
-            contents: addIf(!BuildXLSdk.Flags.excludeBuildXLExplorer,
-                {
+            contents: [
+                ...(BuildXLSdk.Flags.excludeBuildXLExplorer
+                ? []
+                : [{
                     // There is an error when deploying a single sealed directory where the graph
                     // invalidly thinks there is a duplicate deployment between robocopy and the sealed
                     // directory... Using a subfolder is a workaround for now.
@@ -83,8 +85,8 @@ namespace Tools {
                     contents: [
                         importFrom("BuildXL.Explorer").App.app.appFolder
                     ]
-                }
-            )
+                }])
+            ]            
         };
             
         const deployed = BuildXLSdk.DeploymentHelpers.deploy({


### PR DESCRIPTION
The addIf(param1, param2) would evaluate param2 even though param1 is false. importFrom("BuildXL.Explorer").App.app is undefined if BuildXLSdk.Flags.excludeBuildXLExplorer is true. So we will have "'.app' evaluates to 'undefined'" exception when BuildXLSdk.Flags.excludeBuildXLExplorer is set.

This PR will fix the problem.