### PR TITLE
Reduce BuildXL Kusto logging by 8%

### DIFF
--- a/Public/Src/Engine/Dll/Tracing/Log.cs
+++ b/Public/Src/Engine/Dll/Tracing/Log.cs
@@ -860,7 +860,7 @@ namespace BuildXL.Engine.Tracing
             Message = "[{pipDescription}] Pip output '{filePath}' with hash '{hash}' reported to master.",
             EventLevel = Level.Verbose,
             EventTask = (ushort)Tasks.Distribution,
-            Keywords = (int)Keywords.UserMessage)]
+            Keywords = (int)(Keywords.UserMessage | Keywords.Diagnostics))]
         public abstract void DistributionWorkerPipOutputContent(LoggingContext context, long pipSemiStableHash, string pipDescription, string filePath, string hash);
 
         [GeneratedEvent(

--- a/Public/Src/Engine/Scheduler/Tracing/Log.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/Log.cs
@@ -730,7 +730,7 @@ namespace BuildXL.Scheduler.Tracing
         [GeneratedEvent(
             (ushort)LogEventId.DistributionExecutePipRequest,
             EventGenerators = EventGenerators.LocalOnly,
-            Message = "[{pipDescription}] Requesting pip execution of step {step} on worker {workerName}",
+            Message = "[{pipDescription}] Requesting {step} on {workerName}",
             EventLevel = Level.Verbose,
             EventTask = (ushort)Tasks.Distribution,
             EventOpcode = (byte)EventOpcode.Info,
@@ -740,7 +740,7 @@ namespace BuildXL.Scheduler.Tracing
         [GeneratedEvent(
             (ushort)LogEventId.DistributionFinishedPipRequest,
             EventGenerators = EventGenerators.LocalOnly,
-            Message = "[{pipDescription}] Finished pip execution of step {step} on worker {workerName}",
+            Message = "[{pipDescription}] Finished {step} on {workerName}",
             EventLevel = Level.Verbose,
             EventTask = (ushort)Tasks.Distribution,
             EventOpcode = (byte)EventOpcode.Info,
@@ -753,7 +753,7 @@ namespace BuildXL.Scheduler.Tracing
             Message = "[{pipDescription}] Pip output '{filePath}' with hash '{hash} reported from worker '{workerName}'. {reparsePointInfo}.",
             EventLevel = Level.Verbose,
             EventTask = (ushort)Tasks.Distribution,
-            Keywords = (int)Keywords.UserMessage)]
+            Keywords = (int)(Keywords.UserMessage | Keywords.Diagnostics))]
         public abstract void DistributionMasterWorkerProcessOutputContent(LoggingContext context, long pipSemiStableHash, string pipDescription, string filePath, string hash, string reparsePointInfo, string workerName);
 
         [GeneratedEvent(


### PR DESCRIPTION
These messages would be redundant with what the workers locally log about the files they produce or become aware of via performing cache lookups.