### PR TITLE
Add logging for RocksDb critical failures

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/RocksDbContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/RocksDbContentLocationDatabase.cs
@@ -195,7 +195,12 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                 Tracer.Info(context, $"Creating rocksdb store at '{storeLocation}'.");
 
                 var possibleStore = KeyValueStoreAccessor.Open(storeLocation,
-                    additionalColumns: new[] { nameof(Columns.ClusterState), nameof(Columns.Metadata) }, rotateLogs: true);
+                    additionalColumns: new[] { nameof(Columns.ClusterState), nameof(Columns.Metadata) },
+                    rotateLogs: true,
+                    failureHandler: failure => {
+                        Tracer.Error(context, $"RocksDb critical error caused store deprecation: {failure.DescribeIncludingInnerFailures()}");
+                    });
+
                 if (possibleStore.Succeeded)
                 {
                     var oldKeyValueStore = _keyValueStore;


### PR DESCRIPTION
If code running inside `store.Use()` generates an exception at any point, the RocksDb instance is subsequently "deprecated", which means it will fail to open after the disposal of the current instance.

This is NOT necessarily due to a RocksDb critical error, but only a design choice by `KeyValueStoreAccessor`. The issue is that the handling of that exception depends on the caller. This code ensures at least we will always know the reason why that happened.

We should look into a different failure handling methodology.