### PR TITLE
Use /p to set the inputchanges path

### DIFF
--- a/Public/Sdk/SelfHost/BuildXL/Tools/QTest/Tool.QTestRunner.dsc
+++ b/Public/Sdk/SelfHost/BuildXL/Tools/QTest/Tool.QTestRunner.dsc
@@ -6,7 +6,11 @@ import {Artifact, Cmd, Transformer, Tool} from "Sdk.Transformers";
 const root = Environment.hasVariable("QTEST_DEPLOYMENT_PATH") ? d`${Environment.getFileValue("QTEST_DEPLOYMENT_PATH")}` : d`.`;
 const qCodeCoverageEnumType = Environment.hasVariable("[Sdk.BuildXL]qCodeCoverageEnumType")
     ? Environment.getStringValue("[Sdk.BuildXL]qCodeCoverageEnumType")
-    : "None";
+    : "None"; 
+
+const qInputChangesFilePath = Environment.hasVariable("[Sdk.BuildXL]inputChanges") 
+    ? f`${Environment.getFileValue("[Sdk.BuildXL]inputChanges")}`
+    : undefined;
 
 @@public
 export const qTestTool: Transformer.ToolDefinition = {
@@ -126,7 +130,7 @@ export function runQTest(args: QTestArguments): Result {
      
     let changeAffectedInputListWrittenFile = undefined;
     let changeAffectedInputListWrittenFileArg = {};
-    if (qCodeCoverageEnumType === "DynamicCodeCov"){
+    if (qCodeCoverageEnumType === "DynamicCodeCov" && File.exists(qInputChangesFilePath)){
         const parentDir = d`${logDir}`.parent;
         const leafDir = d`${logDir}`.nameWithoutExtension;
         const dir = d`${parentDir}/changeAffectedInput/${leafDir}`;

--- a/Public/Src/App/Bxl/Args.cs
+++ b/Public/Src/App/Bxl/Args.cs
@@ -537,9 +537,6 @@ namespace BuildXL
                         OptionHandlerFactory.CreateOption(
                             "injectCacheMisses",
                             opt => HandleArtificialCacheMissOption(opt, cacheConfiguration)),
-                        OptionHandlerFactory.CreateOption(
-                            "inputChanges",
-                            opt => schedulingConfiguration.InputChanges = CommandLineUtilities.ParsePathOption(opt, pathTable)),
                         OptionHandlerFactory.CreateBoolOption(
                             "interactive",
                             sign => configuration.Interactive = sign),

--- a/Public/Src/App/Bxl/HelpText.cs
+++ b/Public/Src/App/Bxl/HelpText.cs
@@ -1089,10 +1089,6 @@ namespace BuildXL
                 Strings.HelpText_DisplayHelp_SymlinkDefinitionFile);
 
             hw.WriteOption(
-                "/inputChanges:<file>",
-                Strings.HelpText_DisplayHelp_InputChanges);
-
-            hw.WriteOption(
                 "/telemetryTagPrefix:<string>",
                 Strings.HelpText_DisplayHelp_TelemetryTagPrefix);
 

--- a/Public/Src/App/Bxl/Strings.resx
+++ b/Public/Src/App/Bxl/Strings.resx
@@ -1018,7 +1018,4 @@ Example: ad2d42d2ec5d2ca0c0b7ad65402d07c7ef40b91e</value>
   <data name="HelpText_DisplayHelp_Interactive" xml:space="preserve">
     <value>When enabled indicates that {ShortProductName} is allowed to interact with the user either via console or popups. A common use case is to allow front ends like nuget to display authentication prompts in case the user is not authenticated.</value>
   </data>
-  <data name="HelpText_DisplayHelp_InputChanges" xml:space="preserve">
-    <value>Path to file containing a list of input changes, separated by new lines. The formats of an input change is '&lt;path&gt;|&lt;change kind&gt;' or '&lt;path&gt;', where change kinds are 'DataOrMetadataChanged', 'Removed', 'MembershipChanged', 'NewlyPresentAsFile', 'NewlyPresentAsDirectory'.</value>
-  </data>
 </root>

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/IncrementalSchedulingTests/IncrementalSchedulingTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/IncrementalSchedulingTests/IncrementalSchedulingTests.cs
@@ -418,7 +418,7 @@ namespace IntegrationTest.BuildXL.Scheduler.IncrementalSchedulingTests
         {
             var changeFile = CreateSourceFileWithPrefix(SourceRoot, "changeFile");
             File.WriteAllText(ArtifactToString(changeFile), string.Empty);
-            Configuration.Schedule.InputChanges = changeFile.Path;
+            Environment.SetEnvironmentVariable("[Sdk.BuildXL]inputChanges", changeFile.Path.ToString(Context.PathTable));
 
             var sourceFile = CreateSourceFileWithPrefix(SourceRoot, "sourceFile");
 

--- a/Public/Src/Utilities/Configuration/IScheduleConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/IScheduleConfiguration.cs
@@ -311,10 +311,5 @@ namespace BuildXL.Utilities.Configuration
         /// Instead of creating a random moniker for API server, use a fixed predetermined moniker.
         /// </summary>
         bool UseFixedApiServerMoniker { get; }
-
-        /// <summary>
-        /// Path to file containing input changes.
-        /// </summary>
-        AbsolutePath InputChanges { get; }
     }
 }

--- a/Public/Src/Utilities/Configuration/Mutable/ScheduleConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/ScheduleConfiguration.cs
@@ -71,7 +71,6 @@ namespace BuildXL.Utilities.Configuration.Mutable
             SkipHashSourceFile = false;
 
             UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing = false;
-            InputChanges = AbsolutePath.Invalid;
         }
 
         /// <nodoc />
@@ -136,7 +135,6 @@ namespace BuildXL.Utilities.Configuration.Mutable
 
             UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing = template.UnsafeDisableSharedOpaqueEmptyDirectoryScrubbing;
             UseFixedApiServerMoniker = template.UseFixedApiServerMoniker;
-            InputChanges = pathRemapper.Remap(template.InputChanges);
         }
 
         /// <inheritdoc />
@@ -320,8 +318,5 @@ namespace BuildXL.Utilities.Configuration.Mutable
 
         /// <inheritdoc />
         public bool UseFixedApiServerMoniker { get; set; }
-
-        /// <inheritdoc />
-        public AbsolutePath InputChanges { get; set; }
     }
 }


### PR DESCRIPTION
The QTest SDK need to aware the existence of the input changes passed from GBR. Change /InputChanges command line option to a environment parameter /p:[Sdk.BuildXL]inputChanges