### PR TITLE
Add sdk-level nullability options of csharp projects

### DIFF
--- a/Public/Sdk/Public/Managed/Tools/Csc/csc.dsc
+++ b/Public/Sdk/Public/Managed/Tools/Csc/csc.dsc
@@ -94,6 +94,8 @@ export function compile(inputArgs: Arguments) : Result {
         Cmd.sign("/debug",                 args.emitDebugInformation),
         Cmd.sign("/highentropyva",         args.highEntropyVa),
         Cmd.option("/subsystemversion:",   args.subSystemVersion),
+        Cmd.sign("/nullable",              args.nullable),
+        Cmd.option("/nullable:",           args.nullabilityContext),
 
         Cmd.option("/checksumalgorithm:",  args.checksumAlgorithm ? args.checksumAlgorithm.toString() : undefined),
 
@@ -266,6 +268,11 @@ export interface Arguments extends Transformer.RunnerArguments{
     defines?: string[];
     /** This option instructs the compiler to only use ISO-1 C# language features, i.e which basically boils down to C# 1.0 language features. */
     languageVersion?: string;
+    
+    /** Specify nullable context option enable|disable. */
+    nullable?: boolean;
+    /** Specify nullable context option enable|disable|safeonly|warnings|safeonlywarnings.*/
+    nullabilityContext?: NullabilityContext;
 
     // security
     /** Allows you to build an assembly using delayed signing of the strong name. */
@@ -342,6 +349,10 @@ export interface Result {
     binary: Shared.Binary,
     reference?: Shared.Binary,
 }
+
+/** Defines nullable context options.*/
+@@public
+export type NullabilityContext = "enable" | "disable" | "safeonly" | "warnings" | "safeonlywarnings";
 
 @@public
 export type TargetType = "exe" | "winexe" | "library" | "module" | "appcontainerexe" | "winmdobj";

--- a/Public/Sdk/Public/Managed/managedSdk.dsc
+++ b/Public/Sdk/Public/Managed/managedSdk.dsc
@@ -190,7 +190,9 @@ export function assembly(args: Arguments, targetType: Csc.TargetType) : Result {
             ...(args.defineConstants || []),
             // Defining a special symbol that can be used in C# code for using new API available in .NET 4.6.1+
             ...(qualifier.targetFramework !== "net451" ? ["NET461Plus"] : []),
-        ]
+        ],
+        nullable: args.nullable,
+        nullabilityContext: args.nullabilityContext,
     };
 
     const references = [
@@ -329,6 +331,12 @@ export interface Arguments {
     /** Platform to build. */
     platform?: Csc.Platform;
 
+    /** Specify nullable context option enable|disable. */
+    nullable?: boolean;
+    
+    /** Specify nullable context option enable|disable|safeonly|warnings|safeonlywarnings.*/
+    nullabilityContext?: Csc.NullabilityContext;
+    
     noConfig?: boolean;
 
     /** Extra content/files to be deployed with the assembly when running. i.e. native dlls that are p-invoked, config files etc. */


### PR DESCRIPTION
Add an option to csc and managed sdk to enable nullable reference types for the entire project.