### PR TITLE
Fix overflow exceptions cause by universally switching to using checked flag to csc.

### DIFF
--- a/Public/Src/Cache/ContentStore/Interfaces/FileSystem/Hresult.cs
+++ b/Public/Src/Cache/ContentStore/Interfaces/FileSystem/Hresult.cs
@@ -11,11 +11,11 @@ namespace BuildXL.Cache.ContentStore.Interfaces.FileSystem
         /// <summary>
         ///     E_ACCESSDENIED
         /// </summary>
-        public const uint AccessDenied = 0x80070005;
+        public const int AccessDenied = unchecked((int)0x80070005);
 
         /// <summary>
         ///     FILE_EXISTS
         /// </summary>
-        public const uint FileExists = 0x80070050;
+        public const int FileExists = unchecked((int)0x80070050);
     }
 }

--- a/Public/Src/Cache/ContentStore/InterfacesTest/FileSystem/MemoryFileSystem.cs
+++ b/Public/Src/Cache/ContentStore/InterfacesTest/FileSystem/MemoryFileSystem.cs
@@ -886,7 +886,7 @@ namespace BuildXL.Cache.ContentStore.InterfacesTest.FileSystem
                         {
                             unchecked
                             {
-                                throw new IOException("File already exists", new IOException("File exists", (int)Hresult.FileExists));
+                                throw new IOException("File already exists", new IOException("File exists", Hresult.FileExists));
                             }
                         }
 

--- a/Public/Src/Cache/ContentStore/Library/FileSystem/PassThroughFileSystem.cs
+++ b/Public/Src/Cache/ContentStore/Library/FileSystem/PassThroughFileSystem.cs
@@ -230,7 +230,7 @@ namespace BuildXL.Cache.ContentStore.FileSystem
             {
                 if ((deleteOptions & DeleteOptions.ReadOnly) != 0 &&
                     accessException.HResult > 0 &&
-                    (uint)accessException.HResult == Hresult.AccessDenied)
+                    accessException.HResult == Hresult.AccessDenied)
                 {
                     bool foundReadonly = false;
 

--- a/Public/Src/Cache/ContentStore/Library/Stores/FileSystemContentStoreInternal.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/FileSystemContentStoreInternal.cs
@@ -2496,8 +2496,8 @@ namespace BuildXL.Cache.ContentStore.Stores
                     }
                     catch (IOException e)
                     {
-                        if ((uint)e.HResult == Hresult.FileExists || (e.InnerException != null &&
-                                                                      (uint)e.InnerException.HResult == Hresult.FileExists))
+                        if (e.HResult == Hresult.FileExists || (e.InnerException != null &&
+                                                                      e.InnerException.HResult == Hresult.FileExists))
                         {
                             // File existing in the racing SkipIfExists case.
                             code = PlaceFileResult.ResultCode.NotPlacedAlreadyExists;
@@ -2561,7 +2561,7 @@ namespace BuildXL.Cache.ContentStore.Stores
                         }
                         catch (IOException e)
                         {
-                            if (e.InnerException != null && (long)e.InnerException.HResult == Hresult.FileExists)
+                            if (e.InnerException != null && e.InnerException.HResult == Hresult.FileExists)
                             {
                                 // File existing in the racing SkipIfExists case.
                                 code = PlaceFileResult.ResultCode.NotPlacedAlreadyExists;


### PR DESCRIPTION
Fix overflow exceptions cause by universally switching to using checked flag to csc.