### PR TITLE
Removed consumer description from pip error logs, bug: 1586413

### DIFF
--- a/Public/Src/Engine/Scheduler/Artifacts/FileContentManager.cs
+++ b/Public/Src/Engine/Scheduler/Artifacts/FileContentManager.cs
@@ -2815,15 +2815,7 @@ namespace BuildXL.Scheduler.Artifacts
             if (declaredArtifact.IsFile)
             {
                 DirectoryArtifact dynamicDirectoryArtifact;
-                if (declaredArtifact.FileArtifact.IsSourceFile)
-                {
-                    consumerDescription = m_host.GetConsumerDescription(declaredArtifact);
-                    if (consumerDescription != null)
-                    {
-                        return consumerDescription;
-                    }
-                }
-                else if (m_dynamicOutputFileDirectories.TryGetValue(declaredArtifact.FileArtifact, out dynamicDirectoryArtifact))
+                if (m_dynamicOutputFileDirectories.TryGetValue(declaredArtifact.FileArtifact, out dynamicDirectoryArtifact))
                 {
                     declaredArtifact = dynamicDirectoryArtifact;
                 }


### PR DESCRIPTION
GetAssociatedPipDescription is only used for logging within the same file. Removed unexpected consumer pip description from all error pip logs. Bug: 1586413