### PR TITLE
Turn on limited threading for evalution not just on MAC but on Windows

### DIFF
--- a/Public/Sdk/SelfHost/BuildXL/BuildXLSdk.dsc
+++ b/Public/Sdk/SelfHost/BuildXL/BuildXLSdk.dsc
@@ -423,7 +423,7 @@ function processArguments(args: Arguments, targetType: Csc.TargetType) : Argumen
             assemblyInfo: Object.merge(assemblyInfo, {title: title}, args.assemblyInfo),
             defineConstants: [
                 "DEFTEMP",
-
+                "FEATURE_THROTTLE_EVAL_SCHEDULER",
                 ...addIf(isDotNetCoreBuild,
                     "FEATURE_SAFE_PROCESS_HANDLE",
                     "DISABLE_FEATURE_VSEXTENSION_INSTALL_CHECK",
@@ -432,9 +432,6 @@ function processArguments(args: Arguments, targetType: Csc.TargetType) : Argumen
                 ),
                 ...addIf(Flags.isMicrosoftInternal,
                     "FEATURE_ARIA_TELEMETRY"
-                ),
-                ...addIf(isTargetRuntimeOsx,
-                    "FEATURE_THROTTLE_EVAL_SCHEDULER"
                 ),
             ],
             references: [

--- a/Public/Sdk/SelfHost/BuildXL/BuildXLSdk.dsc
+++ b/Public/Sdk/SelfHost/BuildXL/BuildXLSdk.dsc
@@ -423,7 +423,6 @@ function processArguments(args: Arguments, targetType: Csc.TargetType) : Argumen
             assemblyInfo: Object.merge(assemblyInfo, {title: title}, args.assemblyInfo),
             defineConstants: [
                 "DEFTEMP",
-                "FEATURE_THROTTLE_EVAL_SCHEDULER",
                 ...addIf(isDotNetCoreBuild,
                     "FEATURE_SAFE_PROCESS_HANDLE",
                     "DISABLE_FEATURE_VSEXTENSION_INSTALL_CHECK",

--- a/Public/Sdk/SelfHost/BuildXL/BuildXLSdk.dsc
+++ b/Public/Sdk/SelfHost/BuildXL/BuildXLSdk.dsc
@@ -423,6 +423,7 @@ function processArguments(args: Arguments, targetType: Csc.TargetType) : Argumen
             assemblyInfo: Object.merge(assemblyInfo, {title: title}, args.assemblyInfo),
             defineConstants: [
                 "DEFTEMP",
+
                 ...addIf(isDotNetCoreBuild,
                     "FEATURE_SAFE_PROCESS_HANDLE",
                     "DISABLE_FEATURE_VSEXTENSION_INSTALL_CHECK",
@@ -431,6 +432,9 @@ function processArguments(args: Arguments, targetType: Csc.TargetType) : Argumen
                 ),
                 ...addIf(Flags.isMicrosoftInternal,
                     "FEATURE_ARIA_TELEMETRY"
+                ),
+                ...addIf(isTargetRuntimeOsx,
+                    "FEATURE_THROTTLE_EVAL_SCHEDULER"
                 ),
             ],
             references: [

--- a/Public/Src/App/Bxl/Args.cs
+++ b/Public/Src/App/Bxl/Args.cs
@@ -619,8 +619,8 @@ namespace BuildXL
                             "mF",
                             opt => frontEndConfiguration.MaxFrontEndConcurrency = CommandLineUtilities.ParseInt32Option(opt, 1, int.MaxValue)),
                         OptionHandlerFactory.CreateOption(
-                            "unlimitedFrontEndConcurrency",
-                            opt => frontEndConfiguration.UnlimitedFrontEndConcurrency = CommandLineUtilities.ParseBooleanOption(opt)),
+                            "enableEvaluationThrottling",
+                            opt => frontEndConfiguration.EnableEvaluationThrottling = CommandLineUtilities.ParseBooleanOption(opt)),
                         OptionHandlerFactory.CreateOption(
                             "maxRestoreNugetConcurrency",
                             opt => frontEndConfiguration.MaxRestoreNugetConcurrency = CommandLineUtilities.ParseInt32Option(opt, 1, int.MaxValue)),

--- a/Public/Src/App/Bxl/Args.cs
+++ b/Public/Src/App/Bxl/Args.cs
@@ -619,6 +619,9 @@ namespace BuildXL
                             "mF",
                             opt => frontEndConfiguration.MaxFrontEndConcurrency = CommandLineUtilities.ParseInt32Option(opt, 1, int.MaxValue)),
                         OptionHandlerFactory.CreateOption(
+                            "unlimitedFrontEndConcurrency",
+                            opt => frontEndConfiguration.UnlimitedFrontEndConcurrency = CommandLineUtilities.ParseBooleanOption(opt)),
+                        OptionHandlerFactory.CreateOption(
                             "maxRestoreNugetConcurrency",
                             opt => frontEndConfiguration.MaxRestoreNugetConcurrency = CommandLineUtilities.ParseInt32Option(opt, 1, int.MaxValue)),
                         OptionHandlerFactory.CreateOption(

--- a/Public/Src/FrontEnd/Core/EvaluationScheduler.cs
+++ b/Public/Src/FrontEnd/Core/EvaluationScheduler.cs
@@ -25,9 +25,9 @@ namespace BuildXL.FrontEnd.Core
     public sealed class EvaluationScheduler : IEvaluationScheduler
     {
         private readonly int m_degreeOfParallelism;
+        private bool m_unlimitedParallelism;
         private readonly CancellationTokenSource m_cancellationSource;
 
-#if FEATURE_THROTTLE_EVAL_SCHEDULER
         private readonly ActionBlock<QueueItem> m_queue;
 
         private class QueueItem
@@ -57,13 +57,12 @@ namespace BuildXL.FrontEnd.Core
                 }
             }
         }
-#endif
 
         /// <summary>
         /// Creates a scheduler without cancellation support (<seealso cref="EvaluationScheduler(int, CancellationToken)"/>)
         /// </summary>
         public EvaluationScheduler(int degreeOfParallelism)
-            : this(degreeOfParallelism, CancellationToken.None) { }
+            : this(degreeOfParallelism, true, CancellationToken.None) { }
 
         /// <summary>
         /// Creates a scheduler.
@@ -72,28 +71,29 @@ namespace BuildXL.FrontEnd.Core
         /// If <paramref name="degreeOfParallelism"/> is greater than 1, then tasks provided to
         /// <see cref="EvaluateValue"/> methods are wrapped in <code>Task.Run</code>.
         /// </remarks>
-        public EvaluationScheduler(int degreeOfParallelism, CancellationToken cancellationToken)
+        public EvaluationScheduler(int degreeOfParallelism, bool unlimitedParalellism, CancellationToken cancellationToken)
         {
             Contract.Requires(degreeOfParallelism >= 1);
 
             m_degreeOfParallelism = degreeOfParallelism;
+            m_unlimitedParallelism = unlimitedParalellism;
             m_cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
-#if FEATURE_THROTTLE_EVAL_SCHEDULER
-            m_queue = new ActionBlock<QueueItem>(
-                item => item.Execute(),
-                new ExecutionDataflowBlockOptions
-                {
-                    BoundedCapacity = DataflowBlockOptions.Unbounded,
-                    MaxDegreeOfParallelism = m_degreeOfParallelism,
-                    CancellationToken = m_cancellationSource.Token
-                }
-            );
-#endif
+            if (!m_unlimitedParallelism)
+            {
+                m_queue = new ActionBlock<QueueItem>(
+                    item => item.Execute(),
+                    new ExecutionDataflowBlockOptions
+                    {
+                        BoundedCapacity = DataflowBlockOptions.Unbounded,
+                        MaxDegreeOfParallelism = m_degreeOfParallelism,
+                        CancellationToken = m_cancellationSource.Token
+                    }
+                );
+            }
         }
 
         /// <inheritdoc/>
-#if FEATURE_THROTTLE_EVAL_SCHEDULER
         public async Task<object> EvaluateValue(Func<Task<object>> evaluateValueFunction)
         {
             if (m_degreeOfParallelism == 1)
@@ -101,24 +101,25 @@ namespace BuildXL.FrontEnd.Core
                 return await evaluateValueFunction();
             }
 
-            var queueItem = new QueueItem(evaluateValueFunction);
-            m_queue.Post(queueItem);
+            if (m_unlimitedParallelism)
+            {
+                return m_degreeOfParallelism > 1
+                    ? Task.Run(evaluateValueFunction)
+                    : evaluateValueFunction();
+            }
+            else
+            {
+                var queueItem = new QueueItem(evaluateValueFunction);
+                m_queue.Post(queueItem);
 
-            // wait on either queueItem.Completion or m_queue.Completion to account for cancellation token
-            // (the cancellation token only cancels m_queue.Completion)
-            var finishedTask = await Task.WhenAny(queueItem.Completion, m_queue.Completion);
-            return finishedTask == queueItem.Completion
-                ? await queueItem.Completion // evaluation task completed
-                : null;                      // cancelled
+                // wait on either queueItem.Completion or m_queue.Completion to account for cancellation token
+                // (the cancellation token only cancels m_queue.Completion)
+                var finishedTask = await Task.WhenAny(queueItem.Completion, m_queue.Completion);
+                return finishedTask == queueItem.Completion
+                    ? await queueItem.Completion // evaluation task completed
+                    : null;                      // cancelled
+            }
         }
-#else
-        public Task<object> EvaluateValue(Func<Task<object>> evaluateValueFunction)
-        {
-            return m_degreeOfParallelism > 1
-                ? Task.Run(evaluateValueFunction)
-                : evaluateValueFunction();
-        }
-#endif
 
         /// <inheritdoc/>
         public CancellationToken CancellationToken => m_cancellationSource.Token;
@@ -127,6 +128,6 @@ namespace BuildXL.FrontEnd.Core
         public void Cancel() => m_cancellationSource.Cancel();
 
         /// <nodoc />
-        public static EvaluationScheduler Default { get; } = new EvaluationScheduler(Environment.ProcessorCount, CancellationToken.None);
+        public static EvaluationScheduler Default { get; } = new EvaluationScheduler(Environment.ProcessorCount, true, CancellationToken.None);
     }
 }

--- a/Public/Src/FrontEnd/Core/EvaluationScheduler.cs
+++ b/Public/Src/FrontEnd/Core/EvaluationScheduler.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 using BuildXL.FrontEnd.Sdk;
+using BuildXL.Utilities.Configuration;
 
 namespace BuildXL.FrontEnd.Core
 {
@@ -62,7 +63,7 @@ namespace BuildXL.FrontEnd.Core
         /// Creates a scheduler without cancellation support (<seealso cref="EvaluationScheduler(int, bool, CancellationToken)"/>)
         /// </summary>
         public EvaluationScheduler(int degreeOfParallelism)
-            : this(degreeOfParallelism, true, CancellationToken.None) { }
+            : this(degreeOfParallelism, FrontEndConfigurationExtensions.DefaultEnableEvaluationThrottling, CancellationToken.None) { }
 
         /// <summary>
         /// Creates a scheduler.
@@ -126,6 +127,6 @@ namespace BuildXL.FrontEnd.Core
         public void Cancel() => m_cancellationSource.Cancel();
 
         /// <nodoc />
-        public static EvaluationScheduler Default { get; } = new EvaluationScheduler(Environment.ProcessorCount, false, CancellationToken.None);
+        public static EvaluationScheduler Default { get; } = new EvaluationScheduler(Environment.ProcessorCount, FrontEndConfigurationExtensions.DefaultEnableEvaluationThrottling, CancellationToken.None);
     }
 }

--- a/Public/Src/FrontEnd/Core/EvaluationScheduler.cs
+++ b/Public/Src/FrontEnd/Core/EvaluationScheduler.cs
@@ -113,12 +113,10 @@ namespace BuildXL.FrontEnd.Core
                     ? await queueItem.Completion // evaluation task completed
                     : null;                      // cancelled
             }
-            else
-            {
-                return m_degreeOfParallelism > 1
-                    ? Task.Run(evaluateValueFunction)
-                    : evaluateValueFunction();
-            }
+
+            return m_degreeOfParallelism > 1
+                ? await Task.Run(evaluateValueFunction)
+                : evaluateValueFunction();
         }
 
         /// <inheritdoc/>

--- a/Public/Src/FrontEnd/Core/EvaluationScheduler.cs
+++ b/Public/Src/FrontEnd/Core/EvaluationScheduler.cs
@@ -59,10 +59,10 @@ namespace BuildXL.FrontEnd.Core
         }
 
         /// <summary>
-        /// Creates a scheduler without cancellation support (<seealso cref="EvaluationScheduler(int, CancellationToken)"/>)
+        /// Creates a scheduler without cancellation support (<seealso cref="EvaluationScheduler(int, bool, CancellationToken)"/>)
         /// </summary>
         public EvaluationScheduler(int degreeOfParallelism)
-            : this(degreeOfParallelism, false, CancellationToken.None) { }
+            : this(degreeOfParallelism, true, CancellationToken.None) { }
 
         /// <summary>
         /// Creates a scheduler.

--- a/Public/Src/FrontEnd/Core/FrontEndHostController.cs
+++ b/Public/Src/FrontEnd/Core/FrontEndHostController.cs
@@ -263,7 +263,8 @@ namespace BuildXL.FrontEnd.Core
             }
 
             var frontEndConcurrency = resultingConfiguration.FrontEnd.MaxFrontEndConcurrency();
-            m_evaluationScheduler = new EvaluationScheduler(frontEndConcurrency, FrontEndContext.CancellationToken);
+            var unlimitedEndConcurrency = resultingConfiguration.FrontEnd.UnlimitedFrontEndConcurrency();
+            m_evaluationScheduler = new EvaluationScheduler(frontEndConcurrency, unlimitedEndConcurrency, FrontEndContext.CancellationToken);
 
             HostState = State.ConfigInterpreted;
 
@@ -1070,7 +1071,7 @@ namespace BuildXL.FrontEnd.Core
             var frontEndHost = new FrontEndHostController(
                 frontEndFactory,
                 new DScriptWorkspaceResolverFactory(),
-                new EvaluationScheduler(degreeOfParallelism: 1, cancellationToken: frontEndContext.CancellationToken),
+                new EvaluationScheduler(degreeOfParallelism: 1, true, cancellationToken: frontEndContext.CancellationToken),
                 moduleRegistry,
                 new FrontEndStatistics(),
                 logger ?? Logger.CreateLogger(),

--- a/Public/Src/FrontEnd/Core/FrontEndHostController.cs
+++ b/Public/Src/FrontEnd/Core/FrontEndHostController.cs
@@ -263,8 +263,8 @@ namespace BuildXL.FrontEnd.Core
             }
 
             var frontEndConcurrency = resultingConfiguration.FrontEnd.MaxFrontEndConcurrency();
-            var unlimitedEndConcurrency = resultingConfiguration.FrontEnd.UnlimitedFrontEndConcurrency();
-            m_evaluationScheduler = new EvaluationScheduler(frontEndConcurrency, unlimitedEndConcurrency, FrontEndContext.CancellationToken);
+            var enableEvaluationThrottling = resultingConfiguration.FrontEnd.EnableEvaluationThrottling();
+            m_evaluationScheduler = new EvaluationScheduler(frontEndConcurrency, enableEvaluationThrottling, FrontEndContext.CancellationToken);
 
             HostState = State.ConfigInterpreted;
 
@@ -1071,7 +1071,7 @@ namespace BuildXL.FrontEnd.Core
             var frontEndHost = new FrontEndHostController(
                 frontEndFactory,
                 new DScriptWorkspaceResolverFactory(),
-                new EvaluationScheduler(degreeOfParallelism: 1, true, cancellationToken: frontEndContext.CancellationToken),
+                new EvaluationScheduler(degreeOfParallelism: 1, false, cancellationToken: frontEndContext.CancellationToken),
                 moduleRegistry,
                 new FrontEndStatistics(),
                 logger ?? Logger.CreateLogger(),

--- a/Public/Src/Utilities/Configuration/FrontEndConfigurationExtensions.cs
+++ b/Public/Src/Utilities/Configuration/FrontEndConfigurationExtensions.cs
@@ -154,6 +154,9 @@ namespace BuildXL.Utilities.Configuration
         public static int MaxFrontEndConcurrency(this IFrontEndConfiguration configuration) => 
             configuration.MaxFrontEndConcurrency ?? DefaultMaxFrontEndConcurrency;
 
+        public static bool UnlimitedFrontEndConcurrency(this IFrontEndConfiguration configuration) =>
+            configuration.UnlimitedFrontEndConcurrency ?? true;
+
         /// <nodoc/>
         public static int MaxRestoreNugetConcurrency(this IFrontEndConfiguration configuration) => 
             configuration.MaxRestoreNugetConcurrency ?? MaxFrontEndConcurrency(configuration);

--- a/Public/Src/Utilities/Configuration/FrontEndConfigurationExtensions.cs
+++ b/Public/Src/Utilities/Configuration/FrontEndConfigurationExtensions.cs
@@ -162,6 +162,7 @@ namespace BuildXL.Utilities.Configuration
         public static int MaxFrontEndConcurrency(this IFrontEndConfiguration configuration) => 
             configuration.MaxFrontEndConcurrency ?? DefaultMaxFrontEndConcurrency;
 
+        /// <nodoc/>
         public static bool EnableEvaluationThrottling(this IFrontEndConfiguration configuration) =>
             configuration.EnableEvaluationThrottling ?? DefaultEnableEvaluationThrottling;
 

--- a/Public/Src/Utilities/Configuration/FrontEndConfigurationExtensions.cs
+++ b/Public/Src/Utilities/Configuration/FrontEndConfigurationExtensions.cs
@@ -90,6 +90,14 @@ namespace BuildXL.Utilities.Configuration
         public static readonly int DefaultMaxFrontEndConcurrency = Math.Max(Environment.ProcessorCount, 256 / Environment.ProcessorCount); // the more cores, the lower the threshold.
 
         /// <nodoc/>
+        public static readonly bool DefaultEnableEvaluationThrottling =
+#if FEATURE_THROTTLE_EVAL_SCHEDULER
+            true;
+#else
+            false;
+#endif
+
+        /// <nodoc/>
         public static readonly int DefaultintThreadPoolMinThreadCountMultiplier = 3;
 
         /// <nodoc/>
@@ -154,8 +162,8 @@ namespace BuildXL.Utilities.Configuration
         public static int MaxFrontEndConcurrency(this IFrontEndConfiguration configuration) => 
             configuration.MaxFrontEndConcurrency ?? DefaultMaxFrontEndConcurrency;
 
-        public static bool UnlimitedFrontEndConcurrency(this IFrontEndConfiguration configuration) =>
-            configuration.UnlimitedFrontEndConcurrency ?? true;
+        public static bool EnableEvaluationThrottling(this IFrontEndConfiguration configuration) =>
+            configuration.EnableEvaluationThrottling ?? DefaultEnableEvaluationThrottling;
 
         /// <nodoc/>
         public static int MaxRestoreNugetConcurrency(this IFrontEndConfiguration configuration) => 

--- a/Public/Src/Utilities/Configuration/IFrontEndConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/IFrontEndConfiguration.cs
@@ -100,6 +100,11 @@ namespace BuildXL.Utilities.Configuration
         int? MaxFrontEndConcurrency { get; }
 
         /// <summary>
+        /// If true, spawn unlimited tasks at once in the front end
+        /// </summary>
+        bool? UnlimitedFrontEndConcurrency { get; }
+
+        /// <summary>
         /// The max concurrency to use for restoring nuget packages.
         /// </summary>
         int? MaxRestoreNugetConcurrency { get; }

--- a/Public/Src/Utilities/Configuration/IFrontEndConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/IFrontEndConfiguration.cs
@@ -102,7 +102,7 @@ namespace BuildXL.Utilities.Configuration
         /// <summary>
         /// If true, spawn unlimited tasks at once in the front end
         /// </summary>
-        bool? UnlimitedFrontEndConcurrency { get; }
+        bool? EnableEvaluationThrottling { get; }
 
         /// <summary>
         /// The max concurrency to use for restoring nuget packages.

--- a/Public/Src/Utilities/Configuration/Mutable/FrontEndConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/FrontEndConfiguration.cs
@@ -94,6 +94,8 @@ namespace BuildXL.Utilities.Configuration.Mutable
         /// <inheritdoc />
         public int? MaxFrontEndConcurrency { get; set; }
 
+        public bool? UnlimitedFrontEndConcurrency { get; set; }
+
         /// <inheritdoc />
         public int? MaxRestoreNugetConcurrency { get; set; }
 

--- a/Public/Src/Utilities/Configuration/Mutable/FrontEndConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/FrontEndConfiguration.cs
@@ -94,7 +94,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
         /// <inheritdoc />
         public int? MaxFrontEndConcurrency { get; set; }
 
-        public bool? UnlimitedFrontEndConcurrency { get; set; }
+        public bool? EnableEvaluationThrottling { get; set; }
 
         /// <inheritdoc />
         public int? MaxRestoreNugetConcurrency { get; set; }

--- a/Public/Src/Utilities/Configuration/Mutable/FrontEndConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/FrontEndConfiguration.cs
@@ -94,6 +94,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
         /// <inheritdoc />
         public int? MaxFrontEndConcurrency { get; set; }
 
+        /// <inheritdoc />
         public bool? EnableEvaluationThrottling { get; set; }
 
         /// <inheritdoc />


### PR DESCRIPTION
Turn on limited threading for evalution not just on MAC but on Windows as well.  This helps evaluation not stall when using binary graph