### PR TITLE
Inline unsafe ambient calls when arguments are literals

### DIFF
--- a/Public/Src/FrontEnd/Script/Ambients/AmbientUnsafe.cs
+++ b/Public/Src/FrontEnd/Script/Ambients/AmbientUnsafe.cs
@@ -14,13 +14,13 @@ namespace BuildXL.FrontEnd.Script.Ambients
     /// </summary>
     public sealed class AmbientUnsafe : AmbientDefinitionBase
     {
-        private const string UnsafeName = "Unsafe";
-        private const string OutputFile = "outputFile";
-        private const string ExOutputDirectory = "exOutputDirectory";
+        private const string UnsafeNamespace = Constants.Names.UnsafeNamespace;
+        private const string OutputFile = Constants.Names.UnsafeOutputFile;
+        private const string ExOutputDirectory = Constants.Names.UnsafeExOutputDirectory;
 
         /// <nodoc />
         public AmbientUnsafe(PrimitiveTypes knownTypes)
-            : base(UnsafeName, knownTypes)
+            : base(UnsafeNamespace, knownTypes)
         {
         }
 
@@ -28,7 +28,7 @@ namespace BuildXL.FrontEnd.Script.Ambients
         protected override AmbientNamespaceDefinition? GetNamespaceDefinition()
         {
             return new AmbientNamespaceDefinition(
-                UnsafeName,
+                UnsafeNamespace,
                 new[]
                 {
                     Function(OutputFile, UnsafeOutputFile, UnsafeOutputFileSignature),

--- a/Public/Src/FrontEnd/Script/Ast/Literals/FileLiteral.cs
+++ b/Public/Src/FrontEnd/Script/Ast/Literals/FileLiteral.cs
@@ -43,6 +43,16 @@ namespace BuildXL.FrontEnd.Script.Literals
             Value = FileArtifact.CreateSourceFile(value);
         }
 
+        /// <summary>
+        /// Constructor that takes path literal and rewrite count.
+        /// </summary>
+        public FileLiteral(AbsolutePath value, int rewriteCount, LineInfo location)
+            : base(location)
+        {
+            Contract.Requires(value.IsValid);
+            Value = new FileArtifact(value, rewriteCount);
+        }
+
         /// <nodoc />
         public FileLiteral(DeserializationContext context, LineInfo location)
             : base(location)

--- a/Public/Src/FrontEnd/Script/RuntimeModel/AstBridge/AstConversionContext.cs
+++ b/Public/Src/FrontEnd/Script/RuntimeModel/AstBridge/AstConversionContext.cs
@@ -22,6 +22,10 @@ namespace BuildXL.FrontEnd.Script.RuntimeModel.AstBridge
         internal readonly SymbolAtom TemplateReference;
         internal readonly SymbolAtom RuntimeRootNamespaceSymbol;
 
+        internal readonly FullSymbol UnsafeNamespace;
+        internal readonly SymbolAtom UnsafeOutputFile;
+        internal readonly SymbolAtom UnsafeExOutputDirectory;
+
         public AstConversionContext(
             RuntimeModelContext runtimeModelContext,
             AbsolutePath currentSpecPath,
@@ -40,12 +44,15 @@ namespace BuildXL.FrontEnd.Script.RuntimeModel.AstBridge
             ModuleKeyword = CreateSymbol(Constants.Names.ModuleConfigurationFunctionCall);
             TemplateReference = CreateSymbol(Constants.Names.TemplateReference);
             RuntimeRootNamespaceSymbol = CreateSymbol(Constants.Names.RuntimeRootNamespaceAlias);
+
+            UnsafeNamespace = CreateFullSymbol(Constants.Names.UnsafeNamespace);
+            UnsafeOutputFile = CreateSymbol(Constants.Names.UnsafeOutputFile);
+            UnsafeExOutputDirectory = CreateSymbol(Constants.Names.UnsafeExOutputDirectory);
         }
 
-        private SymbolAtom CreateSymbol(string name)
-        {
-            return SymbolAtom.Create(RuntimeModelContext.StringTable, name);
-        }
+        private SymbolAtom CreateSymbol(string name) => SymbolAtom.Create(RuntimeModelContext.StringTable, name);
+
+        private FullSymbol CreateFullSymbol(string name) => FullSymbol.Create(RuntimeModelContext.SymbolTable, name);
 
         public RuntimeModelContext RuntimeModelContext { get; }
 

--- a/Public/Src/Utilities/Script.Constants/Names.cs
+++ b/Public/Src/Utilities/Script.Constants/Names.cs
@@ -288,5 +288,24 @@ namespace BuildXL.FrontEnd.Script.Constants
         public const string ConfigModuleName = "__ConfigModule__";
 
         #endregion Packages
+
+        #region Unsafe
+
+        /// <summary>
+        /// Unsafe namespace.
+        /// </summary>
+        public const string UnsafeNamespace = "Unsafe";
+
+        /// <summary>
+        /// Unsafe output file.
+        /// </summary>
+        public const string UnsafeOutputFile = "outputFile";
+
+        /// <summary>
+        /// Unsafe exclusive output directory.
+        /// </summary>
+        public const string UnsafeExOutputDirectory = "exOutputDirectory";
+
+        #endregion
     }
 }


### PR DESCRIPTION
Inline unsafe ambient calls when arguments are literals. Inlining is done during the AST conversion phase.