### PR TITLE
Treat error "Unable to read data from the  transport connection" as transient

### DIFF
--- a/Public/Src/Cache/ContentStore/Vsts/ArtifactHttpClientErrorDetectionStrategy.cs
+++ b/Public/Src/Cache/ContentStore/Vsts/ArtifactHttpClientErrorDetectionStrategy.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -133,7 +134,21 @@ namespace BuildXL.Cache.ContentStore.Vsts
         /// <inheritdoc />
         public bool IsTransient(Exception ex)
         {
-            return ex is TimeoutException || (ex is HttpRequestException && ex.InnerException is WebException);
+            if (ex is TimeoutException)
+            {
+                return true;
+            }
+
+            if (ex is HttpRequestException)
+            {
+                if (ex.InnerException is WebException ||
+                    (ex.InnerException is IOException && ex.InnerException.Message.Contains("Unable to read data from the transport connection")))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
We've seen failures with the unified cache when 'AddTarget' call failed with the following error without retries:

```
2019-09-11 21:43:27,424 [568] DEBUG 1b284919-6276-4d57-9b8d-b221c9e199e9 BuildCacheCache.AddOrGetContentHashList() stop 3615.295ms result=[Error Error=[HttpRequestException: Error while copying content to a stream.: 
Unable to read data from the transport connection: The connection was closed.] Diagnostics=[System.Net.Http.HttpRequestException: Error while copying content to a stream. ---> System.IO.IOException: Unable to read data from the transport connection: The connection was closed.
```

