### PR TITLE
Allow for error regex to match across multiple lines

### DIFF
--- a/Public/Sdk/Public/Transformers/Transformer.Execute.dsc
+++ b/Public/Sdk/Public/Transformers/Transformer.Execute.dsc
@@ -33,7 +33,7 @@ namespace Transformer {
 
         /** Grant permissions permanently, i.e., until the service pip terminates. */
         permanent
-    } 
+    }
 
     @@public
     export interface ExecuteArgumentsCommon extends ExecuteArgumentsComposible {
@@ -83,9 +83,12 @@ namespace Transformer {
 
         /** Regex that would be used to extract warnings from the output. */
         warningRegex?: string;
-        
+
         /** Regex that would be used to extract errors from the output. */
         errorRegex?: string;
+
+        /** Options used to construct error regex (see the RegexOptions C# enum for valid values) */
+        errorRegexOptions?: number;
 
         /** Semaphores to acquire */
         acquireSemaphores?: SemaphoreInfo[];

--- a/Public/Sdk/Public/Transformers/Transformer.Execute.dsc
+++ b/Public/Sdk/Public/Transformers/Transformer.Execute.dsc
@@ -87,8 +87,8 @@ namespace Transformer {
         /** Regex that would be used to extract errors from the output. */
         errorRegex?: string;
 
-        /** Options used to construct error regex (see the RegexOptions C# enum for valid values) */
-        errorRegexOptions?: number;
+        /** Whether 'errorRegex' should be matched across multiple lines. */
+        errorRegexEnableMultiLineMatches?: number;
 
         /** Semaphores to acquire */
         acquireSemaphores?: SemaphoreInfo[];

--- a/Public/Sdk/Public/Transformers/Transformer.Execute.dsc
+++ b/Public/Sdk/Public/Transformers/Transformer.Execute.dsc
@@ -87,8 +87,23 @@ namespace Transformer {
         /** Regex that would be used to extract errors from the output. */
         errorRegex?: string;
 
-        /** Whether 'errorRegex' should be matched across multiple lines. */
-        errorRegexEnableMultiLineMatches?: boolean;
+        /** 
+         * When false (or not set): process output is scanned for error messages line by line;
+         * 'errorRegex' is applied to each line and if ANY match is found the ENTIRE line is reported.
+         *
+         * When true: process output is scanned in chunks of up to 1000 lines; 'errorRegex' is applied to
+         * each chunk and only the matches are reported.  Furthermore, if 'errorRegex' contains a capture 
+         * group named "ErrorMessage", the value of that group is reported; otherwise, the value of the
+         * entire match is reported.
+         * 
+         *   NOTE: because this scanning is done against chunks of text (instead of the entire process output),
+         *         false negatives are possible if an error message spans across multiple chunks.  The scanning
+         *         is done in chunks because attempting to construct a single string from the entire process
+         *         output can easily lead to OutOfMemory exception.
+         * 
+         * Default: false
+         */
+        enableMultiLineErrorScanning?: boolean;
 
         /** Semaphores to acquire */
         acquireSemaphores?: SemaphoreInfo[];

--- a/Public/Sdk/Public/Transformers/Transformer.Execute.dsc
+++ b/Public/Sdk/Public/Transformers/Transformer.Execute.dsc
@@ -91,7 +91,7 @@ namespace Transformer {
          * When false (or not set): process output is scanned for error messages line by line;
          * 'errorRegex' is applied to each line and if ANY match is found the ENTIRE line is reported.
          *
-         * When true: process output is scanned in chunks of up to 1000 lines; 'errorRegex' is applied to
+         * When true: process output is scanned in chunks of up to 10000 lines; 'errorRegex' is applied to
          * each chunk and only the matches are reported.  Furthermore, if 'errorRegex' contains a capture 
          * group named "ErrorMessage", the value of that group is reported; otherwise, the value of the
          * entire match is reported.

--- a/Public/Sdk/Public/Transformers/Transformer.Execute.dsc
+++ b/Public/Sdk/Public/Transformers/Transformer.Execute.dsc
@@ -88,7 +88,7 @@ namespace Transformer {
         errorRegex?: string;
 
         /** Whether 'errorRegex' should be matched across multiple lines. */
-        errorRegexEnableMultiLineMatches?: number;
+        errorRegexEnableMultiLineMatches?: boolean;
 
         /** Semaphores to acquire */
         acquireSemaphores?: SemaphoreInfo[];

--- a/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
@@ -517,26 +517,77 @@ namespace BuildXL.Processes
             return m_warningRegex.IsMatch(line);
         }
 
-        private bool IsError(string line)
+        private readonly struct OutputFilter
         {
-            Contract.Requires(line != null, "line must not be null.");
+            internal readonly Predicate<string> LinePredicate;
+            internal readonly Regex Regex;
 
-            // in absence of regex, treating everything as error.
-            if (m_errorRegex == null)
+            internal OutputFilter(Predicate<string> linePredicate) 
+                : this(linePredicate, null)
             {
-                return true;
+                Contract.Requires(linePredicate != null);
             }
 
-            // An unusually long string causes pathologically slow Regex back-tracking.
-            // To avoid that, only scan the first 400 characters. That's enough for
-            // the longest possible prefix: MAX_PATH, plus a huge subcategory string, and an error location.
-            // After the regex is done, we can append the overflow.
-            if (line.Length > 400)
+            internal OutputFilter(Regex regex)
+                : this(null, regex)
             {
-                line = line.Substring(0, 400);
+                Contract.Requires(regex != null);
             }
 
-            return m_errorRegex.IsMatch(line);
+            private OutputFilter(Predicate<string> linePredicate, Regex regex)
+            {
+                Contract.Requires(linePredicate != null || regex != null);
+                LinePredicate = linePredicate;
+                Regex = regex;
+            }
+
+            internal string ExtractMatches(string inputChunk, string separator = null)
+            {
+                return LinePredicate != null
+                    ? (LinePredicate(inputChunk) ? inputChunk : string.Empty)
+                    : string.Join(separator ?? Environment.NewLine, Regex.Matches(inputChunk).Cast<Match>().Select(m => m.Value));
+            }
+        }
+
+        /// <summary>
+        /// If <see cref="m_errorRegex"/> is set and its options include <see cref="RegexOptions.Singleline"/> (which means that 
+        /// the whole input string---which in turn may contain multiple lines---should be treated as a single line), returns the 
+        /// regex itself (which is then used to find all the matches in the input string); otherwise, returns a line filter 
+        /// to be used to match individual lines from the input string.
+        /// </summary>
+        /// <remarks>
+        /// Must not be called before <see cref="TryInitializeErrorRegexAsync"/> is called.
+        /// </remarks>
+        private OutputFilter GetErrorFilter()
+        {
+            if (m_errorRegex != null && m_errorRegex.Options.HasFlag(RegexOptions.Singleline))
+            {
+                return new OutputFilter(m_errorRegex);
+            }
+            else
+            {
+                return new OutputFilter(line =>
+                {
+                    Contract.Requires(line != null, "line must not be null.");
+
+                    // in absence of regex, treating everything as error.
+                    if (m_errorRegex == null)
+                    {
+                        return true;
+                    }
+
+                    // An unusually long string causes pathologically slow Regex back-tracking.
+                    // To avoid that, only scan the first 400 characters. That's enough for
+                    // the longest possible prefix: MAX_PATH, plus a huge subcategory string, and an error location.
+                    // After the regex is done, we can append the overflow.
+                    if (line.Length > 400)
+                    {
+                        line = line.Substring(0, 400);
+                    }
+
+                    return m_errorRegex.IsMatch(line);
+                });
+            }
         }
 
         private void Observe(string line)
@@ -553,24 +604,36 @@ namespace BuildXL.Processes
         /// <param name="output">Output stream (from sandboxed process) to read from.</param>
         /// <param name="filterPredicate"> Predicate, used to filter lines of interest.</param>
         /// <param name="appendNewLine">Whether to append newLine on non-empty content. Defaults to false.</param>
-        private async Task<string> TryFilterAsync(SandboxedProcessOutput output, Predicate<string> filterPredicate, bool appendNewLine = false)
+        private Task<string> TryFilterLineByLineAsync(SandboxedProcessOutput output, Predicate<string> filterPredicate, bool appendNewLine = false)
+            => TryFilterAsync(output, new OutputFilter(filterPredicate), appendNewLine);
+
+        private async Task<string> TryFilterAsync(SandboxedProcessOutput output, OutputFilter filter, bool appendNewLine)
         {
+            Contract.Assert(filter.LinePredicate != null || filter.Regex != null);
+
+            bool isLineByLine = filter.LinePredicate != null;
             try
             {
                 using (PooledObjectWrapper<StringBuilder> wrapper = Pools.StringBuilderPool.GetInstance())
                 {
+                    StringBuilder sb = wrapper.Instance;
+
                     using (TextReader reader = output.CreateReader())
                     {
-                        StringBuilder sb = wrapper.Instance;
-                        while (true)
+                        while (reader.Peek() != -1)
                         {
-                            string line = await reader.ReadLineAsync();
-                            if (line == null)
+                            string inputChunk = isLineByLine
+                                ? await reader.ReadLineAsync()
+                                : await ReadNextChunkAsync(reader, output);
+
+                            if (inputChunk == null)
                             {
                                 break;
                             }
 
-                            if (filterPredicate(line))
+                            string outputText = filter.ExtractMatches(inputChunk);
+                                
+                            if (!string.IsNullOrEmpty(outputText))
                             {
                                 // only add leading newlines (when needed).
                                 // Trailing newlines would cause the message logged to have double newlines
@@ -579,7 +642,7 @@ namespace BuildXL.Processes
                                     sb.AppendLine();
                                 }
 
-                                sb.Append(line);
+                                sb.Append(outputText);
                                 if (sb.Length >= MaxConsoleLength)
                                 {
                                     // Make sure we have a newline before the ellipsis
@@ -591,9 +654,9 @@ namespace BuildXL.Processes
                                 }
                             }
                         }
-
-                        return sb.ToString();
                     }
+
+                    return sb.ToString();
                 }
             }
             catch (IOException ex)
@@ -3577,22 +3640,24 @@ namespace BuildXL.Processes
 
         private async Task<LogErrorResult> TryLogErrorAsync(SandboxedProcessResult result, bool exitedWithSuccessExitCode)
         {
-            bool errorWasTruncated = false;
             // Initializing error regex just before it is actually needed to save some cycles.
             if (!await TryInitializeErrorRegexAsync())
             {
-                return new LogErrorResult(success: false, errorWasTruncated: errorWasTruncated);
+                return new LogErrorResult(success: false, errorWasTruncated: false);
             }
 
+            var errorFilter = GetErrorFilter();
+
+            bool errorWasTruncated = false;
             var exceedsLimit = OutputExceedsLimit(result.StandardOutput) || OutputExceedsLimit(result.StandardError);
             if (!exceedsLimit || m_sandboxConfig.OutputReportingMode == OutputReportingMode.TruncatedOutputOnError)
             {
-                string standardError = await TryFilterAsync(result.StandardError, IsError, appendNewLine: true);
-                string standardOutput = await TryFilterAsync(result.StandardOutput, IsError, appendNewLine: true);
+                string standardError = await TryFilterAsync(result.StandardError, errorFilter, appendNewLine: true);
+                string standardOutput = await TryFilterAsync(result.StandardOutput, errorFilter, appendNewLine: true);
 
                 if (standardError == null || standardOutput == null)
                 {
-                    return new LogErrorResult(success: false, errorWasTruncated: errorWasTruncated);
+                    return new LogErrorResult(success: false, errorWasTruncated: false);
                 }
 
                 if (string.IsNullOrEmpty(standardError) && string.IsNullOrEmpty(standardOutput))
@@ -3600,8 +3665,8 @@ namespace BuildXL.Processes
                     // Standard error and standard output are empty.
                     // This could be because the filter is too aggressive and the entire output was filtered out.
                     // Rolling back to a non-filtered approach because some output is better than nothing.
-                    standardError = await TryFilterAsync(result.StandardError, s => true, appendNewLine: true);
-                    standardOutput = await TryFilterAsync(result.StandardOutput, s => true, appendNewLine: true);
+                    standardError = await TryFilterLineByLineAsync(result.StandardError, s => true, appendNewLine: true);
+                    standardOutput = await TryFilterLineByLineAsync(result.StandardOutput, s => true, appendNewLine: true);
                 }
 
                 if (standardError.Length != result.StandardError.Length ||
@@ -3622,7 +3687,7 @@ namespace BuildXL.Processes
             long stdErrTotalLength = 0;
 
             // The output exceeds the limit and the full output has been requested. Emit it in chunks
-            if (!await TryEmitFullOutputInChunks(IsError))
+            if (!await TryEmitFullOutputInChunks(errorFilter))
             {
                 return new LogErrorResult(success: false, errorWasTruncated: errorWasTruncated);
             }
@@ -3633,7 +3698,7 @@ namespace BuildXL.Processes
                 // This could be because the filter is too aggressive and the entire output was filtered out.
                 // Rolling back to a non-filtered approach because some output is better than nothing.
                 errorWasTruncated = false;
-                if (!await TryEmitFullOutputInChunks(filterPredicate: null))
+                if (!await TryEmitFullOutputInChunks(filter: null))
                 {
                     return new LogErrorResult(success: false, errorWasTruncated: errorWasTruncated);
                 }
@@ -3641,7 +3706,7 @@ namespace BuildXL.Processes
 
             return new LogErrorResult(success: true, errorWasTruncated: errorWasTruncated);
 
-            async Task<bool> TryEmitFullOutputInChunks(Predicate<string> filterPredicate)
+            async Task<bool> TryEmitFullOutputInChunks(OutputFilter? filter)
             {
                 using (TextReader errorReader = CreateReader(result.StandardError))
                 {
@@ -3654,12 +3719,18 @@ namespace BuildXL.Processes
 
                         while (errorReader.Peek() != -1 || outReader.Peek() != -1)
                         {
-                            string stdError = await ReadNextChunkAsync(errorReader, result.StandardError, filterPredicate);
-                            string stdOut = await ReadNextChunkAsync(outReader, result.StandardOutput, filterPredicate);
+                            string stdError = await ReadNextChunkAsync(errorReader, result.StandardError, filter?.LinePredicate);
+                            string stdOut = await ReadNextChunkAsync(outReader, result.StandardOutput, filter?.LinePredicate);
 
                             if (stdError == null || stdOut == null)
                             {
                                 return false;
+                            }
+
+                            if (filter?.Regex != null)
+                            {
+                                stdError = filter.Value.ExtractMatches(stdError);
+                                stdOut = filter.Value.ExtractMatches(stdOut);
                             }
 
                             if (string.IsNullOrEmpty(stdOut) && string.IsNullOrEmpty(stdError))
@@ -3682,7 +3753,6 @@ namespace BuildXL.Processes
                         }
 
                         return true;
-
                     }
                 }
             }
@@ -3873,8 +3943,8 @@ namespace BuildXL.Processes
         /// </summary>
         public async Task<bool> TryLogWarningAsync(SandboxedProcessOutput standardError, SandboxedProcessOutput standardOutput)
         {
-            string warningsError = standardError == null ? string.Empty : await TryFilterAsync(standardError, IsWarning, appendNewLine: true);
-            string warningsOutput = standardOutput == null ? string.Empty : await TryFilterAsync(standardOutput, IsWarning, appendNewLine: true);
+            string warningsError = standardError == null ? string.Empty : await TryFilterLineByLineAsync(standardError, IsWarning, appendNewLine: true);
+            string warningsOutput = standardOutput == null ? string.Empty : await TryFilterLineByLineAsync(standardOutput, IsWarning, appendNewLine: true);
 
             if (warningsError == null ||
                 warningsOutput == null)

--- a/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
@@ -541,19 +541,27 @@ namespace BuildXL.Processes
                 Regex = regex;
             }
 
-            internal string ExtractMatches(string inputChunk, string separator = null)
+            /// <summary>
+            /// When <see cref="LinePredicate" /> is specified: it is invoked against <paramref name="source" /> and if 
+            /// it returns true <paramref name="source" /> is returned.
+            ///
+            /// When <see cref="Regex" /> is specified: it is invoked against <paramref name="source" /> to find all
+            /// matches; the matches are joined by <paramref name="outputSeparator"/> (or <see cref="Environment.NewLine" />
+            /// if null) and returned.
+            /// </summary>
+            internal string ExtractMatches(string source, string outputSeparator = null)
             {
                 return LinePredicate != null
-                    ? (LinePredicate(inputChunk) ? inputChunk : string.Empty)
-                    : string.Join(separator ?? Environment.NewLine, Regex.Matches(inputChunk).Cast<Match>().Select(m => m.Value));
+                    ? (LinePredicate(source) ? source : string.Empty)
+                    : string.Join(outputSeparator ?? Environment.NewLine, Regex.Matches(source).Cast<Match>().Select(m => m.Value));
             }
         }
 
         /// <summary>
         /// If <see cref="m_errorRegex"/> is set and its options include <see cref="RegexOptions.Singleline"/> (which means that 
         /// the whole input string---which in turn may contain multiple lines---should be treated as a single line), returns the 
-        /// regex itself (which is then used to find all the matches in the input string); otherwise, returns a line filter 
-        /// to be used to match individual lines from the input string.
+        /// regex itself (to be used later to find all the matches in the input string); otherwise, returns a line filter 
+        /// (to be used later to match individual lines from the input string).
         /// </summary>
         /// <remarks>
         /// Must not be called before <see cref="TryInitializeErrorRegexAsync"/> is called.

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/ErrorRegexTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/ErrorRegexTests.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using BuildXL.Pips.Operations;
+using BuildXL.Processes.Tracing;
+using BuildXL.Utilities;
+using Test.BuildXL.Executables.TestProcess;
+using Test.BuildXL.Scheduler;
+using Test.BuildXL.TestUtilities.Xunit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace IntegrationTest.BuildXL.Scheduler
+{
+    public class ErrorRegexTests : SchedulerIntegrationTestBase
+    {
+        private readonly List<string> m_loggedPipFailures;
+
+        public ErrorRegexTests(ITestOutputHelper output) : base(output)
+        {
+            m_loggedPipFailures = new List<string>();
+            EventListener.NestedLoggerHandler += eventData =>
+            {
+                if (eventData.EventId == (int)LogEventId.PipProcessError)
+                {
+                    var loggedMessage = eventData.Payload.ToArray()[5].ToString();
+                    m_loggedPipFailures.Add(loggedMessage);
+                }
+            };
+        }
+
+        public static IEnumerable<object[]> Test1Data()
+        {
+            const string Text = @"
+* BEFORE *
+* <error> *
+* inside *
+* </error> *
+* AFTER *
+";
+            const string Regex1 = "error";
+            const string Regex2 = "<error>.*</error>";
+
+            foreach (var useStdErr in new[] { true, false })
+            {
+                yield return new object[] { useStdErr, Text, Regex1, RegexOptions.None, @"
+* <error> *
+* </error> *" };
+
+                yield return new object[] { useStdErr, Text, Regex1, RegexOptions.Singleline, @"
+error
+error" };
+
+                yield return new object[] { useStdErr, Text, Regex2, RegexOptions.None, Text };
+
+                yield return new object[] { useStdErr, Text, Regex2, RegexOptions.Singleline, @"
+<error> *
+* inside *
+* </error>" };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Test1Data))]
+        public void Test1(bool useStdErr, string text, string errRegex, RegexOptions opts, string expectedPrintedError)
+        {
+            var ops = SplitLines(text)
+                .Select(l => Operation.Echo(l, useStdErr))
+                .Concat(new[]
+                {
+                    Operation.WriteFile(CreateOutputFileArtifact()),
+                    Operation.Fail()
+                });
+            var pipBuilder = CreatePipBuilder(ops);
+            pipBuilder.ErrorRegex = new RegexDescriptor(StringId.Create(Context.StringTable, errRegex), opts);
+            SchedulePipBuilder(pipBuilder);
+            RunScheduler().AssertFailure();
+            AssertErrorEventLogged(LogEventId.PipProcessError);
+            XAssert.ArrayEqual(
+                SplitLines(expectedPrintedError), 
+                m_loggedPipFailures.SelectMany(SplitLines).ToArray());
+        }
+
+        private string[] SplitLines(string text)
+        {
+            return text.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        }
+    }
+}

--- a/Public/Src/FrontEnd/Script/Ambients/Transformers/AmbientTransformer.Process.cs
+++ b/Public/Src/FrontEnd/Script/Ambients/Transformers/AmbientTransformer.Process.cs
@@ -100,7 +100,7 @@ namespace BuildXL.FrontEnd.Script.Ambients.Transformers
         private SymbolAtom m_disableCacheLookup;
         private SymbolAtom m_executeWarningRegex;
         private SymbolAtom m_executeErrorRegex;
-        private SymbolAtom m_executeErrorRegexEnableMultiLineMatches;
+        private SymbolAtom m_executeEnableMultiLineErrorScanning;
         private SymbolAtom m_executeTags;
         private SymbolAtom m_executeServiceShutdownCmd;
         private SymbolAtom m_executeServiceFinalizationCmds;
@@ -244,7 +244,7 @@ namespace BuildXL.FrontEnd.Script.Ambients.Transformers
             m_executeAdditionalTempDirectories = Symbol("additionalTempDirectories");
             m_executeWarningRegex = Symbol("warningRegex");
             m_executeErrorRegex = Symbol("errorRegex");
-            m_executeErrorRegexEnableMultiLineMatches = Symbol("errorRegexEnableMultiLineMatches");
+            m_executeEnableMultiLineErrorScanning = Symbol("enableMultiLineErrorScanning");
             m_executeAllowedSurvivingChildProcessNames = Symbol("allowedSurvivingChildProcessNames");
             m_executeNestedProcessTerminationTimeoutMs = Symbol("nestedProcessTerminationTimeoutMs");
             m_executeDependsOnCurrentHostOSDirectories = Symbol("dependsOnCurrentHostOSDirectories");
@@ -547,10 +547,13 @@ namespace BuildXL.FrontEnd.Script.Ambients.Transformers
             var errorRegex = Converter.ExtractString(obj, m_executeErrorRegex, allowUndefined: true);
             if (errorRegex != null)
             {
-                var enableMultiLine = Converter.ExtractOptionalBoolean(obj, m_executeErrorRegexEnableMultiLineMatches);
-                processBuilder.ErrorRegex = new RegexDescriptor(
-                    StringId.Create(context.StringTable, errorRegex),
-                    enableMultiLine == true ? RegexOptions.Singleline : RegexOptions.None);
+                processBuilder.ErrorRegex = new RegexDescriptor(StringId.Create(context.StringTable, errorRegex), RegexOptions.None);
+            }
+
+            var enableMultiLineErrorScanning = Converter.ExtractOptionalBoolean(obj, m_executeEnableMultiLineErrorScanning);
+            if (enableMultiLineErrorScanning != null)
+            {
+                processBuilder.EnableMultiLineErrorScanning = enableMultiLineErrorScanning.Value;
             }
 
             // Tags.

--- a/Public/Src/Pips/Dll/Builders/ProcessBuilder.cs
+++ b/Public/Src/Pips/Dll/Builders/ProcessBuilder.cs
@@ -121,6 +121,9 @@ namespace BuildXL.Pips.Builders
         public RegexDescriptor? ErrorRegex { get; set; }
 
         /// <nodoc />
+        public bool EnableMultiLineErrorScanning { get; set; }
+
+        /// <nodoc />
         public Options Options { get; set; }
 
         /// <nodoc />
@@ -662,6 +665,7 @@ namespace BuildXL.Pips.Builders
                 timeout: Timeout,
                 warningRegex: WarningRegex ?? RegexDescriptor.CreateDefaultForWarnings(m_pathTable.StringTable),
                 errorRegex: ErrorRegex ?? RegexDescriptor.CreateDefaultForErrors(m_pathTable.StringTable),
+                enableMultiLineErrorScanning: EnableMultiLineErrorScanning,
 
                 uniqueOutputDirectory: defaultDirectory,
                 uniqueRedirectedDirectoryRoot: redirectedDirectoryRoot,

--- a/Public/Src/Pips/Dll/Operations/Process.cs
+++ b/Public/Src/Pips/Dll/Operations/Process.cs
@@ -256,7 +256,7 @@ namespace BuildXL.Pips.Operations
         /// When false (or not set): process output is scanned for error messages line by line;
         /// 'errorRegex' is applied to each line and if ANY match is found the ENTIRE line is reported.
         /// 
-        /// When true: process output is scanned in chunks of up to 1000 lines; 'errorRegex' is applied to
+        /// When true: process output is scanned in chunks of up to 10000 lines; 'errorRegex' is applied to
         /// each chunk and only the matches are reported. Furthermore, if 'errorRegex' contains a capture
         /// group named "ErrorMessage", the value of that group is reported; otherwise, the value of the
         /// entire match is reported.

--- a/Public/Src/Pips/Dll/Operations/Process.cs
+++ b/Public/Src/Pips/Dll/Operations/Process.cs
@@ -257,7 +257,7 @@ namespace BuildXL.Pips.Operations
         /// 'errorRegex' is applied to each line and if ANY match is found the ENTIRE line is reported.
         /// 
         /// When true: process output is scanned in chunks of up to 1000 lines; 'errorRegex' is applied to
-        /// each chunk and only the matches are reported.Furthermore, if 'errorRegex' contains a capture
+        /// each chunk and only the matches are reported. Furthermore, if 'errorRegex' contains a capture
         /// group named "ErrorMessage", the value of that group is reported; otherwise, the value of the
         /// entire match is reported.
         /// 

--- a/Public/Src/Pips/Dll/Operations/Process.cs
+++ b/Public/Src/Pips/Dll/Operations/Process.cs
@@ -261,10 +261,9 @@ namespace BuildXL.Pips.Operations
         ///         output can easily lead to OutOfMemory exception.
         /// </summary>
         /// <remarks>
-        /// Regarding fingerprinting: <see cref="ErrorRegex"/> and <see cref="WarningRegex"/> are
-        /// currently part of the process fingerprint, even though those two properties cannot affect
-        /// the outcome (success vs failure) of the process.  This is kind of strange and should probably
-        /// be changed at some point in the future.  In that vain, <see cref="EnableMultiLineErrorScanning"/>
+        /// Regarding fingerprinting: <see cref="ErrorRegex"/> is currently a part of the process fingerprint, 
+        /// even though it cannot affect the outcome (success vs failure) of the process.  This is kind of
+        /// strange and should probably be changed in the future.  In that vain, <see cref="EnableMultiLineErrorScanning"/>
         /// is decided to not be included in the process fingerprint.
         /// </remarks>
         [PipCaching(FingerprintingRole = FingerprintingRole.None)]

--- a/Public/Src/Pips/Dll/Operations/Process.cs
+++ b/Public/Src/Pips/Dll/Operations/Process.cs
@@ -264,7 +264,7 @@ namespace BuildXL.Pips.Operations
         ///   NOTE: because this scanning is done against chunks of text (instead of the entire process output),
         ///         false negatives are possible if an error message spans across multiple chunks.  The scanning
         ///         is done in chunks because attempting to construct a single string from the entire process
-        ///         output can easily lead to OutOfMemory exception.
+        ///         output can easily lead to an "out of memory" exception.
         /// </summary>
         /// <remarks>
         /// Regarding fingerprinting: <see cref="ErrorRegex"/> is currently a part of the process fingerprint, 

--- a/Public/Src/Utilities/UnitTests/Executables/TestProcess/Operation.cs
+++ b/Public/Src/Utilities/UnitTests/Executables/TestProcess/Operation.cs
@@ -1058,7 +1058,6 @@ namespace Test.BuildXL.Executables.TestProcess
         private void DoFail()
         {
             int exitCode = int.TryParse(Content, out var result) ? result : -1;
-            Console.Error.WriteLine($"{Type.Fail} requested: Exiting with exit code {exitCode}");
             Environment.Exit(exitCode);
         }
 

--- a/Public/Src/Utilities/UnitTests/TestUtilities/TestEventListenerBase.cs
+++ b/Public/Src/Utilities/UnitTests/TestUtilities/TestEventListenerBase.cs
@@ -146,15 +146,14 @@ namespace Test.BuildXL.TestUtilities
             return logBuilder.ToString();
         }
 
-        private event Action<EventWrittenEventArgs> NestedLoggerHandler;
+        /// <summary>
+        /// Nested handler to be invoked first.
+        /// </summary>
+        public event Action<EventWrittenEventArgs> NestedLoggerHandler;
 
         private void Log(EventWrittenEventArgs eventData)
         {
-            if (NestedLoggerHandler != null)
-            {
-                NestedLoggerHandler(eventData);
-                return;
-            }
+            NestedLoggerHandler?.Invoke(eventData);
 
             string s = FormattingEventListener.CreateFullMessageString(eventData, eventData.Level.ToString(), eventData.Message, m_baseTime, false);
             lock (m_logMessagesLock)


### PR DESCRIPTION
[AB#1570216](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1570216)

When multi-line regex matching for error messages is enabled, pip output is processes in chunks (of 10000 lines by default) against which the regex is applied and used to find all matches; those matches are returned verbatim (subject to truncating and and other existing logic)

Previously, pip output was always processed line by line, where the error regex is checked against each line and if any matches are found the whole line is returned/printed to the user.  This is in contrast to multi-line regex matching where only the exact match is printed. 

When multi-line regex matching is not enabled, the behavior remains the same.