### PR TITLE
Share stores with Grpc

### DIFF
--- a/Public/Src/Cache/ContentStore/Library/Service/LocalContentServerBase.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/LocalContentServerBase.cs
@@ -76,7 +76,13 @@ namespace BuildXL.Cache.ContentStore.Service
         /// <summary>
         /// Collection of stores by name.
         /// </summary>
-        protected internal readonly Dictionary<string, TStore> StoresByName = new Dictionary<string, TStore>();
+        /// <remarks>
+        /// This is only supposed to be used by this class and inheritors, do not make internal or public.
+        /// 
+        /// It is also expected to be immutable, because inheritors may copy it around. So do NOT add keys after
+        /// constructed.
+        /// </remarks>
+        protected readonly Dictionary<string, TStore> StoresByName = new Dictionary<string, TStore>();
 
         /// <nodoc />
         protected LocalContentServerBase(

--- a/Public/Src/Cache/ContentStore/Library/Service/LocalContentServerBase.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/LocalContentServerBase.cs
@@ -76,7 +76,7 @@ namespace BuildXL.Cache.ContentStore.Service
         /// <summary>
         /// Collection of stores by name.
         /// </summary>
-        internal readonly Dictionary<string, TStore> StoresByName = new Dictionary<string, TStore>();
+        protected internal readonly Dictionary<string, TStore> StoresByName = new Dictionary<string, TStore>();
 
         /// <nodoc />
         protected LocalContentServerBase(

--- a/Public/Src/Cache/MemoizationStore/Library/Service/LocalCacheServer.cs
+++ b/Public/Src/Cache/MemoizationStore/Library/Service/LocalCacheServer.cs
@@ -42,15 +42,9 @@ namespace BuildXL.Cache.MemoizationStore.Service
         : base(logger, fileSystem, scenario, cacheFactory, localContentServerConfiguration)
         {
             var storesByName = new Dictionary<string, IContentStore>();
-            foreach (var kvp in localContentServerConfiguration.NamedCacheRoots)
+            foreach (var kvp in StoresByName)
             {
-                AbsolutePath cacheRootPath = kvp.Value;
-                fileSystem.CreateDirectory(cacheRootPath);
-
-                var cache = cacheFactory(cacheRootPath);
-                Contract.Assert(cache is IContentStore, $"Attempted to setup a cache named '{kvp.Key}' that is not an {nameof(IContentStore)} at path {cacheRootPath}, type used is {cache.GetType().Name}");
-
-                storesByName.Add(kvp.Key, (IContentStore)cache);
+                storesByName.Add(kvp.Key, (IContentStore)kvp.Value);
             }
 
             _grpcContentServer = new GrpcContentServer(logger, capabilities, this, storesByName);


### PR DESCRIPTION
Creating a LocalCacheServer would force creation of 2 DistributedContentStores, one of which wouldn't be initialized.

The uninitialized one was given to the GrpcContentServer, and the initialized one would be used by the LocalCacheServer. The GrpcContentServer only ever uses the ContentStore given when doing grpc copying, so all other operations would run just fine.