### PR TITLE
Resource based canceling with shared opaque output producers

### DIFF
--- a/Public/Src/App/Bxl/Args.cs
+++ b/Public/Src/App/Bxl/Args.cs
@@ -376,9 +376,9 @@ namespace BuildXL
                             }),
                         OptionHandlerFactory.CreateBoolOption(
                             "enableGrpc",
-                            sign => 
-                            { 
-                                // Noop for legacy command line compatibility 
+                            sign =>
+                            {
+                                // Noop for legacy command line compatibility
                             }),
                         OptionHandlerFactory.CreateBoolOption(
                             "enableIncrementalFrontEnd",
@@ -492,8 +492,8 @@ namespace BuildXL
                             "kextEnableReportBatching",
                             sign => sandboxConfiguration.KextEnableReportBatching = sign),
                         OptionHandlerFactory.CreateBoolOption(
-                            "kextMeasureProcessCpuTimes",
-                            sign => sandboxConfiguration.KextMeasureProcessCpuTimes = sign),
+                            "measureProcessCpuTimes",
+                            sign => sandboxConfiguration.MeasureProcessCpuTimes = sign),
                         OptionHandlerFactory.CreateOption(
                             "kextNumberOfConnections",
                             opt =>

--- a/Public/Src/Deployment/Tests.Osx/test_runner.sh
+++ b/Public/Src/Deployment/Tests.Osx/test_runner.sh
@@ -15,8 +15,6 @@ find "$MY_DIR/TestProj/tests" -name "*.TestProcess" -exec chmod +x {} \;
 find "$MY_DIR/TestProj/tests" -name "*CoreDump*" -exec chmod +x {} \;
 
 # run the build
-# Temporarily disable this until we have the new macOS based CI
-# /kextMeasureProcessCpuTimes
 
 "$bxlSh"                                 \
   --config "$projRootDir/config.dsc"     \

--- a/Public/Src/Engine/Dll/Engine.cs
+++ b/Public/Src/Engine/Dll/Engine.cs
@@ -279,10 +279,10 @@ namespace BuildXL.Engine
             GrpcEnvironment.InitializeIfNeeded(GrpcSettings.ThreadPoolSize, grpcHandlerInliningEnabled);
 
             Logger.Log.GrpcSettings(
-                loggingContext, 
-                GrpcSettings.ThreadPoolSize, 
-                grpcHandlerInliningEnabled, 
-                (int)GrpcSettings.CallTimeout.TotalMinutes, 
+                loggingContext,
+                GrpcSettings.ThreadPoolSize,
+                grpcHandlerInliningEnabled,
+                (int)GrpcSettings.CallTimeout.TotalMinutes,
                 (int)GrpcSettings.InactiveTimeout.TotalMinutes);
 
             Context = context;
@@ -326,7 +326,7 @@ namespace BuildXL.Engine
             if (loggingConfig.OptimizeConsoleOutputForAzureDevOps || loggingConfig.OptimizeVsoAnnotationsForAzureDevOps)
             {
                 var filePath = Path.Combine(loggingConfig.LogsDirectory.ToString(Context.PathTable), loggingConfig.LogPrefix + ".Summary.md");
-                
+
                 // Tell the build viewmodel to collect a builder summary which we report to azure devops.
                 m_buildViewModel.BuildSummary = new BuildSummary(filePath);
             }
@@ -763,9 +763,9 @@ namespace BuildXL.Engine
         /// Populates file system capability.
         /// </summary>
         public static void PopulateFileSystemCapabilities(
-            ConfigurationImpl mutableConfig, 
-            ICommandLineConfiguration initialCommandLineConfiguration, 
-            PathTable pathTable, 
+            ConfigurationImpl mutableConfig,
+            ICommandLineConfiguration initialCommandLineConfiguration,
+            PathTable pathTable,
             LoggingContext loggingContext)
         {
             if (OperatingSystemHelper.IsUnixOS)
@@ -1677,7 +1677,7 @@ namespace BuildXL.Engine
                             }
 
                             // Returns stub if explicitly not use file content table.
-                            m_fileContentTask = Configuration.Engine.UseFileContentTable == false 
+                            m_fileContentTask = Configuration.Engine.UseFileContentTable == false
                                 ? Task.FromResult(FileContentTable.CreateStub())
                                 : FileContentTable.LoadOrCreateAsync(
                                     Configuration.Layout.FileContentTableFile.ToString(Context.PathTable),
@@ -1781,29 +1781,6 @@ namespace BuildXL.Engine
                                 ValidateSuccessMatches(success, pm.LoggingContext);
 
                                 var phase = Configuration.Engine.Phase;
-
-                                if (success && phase.HasFlag(EnginePhases.Schedule) && !Configuration.Schedule.DisableProcessRetryOnResourceExhaustion)
-                                {
-                                    // TODO: update this once shared opaques play nicely with resource based cancellation
-                                    // Resource based cancellation might lead to wrong cache entries.
-                                    // Consider this scenario:
-                                    // - a pip is to produce a shared opaque directory dir and files a, b, c, and d inside of this directory
-                                    // - the pip is cancelled after it has produced files dir/a and dir/b
-                                    // - pip is re-run
-                                    // - before producing dir/a and dir/b, the pip probes those files for existence and decides not to produce them;
-                                    //   the pip produces dir/c and dir/d, and finishes successfully
-                                    // - while processing outputs in shared opaques, we rely on a list of write accesses reported by detours;
-                                    //   since the pip only probed files a and b, we do not treat them as pip's output => cache entry does not contain
-                                    //   full output of the pip
-
-                                    var sharedOpaqueDir = engineSchedule.Scheduler.PipGraph.AllSealDirectories.FirstOrDefault(directoryArtifact => directoryArtifact.IsSharedOpaque);
-                                    if (sharedOpaqueDir.IsValid)
-                                    {
-                                        success = false;
-                                        Logger.Log.ResourceBasedCancellationIsEnabledWithSharedOpaquesPresent(pm.LoggingContext, sharedOpaqueDir.Path.ToString(Context.PathTable));
-                                    }
-                                    ValidateSuccessMatches(success, pm.LoggingContext);
-                                }
 
                                 if (success && phase.HasFlag(EnginePhases.Schedule) && Configuration.Ide.IsEnabled)
                                 {
@@ -2215,12 +2192,12 @@ namespace BuildXL.Engine
                 if (Configuration.Logging.RedirectedLogsDirectory.IsValid)
                 {
                     locker.CreateRedirectionAndPreventDeletion(
-                        Configuration.Logging.RedirectedLogsDirectory.ToString(pathTable), 
-                        Configuration.Logging.LogsDirectory.ToString(pathTable), 
+                        Configuration.Logging.RedirectedLogsDirectory.ToString(pathTable),
+                        Configuration.Logging.LogsDirectory.ToString(pathTable),
                         deleteExisting: true,
                         deleteOnClose: true);
                 }
-                
+
                 locker.CreateAndPreventDeletion(m_moveDeleteTempDirectory);
 
                 success = true;

--- a/Public/Src/Engine/Dll/Tracing/Log.cs
+++ b/Public/Src/Engine/Dll/Tracing/Log.cs
@@ -2673,16 +2673,6 @@ If you can't update and need this feature after July 2018 please reach out to th
         public abstract void FailedToRedirectUserProfile(LoggingContext context, string detailedErrorMessage);
 
         [GeneratedEvent(
-            (ushort)LogEventId.ResourceBasedCancellationIsEnabledWithSharedOpaquesPresent,
-            EventGenerators = EventGenerators.LocalOnly,
-            EventLevel = Level.Error,
-            Keywords = (int)(Keywords.UserMessage | Keywords.UserError),
-            EventTask = (ushort)Tasks.PipExecutor,
-            Message = "Scheduler has been configured to cancel/re-run pips due to resource exhaustion. There is at least one pip that produces a shared opaque directory ('{sharedOpaquePath}'). "
-                      + "Resource based cancellation and shared opaque directories are not compatible. Please use /disableProcessRetryOnResourceExhaustion+ argument to disable resource based cancellation.")]
-        internal abstract void ResourceBasedCancellationIsEnabledWithSharedOpaquesPresent(LoggingContext loggingContext, string sharedOpaquePath);
-
-        [GeneratedEvent(
             (ushort)LogEventId.GrpcSettings,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,

--- a/Public/Src/Engine/Dll/Tracing/LogEventId.cs
+++ b/Public/Src/Engine/Dll/Tracing/LogEventId.cs
@@ -216,7 +216,7 @@ namespace BuildXL.Engine.Tracing
         FailedToAcquireDirectoryLock = 7116,
         UsingRedirectedUserProfile = 7117,
         FailedToRedirectUserProfile = 7118,
-        ResourceBasedCancellationIsEnabledWithSharedOpaquesPresent = 7119,
+        // ResourceBasedCancellationIsEnabledWithSharedOpaquesPresent = 7119,
         BusyOrUnavailableOutputDirectoriesException = 7120,
         GrpcSettings = 7121,
 

--- a/Public/Src/Engine/Dll/Tracing/LogEventId.cs
+++ b/Public/Src/Engine/Dll/Tracing/LogEventId.cs
@@ -216,7 +216,7 @@ namespace BuildXL.Engine.Tracing
         FailedToAcquireDirectoryLock = 7116,
         UsingRedirectedUserProfile = 7117,
         FailedToRedirectUserProfile = 7118,
-        // ResourceBasedCancellationIsEnabledWithSharedOpaquesPresent = 7119,
+        // was: ResourceBasedCancellationIsEnabledWithSharedOpaquesPresent = 7119,
         BusyOrUnavailableOutputDirectoriesException = 7120,
         GrpcSettings = 7121,
 

--- a/Public/Src/Engine/Processes/SandboxConnectionES.cs
+++ b/Public/Src/Engine/Processes/SandboxConnectionES.cs
@@ -54,13 +54,13 @@ namespace BuildXL.Processes
         /// <summary>
         /// Initializes the ES sandbox
         /// </summary>
-        public SandboxConnectionES()
+        public SandboxConnectionES(bool isInTestMode = false, bool measureCpuTimes = false)
         {
             m_reportQueueLastEnqueueTime = 0;
             m_esConnectionInfo = new Sandbox.ESConnectionInfo() { Error = Sandbox.SandboxSuccess };
 
-            MeasureCpuTimes = false;
-            IsInTestMode = false;
+            MeasureCpuTimes = measureCpuTimes;
+            IsInTestMode = isInTestMode;
 
             var process = System.Diagnostics.Process.GetCurrentProcess();
 
@@ -74,7 +74,7 @@ namespace BuildXL.Processes
             ProcessUtilities.SetNativeConfiguration(true);
 #else
             ProcessUtilities.SetNativeConfiguration(false);
-            
+
 #endif
 
             m_workerThread = new Thread(() => StartReceivingAccessReports());
@@ -110,13 +110,13 @@ namespace BuildXL.Processes
         private void StartReceivingAccessReports()
         {
             Sandbox.AccessReportCallback callback = (Sandbox.AccessReport report, int code) =>
-            {   
+            {
                 if (code != Sandbox.ReportQueueSuccessCode)
                 {
                     var message = "EndpointSecurity event delivery failed with error: " + code;
                     throw new BuildXLException(message, ExceptionRootCause.MissingRuntimeDependency);
                 }
-                
+
                 // Stamp the access report as it has been dequeued at this point
                 report.Statistics.DequeueTime = Sandbox.GetMachAbsoluteTime();
 

--- a/Public/Src/Engine/Processes/SandboxConnectionKext.cs
+++ b/Public/Src/Engine/Processes/SandboxConnectionKext.cs
@@ -67,7 +67,7 @@ Use the the following command to load/reload the sandbox kernel extension and fi
         /// Until some automation for kernel extension building and deployment is in place, this number has to be kept in sync with the 'CFBundleVersion'
         /// inside the Info.plist file of the kernel extension code base. BuildXL will not work if a version mismatch is detected!
         /// </summary>
-        public const string RequiredKextVersionNumber = "1.98.99";
+        public const string RequiredKextVersionNumber = "1.99.99";
 
         /// <summary>
         /// See TN2420 (https://developer.apple.com/library/archive/technotes/tn2420/_index.html) on how versioning numbers are formatted in the Apple ecosystem

--- a/Public/Src/Engine/Processes/SandboxedProcessMac.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessMac.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks.Dataflow;
 using BuildXL.Interop;
 using BuildXL.Interop.MacOS;
 using BuildXL.Native.IO;
+using BuildXL.Native.Processes;
 using BuildXL.Utilities;
 using BuildXL.Utilities.Tasks;
 using JetBrains.Annotations;
@@ -34,6 +35,8 @@ namespace BuildXL.Processes
             internal PerformanceCollector.Aggregation JobKernelTimeMs { get; } = new PerformanceCollector.Aggregation();
             internal PerformanceCollector.Aggregation JobUserTimeMs { get; } = new PerformanceCollector.Aggregation();
             internal PerformanceCollector.Aggregation PeakMemoryBytes { get; } = new PerformanceCollector.Aggregation();
+            internal PerformanceCollector.Aggregation BytesRead { get; } = new PerformanceCollector.Aggregation();
+            internal PerformanceCollector.Aggregation BytesWritten { get; } = new PerformanceCollector.Aggregation();
         }
 
         /// <summary>
@@ -48,8 +51,6 @@ namespace BuildXL.Processes
         private readonly Timer m_perfTimer;
         private readonly PerfAggregator m_perfAggregator;
 
-        private IEnumerable<ReportedProcess> m_survivingChildProcesses;
-
         private long m_processKilledFlag = 0;
 
         /// <summary>
@@ -63,7 +64,7 @@ namespace BuildXL.Processes
 
         private readonly CancellationTokenSource m_timeoutTaskCancelationSource = new CancellationTokenSource();
 
-        private ISandboxConnection SandboxConnectionKext => ProcessInfo.SandboxConnection;
+        private ISandboxConnection SandboxConnection => ProcessInfo.SandboxConnection;
 
         private TimeSpan ChildProcessTimeout => ProcessInfo.NestedProcessTerminationTimeout;
 
@@ -80,7 +81,7 @@ namespace BuildXL.Processes
         /// <summary>
         /// Timeout period for inactivity from the sandbox kernel extension.
         /// </summary>
-        internal TimeSpan ReportQueueProcessTimeout => SandboxConnectionKext.IsInTestMode ? TimeSpan.FromSeconds(100) : TimeSpan.FromMinutes(45);
+        internal TimeSpan ReportQueueProcessTimeout => SandboxConnection.IsInTestMode ? TimeSpan.FromSeconds(100) : TimeSpan.FromMinutes(45);
 
         private Task m_processTreeTimeoutTask;
 
@@ -108,7 +109,7 @@ namespace BuildXL.Processes
 
             IgnoreReportedAccesses = ignoreReportedAccesses;
 
-            MeasureCpuTime =  overrideMeasureTime.HasValue
+            MeasureCpuTime = overrideMeasureTime.HasValue
                 ? overrideMeasureTime.Value
                 : info.SandboxConnection.MeasureCpuTimes;
 
@@ -129,7 +130,7 @@ namespace BuildXL.Processes
                 info.DetoursEventListener);
 
             m_pendingReports = new ActionBlock<AccessReport>(
-                HandleKextReport,
+                HandleAccessReport,
                 new ExecutionDataflowBlockOptions
                 {
                     EnsureOrdered = true,
@@ -137,17 +138,17 @@ namespace BuildXL.Processes
                     MaxDegreeOfParallelism = 1, // Must be one, otherwise SandboxedPipExecutor will fail asserting valid reports
                 });
 
-            // install a 'ProcessStarted' handler that informs the kext of the newly started process
+            // install a 'ProcessStarted' handler that informs the sandbox of the newly started process
             ProcessStarted += () => OnProcessStartedAsync().GetAwaiter().GetResult();
         }
 
         private static void UpdatePerfCounters(object state)
         {
-            var proc = (SandboxedProcessMac)state;
-            var buffer = new Process.ProcessTimesInfo();
+            var proc = (SandboxedProcessMac) state;
+            var buffer = new Process.ProcessResourceUsage();
 
             // get processor times for the root process itself
-            int errCode = Interop.MacOS.Process.GetProcessTimes(proc.ProcessId, ref buffer, includeChildProcesses: false);
+            int errCode = Interop.MacOS.Process.GetProcessResourceUsage(proc.ProcessId, ref buffer, includeChildProcesses: false);
             if (errCode == 0)
             {
                 proc.m_perfAggregator.KernelTimeMs.RegisterSample(buffer.SystemTimeNs / 1000);
@@ -155,17 +156,24 @@ namespace BuildXL.Processes
             }
 
             // get processor times for the process tree
-            errCode = Interop.MacOS.Process.GetProcessTimes(proc.ProcessId, ref buffer, includeChildProcesses: true);
+            errCode = Interop.MacOS.Process.GetProcessResourceUsage(proc.ProcessId, ref buffer, includeChildProcesses: true);
             if (errCode == 0)
             {
                 proc.m_perfAggregator.JobKernelTimeMs.RegisterSample(buffer.SystemTimeNs / 1000);
                 proc.m_perfAggregator.JobUserTimeMs.RegisterSample(buffer.UserTimeNs / 1000);
             }
 
+            // get memory usage for the process tree
             proc.m_perfAggregator.PeakMemoryBytes.RegisterSample(Dispatch.GetActivePeakMemoryUsage(default, proc.ProcessId));
 
+            proc.m_perfAggregator.BytesRead.RegisterSample(buffer.BytesRead);
+            proc.m_perfAggregator.BytesWritten.RegisterSample(buffer.BytesWritten);
+
             // reschedule the timer to fire again in PerfProbeInterval time (2 seconds)
-            proc.m_perfTimer.Change(dueTime: PerfProbeInternal, period: Timeout.InfiniteTimeSpan);
+            if (!proc.Killed)
+            {
+                proc.m_perfTimer.Change(dueTime: PerfProbeInternal, period: Timeout.InfiniteTimeSpan);
+            }
         }
 
         /// <inheritdoc />
@@ -186,12 +194,11 @@ namespace BuildXL.Processes
 
         /// <summary>
         /// Called right after the process starts executing.
-        /// 
+        ///
         /// Since we set the process file name to be /bin/sh and its arguments to be empty (<see cref="CreateProcess"/>),
         /// the process will effectively start in a "suspended" mode, with /bin/sh just waiting for some content to be
-        /// piped to its standard input.  Therefore, in this handler we first notify the kext of the new process (so that
-        /// the kext starts tracking it) and then just send the actual process command line to /bin/sh via its standard
-        /// input.
+        /// piped to its standard input.  Therefore, in this handler we first notify the sandbox of the new process (so that
+        /// it starts tracking it) and then just send the actual process command line to /bin/sh via its standard input.
         /// </summary>
         private async Task OnProcessStartedAsync()
         {
@@ -214,7 +221,7 @@ namespace BuildXL.Processes
                 m_perfTimer.Change(dueTime: TimeSpan.FromSeconds(0), period: Timeout.InfiniteTimeSpan);
             }
 
-            if (!SandboxConnectionKext.NotifyPipStarted(ProcessInfo.FileAccessManifest, this))
+            if (!SandboxConnection.NotifyPipStarted(ProcessInfo.FileAccessManifest, this))
             {
                 ThrowCouldNotStartProcess("Failed to notify kernel extension about process start, make sure the extension is loaded");
             }
@@ -249,16 +256,10 @@ namespace BuildXL.Processes
             // Make sure this is done no more than once.
             if (incrementedValue == 1)
             {
-                m_pendingReports.Complete();
-                KillAllChildProcesses();
                 await base.KillAsync();
+                KillAllChildProcesses();
+                await m_pendingReports.Completion;
             }
-        }
-
-        /// <inheritdoc />
-        protected override IEnumerable<ReportedProcess> GetSurvivingChildProcesses()
-        {
-            return m_survivingChildProcesses;
         }
 
         /// <summary>
@@ -283,7 +284,7 @@ namespace BuildXL.Processes
 
             // at this point this pip is done executing (it's only left to construct SandboxedProcessResult,
             // which is done by the base class) so notify the sandbox kernel extension connection manager about it.
-            SandboxConnectionKext.NotifyProcessFinished(PipId, this);
+            SandboxConnection.NotifyProcessFinished(PipId, this);
 
             return IgnoreReportedAccesses ? null : m_reports;
         }
@@ -318,13 +319,12 @@ namespace BuildXL.Processes
         /// </summary>
         private IReadOnlyList<ReportedProcess> GetCurrentlyActiveProcesses()
         {
-            return m_reports.GetCurrentlyActiveProcesses();
+            return m_reports.GetActiveProcesses();
         }
 
         private void KillAllChildProcesses()
         {
-            m_survivingChildProcesses = CoalesceProcesses(GetCurrentlyActiveProcesses());
-            NotifyPipTerminated(PipId, m_survivingChildProcesses);
+            NotifyPipTerminated(PipId, CoalesceProcesses(GetCurrentlyActiveProcesses()));
         }
 
         private bool ShouldWaitForSurvivingChildProcesses()
@@ -359,7 +359,7 @@ namespace BuildXL.Processes
             var distinctProcessIds = new HashSet<uint>(survivingChildProcesses.Select(p => p.ProcessId));
             foreach (var processId in distinctProcessIds)
             {
-                SandboxConnectionKext.NotifyPipProcessTerminated(pipId, (int)processId);
+                SandboxConnection.NotifyPipProcessTerminated(pipId, (int)processId);
             }
         }
 
@@ -399,6 +399,13 @@ namespace BuildXL.Processes
                 ? base.GetJobAccountingInfo()
                 : new JobObject.AccountingInformation
                 {
+                    IO = new IOCounters(new IO_COUNTERS()
+                    {
+                        ReadOperationCount = 1,
+                        WriteOperationCount = 1,
+                        ReadTransferCount = Convert.ToUInt64(m_perfAggregator.BytesRead.Total),
+                        WriteTransferCount = Convert.ToUInt64(m_perfAggregator.BytesWritten.Total)
+                    }),
                     PeakMemoryUsage = (ulong)m_perfAggregator.PeakMemoryBytes.Maximum,
                     KernelTime = TimeSpan.FromMilliseconds(m_perfAggregator.JobKernelTimeMs.Latest),
                     UserTime = TimeSpan.FromMilliseconds(m_perfAggregator.JobUserTimeMs.Latest),
@@ -445,11 +452,11 @@ namespace BuildXL.Processes
                         break;
                     }
 
-                    var minEnqueueTime = SandboxConnectionKext.MinReportQueueEnqueueTime;
+                    var minEnqueueTime = SandboxConnection.MinReportQueueEnqueueTime;
 
                     // Ensure we time out if the sandbox stops sending any events within ReportQueueProcessTimeout
                     if (minEnqueueTime != 0 &&
-                        SandboxConnectionKext.CurrentDrought >= ReportQueueProcessTimeout &&
+                        SandboxConnection.CurrentDrought >= ReportQueueProcessTimeout &&
                         CurrentRunningTime() >= ReportQueueProcessTimeout)
                     {
                         LogProcessState("Process timed out due to inactivity from sandbox kernel extension report queue: " +
@@ -462,7 +469,7 @@ namespace BuildXL.Processes
 
                     if (HasProcessExitBeenReceived)
                     {
-                        // Proceed if all queues are beyond the point when ProcessExit was received
+                        // Proceed if the event queue is beyond the point when ProcessExit was received
                         if (m_processExitTimeNs <= minEnqueueTime)
                         {
                             bool shouldWait = ShouldWaitForSurvivingChildProcesses();
@@ -478,7 +485,7 @@ namespace BuildXL.Processes
                         else
                         {
                             LogProcessState($"Process exited but still waiting for reports :: exit time = {m_processExitTimeNs}, " +
-                                $"min enqueue time = {minEnqueueTime}, current drought = {SandboxConnectionKext.CurrentDrought.TotalMilliseconds}ms");
+                                $"min enqueue time = {minEnqueueTime}, current drought = {SandboxConnection.CurrentDrought.TotalMilliseconds}ms");
                         }
                     }
 
@@ -495,7 +502,7 @@ namespace BuildXL.Processes
             m_sumOfReportQueueTimesUs += (long) (stats.DequeueTime - stats.EnqueueTime) / 1000;
         }
 
-        private void HandleKextReport(AccessReport report)
+        private void HandleAccessReport(AccessReport report)
         {
             if (ProcessInfo.FileAccessManifest.ReportFileAccesses)
             {
@@ -577,11 +584,6 @@ namespace BuildXL.Processes
 
         private void ReportFileAccess(ref AccessReport report)
         {
-            if (Killed)
-            {
-                return;
-            }
-
             if (IgnoreReportedAccesses &&
                 report.Operation != FileOperation.OpProcessStart &&
                 report.Operation != FileOperation.OpProcessExit)

--- a/Public/Src/Engine/Processes/SandboxedProcessMac.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessMac.cs
@@ -470,6 +470,10 @@ namespace BuildXL.Processes
                         LogProcessState("Process timed out due to inactivity from sandbox kernel extension report queue: " +
                                         $"the process has been running for {CurrentRunningTime().TotalSeconds} seconds " +
                                         $"and no reports have been received for over {ReportQueueProcessTimeout.TotalSeconds} seconds!");
+
+                        m_pendingReports.Complete();
+                        m_survivingChildProcesses = CoalesceProcesses(GetCurrentlyActiveProcesses());
+
                         await KillAsync();
                         processTreeTimeoutSource.SetResult(Unit.Void);
                         break;

--- a/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
@@ -50,7 +50,7 @@ namespace BuildXL.Processes
         private const uint AzureWatsonExitCode = 0xDEAD;
 
         /// <summary>
-        /// Group name in <see cref="Process.ErrorRegex"/> to use to extract error message. 
+        /// Group name in <see cref="Process.ErrorRegex"/> to use to extract error message.
         /// When no such group exists, the entire match is used.
         /// </summary>
         private const string ErrorMessageGroupName = "ErrorMessage";
@@ -528,7 +528,7 @@ namespace BuildXL.Processes
             internal readonly Predicate<string> LinePredicate;
             internal readonly Regex Regex;
 
-            internal OutputFilter(Predicate<string> linePredicate) 
+            internal OutputFilter(Predicate<string> linePredicate)
                 : this(linePredicate, null)
             {
                 Contract.Requires(linePredicate != null);
@@ -548,7 +548,7 @@ namespace BuildXL.Processes
             }
 
             /// <summary>
-            /// When <see cref="LinePredicate" /> is specified: it is invoked against <paramref name="source" /> and if 
+            /// When <see cref="LinePredicate" /> is specified: it is invoked against <paramref name="source" /> and if
             /// it returns true <paramref name="source" /> is returned.
             ///
             /// When <see cref="Regex" /> is specified: it is invoked against <paramref name="source" /> to find all
@@ -582,9 +582,9 @@ namespace BuildXL.Processes
         }
 
         /// <summary>
-        /// If <see cref="m_errorRegex"/> is set and its options include <see cref="RegexOptions.Singleline"/> (which means that 
-        /// the whole input string---which in turn may contain multiple lines---should be treated as a single line), returns the 
-        /// regex itself (to be used later to find all the matches in the input string); otherwise, returns a line filter 
+        /// If <see cref="m_errorRegex"/> is set and its options include <see cref="RegexOptions.Singleline"/> (which means that
+        /// the whole input string---which in turn may contain multiple lines---should be treated as a single line), returns the
+        /// regex itself (to be used later to find all the matches in the input string); otherwise, returns a line filter
         /// (to be used later to match individual lines from the input string).
         /// </summary>
         /// <remarks>
@@ -655,7 +655,7 @@ namespace BuildXL.Processes
                             }
 
                             string outputText = filter.ExtractMatches(inputChunk);
-                                
+
                             if (!string.IsNullOrEmpty(outputText))
                             {
                                 // only add leading newlines (when needed).
@@ -790,7 +790,7 @@ namespace BuildXL.Processes
                     };
 
                     return ShouldSandboxedProcessExecuteExternal
-                        ? await RunExternalAsync(info, allInputPathsUnderSharedOpaques, sandboxPrepTime, cancellationToken) 
+                        ? await RunExternalAsync(info, allInputPathsUnderSharedOpaques, sandboxPrepTime, cancellationToken)
                         : await RunInternalAsync(info, allInputPathsUnderSharedOpaques, sandboxPrepTime, cancellationToken);
                 }
             }
@@ -1050,7 +1050,7 @@ namespace BuildXL.Processes
         /// Translates VMs' host shared drive.
         /// </summary>
         /// <remarks>
-        /// VMs' host net shares the drive where the enlistiment resides, e.g., D, that is net used by the VMs. When the process running in a VM 
+        /// VMs' host net shares the drive where the enlistiment resides, e.g., D, that is net used by the VMs. When the process running in a VM
         /// accesses D:\E\f.txt, the process actually accesses D:\E\f.txt in the host. Thus, the file access manifest constructed in the host
         /// is often sufficient for running pips in VMs. However, some tools, like dotnet.exe, can access the path in UNC format, i.e.,
         /// \\192.168.0.1\D\E\f.txt. In this case, we need to supply a directory translation from that UNC path to the non-UNC path.
@@ -1737,10 +1737,10 @@ namespace BuildXL.Processes
                 }
             }
 
-            // Untrack the globally untracked paths specified in the configuration     
+            // Untrack the globally untracked paths specified in the configuration
             foreach (var path in m_sandboxConfig.GlobalUnsafeUntrackedScopes)
             {
-                // Translate the path and untrack the translated one                
+                // Translate the path and untrack the translated one
                 if (m_fileAccessManifest.DirectoryTranslator != null)
                 {
                     var pathString = path.ToString(m_pathTable);
@@ -1806,8 +1806,8 @@ namespace BuildXL.Processes
                     }
 
                     // TODO: named semaphores are not supported in NetStandard2.0
-                    if ((!m_pip.RequiresAdmin || m_sandboxConfig.AdminRequiredProcessExecutionMode == AdminRequiredProcessExecutionMode.Internal) 
-                        && checkMessageCount 
+                    if ((!m_pip.RequiresAdmin || m_sandboxConfig.AdminRequiredProcessExecutionMode == AdminRequiredProcessExecutionMode.Internal)
+                        && checkMessageCount
                         && !OperatingSystemHelper.IsUnixOS)
                     {
                         // Semaphore names don't allow '\\' chars.
@@ -1964,7 +1964,7 @@ namespace BuildXL.Processes
                             FileAccessPolicy.AllowRealInputTimestamps |
                             // For shared opaques, we need to know the (write) accesses that occurred, since we determine file ownership based on that.
                             (directory.IsSharedOpaque? FileAccessPolicy.ReportAccess : FileAccessPolicy.Deny) |
-                            // For shared opaques and if allowed undeclared source reads is enabled, make sure that any file used as an undeclared input under the 
+                            // For shared opaques and if allowed undeclared source reads is enabled, make sure that any file used as an undeclared input under the
                             // shared opaque gets deny write access. Observe that with exclusive opaques they are wiped out before the pip runs, so it is moot to check for inputs
                             // TODO: considering configuring this policy for all shared opaques, and not only when AllowedUndeclaredSourceReads is set. The case of a write on an undeclared
                             // input is more likely to happen when undeclared sources are allowed, but also possible otherwise. For now, this is just a conservative way to try this feature
@@ -2172,13 +2172,13 @@ namespace BuildXL.Processes
                 values: FileAccessPolicy.AllowRead | FileAccessPolicy.AllowReadIfNonexistent,
                 // Make sure we fake the input timestamp
                 // The file dependency may be under the cone of a shared opaque, which will give write access
-                // to it. Explicitly block this, since we want inputs to not be written. Observe we already know 
+                // to it. Explicitly block this, since we want inputs to not be written. Observe we already know
                 // this is not a rewrite.
                 mask: m_excludeReportAccessMask &
                       DefaultMask &
-                      (pathIsUnderSharedOpaque ? 
-                          ~FileAccessPolicy.AllowWrite: 
-                          FileAccessPolicy.MaskNothing)); 
+                      (pathIsUnderSharedOpaque ?
+                          ~FileAccessPolicy.AllowWrite:
+                          FileAccessPolicy.MaskNothing));
 
             allInputPaths.Add(path);
 
@@ -2275,8 +2275,8 @@ namespace BuildXL.Processes
                     Tracing.Logger.Log.PipTempDirectorySetupError(
                         m_loggingContext,
                         m_pip.SemiStableHash,
-                        m_pip.GetDescription(m_context), 
-                        path, 
+                        m_pip.GetDescription(m_context),
+                        path,
                         ex.ToStringDemystified());
                     return false;
                 }
@@ -2291,7 +2291,7 @@ namespace BuildXL.Processes
                     // When running in VM, a pip often queries TMP or TEMP to get the path to the temp directory.
                     // For most cases, the original path is sufficient because the path is redirected to the one in VM.
                     // However, a number of operations, like creating/accessing/enumerating junctions, will fail.
-                    // Recall that junctions are evaluated locally, so that creating junction using host path is like creating junctions 
+                    // Recall that junctions are evaluated locally, so that creating junction using host path is like creating junctions
                     // on the host from the VM.
                     string redirectedTempDirectoryPath = redirectedTempDirectory.ToString(m_pathTable);
                     var overridenEnvVars = DisallowedTempVariables
@@ -2319,7 +2319,7 @@ namespace BuildXL.Processes
                 // Temp directories are lazily, best effort cleaned after the pip finished. The previous build may not
                 // have finished this work before exiting so we must double check.
                 PreparePathForDirectory(
-                    tempDirectoryPath.ToString(m_pathTable), 
+                    tempDirectoryPath.ToString(m_pathTable),
                     createIfNonExistent: m_sandboxConfig.EnsureTempDirectoriesExistenceBeforePipExecution);
             }
             catch (BuildXLException ex)
@@ -2360,10 +2360,10 @@ namespace BuildXL.Processes
             catch (BuildXLException ex)
             {
                 Tracing.Logger.Log.PipTempDirectorySetupError(
-                    m_loggingContext, 
-                    m_pip.SemiStableHash, 
-                    m_pip.GetDescription(m_context), 
-                    path, 
+                    m_loggingContext,
+                    m_pip.SemiStableHash,
+                    m_pip.GetDescription(m_context),
+                    path,
                     ex.ToStringDemystified());
                 return false;
             }
@@ -2391,11 +2391,11 @@ namespace BuildXL.Processes
             if (!createDirectorySymlink.Succeeded)
             {
                 Tracing.Logger.Log.PipTempSymlinkRedirectionError(
-                    m_loggingContext, 
+                    m_loggingContext,
                     m_pip.SemiStableHash,
                     m_pip.GetDescription(m_context),
-                    redirectedPath, 
-                    path, 
+                    redirectedPath,
+                    path,
                     createDirectorySymlink.Failure.Describe());
                 return false;
             }
@@ -2408,8 +2408,8 @@ namespace BuildXL.Processes
             Tracing.Logger.Log.PipTempSymlinkRedirection(
                 m_loggingContext,
                 m_pip.SemiStableHash,
-                m_pip.GetDescription(m_context), 
-                redirectedPath, 
+                m_pip.GetDescription(m_context),
+                redirectedPath,
                 path);
 
             return true;
@@ -3035,7 +3035,7 @@ namespace BuildXL.Processes
                     // (and for NtQueryDirectoryFile, we can't always report the individual probes anyway).
                     if (reported.RequestedAccess == RequestedAccess.EnumerationProbe)
                     {
-                        // If it is an incremental tool and the pip allows preserving outputs, do not ignore. 
+                        // If it is an incremental tool and the pip allows preserving outputs, do not ignore.
                         if (!IsIncrementalToolAccess(reported))
                         {
                             continue;
@@ -3159,7 +3159,7 @@ namespace BuildXL.Processes
                             {
                                 isProbe = false;
                             }
-                            
+
                             // TODO: Remove this when WDG can grog this feature with no flag.
                                 if (m_sandboxConfig.UnsafeSandboxConfiguration.ExistingDirectoryProbesAsEnumerations ||
                                 access.RequestedAccess == RequestedAccess.Enumerate)
@@ -3194,7 +3194,7 @@ namespace BuildXL.Processes
                             // If the access occurred under any of the pip shared opaque outputs, and the access is not happening on any known input paths (neither dynamic nor static)
                             // then we just skip reporting the access. Together with the above step, this means that no accesses under shared opaques that represent outputs are actually
                             // reported as observed accesses. This matches the same behavior that occurs on static outputs.
-                            if (!allInputPathsUnderSharedOpaques.Contains(entry.Key) && 
+                            if (!allInputPathsUnderSharedOpaques.Contains(entry.Key) &&
                                 (isAccessUnderASharedOpaque == true || IsAccessUnderASharedOpaque(firstAccess, dynamicWriteAccesses, out _)))
                             {
                                 continue;
@@ -3231,9 +3231,9 @@ namespace BuildXL.Processes
                         foreach (var file in sod.Value)
                         {
                             var pathElement = file.GetParent(m_context.PathTable);
-                            
+
                             while (pathElement.IsValid && pathElement != sod.Key && excludedPaths.Add(pathElement))
-                            {                                
+                            {
                                 pathElement = pathElement.GetParent(m_context.PathTable);
                             }
                         }
@@ -3243,7 +3243,7 @@ namespace BuildXL.Processes
                         .Where(access =>
                             // if it's an enumeration -> include always
                             (access.ObservationFlags & ObservationFlags.Enumeration) == ObservationFlags.Enumeration
-                            // otherwise, check whether it's an excluded path 
+                            // otherwise, check whether it's an excluded path
                             || !excludedPaths.Contains(access.Path))
                         .ToList();
 

--- a/Public/Src/Engine/Processes/SandboxedProcessReports.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessReports.cs
@@ -127,7 +127,7 @@ namespace BuildXL.Processes
         /// Returns a list of still active child processes for which we only received a ProcessCreate but no
         /// ProcessExit event.
         /// </summary>
-        internal IReadOnlyList<ReportedProcess> GetCurrentlyActiveProcesses()
+        internal IReadOnlyList<ReportedProcess> GetActiveProcesses()
         {
             var matches = new HashSet<uint>(m_processesExits.Select(entry => entry.Key));
             return m_activeProcesses.Where(entry => !matches.Contains(entry.Key)).Select(entry => entry.Value).ToList();
@@ -654,12 +654,12 @@ namespace BuildXL.Processes
                 // within the scope of a process. The status of the operation represents whether that access should
                 // have been allowed/denied, based on the existence of the file.
                 // However, we need to determine whether to deny the access based on the first time the path was
-                // checked for writes across the whole process tree. This means checking the first time this operation 
+                // checked for writes across the whole process tree. This means checking the first time this operation
                 // is reported for a given path, and ignore subsequent reports.
                 // Races are ignored: a race means two child processes are racing to create or delete the same file
-                // - something that is not a good build behavior anyway - and the outcome will be that we will 
+                // - something that is not a good build behavior anyway - and the outcome will be that we will
                 // non-deterministically deny the access
-                // We store the path as an absolute path in order to guarantee canonicalization: e.g. prefixes like \\?\ 
+                // We store the path as an absolute path in order to guarantee canonicalization: e.g. prefixes like \\?\
                 // are not canonicalized in detours
                 if (path != null && AbsolutePath.TryCreate(m_pathTable, path, out var pathAsAbsolutePath) && !m_overrideAllowedWritePaths.ContainsKey(pathAsAbsolutePath))
                 {
@@ -672,7 +672,7 @@ namespace BuildXL.Processes
 
             FileAccessStatusMethod method = FileAccessStatusMethod.PolicyBased;
 
-            // If we are processing an allowed write, but this should be overridden based on file existence, 
+            // If we are processing an allowed write, but this should be overridden based on file existence,
             // we change the status here
             if (path != null &&
                 (requestedAccess & RequestedAccess.Write) != 0 &&

--- a/Public/Src/Engine/Processes/UnSandboxedProcess.cs
+++ b/Public/Src/Engine/Processes/UnSandboxedProcess.cs
@@ -229,6 +229,7 @@ namespace BuildXL.Processes
 
             var reportFileAccesses = ProcessInfo.FileAccessManifest?.ReportFileAccesses == true;
             var fileAccesses = reportFileAccesses ? (reports?.FileAccesses ?? s_emptyFileAccessesSet) : null;
+
             return new SandboxedProcessResult
             {
                 ExitCode                            = m_processExecutor.TimedOut ? ExitCodes.Timeout : Process.ExitCode,
@@ -248,7 +249,7 @@ namespace BuildXL.Processes
                 DumpCreationException               = m_dumpCreationException,
                 DumpFileDirectory                   = ProcessInfo.TimeoutDumpDirectory,
                 PrimaryProcessTimes                 = GetProcessTimes(),
-                SurvivingChildProcesses             = CoalesceProcesses(reports?.GetActiveProcesses())
+                SurvivingChildProcesses             = CoalesceProcesses(GetSurvivingChildProcesses())
             };
         }
 
@@ -364,6 +365,13 @@ namespace BuildXL.Processes
                 Tracing.Logger.Log.LogDetoursDebugMessage(ProcessInfo.LoggingContext, ProcessInfo.PipSemiStableHash, ProcessInfo.PipDescription, fullMessage);
             }
         }
+
+        /// <summary>
+        /// Returns surviving child processes in the case when the pip finished and potential child
+        /// processes didn't exit within an allotted time (<see cref="SandboxedProcessInfo.NestedProcessTerminationTimeout"/>)
+        /// after the main pip parent process has already exited.
+        /// </summary>
+        protected virtual IEnumerable<ReportedProcess> GetSurvivingChildProcesses() => null;
 
         /// <summary>
         /// Returns any collected sandboxed process reports or null.

--- a/Public/Src/Engine/Processes/UnSandboxedProcess.cs
+++ b/Public/Src/Engine/Processes/UnSandboxedProcess.cs
@@ -248,7 +248,7 @@ namespace BuildXL.Processes
                 DumpCreationException               = m_dumpCreationException,
                 DumpFileDirectory                   = ProcessInfo.TimeoutDumpDirectory,
                 PrimaryProcessTimes                 = GetProcessTimes(),
-                SurvivingChildProcesses             = CoalesceProcesses(GetSurvivingChildProcesses())
+                SurvivingChildProcesses             = CoalesceProcesses(reports?.GetActiveProcesses())
             };
         }
 
@@ -366,13 +366,6 @@ namespace BuildXL.Processes
         }
 
         /// <summary>
-        /// Returns surviving child processes in the case when the pip had to be terminated because its child
-        /// processes didn't exit within allotted time (<see cref="SandboxedProcessInfo.NestedProcessTerminationTimeout"/>)
-        /// after the main pip process has already exited.
-        /// </summary>
-        protected virtual IEnumerable<ReportedProcess> GetSurvivingChildProcesses() => null;
-
-        /// <summary>
         /// Returns any collected sandboxed process reports or null.
         /// </summary>
         internal virtual Task<SandboxedProcessReports> GetReportsAsync() => Task.FromResult<SandboxedProcessReports>(null);
@@ -389,7 +382,7 @@ namespace BuildXL.Processes
         [NotNull]
         internal virtual CpuTimes GetCpuTimes()
         {
-            // 'Dispatch.GetProcessTimes()' doesn't work because the process has already exited
+            // 'Dispatch.GetProcessResourceUsage()' doesn't work because the process has already exited
             return CpuTimes.Zeros;
         }
 

--- a/Public/Src/Engine/Scheduler/PipExecutor.cs
+++ b/Public/Src/Engine/Scheduler/PipExecutor.cs
@@ -814,7 +814,7 @@ namespace BuildXL.Scheduler
                     else
                     {
                         // Write file pips do not specify execution result since they are not distributed
-                        // (i.e. they only run on the master). Given that, they report directly to the file content manager. 
+                        // (i.e. they only run on the master). Given that, they report directly to the file content manager.
                         fileContentManager.ReportOutputContent(
                             operationContext,
                             pipDescription,
@@ -1178,7 +1178,7 @@ namespace BuildXL.Scheduler
                     {
                         if (!FileUtilities.FileExistsNoFollow(path))
                         {
-                            // Output file doesn't exist. No need to make it private, 
+                            // Output file doesn't exist. No need to make it private,
                             // but return false so BuildXL ensures the output directory is created.
                             return false;
                         }
@@ -1385,8 +1385,8 @@ namespace BuildXL.Scheduler
                                     environment.SetMaxExternalProcessRan();
                                 }
 
-                                IReadOnlyCollection<AbsolutePath> changeAffectedInputs = pip.ChangeAffectedInputListWrittenFilePath.IsValid 
-                                    ? environment.State.FileContentManager.SourceChangeAffectedContents.GetChangeAffectedInputs(pip) 
+                                IReadOnlyCollection<AbsolutePath> changeAffectedInputs = pip.ChangeAffectedInputListWrittenFilePath.IsValid
+                                    ? environment.State.FileContentManager.SourceChangeAffectedContents.GetChangeAffectedInputs(pip)
                                     : null;
 
                                 result = await executor.RunAsync(innerResourceLimitCancellationTokenSource.Token, sandboxConnection: environment.SandboxConnection, changeAffectedInputs);
@@ -1589,7 +1589,7 @@ namespace BuildXL.Scheduler
                     //
                     // Don't track file changes in observed input processor when process execution failed. Running observed input processor has side effects
                     // that some files get tracked by the file change tracker. Suppose that the process failed because it accesses paths that
-                    // are supposed to be untracked (but the user forgot to specify it in the spec). Those paths will be tracked by 
+                    // are supposed to be untracked (but the user forgot to specify it in the spec). Those paths will be tracked by
                     // file change tracker because the observed input processor may try to probe and track those paths.
                     observedInputValidationResult =
                         await ValidateObservedFileAccesses(
@@ -2865,7 +2865,7 @@ namespace BuildXL.Scheduler
             List<FileArtifact> absentArtifacts = null; // Almost never populated, since outputs are almost always required.
             List<(FileArtifact, FileMaterializationInfo)> cachedArtifactContentHashes =
                 new List<(FileArtifact, FileMaterializationInfo)>(pip.Outputs.Length);
- 
+
             // Only the CanBeReferencedOrCached output will be saved in metadata.StaticOutputHashes
             // We looped metadata.StaticOutputHashes and meanwhile find the corresponding output in current executing pip.
             FileArtifactWithAttributes attributedOutput;
@@ -3398,7 +3398,7 @@ namespace BuildXL.Scheduler
             // only check/load "real" files - reparse points are not stored in CAS, they are stored in metadata that we have already obtained
             // if we try to load reparse points' content from CAS, content availability check would fail, and as a result,
             // BuildXL would have to re-run the pip (even if all other outputs are available)
-            // Also, do not load zero-hash files (there is nothing in CAS with this hash) 
+            // Also, do not load zero-hash files (there is nothing in CAS with this hash)
             allHashes.AddRange(cachedArtifactContentHashes
                 .Where(pair => pair.fileMaterializationInfo.IsCacheable)
                 .Select(a => (a.fileArtifact, a.fileMaterializationInfo.Hash)));
@@ -4116,7 +4116,7 @@ namespace BuildXL.Scheduler
                 declaredArtifactPath = process.DirectoryOutputs[fileOutputData.OpaqueDirectoryIndex].Path;
             }
 
-            return PipArtifacts.IsPreservedOutputByPip(process, declaredArtifactPath, environment.Context.PathTable); 
+            return PipArtifacts.IsPreservedOutputByPip(process, declaredArtifactPath, environment.Context.PathTable);
         }
 
         private static bool IsRewriteOutputFile(IPipExecutionEnvironment environment, FileArtifact file)
@@ -4260,11 +4260,11 @@ namespace BuildXL.Scheduler
             // Suppose that we don't include the output hashes. Let's have a pip P whose output o should be preserved.
             // P executes, and stores #M of metadata hash with some strong fingerprint SF.
             // Before the next build, o is deleted from disk. Now, P maintains its SF because its input has not changed.
-            // P gets a cache hit, but when BuildXL tries to load o with #o (stored in M), it fails because o wasn't stored in the cache 
-            // and o doesn't exist on disk. Thus, P executes and produces o with different hash #o'. However, the post-execution of P 
+            // P gets a cache hit, but when BuildXL tries to load o with #o (stored in M), it fails because o wasn't stored in the cache
+            // and o doesn't exist on disk. Thus, P executes and produces o with different hash #o'. However, the post-execution of P
             // will fail to store #M because the entry has existed.
             //
-            // In the next run, P again gets a cache hit, but when BuildXL tries to load o with #o (stored in M) it fails because o wasn't stored 
+            // In the next run, P again gets a cache hit, but when BuildXL tries to load o with #o (stored in M) it fails because o wasn't stored
             // in the cache and o, even though exists on disk, has different hash (#o vs. #o'). Thus, P executes again and produces o with different hash #o''.
             // This will happen over and over again.
             //

--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -2140,7 +2140,7 @@ namespace BuildXL.Scheduler
                 bool exceededMaxRamUtilizationPercentage = perfInfo.RamUsagePercentage.Value > m_configuration.Schedule.MaximumRamUtilizationPercentage;
                 bool underMinimumAvailableRam = perfInfo.AvailableRamMb < m_configuration.Schedule.MinimumTotalAvailableRamMb;
 
-                resourceAvailable = !(exceededMaxRamUtilizationPercentage || underMinimumAvailableRam);
+                resourceAvailable = !(exceededMaxRamUtilizationPercentage && underMinimumAvailableRam);
 
                 // This is the calculation for the low memory perf smell. This is somewhat of a check against how effective
                 // the throttling is. It happens regardless of the throttling limits and is logged when we're pretty

--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -54,6 +54,7 @@ using Logger = BuildXL.Scheduler.Tracing.Logger;
 using Process = BuildXL.Pips.Operations.Process;
 using BuildXL.Scheduler.FileSystem;
 using BuildXL.Scheduler.IncrementalScheduling;
+using BuildXL.Interop;
 using BuildXL.Interop.MacOS;
 using BuildXL.Processes.Containers;
 using static BuildXL.Scheduler.FileMonitoringViolationAnalyzer;
@@ -2132,12 +2133,14 @@ namespace BuildXL.Scheduler
             }
 
             bool resourceAvailable = true;
+            bool isMemoryPressureCritical = false;
+
             if (perfInfo.RamUsagePercentage != null)
             {
                 bool exceededMaxRamUtilizationPercentage = perfInfo.RamUsagePercentage.Value > m_configuration.Schedule.MaximumRamUtilizationPercentage;
                 bool underMinimumAvailableRam = perfInfo.AvailableRamMb < m_configuration.Schedule.MinimumTotalAvailableRamMb;
 
-                resourceAvailable = !(exceededMaxRamUtilizationPercentage && underMinimumAvailableRam);
+                resourceAvailable = !(exceededMaxRamUtilizationPercentage || underMinimumAvailableRam);
 
                 // This is the calculation for the low memory perf smell. This is somewhat of a check against how effective
                 // the throttling is. It happens regardless of the throttling limits and is logged when we're pretty
@@ -2151,7 +2154,17 @@ namespace BuildXL.Scheduler
                 }
             }
 
+#if PLATFORM_OSX
+
+            Memory.PressureLevel pressureLevel = Memory.PressureLevel.Normal;
+            var result = Memory.GetMemoryPressureLevel(ref pressureLevel) == Dispatch.MACOS_INTEROP_SUCCESS;
+            isMemoryPressureCritical = result && (pressureLevel >= Memory.PressureLevel.Warning);
+
+            if (!resourceAvailable || isMemoryPressureCritical)
+#else
             if (!resourceAvailable)
+#endif
+
             {
                 if (LocalWorker.ResourcesAvailable)
                 {
@@ -2175,9 +2188,11 @@ namespace BuildXL.Scheduler
 
                 if (!m_scheduleConfiguration.DisableProcessRetryOnResourceExhaustion)
                 {
-                    // Free down to the specified max RAM utilization percentage with 10% slack
-                    var desiredRamToFreePercentage =
-                        (perfInfo.RamUsagePercentage.Value - m_configuration.Schedule.MaximumRamUtilizationPercentage) + 10;
+                    // Free down to the specified max RAM utilization percentage with 10% slack, if VM memory pressure is critical
+                    // we instantly try to free up 15% of the overall system memory to improve stability
+                    var desiredRamToFreePercentage = !isMemoryPressureCritical
+                        ? (perfInfo.RamUsagePercentage.Value - m_configuration.Schedule.MaximumRamUtilizationPercentage) + 10
+                        : 15;
 
                     // Ensure percentage to free is in valid percent range [0, 100]
                     desiredRamToFreePercentage = Math.Max(0, Math.Min(100, desiredRamToFreePercentage));
@@ -2992,7 +3007,7 @@ namespace BuildXL.Scheduler
             Contract.Assert(runnablePip.IsCancelled);
             if (runnablePip is ProcessRunnablePip processRunnable)
             {
-                FlagSharedOpaqueOutputs(runnablePip.Environment, processRunnable);
+                FlagAndReturnSharedOpaqueOutputs(runnablePip.Environment, processRunnable);
             }
         }
 
@@ -3562,6 +3577,13 @@ namespace BuildXL.Scheduler
                             // reschedule and choose worker again after adjusting expected RAM utilization
                             processRunnable.SetWorker(null);
 
+                            // Because the scheduler will re-run this pip, we have to nuke all outputs created under shared opaque directories
+                            var sharedOpaqueOutputs = FlagAndReturnSharedOpaqueOutputs(environment, processRunnable);
+                            if (worker.IsLocal)
+                            {
+                                ScrubSharedOpaqueOutputs(sharedOpaqueOutputs);
+                            }
+
                             // Use the max of the observed peak memory and the worker's expected RAM usage for the pip
                             var expectedRamUsageMb = Math.Max(
                                     worker.GetExpectedRamUsageMb(processRunnable),
@@ -3602,7 +3624,7 @@ namespace BuildXL.Scheduler
                         // Make sure all shared outputs are flagged as such.
                         // We need to do this even if the pip failed, so any writes under shared opaques are flagged anyway.
                         // This allows the scrubber to remove those files as well in the next run.
-                        FlagSharedOpaqueOutputs(environment, processRunnable);
+                        var sharedOpaqueOutputs = FlagAndReturnSharedOpaqueOutputs(environment, processRunnable);
 
                         // Set the process as executed. NOTE: We do this here rather than during ExecuteProcess to handle
                         // case of processes executed remotely
@@ -3653,6 +3675,9 @@ namespace BuildXL.Scheduler
                             // the content of the (final) outputs
                             if (executionResult.Converged)
                             {
+                                // On convergence, delete shared opaque outputs
+                                ScrubSharedOpaqueOutputs(sharedOpaqueOutputs);
+
                                 executionResult = PipExecutor.AnalyzeDoubleWritesOnCacheConvergence(
                                    operationContext,
                                    environment,
@@ -3699,12 +3724,17 @@ namespace BuildXL.Scheduler
             return IsTerminating && runnablePip.Step != PipExecutionStep.Start && GetPipRuntimeInfo(runnablePip.PipId).State == PipState.Running && !runnablePip.IsCancelled;
         }
 
-        private void FlagSharedOpaqueOutputs(IPipExecutionEnvironment environment, ProcessRunnablePip process)
+        private List<string> FlagAndReturnSharedOpaqueOutputs(IPipExecutionEnvironment environment, ProcessRunnablePip process)
         {
+            List<string> outputPaths = new List<string>();
+
             // Select all declared output files
             foreach (var fileArtifact in process.Process.FileOutputs)
             {
-                MakeSharedOpaqueOutputIfNeeded(fileArtifact.Path);
+                if (MakeSharedOpaqueOutputIfNeeded(fileArtifact.Path))
+                {
+                    outputPaths.Add(fileArtifact.Path.ToString(Context.PathTable));
+                }
             }
 
             // The shared dynamic accesses can be null when the pip failed on preparation, in which case it didn't run at all, so there is
@@ -3717,10 +3747,19 @@ namespace BuildXL.Scheduler
                 {
                     foreach (AbsolutePath writeInPath in writesPerSharedOpaque)
                     {
-                        SharedOpaqueOutputHelper.EnforceFileIsSharedOpaqueOutput(writeInPath.ToString(environment.Context.PathTable));
+                        var path = writeInPath.ToString(environment.Context.PathTable);
+                        SharedOpaqueOutputHelper.EnforceFileIsSharedOpaqueOutput(path);
+                        outputPaths.Add(path);
                     }
                 }
             }
+
+            return outputPaths;
+        }
+
+        private void ScrubSharedOpaqueOutputs(List<string> outputs)
+        {
+            outputs.ForEach(o => FileUtilities.DeleteFile(o));
         }
 
         private static void HandleDeterminismProbe(
@@ -4808,12 +4847,12 @@ namespace BuildXL.Scheduler
                                 }
                             }
                         };
-                        
+
                         switch (m_configuration.Sandbox.UnsafeSandboxConfiguration.SandboxKind)
                         {
                             case SandboxKind.MacOsEndpointSecurity:
                             {
-                                sandboxConnection = (ISandboxConnection) new SandboxConnectionES();
+                                sandboxConnection = (ISandboxConnection) new SandboxConnectionES(isInTestMode: false, m_configuration.Sandbox.KextMeasureProcessCpuTimes);
                                 break;
                             }
                             default:
@@ -5609,12 +5648,15 @@ namespace BuildXL.Scheduler
             MakeSharedOpaqueOutputIfNeeded(artifact.Path);
         }
 
-        private void MakeSharedOpaqueOutputIfNeeded(AbsolutePath path)
+        private bool MakeSharedOpaqueOutputIfNeeded(AbsolutePath path)
         {
             if (IsPathUnderSharedOpaqueDirectory(path))
             {
                 SharedOpaqueOutputHelper.EnforceFileIsSharedOpaqueOutput(path.ToString(Context.PathTable));
+                return true;
             }
+
+            return false;
         }
 
         private bool IsPathUnderSharedOpaqueDirectory(AbsolutePath path)

--- a/Public/Src/Engine/UnitTests/Engine/EngineTests.cs
+++ b/Public/Src/Engine/UnitTests/Engine/EngineTests.cs
@@ -75,7 +75,7 @@ namespace Test.BuildXL.EngineTests
 
             XAssert.AreEqual(violation, contractViolation);
         }
-       
+
         /// <summary>
         /// Checks that the temp directory for FileUtilities file deletions is automatically set and cleaned by TempCleaner
         /// when the engine runs
@@ -88,7 +88,7 @@ namespace Test.BuildXL.EngineTests
             RunEngine();
 
             // After the engine runs, a temp directory for FileUtilities should have been set
-            // It will also be registered for garbage collection with a TempCleaner thread, 
+            // It will also be registered for garbage collection with a TempCleaner thread,
             // but there will be nothing to clean
             XAssert.IsTrue(TestHooks.TempCleanerTempDirectory != null);
             XAssert.IsTrue(Directory.Exists(TestHooks.TempCleanerTempDirectory));
@@ -118,7 +118,7 @@ namespace Test.BuildXL.EngineTests
         public void TestFileUtilitiesTempDirectoryNotScrubbed()
         {
             // Do a run of some valid modules
-            // The engine will set and create the path for the FileUtilities temp directory 
+            // The engine will set and create the path for the FileUtilities temp directory
             // This will also register the directory to be cleaned by TempCleaner
             SetupTestData();
             Configuration.Engine.Scrub = true;
@@ -240,7 +240,7 @@ namespace Test.BuildXL.EngineTests
         public void TestProperLogMessageOnCacheLockAcquisitionFailure()
         {
             var tempDir = Path.Combine(
-                OperatingSystemHelper.IsUnixOS ? "/tmp/bxl-temp" : TemporaryDirectory, 
+                OperatingSystemHelper.IsUnixOS ? "/tmp/bxl-temp" : TemporaryDirectory,
                 Guid.NewGuid().ToString());
             string cacheDirectory = Path.Combine(tempDir, "cache");
 
@@ -286,7 +286,7 @@ namespace Test.BuildXL.EngineTests
                     // need a different name for the log file (due to the order in which the things are initialized)
                     CacheLogFilePath = AbsolutePath.Create(Context.PathTable, tempDir).Combine(Context.PathTable, "cache_2.log"),
                     CacheConfigFile = cacheConfigPath,
-                    
+
                 },
                 translator,
                 recoveryStatus: false,
@@ -383,22 +383,6 @@ namespace Test.BuildXL.EngineTests
         }
 
         [Fact]
-        public void TestResourceBasedCancellationIsNotAllowedWithSharedOpaques()
-        {
-            var spec0 = SpecWithOpaques();
-            AddModule("Module0", ("spec0.dsc", spec0), placeInRoot: true);
-            
-            // enable resource based cancellation
-            Configuration.Schedule.DisableProcessRetryOnResourceExhaustion = false;
-            // do not need to run the pips - the check happens before execution phase
-            Configuration.Engine.Phase = EnginePhases.Schedule;
-
-            RunEngine(expectSuccess: false);
-
-            AssertErrorEventLogged(global::BuildXL.Engine.Tracing.LogEventId.ResourceBasedCancellationIsEnabledWithSharedOpaquesPresent);
-        }
-
-        [Fact]
         public void TestGraphCacheMissReason()
         {
             foreach (var missReason in Enum.GetValues(typeof(GraphCacheMissReason)))
@@ -428,7 +412,7 @@ namespace Namespace1 {
 
 const step1 = Transformer.writeAllLines(
     p`obj/a.txt`,
-    [  
+    [
         Namespace1.value1,
     ]
 );
@@ -466,7 +450,7 @@ const pip = Transformer.execute({
 });
 ";
         }
-        
+
         private static void AssertSuccess<T>(Possible<T, Failure> possible)
         {
             Assert.True(possible.Succeeded);

--- a/Public/Src/Engine/UnitTests/Processes/SandboxedProcessMacTest.cs
+++ b/Public/Src/Engine/UnitTests/Processes/SandboxedProcessMacTest.cs
@@ -97,11 +97,7 @@ namespace Test.BuildXL.Processes
 
             // Set the last enqueue time to now
             s_connection.MinReportQueueEnqueueTime = Sandbox.GetMachAbsoluteTime();
-
-            // NOTE: Not wrapping this process in 'time' because KillAsync can only kill 'time' and the its child process (from 'Operation.Block').
-            //       This is only because we are using a mock sandbox connection here; in production, a real connection instance
-            //       notifies the sandbox which kills the surviving processes.
-            var process = CreateAndStartSandboxedProcess(processInfo, measureTime: false);
+            var process = CreateAndStartSandboxedProcess(processInfo, measureTime: true);
             var taskCancelationSource = new CancellationTokenSource();
 
             // Post nothing to the report queue, and the process tree must be timed out after ReportQueueProcessTimeout

--- a/Public/Src/Engine/UnitTests/Processes/SandboxedProcessMacTest.cs
+++ b/Public/Src/Engine/UnitTests/Processes/SandboxedProcessMacTest.cs
@@ -164,6 +164,30 @@ namespace Test.BuildXL.Processes
                     Path = childProcessPath,
                     Allowed = true
                 },
+                new ReportInstruction() {
+                    Process = process,
+                    Operation = FileOperation.OpProcessExit,
+                    Stats = new Sandbox.AccessReportStatistics()
+                    {
+                        EnqueueTime = time + ((ulong) TimeSpan.FromSeconds(7).Ticks * 100),
+                        DequeueTime = time + ((ulong) TimeSpan.FromSeconds(8).Ticks * 100),
+                    },
+                    Pid = 1235,
+                    Path = childProcessPath,
+                    Allowed = true
+                },
+                new ReportInstruction() {
+                    Process = process,
+                    Operation = FileOperation.OpProcessTreeCompleted,
+                    Stats = new Sandbox.AccessReportStatistics()
+                    {
+                        EnqueueTime = time + ((ulong) TimeSpan.FromSeconds(9).Ticks * 100),
+                        DequeueTime = time + ((ulong) TimeSpan.FromSeconds(10).Ticks * 100),
+                    },
+                    Pid = process.ProcessId,
+                    Path = "/dummy/exe",
+                    Allowed = true
+                },
             };
 
             ContinouslyPostAccessReports(process, taskCancelationSource.Token, instructions);
@@ -213,13 +237,14 @@ namespace Test.BuildXL.Processes
                                             instructions[count].Stats, instructions[count].Pid,
                                             instructions[count].Path, instructions[count].Allowed);
 
+
                             // Advance the minimum enqueue time
                             s_connection.MinReportQueueEnqueueTime = instructions[count].Stats.EnqueueTime;
 
                             count++;
                         }
-
-                        await Task.Delay(100);
+                        // Wait for twice as long as the current timeout task within SandboxedProcessMac
+                        await Task.Delay(500);
                     }
                 }, token)
                 , justification: "Fire and forget"

--- a/Public/Src/Sandbox/MacOs/Interop/Posix/Dependencies.h
+++ b/Public/Src/Sandbox/MacOs/Interop/Posix/Dependencies.h
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <sys/types.h>
 
-#define GET_RUSAGE_ERROR 103
+#define GET_RUSAGE_ERROR    103
+#define RUNTIME_ERROR       -1
 
 #endif /* Dependencies_h */

--- a/Public/Src/Sandbox/MacOs/Interop/Posix/io.c
+++ b/Public/Src/Sandbox/MacOs/Interop/Posix/io.c
@@ -54,7 +54,7 @@ int StatFile(const char *path, bool followSymlink, StatBuffer *statBuffer, long 
     if (sizeof(StatBuffer) != bufferSize)
     {
         printf("ERROR: Wrong size of StatBuffer buffer; expected %ld, received %ld\n", sizeof(StatBuffer), bufferSize);
-        return 1;
+        return RUNTIME_ERROR;
     }
 
     struct stat fileStat;
@@ -73,7 +73,7 @@ int StatFileDescriptor(intptr_t fd, StatBuffer *statBuffer, long bufferSize)
     if (sizeof(StatBuffer) != bufferSize)
     {
         printf("ERROR: Wrong size of StatBuffer buffer; expected %ld, received %ld\n", sizeof(StatBuffer), bufferSize);
-        return 1;
+        return RUNTIME_ERROR;
     }
 
     struct stat fileStat;

--- a/Public/Src/Sandbox/MacOs/Interop/Posix/memory.h
+++ b/Public/Src/Sandbox/MacOs/Interop/Posix/memory.h
@@ -4,10 +4,11 @@
 #ifndef memory_h
 #define memory_h
 
+#include <sys/sysctl.h>
 #include "Dependencies.h"
 
-#define GET_PAGE_SIZE_ERROR 101
-#define GET_VM_STATS_ERROR 102
+#define GET_PAGE_SIZE_ERROR     101
+#define GET_VM_STATS_ERROR      102
 
 // Memory usage information in bytes
 typedef struct {
@@ -24,5 +25,6 @@ typedef struct {
 
 int GetRamUsageInfo(RamUsageInfo *buffer, long bufferSize);
 int GetPeakWorkingSetSize(pid_t pid, uint64_t *buffer);
+int GetMemoryPressureLevel(int *level);
 
 #endif /* memory_h */

--- a/Public/Src/Sandbox/MacOs/Interop/Posix/process.c
+++ b/Public/Src/Sandbox/MacOs/Interop/Posix/process.c
@@ -46,8 +46,8 @@ int GetProcessResourceUsage(pid_t pid, ProcessResourceUsage *buffer, long buffer
     buffer->systemTime = rusage.ri_system_time;
     buffer->userTime = rusage.ri_user_time;
 
-    buffer->bytesRead = rusage.ri_diskio_bytesread;
-    buffer->bytesWritten = rusage.ri_diskio_byteswritten;
+    buffer->diskio_bytesRead = rusage.ri_diskio_bytesread;
+    buffer->diskio_bytesWritten = rusage.ri_diskio_byteswritten;
 
     if (includeChildProcesses)
     {

--- a/Public/Src/Sandbox/MacOs/Interop/Posix/process.h
+++ b/Public/Src/Sandbox/MacOs/Interop/Posix/process.h
@@ -11,9 +11,11 @@ typedef struct {
     double exitTime;
     unsigned long systemTime;
     unsigned long userTime;
-} ProcessTimesInfo;
+    unsigned long bytesRead;
+    unsigned long bytesWritten;
+} ProcessResourceUsage;
 
-int GetProcessTimes(pid_t pid, ProcessTimesInfo *buffer, long bufferSize, bool includeChildProcesses);
+int GetProcessResourceUsage(pid_t pid, ProcessResourceUsage *buffer, long bufferSize, bool includeChildProcesses);
 
 typedef struct {
     char *outputPath;

--- a/Public/Src/Sandbox/MacOs/Interop/Posix/process.h
+++ b/Public/Src/Sandbox/MacOs/Interop/Posix/process.h
@@ -11,8 +11,8 @@ typedef struct {
     double exitTime;
     unsigned long systemTime;
     unsigned long userTime;
-    unsigned long bytesRead;
-    unsigned long bytesWritten;
+    unsigned long diskio_bytesRead;
+    unsigned long diskio_bytesWritten;
 } ProcessResourceUsage;
 
 int GetProcessResourceUsage(pid_t pid, ProcessResourceUsage *buffer, long bufferSize, bool includeChildProcesses);

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/BuildXLSandboxClient.cpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/BuildXLSandboxClient.cpp
@@ -366,8 +366,7 @@ IOReturn BuildXLSandboxClient::ProcessPipTerminated(PipStateChangedRequest *data
         proc_name(data->processId, name, sizeof(name));
         log_debug("Killing process %s(%d)", name, pid);
 #endif
-        handler.HandleProcessUntracked(pid);
-        proc_signal(pid, SIGTERM);
+        proc_signal(pid, SIGKILL);
     }
 
     return kIOReturnSuccess;

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>1.98.99</string>
+	<string>1.99.99</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>BuildXLSandbox</key>

--- a/Public/Src/Tools/SandboxExec/Program.cs
+++ b/Public/Src/Tools/SandboxExec/Program.cs
@@ -185,7 +185,7 @@ namespace BuildXL.SandboxExec
                 ?
 #if PLATFORM_OSX
                 useEndpointSecuritySandbox
-                    ? (ISandboxConnection) new SandboxConnectionES()
+                    ? (ISandboxConnection) new SandboxConnectionES(isInTestMode: false, measureCpuTimes: true)
                     :
 #endif
                     (ISandboxConnection) new SandboxConnectionKext(

--- a/Public/Src/Utilities/Configuration/ISandboxConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/ISandboxConfiguration.cs
@@ -171,13 +171,8 @@ namespace BuildXL.Utilities.Configuration
         bool AllowInternalDetoursErrorNotificationFile { get; }
 
         /// <summary>
-        /// Whether to measure CPU times (user/system) of sandboxed processes.  Default: false.
+        /// Whether to measure CPU times (user/system) of sandboxed processes.  Default: true.
         /// </summary>
-        /// <remarks>
-        /// In principle thre should be no reason not to measure CPU times.  But on macOS this amounts to wrapping
-        /// every process in '/usr/bin/time', which could lead to some unexpected behavior.  Hence this option to
-        /// explicitly turn in on or off.
-        /// </remarks>
         bool KextMeasureProcessCpuTimes { get; }
 
         /// <summary>
@@ -238,20 +233,20 @@ namespace BuildXL.Utilities.Configuration
         /// </summary>
         /// <remarks>
         /// This is a temporary flag for enforcing consistent behavior in temp directories creation.
-        /// If this flag is set to false, then only directories specified in %TMP% and %TEMP% are 
-        /// ensured to exist, but additional temp directories are not. The current default is false. 
+        /// If this flag is set to false, then only directories specified in %TMP% and %TEMP% are
+        /// ensured to exist, but additional temp directories are not. The current default is false.
         /// Eventually, BuildXL will always ensure temp directory creation. However, currently, such a change
         /// can break customers who assume that additional temp directories are not created before the pip executes.
         /// Thus, this enforcement is made opt-in.
         /// </remarks>
         bool EnsureTempDirectoriesExistenceBeforePipExecution { get; }
 
-        /// <summary> 
-        /// Paths and Directory Paths which should be untracked for all processes 
-        /// </summary> 
+        /// <summary>
+        /// Paths and Directory Paths which should be untracked for all processes
+        /// </summary>
         /// <remarks>
         /// When Directory Path is specified, all paths under that directory will be untracked
-        /// This is an unsafe configuration, since it allows read and write access to the paths 
+        /// This is an unsafe configuration, since it allows read and write access to the paths
         /// which is not specified as input or output.
         /// Moreover, this global configuration from cammand line will bypass cache,
         /// which means pips and graph will be cached ignoring paths specified in this configure
@@ -263,13 +258,13 @@ namespace BuildXL.Utilities.Configuration
         /// </summary>
         bool PreserveOutputsForIncrementalTool { get; }
 
-        /// <summary> 
-        /// Environment Variables which should be passed through for all processes 
-        /// </summary> 
+        /// <summary>
+        /// Environment Variables which should be passed through for all processes
+        /// </summary>
         /// <remarks>
         /// This is an unsafe configuration.
         /// This global configuration from cammand line will bypass cache,
-        /// which means pips and graph will be cached ignoring environment variables specified in this configuration.  
+        /// which means pips and graph will be cached ignoring environment variables specified in this configuration.
         /// </remarks>
         IReadOnlyList<string> GlobalUnsafePassthroughEnvironmentVariables { get; }
     }

--- a/Public/Src/Utilities/Configuration/ISandboxConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/ISandboxConfiguration.cs
@@ -173,7 +173,7 @@ namespace BuildXL.Utilities.Configuration
         /// <summary>
         /// Whether to measure CPU times (user/system) of sandboxed processes.  Default: true.
         /// </summary>
-        bool KextMeasureProcessCpuTimes { get; }
+        bool MeasureProcessCpuTimes { get; }
 
         /// <summary>
         /// Indicates how big a single sandbox kernel extension report queue is in MB when it is allocated in the sandbox kernel extension

--- a/Public/Src/Utilities/Configuration/Mutable/SandboxConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/SandboxConfiguration.cs
@@ -37,7 +37,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             CheckDetoursMessageCount = true;
             AllowInternalDetoursErrorNotificationFile = true;
             EnforceAccessPoliciesOnDirectoryCreation = false;
-            KextMeasureProcessCpuTimes = true;              // always measure process times + ram consumption
+            MeasureProcessCpuTimes = true;                  // always measure process times + ram consumption
             KextReportQueueSizeMb = 0;                      // let the sandbox kernel extension apply defaults
             KextEnableReportBatching = true;                // use lock-free queue for batching access reports
             KextThrottleCpuUsageBlockThresholdPercent = 0;  // no throttling by default
@@ -85,7 +85,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             CheckDetoursMessageCount = template.CheckDetoursMessageCount;
             AllowInternalDetoursErrorNotificationFile = template.AllowInternalDetoursErrorNotificationFile;
             EnforceAccessPoliciesOnDirectoryCreation = template.EnforceAccessPoliciesOnDirectoryCreation;
-            KextMeasureProcessCpuTimes = template.KextMeasureProcessCpuTimes;
+            MeasureProcessCpuTimes = template.MeasureProcessCpuTimes;
             KextReportQueueSizeMb = template.KextReportQueueSizeMb;
             KextEnableReportBatching = template.KextEnableReportBatching;
             KextThrottleCpuUsageBlockThresholdPercent = template.KextThrottleCpuUsageBlockThresholdPercent;
@@ -208,7 +208,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
         public bool AllowInternalDetoursErrorNotificationFile { get; set; }
 
         /// <inheritdoc />
-        public bool KextMeasureProcessCpuTimes { get; set; }
+        public bool MeasureProcessCpuTimes { get; set; }
 
         /// <inheritdoc />
         public uint KextReportQueueSizeMb { get; set; }

--- a/Public/Src/Utilities/Configuration/Mutable/SandboxConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/SandboxConfiguration.cs
@@ -37,7 +37,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             CheckDetoursMessageCount = true;
             AllowInternalDetoursErrorNotificationFile = true;
             EnforceAccessPoliciesOnDirectoryCreation = false;
-            KextMeasureProcessCpuTimes = false;             // measuring CPU times amounts to wrapping processes in /usr/bin/time, so let's not do that by default
+            KextMeasureProcessCpuTimes = true;              // always measure process times + ram consumption
             KextReportQueueSizeMb = 0;                      // let the sandbox kernel extension apply defaults
             KextEnableReportBatching = true;                // use lock-free queue for batching access reports
             KextThrottleCpuUsageBlockThresholdPercent = 0;  // no throttling by default
@@ -245,17 +245,17 @@ namespace BuildXL.Utilities.Configuration.Mutable
 
         /// <nodoc />
         public List<AbsolutePath> GlobalUnsafeUntrackedScopes { get; set; }
-        
+
         /// <inheritdoc />
         IReadOnlyList<AbsolutePath> ISandboxConfiguration.GlobalUnsafeUntrackedScopes => GlobalUnsafeUntrackedScopes;
 
-        /// <inheritdoc /> 
+        /// <inheritdoc />
         public bool PreserveOutputsForIncrementalTool { get; set; }
 
-        /// <nodoc /> 
+        /// <nodoc />
         public List<string> GlobalUnsafePassthroughEnvironmentVariables { get; set; }
 
-        /// <inheritdoc /> 
+        /// <inheritdoc />
         IReadOnlyList<string> ISandboxConfiguration.GlobalUnsafePassthroughEnvironmentVariables => GlobalUnsafePassthroughEnvironmentVariables;
     }
 }

--- a/Public/Src/Utilities/Interop/Dispatch.cs
+++ b/Public/Src/Utilities/Interop/Dispatch.cs
@@ -70,8 +70,8 @@ namespace BuildXL.Interop
             {
                 case OperatingSystem.MacOS:
                 {
-                    var buffer = new MacOS.Process.ProcessTimesInfo();
-                    MacOS.Process.GetProcessTimes(proc.Id, ref buffer, includeChildProcesses: false);
+                    var buffer = new MacOS.Process.ProcessResourceUsage();
+                    MacOS.Process.GetProcessResourceUsage(proc.Id, ref buffer, includeChildProcesses: false);
                     long ticks = (long)(buffer.SystemTimeNs + buffer.UserTimeNs) / 100;
                     return new TimeSpan(ticks);
                 }

--- a/Public/Src/Utilities/Interop/MacOS/Memory.cs
+++ b/Public/Src/Utilities/Interop/MacOS/Memory.cs
@@ -64,5 +64,28 @@ namespace BuildXL.Interop.MacOS
         /// <param name="buffer">A long pointer to hold the process peak memory usage</param>
         [DllImport(Libraries.BuildXLInteropLibMacOS)]
         public static extern int GetPeakWorkingSetSize(int pid, ref ulong buffer);
+
+        /// <summary>
+        /// PressureLevel models the possible VM memory pressure levels on macOS
+        /// See: https://developer.apple.com/documentation/dispatch/dispatch_source_memorypressure_flags_t
+        /// </summary>
+        public enum PressureLevel : int
+        {
+            /// <nodoc />
+            Normal = 1,
+
+            /// <nodoc />
+            Warning = 2,
+
+            /// <nodoc />
+            Critical = 4
+        }
+
+        /// <summary>
+        /// Returns the current memory pressure level of the VM
+        /// </summary>
+        /// <param name="level">A PressureLevel pointer to hold the current VM memory pressure level</param>
+        [DllImport(Libraries.BuildXLInteropLibMacOS)]
+        public static extern int GetMemoryPressureLevel(ref PressureLevel level);
     }
 }

--- a/Public/Src/Utilities/Interop/MacOS/Process.cs
+++ b/Public/Src/Utilities/Interop/MacOS/Process.cs
@@ -13,7 +13,7 @@ namespace BuildXL.Interop.MacOS
     {
         /// <nodoc />
         [StructLayout(LayoutKind.Sequential)]
-        public struct ProcessTimesInfo
+        public struct ProcessResourceUsage
         {
             /// <nodoc />
             public double StartTime;
@@ -30,19 +30,29 @@ namespace BuildXL.Interop.MacOS
             /// User time of a given process in nanoseconds.
             /// </summary>
             public ulong UserTimeNs;
+
+            /// <summary>
+            /// User time of a given process in nanoseconds.
+            /// </summary>
+            public ulong BytesRead;
+
+            /// <summary>
+            /// User time of a given process in nanoseconds.
+            /// </summary>
+            public ulong BytesWritten;
         }
 
         [DllImport(Libraries.BuildXLInteropLibMacOS)]
-        private static extern int GetProcessTimes(int pid, ref ProcessTimesInfo buffer, long bufferSize, bool includeChildProcesses);
+        private static extern int GetProcessResourceUsage(int pid, ref ProcessResourceUsage buffer, long bufferSize, bool includeChildProcesses);
 
         /// <summary>
-        /// Returns process timing information to the caller
+        /// Returns process resource usage information to the caller
         /// </summary>
         /// <param name="pid">The process id to check</param>
-        /// <param name="buffer">A ProcesstTimesInfo struct to hold the process timing information</param>
+        /// <param name="buffer">A ProcessResourceUsage struct to hold the process resource information</param>
         /// <param name="includeChildProcesses">Whether the result should include the execution times of all the child processes</param>
-        public static int GetProcessTimes(int pid, ref ProcessTimesInfo buffer, bool includeChildProcesses)
-            => GetProcessTimes(pid, ref buffer, Marshal.SizeOf(buffer), includeChildProcesses);
+        public static int GetProcessResourceUsage(int pid, ref ProcessResourceUsage buffer, bool includeChildProcesses)
+            => GetProcessResourceUsage(pid, ref buffer, Marshal.SizeOf(buffer), includeChildProcesses);
 
         /// <summary>
         /// Returns true if core dump file creation for abnormal process exits has been set up successfully, and passes out

--- a/Public/Src/Utilities/Interop/MacOS/Process.cs
+++ b/Public/Src/Utilities/Interop/MacOS/Process.cs
@@ -32,12 +32,12 @@ namespace BuildXL.Interop.MacOS
             public ulong UserTimeNs;
 
             /// <summary>
-            /// User time of a given process in nanoseconds.
+            /// Bytes read from disk
             /// </summary>
             public ulong BytesRead;
 
             /// <summary>
-            /// User time of a given process in nanoseconds.
+            /// Bytes written to disk
             /// </summary>
             public ulong BytesWritten;
         }

--- a/Public/Src/Utilities/Interop/MacOS/Process.cs
+++ b/Public/Src/Utilities/Interop/MacOS/Process.cs
@@ -34,12 +34,12 @@ namespace BuildXL.Interop.MacOS
             /// <summary>
             /// Bytes read from disk
             /// </summary>
-            public ulong BytesRead;
+            public ulong DiskBytesRead;
 
             /// <summary>
             /// Bytes written to disk
             /// </summary>
-            public ulong BytesWritten;
+            public ulong DiskBytesWritten;
         }
 
         [DllImport(Libraries.BuildXLInteropLibMacOS)]

--- a/Public/Src/Utilities/UnitTests/TestUtilities.XUnit/XunitBuildXLTest.cs
+++ b/Public/Src/Utilities/UnitTests/TestUtilities.XUnit/XunitBuildXLTest.cs
@@ -36,7 +36,7 @@ namespace Test.BuildXL.TestUtilities.Xunit
             return OperatingSystemHelper.IsUnixOS
 #if PLATFORM_OSX
                 ? useEndpointSecuritySandbox
-                    ? (ISandboxConnection) new SandboxConnectionES()
+                    ? (ISandboxConnection) new SandboxConnectionES(isInTestMode: true, measureCpuTimes: true)
                     : (ISandboxConnection) new SandboxConnectionKext(
 #else
                     ? (ISandboxConnection) new SandboxConnectionKext(

--- a/Public/Src/Utilities/Utilities/PerformanceCollector.cs
+++ b/Public/Src/Utilities/Utilities/PerformanceCollector.cs
@@ -465,12 +465,6 @@ namespace BuildXL.Utilities
             // we have to look at VM statistics to calculate the actual available RAM though
             if (GetRamUsageInfo(ref ramUsageInfo) == MACOS_INTEROP_SUCCESS)
             {
-                // OLD formula based on Active pages (does not coincide with Activity Monitor)    
-                //availableAvailablePhysicalBytes =
-                //    totalPhysicalBytes - (ramUsageInfo.Active + ramUsageInfo.Speculative +
-                //        ramUsageInfo.Wired + ramUsageInfo.Compressed - ramUsageInfo.Purgable);
-
-                // "Physical Memory" - "Memory Used" from Activity Monitor
                 availableAvailablePhysicalBytes = totalPhysicalBytes
                     - ramUsageInfo.AppMemory
                     - ramUsageInfo.Wired

--- a/config.microsoftInternal.dsc
+++ b/config.microsoftInternal.dsc
@@ -11,7 +11,7 @@ export const pkgs = isMicrosoftInternal ? [
     { id: "BuildXL.DeviceMap", version: "0.0.1" },
 
     // Runtime dependencies used for macOS deployments
-    { id: "runtime.osx-x64.BuildXL", version: "1.98.99" },
+    { id: "runtime.osx-x64.BuildXL", version: "1.99.99" },
     { id: "Aria.Cpp.SDK", version: "8.5.6" },
 
     { id: "CB.QTest", version: "19.9.6.1149" },


### PR DESCRIPTION
This PR introduced proper support for memory observation (VM pressure + process tree consumption) and resource based canceling for macOS. 

It **also adds logic** to deal with issues present if outputs are created in shared opaque directories and the producing pip gets canceled and rerun due to resource based cancelation mechanics.