### PR TITLE
Compute static fingerprint in the pipgraph fragments

### DIFF
--- a/Public/Src/Engine/Scheduler/Graph/GraphFragmentBuilder.cs
+++ b/Public/Src/Engine/Scheduler/Graph/GraphFragmentBuilder.cs
@@ -29,6 +29,7 @@ namespace BuildXL.Scheduler.Graph
         /// Seal directory table
         /// </summary>
         protected readonly SealedDirectoryTable SealDirectoryTable;
+        protected readonly IConfiguration Configuration;
         private readonly LoggingContext m_loggingContext;
         private readonly PipExecutionContext m_pipExecutionContext;
         private readonly ConcurrentQueue<Pip> m_pips = new ConcurrentQueue<Pip>();
@@ -46,6 +47,7 @@ namespace BuildXL.Scheduler.Graph
             Contract.Requires(loggingContext != null);
             Contract.Requires(pipExecutionContext != null);
 
+            Configuration = configuration;
             m_loggingContext = loggingContext;
             m_pipExecutionContext = pipExecutionContext;
             m_lazyApiServerMoniker = configuration.Schedule.UseFixedApiServerMoniker

--- a/Public/Src/Engine/Scheduler/Graph/GraphFragmentBuilder.cs
+++ b/Public/Src/Engine/Scheduler/Graph/GraphFragmentBuilder.cs
@@ -29,6 +29,10 @@ namespace BuildXL.Scheduler.Graph
         /// Seal directory table
         /// </summary>
         protected readonly SealedDirectoryTable SealDirectoryTable;
+
+        /// <summary>
+        /// Configuration
+        /// </summary>
         protected readonly IConfiguration Configuration;
         private readonly LoggingContext m_loggingContext;
         private readonly PipExecutionContext m_pipExecutionContext;

--- a/Public/Src/Engine/Scheduler/Graph/GraphFragmentBuilderTopSort.cs
+++ b/Public/Src/Engine/Scheduler/Graph/GraphFragmentBuilderTopSort.cs
@@ -43,8 +43,8 @@ namespace BuildXL.Scheduler.Graph
             var extraFingerprintSalts = new ExtraFingerprintSalts(
                 configuration,
                 PipFingerprintingVersion.TwoPhaseV2,
-                string.Empty,
-                searchPathToolsHash: null);
+                configuration.Cache.CacheSalt,
+                new DirectoryMembershipFingerprinterRuleSet(configuration, pipExecutionContext.StringTable).ComputeSearchPathToolsHash());
 
             m_pipStaticFingerprinter = new PipStaticFingerprinter(
                 pipExecutionContext.PathTable,
@@ -82,7 +82,7 @@ namespace BuildXL.Scheduler.Graph
             var result = base.AddCopyFile(copyFile, valuePip);
             AddFileDependent(copyFile.Source, copyFile);
             m_fileProducers[copyFile.Destination] = copyFile.PipId;
-            copyFile.StaticFingerPrint = m_pipStaticFingerprinter.ComputeWeakFingerprint(copyFile).Hash;
+            copyFile.StaticFingerprint = m_pipStaticFingerprinter.ComputeWeakFingerprint(copyFile).Hash;
             return result;
         }
 
@@ -104,8 +104,8 @@ namespace BuildXL.Scheduler.Graph
                 m_opaqueDirectoryProducers[directoryOutput] = process.PipId;
             }
 
-            process.StaticFingerPrint = m_pipStaticFingerprinter.ComputeWeakFingerprint(process).Hash;
-            m_pipStaticFingerprints.AddFingerprint(process, new ContentFingerprint(process.StaticFingerPrint));
+            process.StaticFingerprint = m_pipStaticFingerprinter.ComputeWeakFingerprint(process).Hash;
+            m_pipStaticFingerprints.AddFingerprint(process, new ContentFingerprint(process.StaticFingerprint));
             return result;
         }
 
@@ -115,8 +115,8 @@ namespace BuildXL.Scheduler.Graph
             base.AddSealDirectory(sealDirectory, valuePip);
             AddFileDependents(sealDirectory.Contents, sealDirectory);
             AddDirectoryDependents(sealDirectory.ComposedDirectories, sealDirectory);
-            sealDirectory.StaticFingerPrint = m_pipStaticFingerprinter.ComputeWeakFingerprint(sealDirectory).Hash;
-            m_pipStaticFingerprints.AddFingerprint(sealDirectory, new ContentFingerprint(sealDirectory.StaticFingerPrint));
+            sealDirectory.StaticFingerprint = m_pipStaticFingerprinter.ComputeWeakFingerprint(sealDirectory).Hash;
+            m_pipStaticFingerprints.AddFingerprint(sealDirectory, new ContentFingerprint(sealDirectory.StaticFingerprint));
             return sealDirectory.Directory;
         }
 
@@ -125,7 +125,7 @@ namespace BuildXL.Scheduler.Graph
         {
             var result = base.AddWriteFile(writeFile, valuePip);
             m_fileProducers[writeFile.Destination] = writeFile.PipId;
-            writeFile.StaticFingerPrint = m_pipStaticFingerprinter.ComputeWeakFingerprint(writeFile).Hash;
+            writeFile.StaticFingerprint = m_pipStaticFingerprinter.ComputeWeakFingerprint(writeFile).Hash;
             return result;
         }
 

--- a/Public/Src/Engine/Scheduler/Graph/PipGraph.Builder.cs
+++ b/Public/Src/Engine/Scheduler/Graph/PipGraph.Builder.cs
@@ -2912,9 +2912,9 @@ namespace BuildXL.Scheduler.Graph
                 {
                     fingerprint = m_pipStaticFingerprinter.ComputeWeakFingerprint(pip, out fingerprintText);
                 }
-                else if (pip.StaticFingerPrint.Length > 0)
+                else if (pip.StaticFingerprint.Length > 0)
                 {
-                    fingerprint = new ContentFingerprint(pip.StaticFingerPrint);
+                    fingerprint = new ContentFingerprint(pip.StaticFingerprint);
                 }
                 else
                 {

--- a/Public/Src/Engine/Scheduler/Graph/PipGraph.Builder.cs
+++ b/Public/Src/Engine/Scheduler/Graph/PipGraph.Builder.cs
@@ -2907,9 +2907,19 @@ namespace BuildXL.Scheduler.Graph
 
                 string fingerprintText = null;
 
-                ContentFingerprint fingerprint = m_pipStaticFingerprinter.FingerprintTextEnabled
-                    ? m_pipStaticFingerprinter.ComputeWeakFingerprint(pip, out fingerprintText)
-                    : m_pipStaticFingerprinter.ComputeWeakFingerprint(pip);
+                ContentFingerprint fingerprint;
+                if (m_pipStaticFingerprinter.FingerprintTextEnabled)
+                {
+                    fingerprint = m_pipStaticFingerprinter.ComputeWeakFingerprint(pip, out fingerprintText);
+                }
+                else if (pip.StaticFingerPrint.Length > 0)
+                {
+                    fingerprint = new ContentFingerprint(pip.StaticFingerPrint);
+                }
+                else
+                {
+                    fingerprint = m_pipStaticFingerprinter.ComputeWeakFingerprint(pip);
+                }
 
                 m_pipStaticFingerprints.AddFingerprint(pip, fingerprint);
 

--- a/Public/Src/Pips/Dll/Operations/Pip.cs
+++ b/Public/Src/Pips/Dll/Operations/Pip.cs
@@ -6,7 +6,9 @@ using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.ContractsLight;
 using System.Globalization;
 using System.Text;
+using BuildXL.Cache.MemoizationStore.Interfaces.Sessions;
 using BuildXL.Ipc.Interfaces;
+using BuildXL.Storage;
 using BuildXL.Utilities;
 using BuildXL.Utilities.Collections;
 
@@ -28,6 +30,11 @@ namespace BuildXL.Pips.Operations
         public const string SemiStableHashPrefix = "Pip";
 
         private PipId m_pipId;
+
+        /// <summary>
+        /// Static fingerprint
+        /// </summary>
+        public Fingerprint StaticFingerPrint { get; set; }
 
         /// <summary>
         /// Tags used to enable pip-level filtering of the schedule.
@@ -184,6 +191,10 @@ namespace BuildXL.Pips.Operations
                     break;
             }
 
+            if (reader.ReadBoolean())
+            {
+                pip.StaticFingerPrint = FingerprintUtilities.CreateFrom(reader);
+            }
             reader.End();
             Contract.Assume(pip != null);
             return pip;
@@ -195,6 +206,16 @@ namespace BuildXL.Pips.Operations
             writer.Write((byte)PipType);
             writer.Start(GetType());
             InternalSerialize(writer);
+            if (StaticFingerPrint.Length >0)
+            {
+                writer.Write(true);
+                StaticFingerPrint.WriteTo(writer);
+            }
+            else
+            {
+                writer.Write(false);
+            }
+
             writer.End();
         }
 

--- a/Public/Src/Pips/Dll/Operations/Pip.cs
+++ b/Public/Src/Pips/Dll/Operations/Pip.cs
@@ -34,7 +34,7 @@ namespace BuildXL.Pips.Operations
         /// <summary>
         /// Static fingerprint
         /// </summary>
-        public Fingerprint StaticFingerPrint { get; set; }
+        public Fingerprint StaticFingerprint { get; set; }
 
         /// <summary>
         /// Tags used to enable pip-level filtering of the schedule.
@@ -193,7 +193,7 @@ namespace BuildXL.Pips.Operations
 
             if (reader.ReadBoolean())
             {
-                pip.StaticFingerPrint = FingerprintUtilities.CreateFrom(reader);
+                pip.StaticFingerprint = FingerprintUtilities.CreateFrom(reader);
             }
             reader.End();
             Contract.Assume(pip != null);
@@ -206,10 +206,10 @@ namespace BuildXL.Pips.Operations
             writer.Write((byte)PipType);
             writer.Start(GetType());
             InternalSerialize(writer);
-            if (StaticFingerPrint.Length >0)
+            if (StaticFingerprint.Length >0)
             {
                 writer.Write(true);
-                StaticFingerPrint.WriteTo(writer);
+                StaticFingerprint.WriteTo(writer);
             }
             else
             {

--- a/Public/Src/Tools/BxlScriptAnalyzer/Args.cs
+++ b/Public/Src/Tools/BxlScriptAnalyzer/Args.cs
@@ -75,6 +75,10 @@ namespace BuildXL.FrontEnd.Script.Analyzer
                 {
                     CommandLineConfig.InCloudBuild = ParseBooleanOption(opt);
                 }
+                else if (opt.Name.Equals("ComputeStaticFingerprints", StringComparison.OrdinalIgnoreCase))
+                {
+                    CommandLineConfig.Schedule.ComputePipStaticFingerprints = ParseBooleanOption(opt);
+                }
                 else if (opt.Name.Equals("objectDirectory", StringComparison.OrdinalIgnoreCase))
                 {
                     CommandLineConfig.Layout.ObjectDirectory = AbsolutePath.Create(m_pathTable, GetFullPath(opt.Value, opt));

--- a/Public/Src/Tools/BxlScriptAnalyzer/WorkspaceBuilder.cs
+++ b/Public/Src/Tools/BxlScriptAnalyzer/WorkspaceBuilder.cs
@@ -193,7 +193,7 @@ namespace BuildXL.FrontEnd.Script.Analyzer
 
                         if (topSort)
                         {
-                            pipGraphBuilder = new GraphFragmentBuilderTopSort(loggingContext, engineContext, config);
+                            pipGraphBuilder = new GraphFragmentBuilderTopSort(loggingContext, engineContext, config, mountsTable.MountPathExpander);
                         }
                         else
                         {


### PR DESCRIPTION
Currently, computing pip graph fingerprint is done as the graph is being built in pipgraph.builder.  This is expensive, and so we move it to be done at the time of pip graph fragment creation.  A new field is added in pip, and if it exists, the value of it is used instead of recomputing.  The one caveat is if the pip graph fragments uses sealled directories from another fragment.  This is left as a todo because Office currently does not exercise this functionality.