### PR TITLE
Remove some unnecessary traces from DominoMessage

### DIFF
--- a/Public/Src/Cache/ContentStore/Vsts/BlobReadOnlyContentSession.cs
+++ b/Public/Src/Cache/ContentStore/Vsts/BlobReadOnlyContentSession.cs
@@ -425,10 +425,8 @@ namespace BuildXL.Cache.ContentStore.Vsts
                                 path,
                                 fileMode,
                                 context.Token,
-                                (destinationPath, offset, endOffset) =>
-                                    Tracer.Debug(context, $"Download {destinationPath} [{offset}, {endOffset}) start."),
-                                (destinationPath, offset, endOffset) =>
-                                    Tracer.Debug(context, $"Download {destinationPath} [{offset}, {endOffset}) end."),
+                                logSegmentStart: (destinationPath, offset, endOffset) => { },
+                                logSegmentStop: (destinationPath, offset, endOffset) => { },
                                 (destinationPath, offset, endOffset, message) =>
                                     Tracer.Debug(context, $"Download {destinationPath} [{offset}, {endOffset}) failed. (message: {message})"),
                                 async (offset, token) =>

--- a/Public/Src/Cache/MemoizationStore/Distributed/Metadata/RedisMetadataCache.cs
+++ b/Public/Src/Cache/MemoizationStore/Distributed/Metadata/RedisMetadataCache.cs
@@ -201,10 +201,6 @@ namespace BuildXL.Cache.MemoizationStore.Distributed.Metadata
 
                 var strongDeleted = await deleteStrongFingerprint;
                 var weakDeleted = await deleteWeakFingerprint;
-                if (!strongDeleted || !weakDeleted)
-                {
-                    _tracer.Warning(context, $"Unable to delete some keys. Strong deleted: {strongDeleted}. Weak deleted: {weakDeleted}.");
-                }
 
                 return BoolResult.Success;
             }


### PR DESCRIPTION
Download traces can be removed and we can only trace on errors.

"Unable to delete some keys" can be inferred from other traces.