### PR TITLE
Stop tracing operation starts in ContentSessionBase

### DIFF
--- a/Public/Src/Cache/ContentStore/Library/Sessions/ContentSessionBase.cs
+++ b/Public/Src/Cache/ContentStore/Library/Sessions/ContentSessionBase.cs
@@ -149,8 +149,8 @@ namespace BuildXL.Cache.ContentStore.Sessions
                 operationContext => operationContext.PerformOperationAsync(
                     Tracer,
                     () => PlaceFileCoreAsync(operationContext, contentHash, path, accessMode, replacementMode, realizationMode, urgencyHint, _counters[ContentSessionBaseCounters.PlaceFileRetries]),
-                    extraStartMessage: $"({contentHash.ToShortString()},{path},{accessMode},{replacementMode},{realizationMode})",
-                    extraEndMessage: (_) => $"input={contentHash.ToShortString()}",
+                    traceOperationStarted: false,
+                    extraEndMessage: (_) => $"input=({contentHash.ToShortString()},{path},{accessMode},{replacementMode},{realizationMode})",
                     counter: _counters[ContentSessionBaseCounters.PlaceFile]));
         }
 
@@ -211,10 +211,10 @@ namespace BuildXL.Cache.ContentStore.Sessions
                 operationContext => operationContext.PerformOperationAsync(
                     Tracer,
                     () => PutFileCoreAsync(operationContext, hashType, path, realizationMode, urgencyHint, _counters[ContentSessionBaseCounters.PutFileRetries]),
-                    extraStartMessage: $"({path},{realizationMode},{hashType}) trusted=false",
+                    traceOperationStarted: false,
                     extraEndMessage: result =>
                     {
-                        var message = "trusted=false";
+                        var message = $"({path},{realizationMode}) trusted=false";
                         if (result.Metadata == null)
                         {
                             return message;
@@ -253,8 +253,8 @@ namespace BuildXL.Cache.ContentStore.Sessions
                 operationContext => operationContext.PerformOperationAsync(
                     Tracer,
                     () => PutFileCoreAsync(operationContext, contentHash, path, realizationMode, urgencyHint, _counters[ContentSessionBaseCounters.PutFileRetries]),
-                    extraStartMessage: $"({path},{realizationMode},{contentHash.ToShortString()}) trusted=false",
-                    extraEndMessage: _ => "trusted=false",
+                    traceOperationStarted: false,
+                    extraEndMessage: _ => $"({path},{realizationMode}) trusted=false",
                     counter: _counters[ContentSessionBaseCounters.PutFile]));
         }
 
@@ -285,7 +285,7 @@ namespace BuildXL.Cache.ContentStore.Sessions
                 operationContext => operationContext.PerformOperationAsync(
                     Tracer,
                     () => PutStreamCoreAsync(operationContext, hashType, stream, urgencyHint, _counters[ContentSessionBaseCounters.PutStreamRetries]),
-                    extraStartMessage: $"({hashType})",
+                    traceOperationStarted: false,
                     counter: _counters[ContentSessionBaseCounters.PutStream]));
         }
 
@@ -315,7 +315,7 @@ namespace BuildXL.Cache.ContentStore.Sessions
                 operationContext => operationContext.PerformOperationAsync(
                     Tracer,
                     () => PutStreamCoreAsync(operationContext, contentHash, stream, urgencyHint, _counters[ContentSessionBaseCounters.PutStreamRetries]),
-                    extraStartMessage: $"({contentHash.ToShortString()})",
+                    traceOperationStarted: false,
                     counter: _counters[ContentSessionBaseCounters.PutStream]));
         }
 


### PR DESCRIPTION
Note that PutResult already contains info about the hash, so we are able to not include the hash in the extraEndMessage.