### PR TITLE
Remove #if PLATFORM_WIN from FileSystemConstants

### DIFF
--- a/Public/Src/Cache/ContentStore/Interfaces/FileSystem/AbsolutePath.cs
+++ b/Public/Src/Cache/ContentStore/Interfaces/FileSystem/AbsolutePath.cs
@@ -251,7 +251,7 @@ namespace BuildXL.Cache.ContentStore.Interfaces.FileSystem
         {
             Contract.Requires(path != null);
 
-            if (path.Length < FileSystemConstants.MaxShortPath)
+            if (path.Length < FileSystemConstants.MaxDirectoryPath)
             {
                 return path;
             }

--- a/Public/Src/Cache/ContentStore/Interfaces/FileSystem/AbsolutePath.cs
+++ b/Public/Src/Cache/ContentStore/Interfaces/FileSystem/AbsolutePath.cs
@@ -251,7 +251,7 @@ namespace BuildXL.Cache.ContentStore.Interfaces.FileSystem
         {
             Contract.Requires(path != null);
 
-            if (path.Length < FileSystemConstants.MaxDirectoryPath)
+            if (path.Length < FileSystemConstants.MaxShortPath)
             {
                 return path;
             }

--- a/Public/Src/Cache/ContentStore/InterfacesTest/FileSystem/AbsFileSystemTests.cs
+++ b/Public/Src/Cache/ContentStore/InterfacesTest/FileSystem/AbsFileSystemTests.cs
@@ -1254,12 +1254,12 @@ namespace BuildXL.Cache.ContentStore.InterfacesTest.FileSystem
         [InlineData(100)]
         [InlineData(1000)]
         [Trait("Category", "WindowsOSOnly")]
-        public void HardLinkToLongDestinationFilePaths(int length)
+        public void HardLinkToLongDestinationFilePaths(int deltaMaxShortPath)
         {
             using var testDirectory = new DisposableDirectory(FileSystem);
             CreateTestTree(testDirectory);
 
-            length += FileSystemConstants.MaxShortPath;
+            var length = FileSystemConstants.MaxShortPath + deltaMaxShortPath;
             if ((testDirectory.Path.Length + length) < FileSystemConstants.MaxShortPath || AbsolutePath.LongPathsSupported)
             {
                 // Skipping if the path is a long path but the current system doesn't support it.

--- a/Public/Src/Cache/ContentStore/Library/FileSystem/NativeMethods.cs
+++ b/Public/Src/Cache/ContentStore/Library/FileSystem/NativeMethods.cs
@@ -353,7 +353,7 @@ namespace BuildXL.Cache.ContentStore.FileSystem
             /// <summary>
             ///     Allocates a constant-sized buffer for the FileName.  MAX_PATH for the path, 4 for the DosToNtPathPrefix.
             /// </summary>
-            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = FileSystemConstants.MaxLongPath + 4)]
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = FileSystemConstants.MaxLongPathWindows + 4)]
             private readonly string FileName;
 
             // ReSharper restore PrivateFieldCanBeConvertedToLocalVariable

--- a/Public/Src/Cache/ContentStore/UtilitiesCore/FileSystemConstants.cs
+++ b/Public/Src/Cache/ContentStore/UtilitiesCore/FileSystemConstants.cs
@@ -47,6 +47,19 @@ namespace BuildXL.Cache.ContentStore.Interfaces.FileSystem
         public const int MaxLongPathWindows = 32767;
 
         /// <summary>
+        /// To prevent a change in ordering of static fields to cause bugs, order-dependent field initializations are
+        /// done inside the static constructor.
+        /// </summary>
+        static FileSystemConstants()
+        {
+            // GetLongPathSupport uses some of the readonly static fields. Because of this, it should be run after
+            //  the field initializers have been run. Otherwise, it will malfunction.
+            LongPathsSupported = GetLongPathSupport();
+
+            MaxPath = LongPathsSupported ? MaxLongPath : MaxShortPath;
+        }
+
+        /// <summary>
         /// Maximum path length when long paths are not supported.
         /// </summary>
         public static readonly int MaxShortPath = IsWindowsOS ? 260 : MaxPathUnix;
@@ -69,12 +82,12 @@ namespace BuildXL.Cache.ContentStore.Interfaces.FileSystem
         /// <summary>
         /// Returns true if paths longer than MaxShortPath are supported.
         /// </summary>
-        public static bool LongPathsSupported { get; } = GetLongPathSupport();
+        public static bool LongPathsSupported { get; }
 
         /// <summary>
         /// Maximum path length.
         /// </summary>
-        public static int MaxPath { get; } = LongPathsSupported ? MaxLongPath : MaxShortPath;
+        public static int MaxPath { get; }
 
         private static bool GetLongPathSupport()
         {

--- a/Public/Src/Cache/ContentStore/UtilitiesCore/FileSystemConstants.cs
+++ b/Public/Src/Cache/ContentStore/UtilitiesCore/FileSystemConstants.cs
@@ -86,7 +86,6 @@ namespace BuildXL.Cache.ContentStore.Interfaces.FileSystem
                 string path = $@"{LongPathPrefix}c:\foo{longString}.txt";
                 var directoryName = Path.GetDirectoryName(path);
                 return true;
-
             }
             catch (PathTooLongException)
             {

--- a/Public/Src/Cache/ContentStore/UtilitiesCore/FileSystemConstants.cs
+++ b/Public/Src/Cache/ContentStore/UtilitiesCore/FileSystemConstants.cs
@@ -42,11 +42,6 @@ namespace BuildXL.Cache.ContentStore.Interfaces.FileSystem
         private const int MaxPathUnix = 1024;
 
         /// <summary>
-        /// Returns true if paths longer than MaxShortPath are supported.
-        /// </summary>
-        public static bool LongPathsSupported { get; } = GetLongPathSupport();
-
-        /// <summary>
         /// Maximum path length for \\?\ style paths in Windows.
         /// </summary>
         public const int MaxLongPathWindows = 32767;
@@ -70,6 +65,11 @@ namespace BuildXL.Cache.ContentStore.Interfaces.FileSystem
         /// Maximum number of hard links a single file can have.
         /// </summary>
         public static readonly int MaxLinks = IsWindowsOS ? 1024 : ushort.MaxValue;
+
+        /// <summary>
+        /// Returns true if paths longer than MaxShortPath are supported.
+        /// </summary>
+        public static bool LongPathsSupported { get; } = GetLongPathSupport();
 
         /// <summary>
         /// Maximum path length.

--- a/Public/Src/Cache/ContentStore/UtilitiesCore/FileSystemConstants.cs
+++ b/Public/Src/Cache/ContentStore/UtilitiesCore/FileSystemConstants.cs
@@ -67,7 +67,7 @@ namespace BuildXL.Cache.ContentStore.Interfaces.FileSystem
         public static int MaxPath { get; } = LongPathsSupported ? MaxLongPath : MaxShortPath;
 
         /// <summary>
-        /// Returns true if paths longer then 260 characters are supported.
+        /// Returns true if paths longer than MaxShortPath are supported.
         /// </summary>
         public static bool LongPathsSupported { get; } = GetLongPathSupport();
 

--- a/Public/Src/Cache/ContentStore/UtilitiesCore/FileSystemConstants.cs
+++ b/Public/Src/Cache/ContentStore/UtilitiesCore/FileSystemConstants.cs
@@ -42,6 +42,16 @@ namespace BuildXL.Cache.ContentStore.Interfaces.FileSystem
         private const int MaxPathUnix = 1024;
 
         /// <summary>
+        /// Returns true if paths longer than MaxShortPath are supported.
+        /// </summary>
+        public static bool LongPathsSupported { get; } = GetLongPathSupport();
+
+        /// <summary>
+        /// Maximum path length for \\?\ style paths in Windows.
+        /// </summary>
+        public const int MaxLongPathWindows = 32767;
+
+        /// <summary>
         /// Maximum path length when long paths are not supported.
         /// </summary>
         public static readonly int MaxShortPath = IsWindowsOS ? 260 : MaxPathUnix;
@@ -49,7 +59,7 @@ namespace BuildXL.Cache.ContentStore.Interfaces.FileSystem
         /// <summary>
         /// Maximum path length for \\?\ style paths.
         /// </summary>
-        public static readonly int MaxLongPath = IsWindowsOS ? 32767 : MaxPathUnix;
+        public static readonly int MaxLongPath = IsWindowsOS ? MaxLongPathWindows : MaxPathUnix;
 
         /// <summary>
         /// Maximum path length for directory.
@@ -65,11 +75,6 @@ namespace BuildXL.Cache.ContentStore.Interfaces.FileSystem
         /// Maximum path length.
         /// </summary>
         public static int MaxPath { get; } = LongPathsSupported ? MaxLongPath : MaxShortPath;
-
-        /// <summary>
-        /// Returns true if paths longer than MaxShortPath are supported.
-        /// </summary>
-        public static bool LongPathsSupported { get; } = GetLongPathSupport();
 
         private static bool GetLongPathSupport()
         {


### PR DESCRIPTION
Had to change const to static readonly. Shouldn't be a breaking change, specially since these are only used by ourselves, according to index.