### PR TITLE
Timeout proactive copies

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/FileSystem/IFileCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/FileSystem/IFileCopier.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using BuildXL.Cache.ContentStore.Hashing;
 using BuildXL.Cache.ContentStore.Interfaces.FileSystem;
 using BuildXL.Cache.ContentStore.Interfaces.Results;
-using BuildXL.Cache.ContentStore.Interfaces.Tracing;
+using BuildXL.Cache.ContentStore.Tracing.Internal;
 
 // ReSharper disable All
 namespace BuildXL.Cache.ContentStore.Distributed
@@ -64,6 +64,6 @@ namespace BuildXL.Cache.ContentStore.Distributed
         /// <param name="context">The context of the operation</param>
         /// <param name="hash">The hash of the file to be copied.</param>
         /// <param name="targetMachine">The machine that should copy the file</param>
-        Task<BoolResult> RequestCopyFileAsync(Context context, ContentHash hash, MachineLocation targetMachine);
+        Task<BoolResult> RequestCopyFileAsync(OperationContext context, ContentHash hash, MachineLocation targetMachine);
     }
 }

--- a/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
@@ -247,8 +247,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
                 {
                     var cts = new CancellationTokenSource();
                     cts.CancelAfter(_timeoutForPoractiveCopies);
-                    var innerToken = CancellationTokenSource.CreateLinkedTokenSource(context.Token, cts.Token).Token;
-                    var innerContext = new OperationContext(context, innerToken);
+                    var innerContext = context.CreateNested(cts.Token);
                     return context.PerformOperationAsync(
                         Tracer,
                         operation: () =>
@@ -261,7 +260,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
                             $"TargetLocation=[{targetLocation}] " +
                             $"IOGate.OccupiedCount={_settings.MaxConcurrentProactiveCopyOperations - _proactiveCopyIoGate.CurrentCount} " +
                             $"IOGate.Wait={ts.TotalMilliseconds}ms." +
-                            $"Timeout={innerToken.IsCancellationRequested}"
+                            $"Timeout={cts.Token.IsCancellationRequested}"
                         );
                 },
                 context.Token);

--- a/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentStoreSettings.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentStoreSettings.cs
@@ -146,6 +146,11 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
         public bool EnableProactiveCopy { get; set; } = false;
 
         /// <summary>
+        /// Time before a proactive copy times out.
+        /// </summary>
+        public TimeSpan TimeoutForProactiveCopies { get; set; } = TimeSpan.FromMinutes(15);
+
+        /// <summary>
         /// Maximum number of locations which should trigger a proactive copy.
         /// </summary>
         public int ProactiveCopyLocationsThreshold { get; set; } = 1;

--- a/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcFileCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcFileCopier.cs
@@ -13,6 +13,7 @@ using BuildXL.Cache.ContentStore.Interfaces.Results;
 using BuildXL.Cache.ContentStore.Interfaces.Tracing;
 using BuildXL.Cache.ContentStore.Interfaces.Utils;
 using BuildXL.Cache.ContentStore.Service.Grpc;
+using BuildXL.Cache.ContentStore.Tracing.Internal;
 
 namespace BuildXL.Cache.ContentStore.Distributed.Utilities
 {
@@ -104,7 +105,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Utilities
         }
 
         /// <inheritdoc />
-        public async Task<BoolResult> RequestCopyFileAsync(Context context, ContentHash hash, MachineLocation targetMachine)
+        public async Task<BoolResult> RequestCopyFileAsync(OperationContext context, ContentHash hash, MachineLocation targetMachine)
         {
             var targetPath = new AbsolutePath(targetMachine.Path);
             var targetMachineName = targetPath.IsLocal ? "localhost" : targetPath.GetSegments()[0];

--- a/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/TestFileCopier.cs
+++ b/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/TestFileCopier.cs
@@ -8,12 +8,10 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using BuildXL.Cache.ContentStore.Distributed;
-using BuildXL.Cache.ContentStore.Extensions;
 using BuildXL.Cache.ContentStore.Hashing;
 using BuildXL.Cache.ContentStore.Interfaces.FileSystem;
 using BuildXL.Cache.ContentStore.Interfaces.Results;
-using BuildXL.Cache.ContentStore.Interfaces.Sessions;
-using BuildXL.Cache.ContentStore.Interfaces.Tracing;
+using BuildXL.Cache.ContentStore.Tracing.Internal;
 using BuildXL.Cache.ContentStore.UtilitiesCore;
 using ContentStoreTest.Test;
 
@@ -137,7 +135,7 @@ namespace ContentStoreTest.Distributed.ContentLocation
             return 0;
         }
 
-        public Task<BoolResult> RequestCopyFileAsync(Context context, ContentHash hash, MachineLocation targetMachine)
+        public Task<BoolResult> RequestCopyFileAsync(OperationContext context, ContentHash hash, MachineLocation targetMachine)
         {
             return CopyHandlersByLocation[targetMachine].HandleCopyFileRequestAsync(context, hash);
         }

--- a/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcCopyClient.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcCopyClient.cs
@@ -232,18 +232,18 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
         /// <summary>
         /// Requests host to copy a file from another source machine.
         /// </summary>
-        public async Task<BoolResult> RequestCopyFileAsync(Context context, ContentHash hash)
+        public async Task<BoolResult> RequestCopyFileAsync(OperationContext context, ContentHash hash)
         {
             try
             {
                 var request = new RequestCopyFileRequest
                 {
-                    TraceId = context.Id.ToString(),
+                    TraceId = context.TracingContext.Id.ToString(),
                     ContentHash = hash.ToByteString(),
                     HashType = (int)hash.HashType
                 };
 
-                var response = await _client.RequestCopyFileAsync(request);
+                var response = await _client.RequestCopyFileAsync(request, cancellationToken: context.Token);
 
                 return response.Header.Succeeded
                     ? BoolResult.Success

--- a/Public/Src/Cache/ContentStore/Library/Tracing/OperationContext.cs
+++ b/Public/Src/Cache/ContentStore/Library/Tracing/OperationContext.cs
@@ -55,6 +55,12 @@ namespace BuildXL.Cache.ContentStore.Tracing.Internal
             return new OperationContext(new Context(TracingContext, id), Token);
         }
 
+        public OperationContext CreateNested(CancellationToken linkedCancellationToken)
+        {
+            var token = CancellationTokenSource.CreateLinkedTokenSource(Token, linkedCancellationToken).Token;
+            return new OperationContext(new Context(TracingContext), token);
+        }
+
         /// <nodoc />
         public OperationTracer Trace(Action operationStarted)
         {

--- a/Public/Src/Cache/ContentStore/Library/Tracing/OperationContext.cs
+++ b/Public/Src/Cache/ContentStore/Library/Tracing/OperationContext.cs
@@ -55,6 +55,7 @@ namespace BuildXL.Cache.ContentStore.Tracing.Internal
             return new OperationContext(new Context(TracingContext, id), Token);
         }
 
+        /// <nodoc />
         public OperationContext CreateNested(CancellationToken linkedCancellationToken)
         {
             var token = CancellationTokenSource.CreateLinkedTokenSource(Token, linkedCancellationToken).Token;

--- a/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
@@ -538,6 +538,9 @@ namespace BuildXL.Cache.Host.Configuration
         [DataMember]
         public bool UseRedisMetadataStore{ get; set; } = false;
 
+        [DataMember]
+        public int TimeoutForProactiveCopiesMinutes { get; set; } = 15;
+
         #endregion
 
         /// <summary>

--- a/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
@@ -219,6 +219,7 @@ namespace BuildXL.Cache.Host.Service.Internal
                         EmptyFileHashShortcutEnabled = _distributedSettings.EmptyFileHashShortcutEnabled,
                         RetryIntervalForCopies = _distributedSettings.RetryIntervalForCopies,
                         EnableProactiveCopy = _distributedSettings.EnableProactiveCopy,
+                        TimeoutForProactiveCopies = TimeSpan.FromMinutes(_distributedSettings.TimeoutForProactiveCopiesMinutes),
                         MaxConcurrentProactiveCopyOperations = _distributedSettings.MaxConcurrentProactiveCopyOperations,
                         ProactiveCopyLocationsThreshold = _distributedSettings.ProactiveCopyLocationsThreshold,
                         MaximumConcurrentPutFileOperations = _distributedSettings.MaximumConcurrentPutFileOperations,


### PR DESCRIPTION
Data shows that, after just 1 minute, more than 99% of successful proactive copies have already finished. Doing 15 minutes timeout to account for very large files.