### PR TITLE
Remove duplicate tracing from ContentLocationDatabase

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabaseCounters.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabaseCounters.cs
@@ -105,14 +105,6 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
 
         /// <nodoc />
         [CounterType(CounterType.Stopwatch)]
-        AddOrGetContentHashList,
-
-        /// <nodoc />
-        [CounterType(CounterType.Stopwatch)]
-        GetContentHashList,
-
-        /// <nodoc />
-        [CounterType(CounterType.Stopwatch)]
         GarbageCollectMetadata,
 
         /// <nodoc />


### PR DESCRIPTION
This tracing also happens in `DatabaseMemoizationStore`, rendering the tracing by the CLDB redundant. 