### PR TITLE
Remove #if PLATFORM_WIN from ContentStore Library and Interfaces

### DIFF
--- a/Public/Src/Cache/ContentStore/Interfaces/FileSystem/AbsolutePath.cs
+++ b/Public/Src/Cache/ContentStore/Interfaces/FileSystem/AbsolutePath.cs
@@ -136,13 +136,11 @@ namespace BuildXL.Cache.ContentStore.Interfaces.FileSystem
                     throw CreateIllegalCharactersInPathError(Path);
                 }
 
-#if !PLATFORM_WIN
                 // CoreCLR's GetDirectoryName doesn't throw PathTooLongException for long paths
-                if (Path.Length > FileSystemConstants.MaxPath)
+                if (OperatingSystemHelper.IsWindowsOS && Path.Length > FileSystemConstants.MaxPath)
                 {
                     throw new PathTooLongException(PathTooLongExceptionMessage(Path));
                 }
-#endif
 
                 if (string.IsNullOrEmpty(parent))
                 {

--- a/Public/Src/Cache/ContentStore/Interfaces/FileSystem/AbsolutePath.cs
+++ b/Public/Src/Cache/ContentStore/Interfaces/FileSystem/AbsolutePath.cs
@@ -137,7 +137,7 @@ namespace BuildXL.Cache.ContentStore.Interfaces.FileSystem
                 }
 
                 // CoreCLR's GetDirectoryName doesn't throw PathTooLongException for long paths
-                if (OperatingSystemHelper.IsWindowsOS && Path.Length > FileSystemConstants.MaxPath)
+                if (!OperatingSystemHelper.IsWindowsOS && Path.Length > FileSystemConstants.MaxPath)
                 {
                     throw new PathTooLongException(PathTooLongExceptionMessage(Path));
                 }

--- a/Public/Src/Cache/ContentStore/Library/Service/Grpc/MemoryMappedFilePortExposer.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/Grpc/MemoryMappedFilePortExposer.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.ContractsLight;
 using System.IO;
 using System.IO.MemoryMappedFiles;
 using BuildXL.Cache.ContentStore.Interfaces.Logging;
+using BuildXL.Cache.ContentStore.Interfaces.Utils;
 
 namespace BuildXL.Cache.ContentStore.Service.Grpc
 {
@@ -36,25 +37,29 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
         {
             Contract.Requires(port > 0 && port <= 65535); // Limit on computers' ports.
 
-#if PLATFORM_WIN
-            var fileName = $@"Global\{_baseFileName}";
-            try
+            string fileName = _baseFileName;
+
+            // OSX can't use global memory mapped files, so don't use the "Global" prefix
+            if (OperatingSystemHelper.IsWindowsOS)
             {
-                _file = CreateMemoryMappedFile(port, fileName);
+                fileName = $@"Global\{_baseFileName}";
+                try
+                {
+                    _file = CreateMemoryMappedFile(port, fileName);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    _logger.Warning(
+                        $"Failed to create global memory mapped file {fileName}. MMF will only be available to the current user. If global access is required, try running as administrator.");
+                }
             }
-            catch (UnauthorizedAccessException)
+
+            // Could not create global MMF
+            if (_file == null)
             {
                 fileName = _baseFileName;
-                _logger.Warning(
-                    $"Failed to create global memory mapped file {fileName}. MMF will only be available to the current user. If global access is required, try running as administrator.");
-                _file = CreateMemoryMappedFile(port, fileName);
+                _file = CreateMemoryMappedFile(port, _baseFileName);
             }
-#else
-            // OSX can't use global memory mapped files, so don't use the "Global" prefix
-            var fileName = _baseFileName;
-            _file = CreateMemoryMappedFile(port, _baseFileName);
-            System.Console.WriteLine("Created memory mapped file at " + _baseFileName);
-#endif
 
             return new MemoryMappedFileDisposer(_logger, _file, fileName);
         }
@@ -63,29 +68,15 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
         {
             _logger.Always($"Trying to expose GRPC port {port} at memory mapped file '{fileName}'");
 
-#if PLATFORM_WIN
-            var file = MemoryMappedFile.CreateNew(
-                fileName,
-                FileSize,
-                MemoryMappedFileAccess.ReadWrite);
-#else
-            var file = MemoryMappedFile.CreateFromFile(
-                fileName,
-                FileMode.Create,
-                null,
-                FileSize,
-                MemoryMappedFileAccess.ReadWrite);
-#endif
+            var file = OperatingSystemHelper.IsWindowsOS
+                ? MemoryMappedFile.CreateNew(fileName, FileSize, MemoryMappedFileAccess.ReadWrite)
+                : MemoryMappedFile.CreateFromFile(fileName, FileMode.Create, null, FileSize, MemoryMappedFileAccess.ReadWrite);
 
             try
             {
-                using (var stream = file.CreateViewStream())
-                {
-                    using (var writer = new StreamWriter(stream))
-                    {
-                        writer.Write(port);
-                    }
-                }
+                using var stream = file.CreateViewStream();
+                using var writer = new StreamWriter(stream);
+                writer.Write(port);
             }
             catch
             {

--- a/Public/Src/Cache/ContentStore/Library/Service/Grpc/MemoryMappedFilePortReader.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/Grpc/MemoryMappedFilePortReader.cs
@@ -4,6 +4,7 @@
 using System.IO;
 using System.IO.MemoryMappedFiles;
 using BuildXL.Cache.ContentStore.Interfaces.Logging;
+using BuildXL.Cache.ContentStore.Interfaces.Utils;
 
 namespace BuildXL.Cache.ContentStore.Service.Grpc
 {
@@ -30,30 +31,19 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
         {
             string content = string.Empty;
 
-#if PLATFORM_WIN
             try
             {
-                using (var file = GetMemoryMappedFile(_fileName))
-                using (var stream = file.CreateViewStream(0, 0, MemoryMappedFileAccess.Read))
+                if (OperatingSystemHelper.IsWindowsOS)
                 {
-                    using (var reader = new StreamReader(stream))
-                    {
-                        content = reader.ReadLine();
-                    }
+                    using var file = GetMemoryMappedFile(_fileName);
+                    using var stream = file.CreateViewStream(0, 0, MemoryMappedFileAccess.Read);
+                    using var reader = new StreamReader(stream);
+                    content = reader.ReadLine();
                 }
-            }
-            catch (FileNotFoundException)
-            {
-                throw new PortReaderException(
-                    $"The memory-mapped file '{_fileName}' was not found during GRPC port recognition." +
-                    "Possible cause: Server is not available, or file was created without administrator permissions under a different user.");
-            }
-#else
-            try
-            {
-                using (FileStream fileStream = File.OpenRead(_fileName))
-                using (StreamReader reader = new StreamReader(fileStream))
+                else
                 {
+                    using FileStream fileStream = File.OpenRead(_fileName);
+                    using StreamReader reader = new StreamReader(fileStream);
                     content = reader.ReadLine();
                 }
             }
@@ -63,7 +53,6 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
                     $"The memory-mapped file '{_fileName}' was not found during GRPC port recognition." +
                     "Possible cause: Server is not available, or file was created without administrator permissions under a different user.");
             }
-#endif
 
             if (ushort.TryParse(content, out ushort result))
             {


### PR DESCRIPTION
ServiceReadinessChecker still has these checks in ContentStore.Library.
Interfaces would no longer have these checks.