### PR TITLE
Remove Microsoft.ContentStoreApp.exe

### DIFF
--- a/Public/Src/Cache/ContentStore/BuildXL.Cache.ContentStore.dsc
+++ b/Public/Src/Cache/ContentStore/BuildXL.Cache.ContentStore.dsc
@@ -22,16 +22,7 @@ namespace Default {
             {
                 subfolder: r`App`,
                 contents: [
-                    App.exe,
-                    // Back-Compat naming
-                    {
-                        file: App.exe.runtime.binary,
-                        targetFileName: "Microsoft.ContentStoreApp.exe",
-                    },
-                    {
-                        file: App.exe.runtime.pdb,
-                        targetFileName: "Microsoft.ContentStoreApp.pdb",
-                    }
+                    App.exe
                 ]
             },
             {
@@ -120,14 +111,6 @@ namespace DotNetCore {
 export const deploymentForBuildXL: Deployment.Definition = {
     contents: [
         App.exe,
-        {
-            file: App.exe.runtime.binary,
-            targetFileName: "Microsoft.ContentStoreApp.exe",
-        },
-        {
-            file: App.exe.runtime.pdb,
-            targetFileName: "Microsoft.ContentStoreApp.pdb",
-        },
 
         importFrom("Grpc.Core").pkg,
         importFrom("Google.Protobuf").pkg,


### PR DESCRIPTION
Removing Microsoft.ContentStoreApp.exe from nuget packages. This is the executable which was used prior to the product rename. None of our direct consumers use this anymore (AzDev/CB), so it seems safe to remove.

[AB#1365823](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1365823)