### PR TITLE
Don't sort environment variables when creating pip graph

### DIFF
--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SchedulerIntegrationTestBase.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/SchedulerIntegrationTestBase.cs
@@ -310,9 +310,9 @@ namespace Test.BuildXL.Scheduler
         /// <summary>
         /// Creates and scheduled a <see cref="PipBuilder"/> constructed process
         /// </summary>
-        public ProcessWithOutputs CreateAndSchedulePipBuilder(IEnumerable<Operation> processOperations, IEnumerable<string> tags = null, string description = null)
+        public ProcessWithOutputs CreateAndSchedulePipBuilder(IEnumerable<Operation> processOperations, IEnumerable<string> tags = null, string description = null, IDictionary<string, string> environmentVariables = null)
         {
-            var pipBuilder = CreatePipBuilder(processOperations, tags, description);
+            var pipBuilder = CreatePipBuilder(processOperations, tags, description, environmentVariables);
             return SchedulePipBuilder(pipBuilder);
         }
 

--- a/Public/Src/Engine/UnitTests/Scheduler/PipTestBase.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/PipTestBase.cs
@@ -178,7 +178,7 @@ namespace Test.BuildXL.Scheduler
         }
 
         /// <nodoc />
-        public ProcessBuilder CreatePipBuilder(IEnumerable<Operation> processOperations, IEnumerable<string> tags = null, string description = null)
+        public ProcessBuilder CreatePipBuilder(IEnumerable<Operation> processOperations, IEnumerable<string> tags = null, string description = null, IDictionary<string, string> environmentVariables = null)
         {
             var builder = ProcessBuilder.CreateForTesting(Context.PathTable);
             builder.Executable = TestProcessExecutable;
@@ -212,6 +212,16 @@ namespace Test.BuildXL.Scheduler
             if (description != null)
             {
                 builder.ToolDescription = StringId.Create(Context.StringTable, description);
+            }
+
+            if (environmentVariables != null)
+            {
+                foreach (var envVar in environmentVariables)
+                {
+                    builder.SetEnvironmentVariable(
+                        StringId.Create(Context.StringTable, envVar.Key),
+                        StringId.Create(Context.StringTable, envVar.Value));
+                }
             }
 
             if (OperatingSystemHelper.IsUnixOS)

--- a/Public/Src/FrontEnd/SdkTesting/Helper/TestPipPrinter.cs
+++ b/Public/Src/FrontEnd/SdkTesting/Helper/TestPipPrinter.cs
@@ -312,7 +312,7 @@ namespace BuildXL.FrontEnd.Script.Testing.Helper
 
             if (pip.EnvironmentVariables.Length > 0)
             {
-                properties.Add(new PropertyAssignment("environmentVariables", Generate(pip.EnvironmentVariables, Generate)));
+                properties.Add(new PropertyAssignment("environmentVariables", Generate(pip.EnvironmentVariables.OrderBy(kv => kv.Name, m_pathTable.StringTable.OrdinalComparer).ToArray(), Generate)));
             }
 
             if (pip.WarningRegex != null && pip.WarningRegex.Pattern.ToString(m_stringTable) != RegexDescriptor.DefaultWarningPattern)

--- a/Public/Src/Pips/Dll/Builders/ProcessBuilder.cs
+++ b/Public/Src/Pips/Dll/Builders/ProcessBuilder.cs
@@ -483,7 +483,7 @@ namespace BuildXL.Pips.Builders
 
             EnvironmentVariable[] envVars = new EnvironmentVariable[m_environmentVariables.Count];
             int idx = 0;
-            foreach (var kvp in m_environmentVariables.OrderBy(kv => kv.Key, m_pathTable.StringTable.OrdinalComparer))
+            foreach (var kvp in m_environmentVariables)
             {
                 // if the value is invalid, then it is a pass through env variable.
                 var isPassThrough = !kvp.Value.IsValid;


### PR DESCRIPTION
Don't sort environment variables when creating pip graph, instead add them order independent to the fingerprint

This saves about 33% of evaluation time from buildxlscriptanalyzer, about 10% of overall time in buildxlscriptanalyzer