### PR TITLE
Make CacheServerFactory public again

### DIFF
--- a/Public/Src/Cache/DistributedCache.Host/Service/Internal/CacheServerFactory.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Service/Internal/CacheServerFactory.cs
@@ -25,7 +25,7 @@ namespace BuildXL.Cache.Host.Service.Internal
     /// <summary>
     /// Creates and configures cache server instances.
     /// </summary>
-    internal class CacheServerFactory
+    public class CacheServerFactory
     {
         private readonly IAbsFileSystem _fileSystem;
         private readonly ILogger _logger;

--- a/Public/Src/Cache/DistributedCache.Host/Service/Internal/CacheServerFactory.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Service/Internal/CacheServerFactory.cs
@@ -25,6 +25,7 @@ namespace BuildXL.Cache.Host.Service.Internal
     /// <summary>
     /// Creates and configures cache server instances.
     /// </summary>
+    /// <remarks>Marked as public because it is used externally.<remarks/>
     public class CacheServerFactory
     {
         private readonly IAbsFileSystem _fileSystem;


### PR DESCRIPTION
`CacheServerFactory` was created from `ContentServerFactory`. The latter was public, but the former is internal. This type is used externally, so this PR returns it to its old access modifier.