### PR TITLE
Add mac assemblies in cache packages

### DIFF
--- a/Public/Sdk/Public/Managed/Tools/NuGet/pack.dsc
+++ b/Public/Sdk/Public/Managed/Tools/NuGet/pack.dsc
@@ -306,7 +306,7 @@ export function createAssemblyLayout(assembly: Managed.Assembly) : Deployment.De
 }
 
 @@public
-export function createAssemblyLayoutWithSubfolder(assembly: Managed.Assembly, subfolder: string) : Deployment.Definition {
+export function createAssemblyLayoutWithSpecificRuntime(assembly: Managed.Assembly, runtime: string) : Deployment.Definition {
     // When the assembly is undefined, return empty deployment.
     if (assembly === undefined) {
         return {
@@ -317,15 +317,9 @@ export function createAssemblyLayoutWithSubfolder(assembly: Managed.Assembly, su
     return {
         contents: [
             {
-                subfolder: r`lib/${assembly.targetFramework}/${subfolder}`,
+                subfolder: r`runtimes/${runtime}/lib/${assembly.targetFramework}`,
                 contents: [
                     assembly.runtime || emptyFile,
-                ]
-            },
-            {
-                subfolder: r`ref/${assembly.targetFramework}/${subfolder}`,
-                contents: [
-                    assembly.compile || emptyFile,
                 ]
             }
         ]

--- a/Public/Sdk/Public/Managed/Tools/NuGet/pack.dsc
+++ b/Public/Sdk/Public/Managed/Tools/NuGet/pack.dsc
@@ -304,3 +304,30 @@ export function createAssemblyLayout(assembly: Managed.Assembly) : Deployment.De
         ]
     };
 }
+
+@@public
+export function createAssemblyLayoutWithSubfolder(assembly: Managed.Assembly, subfolder: string) : Deployment.Definition {
+    // When the assembly is undefined, return empty deployment.
+    if (assembly === undefined) {
+        return {
+            contents: []
+        };
+    }
+
+    return {
+        contents: [
+            {
+                subfolder: r`lib/${assembly.targetFramework}/${subfolder}`,
+                contents: [
+                    assembly.runtime || emptyFile,
+                ]
+            },
+            {
+                subfolder: r`ref/${assembly.targetFramework}/${subfolder}`,
+                contents: [
+                    assembly.compile || emptyFile,
+                ]
+            }
+        ]
+    };
+}

--- a/Public/Sdk/Public/Managed/Tools/NuGet/pack.dsc
+++ b/Public/Sdk/Public/Managed/Tools/NuGet/pack.dsc
@@ -306,7 +306,7 @@ export function createAssemblyLayout(assembly: Managed.Assembly) : Deployment.De
 }
 
 @@public
-export function createAssemblyLayoutWithSpecificRuntime(assembly: Managed.Assembly, runtime: string) : Deployment.Definition {
+export function createAssemblyLayoutWithSpecificRuntime(assembly: Managed.Assembly, runtime: string, includeInRef: boolean) : Deployment.Definition {
     // When the assembly is undefined, return empty deployment.
     if (assembly === undefined) {
         return {
@@ -321,7 +321,15 @@ export function createAssemblyLayoutWithSpecificRuntime(assembly: Managed.Assemb
                 contents: [
                     assembly.runtime || emptyFile,
                 ]
-            }
+            },
+            ... includeInRef ? [
+                {
+                    subfolder: r`ref/${assembly.targetFramework}`,
+                    contents: [
+                        assembly.compile || emptyFile,
+                    ]
+                }
+            ] : []
         ]
     };
 }

--- a/Public/Src/Deployment/cache.NugetPackages.dsc
+++ b/Public/Src/Deployment/cache.NugetPackages.dsc
@@ -11,13 +11,16 @@ namespace Cache.NugetPackages {
     const Net451ContentStore = importFrom("BuildXL.Cache.ContentStore").withQualifier({ configuration: qualifier.configuration, targetFramework: "net451", targetRuntime: "win-x64" });
     const Net472ContentStore = importFrom("BuildXL.Cache.ContentStore").withQualifier({ configuration: qualifier.configuration, targetFramework: "net472", targetRuntime: "win-x64" });
     const WinX64ContentStore = importFrom("BuildXL.Cache.ContentStore").withQualifier({ configuration: qualifier.configuration, targetFramework: "netcoreapp3.0", targetRuntime: "win-x64" });
+    const OsxX64ContentStore = importFrom("BuildXL.Cache.ContentStore").withQualifier({ configuration: qualifier.configuration, targetFramework: "netcoreapp3.0", targetRuntime: "osx-x64" });
 
     const Net451MemoizationStore = importFrom("BuildXL.Cache.MemoizationStore").withQualifier({ configuration: qualifier.configuration, targetFramework: "net451", targetRuntime: "win-x64" });
     const Net472MemoizationStore = importFrom("BuildXL.Cache.MemoizationStore").withQualifier({ configuration: qualifier.configuration, targetFramework: "net472", targetRuntime: "win-x64" });
     const WinX64MemoizationStore = importFrom("BuildXL.Cache.MemoizationStore").withQualifier({ configuration: qualifier.configuration, targetFramework: "netcoreapp3.0", targetRuntime: "win-x64" });
+    const OsxX64MemoizationStore = importFrom("BuildXL.Cache.MemoizationStore").withQualifier({ configuration: qualifier.configuration, targetFramework: "netcoreapp3.0", targetRuntime: "osx-x64" });
 
     const Net472DistributedCacheHost = importFrom("BuildXL.Cache.DistributedCache.Host").withQualifier({ configuration: qualifier.configuration, targetFramework: "net472", targetRuntime: "win-x64" });
     const WinX64DistributedCacheHost = importFrom("BuildXL.Cache.DistributedCache.Host").withQualifier({ configuration: qualifier.configuration, targetFramework: "netcoreapp3.0", targetRuntime: "win-x64" });
+    const OsxX64DistributedCacheHost = importFrom("BuildXL.Cache.DistributedCache.Host").withQualifier({ configuration: qualifier.configuration, targetFramework: "netcoreapp3.0", targetRuntime: "osx-x64" });
 
     export const tools : Deployment.Definition = {
         contents: [
@@ -38,15 +41,18 @@ namespace Cache.NugetPackages {
             // ContentStore.Distributed
             Nuget.createAssemblyLayout(Net451ContentStore.Distributed.dll),
             Nuget.createAssemblyLayout(Net472ContentStore.Distributed.dll),
-            Nuget.createAssemblyLayout(WinX64ContentStore.Distributed.dll),
+            Nuget.createAssemblyLayoutWithSubfolder(WinX64ContentStore.Distributed.dll, "win-x64"),
+            Nuget.createAssemblyLayoutWithSubfolder(OsxX64ContentStore.Distributed.dll, "osx-x64"),
             // ContentStore.Library
             Nuget.createAssemblyLayout(Net451ContentStore.Library.dll),
             Nuget.createAssemblyLayout(Net472ContentStore.Library.dll),
-            Nuget.createAssemblyLayout(WinX64ContentStore.Library.dll),
+            Nuget.createAssemblyLayoutWithSubfolder(WinX64ContentStore.Library.dll, "win-x64"),
+            Nuget.createAssemblyLayoutWithSubfolder(OsxX64ContentStore.Library.dll, "osx-x64"),
             // ContentStore.Grpc
             Nuget.createAssemblyLayout(Net451ContentStore.Grpc.dll),
             Nuget.createAssemblyLayout(Net472ContentStore.Grpc.dll),
-            Nuget.createAssemblyLayout(WinX64ContentStore.Grpc.dll),
+            Nuget.createAssemblyLayoutWithSubfolder(WinX64ContentStore.Grpc.dll, "win-x64"),
+            Nuget.createAssemblyLayoutWithSubfolder(OsxX64ContentStore.Grpc.dll, "osx-x64"),
 
             // ContentStore.Vsts
             ...addIfLazy(BuildXLSdk.Flags.isVstsArtifactsEnabled, () => [
@@ -57,16 +63,19 @@ namespace Cache.NugetPackages {
             // ContentStore.VstsInterfaces
             Nuget.createAssemblyLayout(Net451ContentStore.VstsInterfaces.dll),
             Nuget.createAssemblyLayout(Net472ContentStore.VstsInterfaces.dll),
-            Nuget.createAssemblyLayout(WinX64ContentStore.VstsInterfaces.dll),
+            Nuget.createAssemblyLayoutWithSubfolder(WinX64ContentStore.VstsInterfaces.dll, "win-x64"),
+            Nuget.createAssemblyLayoutWithSubfolder(OsxX64ContentStore.VstsInterfaces.dll, "osx-x64"),
 
             // MemoizationStore.Distributed
             Nuget.createAssemblyLayout(Net451MemoizationStore.Distributed.dll),
             Nuget.createAssemblyLayout(Net472MemoizationStore.Distributed.dll),
-            Nuget.createAssemblyLayout(WinX64MemoizationStore.Distributed.dll),
+            Nuget.createAssemblyLayoutWithSubfolder(WinX64MemoizationStore.Distributed.dll, "win-x64"),
+            Nuget.createAssemblyLayoutWithSubfolder(OsxX64MemoizationStore.Distributed.dll, "osx-x64"),
             // MemoizationStore.Library
             Nuget.createAssemblyLayout(Net451MemoizationStore.Library.dll),
             Nuget.createAssemblyLayout(Net472MemoizationStore.Library.dll),
-            Nuget.createAssemblyLayout(WinX64MemoizationStore.Library.dll),
+            Nuget.createAssemblyLayoutWithSubfolder(WinX64MemoizationStore.Library.dll, "win-x64"),
+            Nuget.createAssemblyLayoutWithSubfolder(OsxX64MemoizationStore.Library.dll, "osx-x64"),
 
             // MemoizationStore.Vsts
             ...addIfLazy(BuildXLSdk.Flags.isVstsArtifactsEnabled, () => [
@@ -77,15 +86,18 @@ namespace Cache.NugetPackages {
             // MemoizationStore.VstsInterfaces
             Nuget.createAssemblyLayout(Net451MemoizationStore.VstsInterfaces.dll),
             Nuget.createAssemblyLayout(Net472MemoizationStore.VstsInterfaces.dll),
-            Nuget.createAssemblyLayout(WinX64MemoizationStore.VstsInterfaces.dll),
+            Nuget.createAssemblyLayoutWithSubfolder(WinX64MemoizationStore.VstsInterfaces.dll, "win-x64"),
+            Nuget.createAssemblyLayoutWithSubfolder(OsxX64MemoizationStore.VstsInterfaces.dll, "osx-x64"),
 
             // BuildXL.Cache.Host.Services
             Nuget.createAssemblyLayout(Net472DistributedCacheHost.Service.dll),
-            Nuget.createAssemblyLayout(WinX64DistributedCacheHost.Service.dll),
+            Nuget.createAssemblyLayoutWithSubfolder(WinX64DistributedCacheHost.Service.dll, "win-x64"),
+            Nuget.createAssemblyLayoutWithSubfolder(OsxX64DistributedCacheHost.Service.dll, "osx-x64"),
 
             // BuildXL.Cache.Host.Configuration
             Nuget.createAssemblyLayout(Net472DistributedCacheHost.Configuration.dll),
-            Nuget.createAssemblyLayout(WinX64DistributedCacheHost.Configuration.dll),
+            Nuget.createAssemblyLayoutWithSubfolder(WinX64DistributedCacheHost.Configuration.dll, "win-x64"),
+            Nuget.createAssemblyLayoutWithSubfolder(OsxX64DistributedCacheHost.Configuration.dll, "osx-x64"),
         ]
     };
 
@@ -94,7 +106,8 @@ namespace Cache.NugetPackages {
             // ContentStore.Interfaces
             Nuget.createAssemblyLayout(Net451ContentStore.Interfaces.dll),
             Nuget.createAssemblyLayout(Net472ContentStore.Interfaces.dll),
-            Nuget.createAssemblyLayout(WinX64ContentStore.Interfaces.dll),
+            Nuget.createAssemblyLayoutWithSubfolder(WinX64ContentStore.Interfaces.dll, "win-x64"),
+            Nuget.createAssemblyLayoutWithSubfolder(OsxX64ContentStore.Interfaces.dll, "osx-x64"),
             Nuget.createAssemblyLayout(importFrom("BuildXL.Cache.ContentStore").Interfaces.withQualifier(
                 { configuration: qualifier.configuration, targetFramework: "netstandard2.0", targetRuntime: "win-x64" }
             ).dll),
@@ -102,7 +115,8 @@ namespace Cache.NugetPackages {
             // MemoizationStore.Interfaces
             Nuget.createAssemblyLayout(Net451MemoizationStore.Interfaces.dll),
             Nuget.createAssemblyLayout(Net472MemoizationStore.Interfaces.dll),
-            Nuget.createAssemblyLayout(WinX64MemoizationStore.Interfaces.dll),
+            Nuget.createAssemblyLayoutWithSubfolder(WinX64MemoizationStore.Interfaces.dll, "win-x64"),
+            Nuget.createAssemblyLayoutWithSubfolder(OsxX64MemoizationStore.Interfaces.dll, "osx-x64"),
         ]
     };
 
@@ -111,7 +125,8 @@ namespace Cache.NugetPackages {
             // ContentStore.Hashing
             Nuget.createAssemblyLayout(Net451ContentStore.Hashing.dll),
             Nuget.createAssemblyLayout(Net472ContentStore.Hashing.dll),
-            Nuget.createAssemblyLayout(WinX64ContentStore.Hashing.dll),
+            Nuget.createAssemblyLayoutWithSubfolder(WinX64ContentStore.Hashing.dll, "win-x64"),
+            Nuget.createAssemblyLayoutWithSubfolder(OsxX64ContentStore.Hashing.dll, "osx-x64"),
             Nuget.createAssemblyLayout(importFrom("BuildXL.Cache.ContentStore").Hashing.withQualifier(
                 { configuration: qualifier.configuration, targetFramework: "netstandard2.0", targetRuntime: "win-x64" }
             ).dll),
@@ -119,7 +134,8 @@ namespace Cache.NugetPackages {
             // ContentStore.UtilitiesCore
             Nuget.createAssemblyLayout(Net451ContentStore.UtilitiesCore.dll),
             Nuget.createAssemblyLayout(Net472ContentStore.UtilitiesCore.dll),
-            Nuget.createAssemblyLayout(WinX64ContentStore.UtilitiesCore.dll),
+            Nuget.createAssemblyLayoutWithSubfolder(WinX64ContentStore.UtilitiesCore.dll, "win-x64"),
+            Nuget.createAssemblyLayoutWithSubfolder(OsxX64ContentStore.UtilitiesCore.dll, "osx-x64"),
             Nuget.createAssemblyLayout(importFrom("BuildXL.Cache.ContentStore").UtilitiesCore.withQualifier(
                 { configuration: qualifier.configuration, targetFramework: "netstandard2.0", targetRuntime: "win-x64" }
             ).dll),

--- a/Public/Src/Deployment/cache.NugetPackages.dsc
+++ b/Public/Src/Deployment/cache.NugetPackages.dsc
@@ -41,18 +41,18 @@ namespace Cache.NugetPackages {
             // ContentStore.Distributed
             Nuget.createAssemblyLayout(Net451ContentStore.Distributed.dll),
             Nuget.createAssemblyLayout(Net472ContentStore.Distributed.dll),
-            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64ContentStore.Distributed.dll, "win-x64"),
-            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64ContentStore.Distributed.dll, "osx-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64ContentStore.Distributed.dll, "win-x64", true),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64ContentStore.Distributed.dll, "osx-x64", false),
             // ContentStore.Library
             Nuget.createAssemblyLayout(Net451ContentStore.Library.dll),
             Nuget.createAssemblyLayout(Net472ContentStore.Library.dll),
-            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64ContentStore.Library.dll, "win-x64"),
-            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64ContentStore.Library.dll, "osx-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64ContentStore.Library.dll, "win-x64", true),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64ContentStore.Library.dll, "osx-x64", false),
             // ContentStore.Grpc
             Nuget.createAssemblyLayout(Net451ContentStore.Grpc.dll),
             Nuget.createAssemblyLayout(Net472ContentStore.Grpc.dll),
-            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64ContentStore.Grpc.dll, "win-x64"),
-            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64ContentStore.Grpc.dll, "osx-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64ContentStore.Grpc.dll, "win-x64", true),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64ContentStore.Grpc.dll, "osx-x64", false),
 
             // ContentStore.Vsts
             ...addIfLazy(BuildXLSdk.Flags.isVstsArtifactsEnabled, () => [
@@ -63,19 +63,19 @@ namespace Cache.NugetPackages {
             // ContentStore.VstsInterfaces
             Nuget.createAssemblyLayout(Net451ContentStore.VstsInterfaces.dll),
             Nuget.createAssemblyLayout(Net472ContentStore.VstsInterfaces.dll),
-            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64ContentStore.VstsInterfaces.dll, "win-x64"),
-            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64ContentStore.VstsInterfaces.dll, "osx-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64ContentStore.VstsInterfaces.dll, "win-x64", true),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64ContentStore.VstsInterfaces.dll, "osx-x64", false),
 
             // MemoizationStore.Distributed
             Nuget.createAssemblyLayout(Net451MemoizationStore.Distributed.dll),
             Nuget.createAssemblyLayout(Net472MemoizationStore.Distributed.dll),
-            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64MemoizationStore.Distributed.dll, "win-x64"),
-            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64MemoizationStore.Distributed.dll, "osx-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64MemoizationStore.Distributed.dll, "win-x64", true),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64MemoizationStore.Distributed.dll, "osx-x64", false),
             // MemoizationStore.Library
             Nuget.createAssemblyLayout(Net451MemoizationStore.Library.dll),
             Nuget.createAssemblyLayout(Net472MemoizationStore.Library.dll),
-            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64MemoizationStore.Library.dll, "win-x64"),
-            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64MemoizationStore.Library.dll, "osx-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64MemoizationStore.Library.dll, "win-x64", true),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64MemoizationStore.Library.dll, "osx-x64", false),
 
             // MemoizationStore.Vsts
             ...addIfLazy(BuildXLSdk.Flags.isVstsArtifactsEnabled, () => [
@@ -86,18 +86,18 @@ namespace Cache.NugetPackages {
             // MemoizationStore.VstsInterfaces
             Nuget.createAssemblyLayout(Net451MemoizationStore.VstsInterfaces.dll),
             Nuget.createAssemblyLayout(Net472MemoizationStore.VstsInterfaces.dll),
-            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64MemoizationStore.VstsInterfaces.dll, "win-x64"),
-            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64MemoizationStore.VstsInterfaces.dll, "osx-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64MemoizationStore.VstsInterfaces.dll, "win-x64", true),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64MemoizationStore.VstsInterfaces.dll, "osx-x64", false),
 
             // BuildXL.Cache.Host.Services
             Nuget.createAssemblyLayout(Net472DistributedCacheHost.Service.dll),
-            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64DistributedCacheHost.Service.dll, "win-x64"),
-            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64DistributedCacheHost.Service.dll, "osx-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64DistributedCacheHost.Service.dll, "win-x64", true),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64DistributedCacheHost.Service.dll, "osx-x64", false),
 
             // BuildXL.Cache.Host.Configuration
             Nuget.createAssemblyLayout(Net472DistributedCacheHost.Configuration.dll),
-            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64DistributedCacheHost.Configuration.dll, "win-x64"),
-            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64DistributedCacheHost.Configuration.dll, "osx-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64DistributedCacheHost.Configuration.dll, "win-x64", true),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64DistributedCacheHost.Configuration.dll, "osx-x64", false),
         ]
     };
 
@@ -106,8 +106,8 @@ namespace Cache.NugetPackages {
             // ContentStore.Interfaces
             Nuget.createAssemblyLayout(Net451ContentStore.Interfaces.dll),
             Nuget.createAssemblyLayout(Net472ContentStore.Interfaces.dll),
-            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64ContentStore.Interfaces.dll, "win-x64"),
-            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64ContentStore.Interfaces.dll, "osx-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64ContentStore.Interfaces.dll, "win-x64", true),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64ContentStore.Interfaces.dll, "osx-x64", false),
             Nuget.createAssemblyLayout(importFrom("BuildXL.Cache.ContentStore").Interfaces.withQualifier(
                 { configuration: qualifier.configuration, targetFramework: "netstandard2.0", targetRuntime: "win-x64" }
             ).dll),
@@ -115,8 +115,8 @@ namespace Cache.NugetPackages {
             // MemoizationStore.Interfaces
             Nuget.createAssemblyLayout(Net451MemoizationStore.Interfaces.dll),
             Nuget.createAssemblyLayout(Net472MemoizationStore.Interfaces.dll),
-            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64MemoizationStore.Interfaces.dll, "win-x64"),
-            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64MemoizationStore.Interfaces.dll, "osx-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64MemoizationStore.Interfaces.dll, "win-x64", true),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64MemoizationStore.Interfaces.dll, "osx-x64", false),
         ]
     };
 
@@ -125,8 +125,8 @@ namespace Cache.NugetPackages {
             // ContentStore.Hashing
             Nuget.createAssemblyLayout(Net451ContentStore.Hashing.dll),
             Nuget.createAssemblyLayout(Net472ContentStore.Hashing.dll),
-            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64ContentStore.Hashing.dll, "win-x64"),
-            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64ContentStore.Hashing.dll, "osx-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64ContentStore.Hashing.dll, "win-x64", true),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64ContentStore.Hashing.dll, "osx-x64", false),
             Nuget.createAssemblyLayout(importFrom("BuildXL.Cache.ContentStore").Hashing.withQualifier(
                 { configuration: qualifier.configuration, targetFramework: "netstandard2.0", targetRuntime: "win-x64" }
             ).dll),
@@ -134,8 +134,8 @@ namespace Cache.NugetPackages {
             // ContentStore.UtilitiesCore
             Nuget.createAssemblyLayout(Net451ContentStore.UtilitiesCore.dll),
             Nuget.createAssemblyLayout(Net472ContentStore.UtilitiesCore.dll),
-            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64ContentStore.UtilitiesCore.dll, "win-x64"),
-            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64ContentStore.UtilitiesCore.dll, "osx-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64ContentStore.UtilitiesCore.dll, "win-x64", true),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64ContentStore.UtilitiesCore.dll, "osx-x64", false),
             Nuget.createAssemblyLayout(importFrom("BuildXL.Cache.ContentStore").UtilitiesCore.withQualifier(
                 { configuration: qualifier.configuration, targetFramework: "netstandard2.0", targetRuntime: "win-x64" }
             ).dll),

--- a/Public/Src/Deployment/cache.NugetPackages.dsc
+++ b/Public/Src/Deployment/cache.NugetPackages.dsc
@@ -41,18 +41,18 @@ namespace Cache.NugetPackages {
             // ContentStore.Distributed
             Nuget.createAssemblyLayout(Net451ContentStore.Distributed.dll),
             Nuget.createAssemblyLayout(Net472ContentStore.Distributed.dll),
-            Nuget.createAssemblyLayoutWithSubfolder(WinX64ContentStore.Distributed.dll, "win-x64"),
-            Nuget.createAssemblyLayoutWithSubfolder(OsxX64ContentStore.Distributed.dll, "osx-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64ContentStore.Distributed.dll, "win-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64ContentStore.Distributed.dll, "osx-x64"),
             // ContentStore.Library
             Nuget.createAssemblyLayout(Net451ContentStore.Library.dll),
             Nuget.createAssemblyLayout(Net472ContentStore.Library.dll),
-            Nuget.createAssemblyLayoutWithSubfolder(WinX64ContentStore.Library.dll, "win-x64"),
-            Nuget.createAssemblyLayoutWithSubfolder(OsxX64ContentStore.Library.dll, "osx-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64ContentStore.Library.dll, "win-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64ContentStore.Library.dll, "osx-x64"),
             // ContentStore.Grpc
             Nuget.createAssemblyLayout(Net451ContentStore.Grpc.dll),
             Nuget.createAssemblyLayout(Net472ContentStore.Grpc.dll),
-            Nuget.createAssemblyLayoutWithSubfolder(WinX64ContentStore.Grpc.dll, "win-x64"),
-            Nuget.createAssemblyLayoutWithSubfolder(OsxX64ContentStore.Grpc.dll, "osx-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64ContentStore.Grpc.dll, "win-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64ContentStore.Grpc.dll, "osx-x64"),
 
             // ContentStore.Vsts
             ...addIfLazy(BuildXLSdk.Flags.isVstsArtifactsEnabled, () => [
@@ -63,19 +63,19 @@ namespace Cache.NugetPackages {
             // ContentStore.VstsInterfaces
             Nuget.createAssemblyLayout(Net451ContentStore.VstsInterfaces.dll),
             Nuget.createAssemblyLayout(Net472ContentStore.VstsInterfaces.dll),
-            Nuget.createAssemblyLayoutWithSubfolder(WinX64ContentStore.VstsInterfaces.dll, "win-x64"),
-            Nuget.createAssemblyLayoutWithSubfolder(OsxX64ContentStore.VstsInterfaces.dll, "osx-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64ContentStore.VstsInterfaces.dll, "win-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64ContentStore.VstsInterfaces.dll, "osx-x64"),
 
             // MemoizationStore.Distributed
             Nuget.createAssemblyLayout(Net451MemoizationStore.Distributed.dll),
             Nuget.createAssemblyLayout(Net472MemoizationStore.Distributed.dll),
-            Nuget.createAssemblyLayoutWithSubfolder(WinX64MemoizationStore.Distributed.dll, "win-x64"),
-            Nuget.createAssemblyLayoutWithSubfolder(OsxX64MemoizationStore.Distributed.dll, "osx-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64MemoizationStore.Distributed.dll, "win-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64MemoizationStore.Distributed.dll, "osx-x64"),
             // MemoizationStore.Library
             Nuget.createAssemblyLayout(Net451MemoizationStore.Library.dll),
             Nuget.createAssemblyLayout(Net472MemoizationStore.Library.dll),
-            Nuget.createAssemblyLayoutWithSubfolder(WinX64MemoizationStore.Library.dll, "win-x64"),
-            Nuget.createAssemblyLayoutWithSubfolder(OsxX64MemoizationStore.Library.dll, "osx-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64MemoizationStore.Library.dll, "win-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64MemoizationStore.Library.dll, "osx-x64"),
 
             // MemoizationStore.Vsts
             ...addIfLazy(BuildXLSdk.Flags.isVstsArtifactsEnabled, () => [
@@ -86,18 +86,18 @@ namespace Cache.NugetPackages {
             // MemoizationStore.VstsInterfaces
             Nuget.createAssemblyLayout(Net451MemoizationStore.VstsInterfaces.dll),
             Nuget.createAssemblyLayout(Net472MemoizationStore.VstsInterfaces.dll),
-            Nuget.createAssemblyLayoutWithSubfolder(WinX64MemoizationStore.VstsInterfaces.dll, "win-x64"),
-            Nuget.createAssemblyLayoutWithSubfolder(OsxX64MemoizationStore.VstsInterfaces.dll, "osx-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64MemoizationStore.VstsInterfaces.dll, "win-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64MemoizationStore.VstsInterfaces.dll, "osx-x64"),
 
             // BuildXL.Cache.Host.Services
             Nuget.createAssemblyLayout(Net472DistributedCacheHost.Service.dll),
-            Nuget.createAssemblyLayoutWithSubfolder(WinX64DistributedCacheHost.Service.dll, "win-x64"),
-            Nuget.createAssemblyLayoutWithSubfolder(OsxX64DistributedCacheHost.Service.dll, "osx-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64DistributedCacheHost.Service.dll, "win-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64DistributedCacheHost.Service.dll, "osx-x64"),
 
             // BuildXL.Cache.Host.Configuration
             Nuget.createAssemblyLayout(Net472DistributedCacheHost.Configuration.dll),
-            Nuget.createAssemblyLayoutWithSubfolder(WinX64DistributedCacheHost.Configuration.dll, "win-x64"),
-            Nuget.createAssemblyLayoutWithSubfolder(OsxX64DistributedCacheHost.Configuration.dll, "osx-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64DistributedCacheHost.Configuration.dll, "win-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64DistributedCacheHost.Configuration.dll, "osx-x64"),
         ]
     };
 
@@ -106,8 +106,8 @@ namespace Cache.NugetPackages {
             // ContentStore.Interfaces
             Nuget.createAssemblyLayout(Net451ContentStore.Interfaces.dll),
             Nuget.createAssemblyLayout(Net472ContentStore.Interfaces.dll),
-            Nuget.createAssemblyLayoutWithSubfolder(WinX64ContentStore.Interfaces.dll, "win-x64"),
-            Nuget.createAssemblyLayoutWithSubfolder(OsxX64ContentStore.Interfaces.dll, "osx-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64ContentStore.Interfaces.dll, "win-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64ContentStore.Interfaces.dll, "osx-x64"),
             Nuget.createAssemblyLayout(importFrom("BuildXL.Cache.ContentStore").Interfaces.withQualifier(
                 { configuration: qualifier.configuration, targetFramework: "netstandard2.0", targetRuntime: "win-x64" }
             ).dll),
@@ -115,8 +115,8 @@ namespace Cache.NugetPackages {
             // MemoizationStore.Interfaces
             Nuget.createAssemblyLayout(Net451MemoizationStore.Interfaces.dll),
             Nuget.createAssemblyLayout(Net472MemoizationStore.Interfaces.dll),
-            Nuget.createAssemblyLayoutWithSubfolder(WinX64MemoizationStore.Interfaces.dll, "win-x64"),
-            Nuget.createAssemblyLayoutWithSubfolder(OsxX64MemoizationStore.Interfaces.dll, "osx-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64MemoizationStore.Interfaces.dll, "win-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64MemoizationStore.Interfaces.dll, "osx-x64"),
         ]
     };
 
@@ -125,8 +125,8 @@ namespace Cache.NugetPackages {
             // ContentStore.Hashing
             Nuget.createAssemblyLayout(Net451ContentStore.Hashing.dll),
             Nuget.createAssemblyLayout(Net472ContentStore.Hashing.dll),
-            Nuget.createAssemblyLayoutWithSubfolder(WinX64ContentStore.Hashing.dll, "win-x64"),
-            Nuget.createAssemblyLayoutWithSubfolder(OsxX64ContentStore.Hashing.dll, "osx-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64ContentStore.Hashing.dll, "win-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64ContentStore.Hashing.dll, "osx-x64"),
             Nuget.createAssemblyLayout(importFrom("BuildXL.Cache.ContentStore").Hashing.withQualifier(
                 { configuration: qualifier.configuration, targetFramework: "netstandard2.0", targetRuntime: "win-x64" }
             ).dll),
@@ -134,8 +134,8 @@ namespace Cache.NugetPackages {
             // ContentStore.UtilitiesCore
             Nuget.createAssemblyLayout(Net451ContentStore.UtilitiesCore.dll),
             Nuget.createAssemblyLayout(Net472ContentStore.UtilitiesCore.dll),
-            Nuget.createAssemblyLayoutWithSubfolder(WinX64ContentStore.UtilitiesCore.dll, "win-x64"),
-            Nuget.createAssemblyLayoutWithSubfolder(OsxX64ContentStore.UtilitiesCore.dll, "osx-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(WinX64ContentStore.UtilitiesCore.dll, "win-x64"),
+            Nuget.createAssemblyLayoutWithSpecificRuntime(OsxX64ContentStore.UtilitiesCore.dll, "osx-x64"),
             Nuget.createAssemblyLayout(importFrom("BuildXL.Cache.ContentStore").UtilitiesCore.withQualifier(
                 { configuration: qualifier.configuration, targetFramework: "netstandard2.0", targetRuntime: "win-x64" }
             ).dll),

--- a/Public/Src/Deployment/privatePackages.dsc
+++ b/Public/Src/Deployment/privatePackages.dsc
@@ -17,6 +17,7 @@ namespace PrivatePackages {
     const net451Qualifier : BuildXLSdk.DefaultQualifierWithNet451 = { configuration: qualifier.configuration, targetFramework: "net451", targetRuntime: "win-x64" };
     const net472Qualifier : BuildXLSdk.DefaultQualifier = { configuration: qualifier.configuration, targetFramework: "net472", targetRuntime: "win-x64" };
     const winx64Qualifier : BuildXLSdk.DefaultQualifier = { configuration: qualifier.configuration, targetFramework: "netcoreapp3.0", targetRuntime: "win-x64" };
+    const osxx64Qualifier : BuildXLSdk.DefaultQualifier = { configuration: qualifier.configuration, targetFramework: "netcoreapp3.0", targetRuntime: "osx-x64" };
 
     const cloudBuildlibrary = NugetPackages.pack({
         id: "BuildXL.library.forCloudBuild",
@@ -92,6 +93,17 @@ namespace PrivatePackages {
                         importFrom("BuildXL.Utilities").withQualifier(winx64Qualifier).Native.dll.runtime,
                         importFrom("BuildXL.Utilities").withQualifier(winx64Qualifier).Interop.dll.runtime,
                         importFrom("BuildXL.Utilities.Instrumentation").withQualifier(winx64Qualifier).Common.dll.runtime,
+                    ],
+                },
+                {
+                    subfolder: r`lib/netcoreapp3.0/osx-x64`,
+                    contents: [
+                        importFrom("BuildXL.Utilities").withQualifier(osxx64Qualifier).dll.runtime,
+                        importFrom("BuildXL.Utilities").withQualifier(osxx64Qualifier).Collections.dll.runtime,
+                        importFrom("BuildXL.Utilities").withQualifier(osxx64Qualifier).Configuration.dll.runtime,
+                        importFrom("BuildXL.Utilities").withQualifier(osxx64Qualifier).Native.dll.runtime,
+                        importFrom("BuildXL.Utilities").withQualifier(osxx64Qualifier).Interop.dll.runtime,
+                        importFrom("BuildXL.Utilities.Instrumentation").withQualifier(osxx64Qualifier).Common.dll.runtime,
                     ],
                 },
                 {

--- a/Public/Src/Deployment/privatePackages.dsc
+++ b/Public/Src/Deployment/privatePackages.dsc
@@ -85,7 +85,7 @@ namespace PrivatePackages {
                     ],
                 },
                 {
-                    subfolder: r`lib/netcoreapp3.0/win-x64`,
+                    subfolder: r`runtimes/win-x64/lib/netcoreapp3.0`,
                     contents: [
                         importFrom("BuildXL.Utilities").withQualifier(winx64Qualifier).dll.runtime,
                         importFrom("BuildXL.Utilities").withQualifier(winx64Qualifier).Collections.dll.runtime,
@@ -96,7 +96,7 @@ namespace PrivatePackages {
                     ],
                 },
                 {
-                    subfolder: r`lib/netcoreapp3.0/osx-x64`,
+                    subfolder: r`runtimes/osx-x64/lib/netcoreapp3.0/`,
                     contents: [
                         importFrom("BuildXL.Utilities").withQualifier(osxx64Qualifier).dll.runtime,
                         importFrom("BuildXL.Utilities").withQualifier(osxx64Qualifier).Collections.dll.runtime,


### PR DESCRIPTION
For now, netcoreapp3.0 assemblies will be put into windows and mac subfolders. This is the only short term solution that we have time for now, and this will be of use to Artifact Services, which is trying to move to netcoreapp.

The layout change of our NuGet packages should not be a breaking change since no one seems to be using our netcoreapp3 assemblies.