### PR TITLE
Change working directory for running VmCommandProxy

### DIFF
--- a/Public/Src/Engine/Processes/ExternalVMSandboxedProcess.cs
+++ b/Public/Src/Engine/Processes/ExternalVMSandboxedProcess.cs
@@ -134,7 +134,7 @@ namespace BuildXL.Processes
             {
                 AbsolutePath = m_tool.ExecutablePath,
                 Arguments = m_tool.CreateArguments(GetSandboxedProcessInfoFile(), GetSandboxedProcessResultsFile()),
-                WorkingDirectory = SandboxedProcessInfo.WorkingDirectory
+                WorkingDirectory = GetOutputDirectory()
             };
 
             VmSerializer.SerializeToFile(RunRequestPath, runRequest);

--- a/Public/Src/Engine/Processes/ExternalVMSandboxedProcess.cs
+++ b/Public/Src/Engine/Processes/ExternalVMSandboxedProcess.cs
@@ -143,7 +143,7 @@ namespace BuildXL.Processes
             string arguments = $"{VmCommands.Run} /{VmCommands.Params.InputJsonFile}:\"{RunRequestPath}\" /{VmCommands.Params.OutputJsonFile}:\"{RunOutputPath}\"";
             var process = CreateVmCommandProxyProcess(arguments);
 
-            LogExternalExecution($"call {m_vmInitializer.VmCommandProxy} {arguments}");
+            LogExternalExecution($"call (wd: {process.StartInfo.WorkingDirectory}) {m_vmInitializer.VmCommandProxy} {arguments}");
 
             m_processExecutor = new AsyncProcessExecutor(
                 process,

--- a/Public/Src/Engine/Processes/ExternalVMSandboxedProcess.cs
+++ b/Public/Src/Engine/Processes/ExternalVMSandboxedProcess.cs
@@ -170,7 +170,7 @@ namespace BuildXL.Processes
                 {
                     FileName = m_vmInitializer.VmCommandProxy,
                     Arguments = arguments,
-                    WorkingDirectory = SandboxedProcessInfo.WorkingDirectory,
+                    WorkingDirectory = GetOutputDirectory(),
                     RedirectStandardError = true,
                     RedirectStandardOutput = true,
                     UseShellExecute = false,

--- a/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
@@ -1022,9 +1022,10 @@ namespace BuildXL.Processes
                 {
                     Contract.Assert(m_sandboxConfig.AdminRequiredProcessExecutionMode == AdminRequiredProcessExecutionMode.ExternalVM);
 
-                    Tracing.Logger.Log.PipProcessStartExternalVm(m_loggingContext, m_pip.SemiStableHash, m_pip.GetDescription(m_context));
-
+                    // Initialize VM once.
                     await m_vmInitializer.LazyInitVmAsync.Value;
+
+                    Tracing.Logger.Log.PipProcessStartExternalVm(m_loggingContext, m_pip.SemiStableHash, m_pip.GetDescription(m_context));
 
                     process = await ExternalSandboxedProcess.StartAsync(
                         info,


### PR DESCRIPTION
Currently when running VmCommandProxy, the working directory is set to the working directory of the pip. However this can "conflict" with the operation that the pip will do to that working directory. 

VmCommandProxy writes log files to that working directory.  QTest pips set their working directory to the deployment directory. Later the pips robocopy this directory. The robocopy process will cause DFA when it finds the logs written by VmCommandProxy.

[AB#1590524](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1590524)