### PR TITLE
Add missing information to stop traces

### DIFF
--- a/Public/Src/Cache/ContentStore/Library/Tracing/ContentSessionTracer.cs
+++ b/Public/Src/Cache/ContentStore/Library/Tracing/ContentSessionTracer.cs
@@ -127,16 +127,6 @@ namespace BuildXL.Cache.ContentStore.Tracing
             }
         }
 
-        public void PinBulkStop(Context context, TimeSpan duration)
-        {
-            if (context.IsEnabled)
-            {
-                Debug(context, $"{Name}.{PinBulkCallName}() stop {duration.TotalMilliseconds}ms");
-            }
-
-            _pinBulkCallCounter.Completed(duration.Ticks);
-        }
-
         public void PinBulkStop(Context context, TimeSpan duration, IReadOnlyList<ContentHash> contentHashes, IEnumerable<Indexed<PinResult>> results, Exception error)
         {
             if (context.IsEnabled)
@@ -182,11 +172,11 @@ namespace BuildXL.Cache.ContentStore.Tracing
             _openStreamCallCounter.Started();
         }
 
-        public virtual void OpenStreamStop(Context context, OpenStreamResult result)
+        public virtual void OpenStreamStop(Context context, ContentHash contentHash, OpenStreamResult result)
         {
             if (context.IsEnabled)
             {
-                TracerOperationFinished(context, result, $"{Name}.{OpenStreamCallName} stop {result.DurationMs}ms result=[{result}]");
+                TracerOperationFinished(context, result, $"{Name}.{OpenStreamCallName} stop {result.DurationMs}ms input=[{contentHash.ToShortString()}] result=[{result}]");
             }
 
             _openStreamCallCounter.Completed(result.Duration.Ticks);
@@ -219,11 +209,11 @@ namespace BuildXL.Cache.ContentStore.Tracing
             _placeFileRetryCounter.Increment();
         }
 
-        public virtual void PlaceFileStop(Context context, ContentHash input, PlaceFileResult result)
+        public virtual void PlaceFileStop(Context context, ContentHash contentHash, PlaceFileResult result, AbsolutePath path, FileAccessMode accessMode, FileReplacementMode replacementMode, FileRealizationMode realizationMode)
         {
             if (context.IsEnabled)
             {
-                TracerOperationFinished(context, result, $"{Name}.{PlaceFileCallName} stop {result.DurationMs}ms input=[{input.ToShortString()}] result=[{result}]");
+                TracerOperationFinished(context, result, $"{Name}.{PlaceFileCallName}({contentHash.ToShortString()},{path},{accessMode},{replacementMode},{realizationMode}) stop {result.DurationMs}ms result=[{result}]");
             }
 
             _placeFileCallCounter.Completed(result.Duration.Ticks);
@@ -241,11 +231,11 @@ namespace BuildXL.Cache.ContentStore.Tracing
             _putFileCallCounter.Started();
         }
 
-        public virtual void PutFileStop(Context context, PutResult result, bool trusted)
+        public virtual void PutFileStop(Context context, PutResult result, bool trusted, AbsolutePath path, FileRealizationMode mode)
         {
             if (context.IsEnabled)
             {
-                TracerOperationFinished(context, result, $"{Name}.{PutFileCallName} stop {result.DurationMs}ms result=[{result}] trusted={trusted}");
+                TracerOperationFinished(context, result, $"{Name}.{PutFileCallName}({path},{mode},{result.ContentHash.HashType}) stop {result.DurationMs}ms result=[{result}] trusted={trusted}");
             }
 
             _putFileCallCounter.Completed(result.Duration.Ticks);

--- a/Public/Src/Cache/ContentStore/Library/Tracing/ContentStoreInternalTracer.cs
+++ b/Public/Src/Cache/ContentStore/Library/Tracing/ContentStoreInternalTracer.cs
@@ -212,14 +212,14 @@ namespace BuildXL.Cache.ContentStore.Tracing
             base.OpenStreamStart(context, contentHash);
         }
 
-        public override void OpenStreamStop(Context context, OpenStreamResult result)
+        public override void OpenStreamStop(Context context, ContentHash contentHash, OpenStreamResult result)
         {
             if (_eventSource.IsEnabled())
             {
                 _eventSource.OpenStreamStop(context.Id.ToString(), (int)result.Code, result.ErrorMessage);
             }
 
-            base.OpenStreamStop(context, result);
+            base.OpenStreamStop(context, contentHash, result);
         }
 
         public void PinStart(Context context, ContentHash contentHash)
@@ -259,14 +259,14 @@ namespace BuildXL.Cache.ContentStore.Tracing
             base.PlaceFileStart(context, contentHash, path, accessMode, replacementMode, realizationMode);
         }
 
-        public override void PlaceFileStop(Context context, ContentHash input, PlaceFileResult result)
+        public override void PlaceFileStop(Context context, ContentHash contentHash, PlaceFileResult result, AbsolutePath path, FileAccessMode accessMode, FileReplacementMode replacementMode, FileRealizationMode realizationMode)
         {
             if (_eventSource.IsEnabled())
             {
                 _eventSource.PlaceFileStop(context.Id.ToString(), (int)result.Code, result.ErrorMessage);
             }
 
-            base.PlaceFileStop(context, input, result);
+            base.PlaceFileStop(context, contentHash, result, path, accessMode, replacementMode, realizationMode);
         }
 
         public override void PutFileStart(Context context, AbsolutePath path, FileRealizationMode mode, HashType hashType, bool trusted)
@@ -289,7 +289,7 @@ namespace BuildXL.Cache.ContentStore.Tracing
             base.PutFileStart(context, path, mode, contentHash, trusted);
         }
 
-        public override void PutFileStop(Context context, PutResult result, bool trusted)
+        public override void PutFileStop(Context context, PutResult result, bool trusted, AbsolutePath path, FileRealizationMode mode)
         {
             if (_eventSource.IsEnabled())
             {
@@ -297,7 +297,7 @@ namespace BuildXL.Cache.ContentStore.Tracing
                     context.Id.ToString(), result.Succeeded, result.ErrorMessage, result.ContentHash.ToString());
             }
 
-            base.PutFileStop(context, result, trusted);
+            base.PutFileStop(context, result, trusted, path, mode);
         }
 
         public override void PutStreamStart(Context context, HashType hashType)

--- a/Public/Src/Cache/ContentStore/Library/Tracing/OpenStreamCall.cs
+++ b/Public/Src/Cache/ContentStore/Library/Tracing/OpenStreamCall.cs
@@ -15,6 +15,8 @@ namespace BuildXL.Cache.ContentStore.Tracing
     public sealed class OpenStreamCall<TTracer> : TracedCall<TTracer, OpenStreamResult>, IDisposable
         where TTracer : ContentSessionTracer
     {
+        private readonly ContentHash _contentHash;
+
         /// <summary>
         ///     Run the call.
         /// </summary>
@@ -33,6 +35,8 @@ namespace BuildXL.Cache.ContentStore.Tracing
         private OpenStreamCall(TTracer tracer, OperationContext context, ContentHash contentHash)
             : base(tracer, context)
         {
+            _contentHash = contentHash;
+
             Tracer.OpenStreamStart(Context, contentHash);
         }
 
@@ -45,7 +49,7 @@ namespace BuildXL.Cache.ContentStore.Tracing
         /// <inheritdoc />
         public void Dispose()
         {
-            Tracer.OpenStreamStop(Context, Result);
+            Tracer.OpenStreamStop(Context, _contentHash, Result);
         }
     }
 }

--- a/Public/Src/Cache/ContentStore/Library/Tracing/PlaceFileCall.cs
+++ b/Public/Src/Cache/ContentStore/Library/Tracing/PlaceFileCall.cs
@@ -17,6 +17,11 @@ namespace BuildXL.Cache.ContentStore.Tracing
     public sealed class PlaceFileCall<TTracer> : TracedCallWithInput<TTracer, ContentHash, PlaceFileResult>, IDisposable
         where TTracer : ContentSessionTracer
     {
+        private readonly AbsolutePath _path;
+        private readonly FileAccessMode _accessMode;
+        private readonly FileReplacementMode _replacementMode;
+        private readonly FileRealizationMode _realizationMode;
+
         /// <summary>
         ///     Run the call.
         /// </summary>
@@ -49,6 +54,11 @@ namespace BuildXL.Cache.ContentStore.Tracing
             FileRealizationMode realizationMode)
             : base(tracer, context, contentHash)
         {
+            _path = path;
+            _accessMode = accessMode;
+            _replacementMode = replacementMode;
+            _realizationMode = realizationMode;
+
             Tracer.PlaceFileStart(Context, contentHash, path, accessMode, replacementMode, realizationMode);
         }
 
@@ -61,7 +71,7 @@ namespace BuildXL.Cache.ContentStore.Tracing
         /// <inheritdoc />
         public void Dispose()
         {
-            Tracer.PlaceFileStop(Context, Input, Result);
+            Tracer.PlaceFileStop(Context, Input, Result, _path, _accessMode, _replacementMode, _realizationMode);
         }
     }
 }

--- a/Public/Src/Cache/ContentStore/Library/Tracing/PutFileCall.cs
+++ b/Public/Src/Cache/ContentStore/Library/Tracing/PutFileCall.cs
@@ -22,6 +22,10 @@ namespace BuildXL.Cache.ContentStore.Tracing
 
         private readonly bool _trustedHash;
 
+        private readonly AbsolutePath _path;
+
+        private readonly FileRealizationMode _mode;
+
         /// <summary>
         ///     Run the call.
         /// </summary>
@@ -74,6 +78,8 @@ namespace BuildXL.Cache.ContentStore.Tracing
 
             _contentHash = new ContentHash(hashType);
             _trustedHash = trustedHash;
+            _path = path;
+            _mode = mode;
             Tracer.PutFileStart(Context, path, mode, hashType, trustedHash);
         }
 
@@ -93,6 +99,8 @@ namespace BuildXL.Cache.ContentStore.Tracing
 
             _contentHash = contentHash;
             _trustedHash = trustedHash;
+            _path = path;
+            _mode = mode;
             Tracer.PutFileStart(Context, path, mode, contentHash, _trustedHash);
         }
 
@@ -105,7 +113,7 @@ namespace BuildXL.Cache.ContentStore.Tracing
         /// <inheritdoc />
         public void Dispose()
         {
-            Tracer.PutFileStop(Context, Result, _trustedHash);
+            Tracer.PutFileStop(Context, Result, _trustedHash, _path, _mode);
         }
     }
 }


### PR DESCRIPTION
This adds information that was previously removed from traces, as they belonged to start messages which are no longer logged.