### PR TITLE
Allow minimal graph enumerations to elide absent path probes

### DIFF
--- a/Public/Sdk/SelfHost/BuildXL/BuildXLSdk.dsc
+++ b/Public/Sdk/SelfHost/BuildXL/BuildXLSdk.dsc
@@ -566,8 +566,10 @@ const testFrameworkOverrideAttribute = Transformer.writeAllLines({
 function processTestArguments(args: Managed.TestArguments) : Managed.TestArguments {
     args = processArguments(args, "library");
 
-    let xunitSemaphoreLimit = Environment.hasVariable(envVarNamePrefix + "xunitSemaphoreCount") ? Environment.getNumberValue(envVarNamePrefix + "xunitSemaphoreCount") : 8;
-    let useQTest = Flags.isQTestEnabled && qualifier.targetFramework !== "netcoreapp3.0";
+    let xunitSemaphoreLimit = Environment.hasVariable(envVarNamePrefix + "xunitSemaphoreCount") ? Environment.getNumberValue(envVarNamePrefix + "xunitSemaphoreCount") : 8; 
+    let useQTest = Flags.isQTestEnabled 
+        && qualifier.targetFramework !== "netcoreapp3.0" // QTest is not support for .net core apps
+        && !(args.runTestArgs && args.runTestArgs.parallelBucketCount); // QTest does not support passing environment variables to the underlying process
     let testFramework = args.testFramework || (useQTest ? QTest.getFramework(XUnit.framework) : XUnit.framework);
 
     args = Object.merge<Managed.TestArguments>({

--- a/Public/Src/App/Bxl/Args.cs
+++ b/Public/Src/App/Bxl/Args.cs
@@ -359,6 +359,9 @@ namespace BuildXL
                             "dbw",
                             opt => ParseServiceLocation(opt, distributionConfiguration.BuildWorkers)),
                         OptionHandlerFactory.CreateBoolOption(
+                            "elideMinimalGraphEnumerationAbsentPathProbes",
+                            sign => cacheConfiguration.ElideMinimalGraphEnumerationAbsentPathProbes = sign),
+                        OptionHandlerFactory.CreateBoolOption(
                             "enableAsyncLogging",
                             sign => loggingConfiguration.EnableAsyncLogging = sign),
                         OptionHandlerFactory.CreateBoolOption(

--- a/Public/Src/Engine/Scheduler/Fingerprints/ObservedInputProcessor.cs
+++ b/Public/Src/Engine/Scheduler/Fingerprints/ObservedInputProcessor.cs
@@ -758,7 +758,9 @@ namespace BuildXL.Scheduler.Fingerprints
             (DirectoryMembershipFilter directoryMemberShipFilter, DirectoryEnumerationMode directoryEnumerationMode) tuple;
 
             AbsolutePath parent = path.GetParent(pathTable);
-            if (enumeratedDirectories.TryGetValue(parent, out tuple) && tuple.directoryEnumerationMode == DirectoryEnumerationMode.RealFilesystem && tuple.directoryMemberShipFilter.Include(pathTable, path))
+            if (enumeratedDirectories.TryGetValue(parent, out tuple) 
+                && (tuple.directoryEnumerationMode == DirectoryEnumerationMode.RealFilesystem || tuple.directoryEnumerationMode == DirectoryEnumerationMode.MinimalGraph)
+                && tuple.directoryMemberShipFilter.Include(pathTable, path))
             {
                 return true;
             }

--- a/Public/Src/Engine/Scheduler/Fingerprints/ObservedInputProcessor.cs
+++ b/Public/Src/Engine/Scheduler/Fingerprints/ObservedInputProcessor.cs
@@ -497,7 +497,7 @@ namespace BuildXL.Scheduler.Fingerprints
                         {
                             // We need to iterate the observations in the order so that we can first visit the directory and then the child paths under that directory.
                             // CanIgnoreAbsentPathProbe relies on that assumption.
-                            if (CanIgnoreAbsentPathProbe(environment.PathExpander, enumeratedDirectories, pathTable, path, lastAbsentPath, isCacheLookup))
+                            if (CanIgnoreAbsentPathProbe(environment, enumeratedDirectories, pathTable, path, lastAbsentPath, isCacheLookup))
                             {
                                 numAbsentPathsEliminated++;
                                 continue;
@@ -742,13 +742,14 @@ namespace BuildXL.Scheduler.Fingerprints
             }
         }
 
-        private static bool CanIgnoreAbsentPathProbe(
-            SemanticPathExpander pathExpander,
+        private static bool CanIgnoreAbsentPathProbe<TEnv>(
+            TEnv env,
             Dictionary<AbsolutePath, (DirectoryMembershipFilter, DirectoryEnumerationMode)> enumeratedDirectories,
             PathTable pathTable,
             AbsolutePath path,
             AbsolutePath lastAbsentPath,
             bool isCacheLookup)
+            where TEnv : IObservedInputProcessingEnvironment
         {
             if (isCacheLookup)
             {
@@ -758,8 +759,8 @@ namespace BuildXL.Scheduler.Fingerprints
             (DirectoryMembershipFilter directoryMemberShipFilter, DirectoryEnumerationMode directoryEnumerationMode) tuple;
 
             AbsolutePath parent = path.GetParent(pathTable);
-            if (enumeratedDirectories.TryGetValue(parent, out tuple) 
-                && (tuple.directoryEnumerationMode == DirectoryEnumerationMode.RealFilesystem || tuple.directoryEnumerationMode == DirectoryEnumerationMode.MinimalGraph)
+            if (enumeratedDirectories.TryGetValue(parent, out tuple)
+                && (enumerationAllowsAbsentProbeElision(tuple))
                 && tuple.directoryMemberShipFilter.Include(pathTable, path))
             {
                 return true;
@@ -767,6 +768,20 @@ namespace BuildXL.Scheduler.Fingerprints
 
             // Skip nested absent paths except the uppermost one
             return lastAbsentPath.IsValid && path.IsWithin(pathTable, lastAbsentPath);
+
+            bool enumerationAllowsAbsentProbeElision((DirectoryMembershipFilter directoryMemberShipFilter, DirectoryEnumerationMode directoryEnumerationMode) info)
+            {
+                if (info.directoryEnumerationMode == DirectoryEnumerationMode.RealFilesystem)
+                {
+                    return true;
+                }
+                else if (info.directoryEnumerationMode == DirectoryEnumerationMode.MinimalGraph && env.Configuration.ElideMinimalGraphEnumerationAbsentPathProbes)
+                {
+                    return true;
+                }
+
+                return false;
+            }
         }
 
         /// <summary>
@@ -1159,6 +1174,11 @@ namespace BuildXL.Scheduler.Fingerprints
         SemanticPathExpander PathExpander { get; }
 
         /// <summary>
+        /// Configuration for caching behavior
+        /// </summary>
+        ICacheConfiguration Configuration { get; }
+
+        /// <summary>
         /// Probes a path for existence
         /// </summary>
         Possible<PathExistence> TryProbeAndTrackForExistence(AbsolutePath path, CacheablePipInfo pipInfo, bool isReadOnly, bool trackPathExistence);
@@ -1546,6 +1566,8 @@ namespace BuildXL.Scheduler.Fingerprints
         public PathTable PathTable => m_env.Context.PathTable;
 
         public PipExecutionContext Context => m_env.Context;
+
+        public ICacheConfiguration Configuration => m_env.Configuration.Cache;
 
         public CounterCollection<PipExecutorCounter> Counters => m_env.Counters;
 

--- a/Public/Src/Engine/Scheduler/Fingerprints/PipFingerprintingVersion.cs
+++ b/Public/Src/Engine/Scheduler/Fingerprints/PipFingerprintingVersion.cs
@@ -37,6 +37,6 @@ namespace BuildXL.Scheduler.Fingerprints
         /// 62: FileContentInfo - change how length/existence is stored.
         /// 63: IncrementalTool - change reparsepoint probes and enumeration probes to read.
         /// </remarks>
-        TwoPhaseV2 = 63,
+        TwoPhaseV2 = 64,
     }
 }

--- a/Public/Src/Engine/UnitTests/Scheduler/ObservedInputProcessorTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/ObservedInputProcessorTests.cs
@@ -640,6 +640,10 @@ namespace Test.BuildXL.Scheduler
             {
                 private readonly Harness m_harness;
 
+                public CacheConfiguration Configuration { get; } = new CacheConfiguration();
+
+                ICacheConfiguration IObservedInputProcessingEnvironment.Configuration => Configuration;
+
                 public Environment(Harness harness)
                 {
                     m_harness = harness;

--- a/Public/Src/FrontEnd/UnitTests/Script.Interpretation/Test.BuildXL.FrontEnd.Script.Interpretation.dsc
+++ b/Public/Src/FrontEnd/UnitTests/Script.Interpretation/Test.BuildXL.FrontEnd.Script.Interpretation.dsc
@@ -25,6 +25,9 @@ namespace Script.Interpretation {
             importFrom("BuildXL.FrontEnd").Sdk.dll,
         ],
         //increase weight for frequent timeout pip
-        runTestArgs: { weight: 2 },
+        runTestArgs: { 
+            weight: 2,
+            parallelBucketCount: 8,
+        },
     });
 }

--- a/Public/Src/FrontEnd/UnitTests/Script.Interpretation/Test.BuildXL.FrontEnd.Script.Interpretation.dsc
+++ b/Public/Src/FrontEnd/UnitTests/Script.Interpretation/Test.BuildXL.FrontEnd.Script.Interpretation.dsc
@@ -27,7 +27,6 @@ namespace Script.Interpretation {
         //increase weight for frequent timeout pip
         runTestArgs: { 
             weight: 2,
-            parallelBucketCount: 8,
         },
     });
 }

--- a/Public/Src/FrontEnd/UnitTests/Script.Interpretation/Test.BuildXL.FrontEnd.Script.Interpretation.dsc
+++ b/Public/Src/FrontEnd/UnitTests/Script.Interpretation/Test.BuildXL.FrontEnd.Script.Interpretation.dsc
@@ -26,7 +26,7 @@ namespace Script.Interpretation {
         ],
         //increase weight for frequent timeout pip
         runTestArgs: { 
-            weight: 2,
+            weight: 8,
         },
     });
 }

--- a/Public/Src/Utilities/Configuration/ICacheConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/ICacheConfiguration.cs
@@ -123,6 +123,11 @@ namespace BuildXL.Utilities.Configuration
         bool UseDedupStore { get; }
 
         /// <summary>
+        /// Indicates whether minimal graph enumerations should elide absent path probes in the directory root
+        /// </summary>
+        bool ElideMinimalGraphEnumerationAbsentPathProbes { get; }
+
+        /// <summary>
         /// When enabled, the cache will be responsible for replacing exisiting file during file materialization.
         /// </summary>
         bool ReplaceExistingFileOnMaterialization { get; }

--- a/Public/Src/Utilities/Configuration/Mutable/CacheConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/CacheConfiguration.cs
@@ -26,6 +26,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             FileChangeTrackingExclusionRoots = new List<AbsolutePath>();
             FileChangeTrackingInclusionRoots = new List<AbsolutePath>();
             ReplaceExistingFileOnMaterialization = false;
+            ElideMinimalGraphEnumerationAbsentPathProbes = true;
         }
 
         /// <nodoc />
@@ -56,6 +57,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             UseDedupStore = template.UseDedupStore;
             ReplaceExistingFileOnMaterialization = template.ReplaceExistingFileOnMaterialization;
             VfsCasRoot = pathRemapper.Remap(template.VfsCasRoot);
+            ElideMinimalGraphEnumerationAbsentPathProbes = template.ElideMinimalGraphEnumerationAbsentPathProbes;
         }
 
         /// <nodoc />
@@ -109,6 +111,9 @@ namespace BuildXL.Utilities.Configuration.Mutable
 
         /// <inheritdoc />
         public bool DeterminismProbe { get; set; }
+
+        /// <inheritdoc />
+        public bool ElideMinimalGraphEnumerationAbsentPathProbes { get; set; }
 
         /// <inheritdoc />
         public bool? HistoricMetadataCache { get; set; }

--- a/Shared/Scripts/bxl.ps1
+++ b/Shared/Scripts/bxl.ps1
@@ -536,6 +536,7 @@ if (!$skipFilter){
     $IdeFilter = "spec='Public\src\Deployment\ide.dsc'";
     $TestDeploymentFilter = "spec='Public\src\Deployment\tests.dsc'";
     $PrivateWdgFilter = "dpt(spec='private\Guests\WDG\*')";
+    $BxlLongRunningFilter = "dpt(spec='*\Test.BuildXL.FrontEnd.Script.Interpretation.dsc')";
 
     if ($Minimal) {
         # filtering by core deployment.
@@ -568,7 +569,7 @@ if (!$skipFilter){
         #Request the same output files from minimal above to make sure that deployment is fully specificed
         #Then request excludes guests\wdg and all downstream projects.
         #The filter does't have spaces because the dominow wrapper doesn't play well with them
-        $AdditionalBuildXLArguments += "/f:~($PrivateWdgFilter)and~($AllCacheProjectsFilter)and~($CacheLongRunningFilter)and~($CacheNugetFilter)and~($PrivateNugetFilter)and~($IdeFilter)and~($TestDeploymentFilter)"
+        $AdditionalBuildXLArguments += "/f:~($PrivateWdgFilter)and~($AllCacheProjectsFilter)and~($CacheLongRunningFilter)and~($BxlLongRunningFilter)and~($CacheNugetFilter)and~($PrivateNugetFilter)and~($IdeFilter)and~($TestDeploymentFilter)"
     }
 
     if ($SkipTests) {

--- a/Shared/Scripts/bxl.ps1
+++ b/Shared/Scripts/bxl.ps1
@@ -536,7 +536,7 @@ if (!$skipFilter){
     $IdeFilter = "spec='Public\src\Deployment\ide.dsc'";
     $TestDeploymentFilter = "spec='Public\src\Deployment\tests.dsc'";
     $PrivateWdgFilter = "dpt(spec='private\Guests\WDG\*')";
-    $BxlLongRunningFilter = "dpt(spec='*\Test.BuildXL.FrontEnd.Script.Interpretation.dsc')";
+    $BxlLongRunningFilter = "spec='*\Test.BuildXL.FrontEnd.Script.Interpretation.dsc'";
 
     if ($Minimal) {
         # filtering by core deployment.


### PR DESCRIPTION
Allow minimal graph enumerations to elide absent path probes to increase path set stability and reduce path set size.