### PR TITLE
Fix MDM errors appearing as success

### DIFF
--- a/Public/Src/Cache/ContentStore/Interfaces/Tracing/Context.cs
+++ b/Public/Src/Cache/ContentStore/Interfaces/Tracing/Context.cs
@@ -156,7 +156,7 @@ namespace BuildXL.Cache.ContentStore.Interfaces.Tracing
                 {
                     return OperationStatus.Cancelled;
                 }
-                else if (resultBase.HasException)
+                else if (!resultBase.Succeeded)
                 {
                     return OperationStatus.Failure;
                 }


### PR DESCRIPTION
Some errors don't have exceptions, and were being categorized as successes