### PR TITLE
Fix Drop Associate method (missing files mismatch)

### DIFF
--- a/Public/Src/Tools/DropDaemon/VsoClient.cs
+++ b/Public/Src/Tools/DropDaemon/VsoClient.cs
@@ -309,7 +309,7 @@ namespace Tool.DropDaemon
 
                 // run 'Associate' on all items from the batch; the result will indicate which files were associated and which need to be uploaded
                 AssociationsStatus associateStatus = await AssociateAsync(blobsForAssociate);
-                IReadOnlyList<AddFileItem> itemsLeftToUpload = await SetResultForAssociatedNonMissingItems(batch, associateStatus, m_config.EnableChunkDedup, Token);
+                IReadOnlyList<AddFileItem> itemsLeftToUpload = await SetResultForAssociatedNonMissingItemsAsync(batch, associateStatus, m_config.EnableChunkDedup, Token);
 
                 // compute blobs for upload
                 startTime = DateTime.UtcNow;
@@ -347,9 +347,31 @@ namespace Tool.DropDaemon
                 abortIfAlreadyExists: false,
                 cancellationToken: Token).ConfigureAwait(false);
 
+            var result = associateResult.Item2;
+
             Interlocked.Add(ref Stats.TotalAssociateTimeMs, ElapsedMillis(startTime));
-            Interlocked.Add(ref Stats.NumFilesAssociated, blobsForAssociate.Length - associateResult.Item2.Missing.Count());
-            return associateResult.Item2;
+
+            var missingBlobIdsCount = associateResult.Item1.Count();
+            var associationsStatusMissingBlobsCount = associateResult.Item2.Missing.Count();
+            Interlocked.Add(ref Stats.NumFilesAssociated, blobsForAssociate.Length - missingBlobIdsCount);
+
+            if (missingBlobIdsCount != associationsStatusMissingBlobsCount)
+            {
+                m_logger.Warning("Mismatch in the number of missing files during Associate call -- missingBlobIdsCount={0}, associationsStatusMissingBlobsCount={1}",
+                    missingBlobIdsCount,
+                    associationsStatusMissingBlobsCount);
+
+                if (missingBlobIdsCount < associationsStatusMissingBlobsCount)
+                {
+                    // This is an unexpected scenario. If there is a mismatch, count(associateResult.Item1) must be >= count(associateResult.Item2.Missing).
+                    Contract.Assert(false, "Unexpected mismatch in the number of missing files.");
+                }
+
+                // 'fix' AssociationsStatus so it contains all the missing files. 
+                result.Missing = associateResult.Item1;
+            }
+
+            return result;
         }
 
         private async Task UploadAndAssociateAsync(AssociationsStatus associateStatus, FileBlobDescriptor[] blobsForUpload)
@@ -398,10 +420,10 @@ namespace Tool.DropDaemon
         ///     (as indicated by <paramref name="associateStatus"/>), and returns <see cref="AddFileItem"/>s
         ///     for those that are missing (<see cref="AssociationsStatus.Missing"/>).
         /// </summary>
-        private static async Task<IReadOnlyList<AddFileItem>> SetResultForAssociatedNonMissingItems(AddFileItem[] batch, AssociationsStatus associateStatus, bool chunkDedup, CancellationToken cancellationToken)
+        private static async Task<IReadOnlyList<AddFileItem>> SetResultForAssociatedNonMissingItemsAsync(AddFileItem[] batch, AssociationsStatus associateStatus, bool chunkDedup, CancellationToken cancellationToken)
         {
             var missingItems = new List<AddFileItem>();
-            var missingBlobIds = associateStatus.Missing;
+            var missingBlobIds = new HashSet<BlobIdentifier>(associateStatus.Missing);
             foreach (AddFileItem item in batch)
             {
                 var itemFileBlobDescriptor = await item.FileBlobDescriptorForAssociateAsync(chunkDedup, cancellationToken);


### PR DESCRIPTION
It appears that during drop associate call we were using a field that might not contain the full list of missing blobs.

[AB#1598050](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1598050)