### PR TITLE
Collision handling for symbols

### DIFF
--- a/Public/Src/Engine/Scheduler/Tracing/Log.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/Log.cs
@@ -3893,6 +3893,24 @@ namespace BuildXL.Scheduler.Tracing
         internal abstract void ApiServerReportStatisticsExecuted(LoggingContext loggingContext, int numStatistics);
 
         [GeneratedEvent(
+            (ushort)EventId.ApiServerReceivedMessage,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Verbose,
+            Keywords = (int)Keywords.UserMessage,
+            EventTask = (ushort)Tasks.Scheduler,
+            Message = "[{ShortProductName} API Server] {message}.")]
+        internal abstract void ApiServerReceivedMessage(LoggingContext loggingContext, string message);
+
+        [GeneratedEvent(
+            (ushort)EventId.ApiServerReceivedWarningMessage,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Warning,
+            Keywords = (int)Keywords.UserMessage,
+            EventTask = (ushort)Tasks.Scheduler,
+            Message = "[{ShortProductName} API Server] {message}.")]
+        internal abstract void ApiServerReceivedWarningMessage(LoggingContext loggingContext, string message);
+
+        [GeneratedEvent(
             (ushort)EventId.ApiServerGetSealedDirectoryContentExecuted,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,

--- a/Public/Src/Tools/SymbolDaemon/SymbolConfig.cs
+++ b/Public/Src/Tools/SymbolDaemon/SymbolConfig.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using Microsoft.VisualStudio.Services.Symbol.WebApi;
 
 namespace Tool.SymbolDaemon
 {
@@ -45,6 +46,11 @@ namespace Tool.SymbolDaemon
         /// </summary>
         public bool Verbose { get; }
 
+        /// <summary>
+        /// The expected behavior when a debug entry to add already exists.
+        /// </summary>
+        public DebugEntryCreateBehavior DebugEntryCreateBehavior { get; }
+
         /// <nodoc/>
         public static TimeSpan DefaultRetention { get; } = TimeSpan.FromDays(10);
 
@@ -61,6 +67,7 @@ namespace Tool.SymbolDaemon
         public SymbolConfig(
             string requestName,
             Uri serviceEndpoint,
+            string debugEntryCreateBehaviorStr = null,
             TimeSpan? retention = null,
             TimeSpan? httpSendTimeout = null,
             bool? verbose = null,
@@ -74,6 +81,19 @@ namespace Tool.SymbolDaemon
             Verbose = verbose ?? DefaultVerbose;
             EnableTelemetry = enableTelemetry ?? DefaultEnableTelemetry;
             LogDir = logDir;
+
+            if (debugEntryCreateBehaviorStr == null)
+            {
+                DebugEntryCreateBehavior = DebugEntryCreateBehavior.ThrowIfExists;
+            }
+            else if (Enum.TryParse(debugEntryCreateBehaviorStr, out DebugEntryCreateBehavior value))
+            {
+                DebugEntryCreateBehavior = value;
+            }
+            else
+            {
+                DebugEntryCreateBehavior = DebugEntryCreateBehavior.ThrowIfExists;
+            }
         }
     }
 }

--- a/Public/Src/Tools/SymbolDaemon/SymbolDaemon.cs
+++ b/Public/Src/Tools/SymbolDaemon/SymbolDaemon.cs
@@ -67,6 +67,14 @@ namespace Tool.SymbolDaemon
             IsRequired = true,
         });
 
+        internal static readonly StrOption DebugEntryCreateBehavior = RegisterSymbolConfigOption(new StrOption("debugEntryCreateBehavior")
+        {
+            ShortName = "de",
+            HelpText = "Debug Entry Create Behavior in case of a collision",
+            IsRequired = false,
+            DefaultValue = Microsoft.VisualStudio.Services.Symbol.WebApi.DebugEntryCreateBehavior.ThrowIfExists.ToString(),
+        });
+
         internal static readonly IntOption RetentionDays = RegisterSymbolConfigOption(new IntOption("retentionDays")
         {
             ShortName = "rt",
@@ -95,6 +103,7 @@ namespace Tool.SymbolDaemon
             return new SymbolConfig(
                 requestName: conf.Get(SymbolRequestNameOption),
                 serviceEndpoint: conf.Get(ServiceEndpoint),
+                debugEntryCreateBehaviorStr: conf.Get(DebugEntryCreateBehavior),
                 retention: TimeSpan.FromDays(conf.Get(RetentionDays)),
                 httpSendTimeout: TimeSpan.FromMilliseconds(conf.Get(HttpSendTimeoutMillis)),
                 verbose: conf.Get(Verbose),
@@ -263,7 +272,7 @@ namespace Tool.SymbolDaemon
             m_logger.Info(I($"Using {nameof(SymbolConfig)}: {JsonConvert.SerializeObject(symbolConfig)}"));
 
             // if no ISymbolServiceClient has been provided, create VsoSymbolClient using the provided SymbolConfig
-            m_symbolServiceClientTask = symbolServiceClientTask ?? Task.Run(() => (ISymbolClient)new VsoSymbolClient(m_logger, symbolConfig));
+            m_symbolServiceClientTask = symbolServiceClientTask ?? Task.Run(() => (ISymbolClient)new VsoSymbolClient(m_logger, symbolConfig, bxlClient));
 
             m_symbolIndexer = new SymbolIndexer(SymbolAppTraceSource.SingleInstance);
         }

--- a/Public/Src/Tools/SymbolDaemon/SymbolFile.cs
+++ b/Public/Src/Tools/SymbolDaemon/SymbolFile.cs
@@ -155,7 +155,8 @@ namespace Tool.SymbolDaemon
         /// <nodoc/>
         public override string ToString()
         {
-            return FileId.ToString(m_file);
+            return $"Path: {FullFilePath}{Environment.NewLine}" +
+                $"   {string.Join(Environment.NewLine, DebugEntries.Select(a=> $"BlobId:{a.BlobIdentifier} - ClientKey:{a.ClientKey} - InfoLevel:{a.InformationLevel}"))}";
         }
     }
 }

--- a/Public/Src/Tools/SymbolDaemon/Tool.SymbolDaemonInterfaces.dsc
+++ b/Public/Src/Tools/SymbolDaemon/Tool.SymbolDaemonInterfaces.dsc
@@ -45,6 +45,21 @@ export interface OperationArguments extends Transformer.RunnerArguments {
 }
 
 /**
+ * The expected behavior when a debug entry to add already exists.
+ */
+@@public
+export const enum DebugEntryCreateBehavior {
+    /** Throw exceptions at server end. This will translate to 409 (Conflict) HTTP status code. */
+    ThrowIfExists = 0,
+
+    /** Do not add this debug entry. The rest of the batch, if any, is not affected. */
+    SkipIfExists,
+
+    /** Overwrite the existing debug entry. */
+    OverwriteIfExists,
+}
+
+/**
  * VSO Symbol settings.
  */
 @@public
@@ -63,6 +78,9 @@ export interface SymbolRequestSettings {
     
     /** Enable symbol telemetry. */
     enableTelemetry?: boolean;
+
+    /** The expected behavior when a debug entry to add already exists. */
+    debugEntryCreateBehavior?: DebugEntryCreateBehavior;
 }
 
 /**

--- a/Public/Src/Tools/SymbolDaemon/Tool.SymbolDaemonRunner.dsc
+++ b/Public/Src/Tools/SymbolDaemon/Tool.SymbolDaemonRunner.dsc
@@ -238,6 +238,7 @@ function getExecuteArguments(command: string, args: UberArguments, ...additional
             Cmd.option("--connectRetryDelayMillis ", args.connectRetryDelayMillis),
             Cmd.flag("--enableCloudBuildIntegration", args.enableCloudBuildIntegration),
             Cmd.flag("--enableTelemetry", args.enableTelemetry),
+            (args.debugEntryCreateBehavior !== undefined) ? Cmd.option("--debugEntryCreateBehavior ", debugEntryCreateBehaviorToString(args.debugEntryCreateBehavior)) : undefined,
             Cmd.flag("--verbose", true),
             Cmd.option("--logDir ", symbolLogDirectory.path),
             ...additionalCmdArgs,
@@ -292,4 +293,17 @@ function getIpcArguments(serviceStartInfo: ServiceStartResult, command: string, 
         outputFile: args.consoleOutput || exeArgs.consoleOutput,
     };
     return overrideIpcArgs !== undefined ? overrideIpcArgs(ipcArgs) : ipcArgs;
+}
+
+function debugEntryCreateBehaviorToString(arg: DebugEntryCreateBehavior) {
+    switch (arg) {
+        case DebugEntryCreateBehavior.ThrowIfExists:
+            return "ThrowIfExists";
+        case DebugEntryCreateBehavior.SkipIfExists:
+            return "SkipIfExists";
+        case DebugEntryCreateBehavior.OverwriteIfExists:
+            return "OverwriteIfExists";
+        default:
+            return "Unspecified";
+    };
 }

--- a/Public/Src/Tools/SymbolDaemon/VsoSymbolClient.cs
+++ b/Public/Src/Tools/SymbolDaemon/VsoSymbolClient.cs
@@ -2,12 +2,15 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.ContractsLight;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BuildXL.Ipc.Common;
+using BuildXL.Ipc.ExternalApi;
 using BuildXL.Ipc.Interfaces;
+using BuildXL.Utilities;
 using Microsoft.VisualStudio.Services.Common;
 using Microsoft.VisualStudio.Services.Content.Common;
 using Microsoft.VisualStudio.Services.Content.Common.Authentication;
@@ -27,14 +30,17 @@ namespace Tool.SymbolDaemon
     /// </summary>
     public sealed class VsoSymbolClient : ISymbolClient
     {
-        private const DebugEntryCreateBehavior DefaultDebugEntryCreateBehavior = DebugEntryCreateBehavior.ThrowIfExists;
 
         private static IAppTraceSource Tracer => SymbolAppTraceSource.SingleInstance;
+
+        private readonly Client m_apiClient;
 
         private readonly ILogger m_logger;
         private readonly SymbolConfig m_config;
         private readonly ISymbolServiceClient m_symbolClient;
         private readonly CancellationTokenSource m_cancellationSource;
+        private readonly DebugEntryCreateBehavior m_debugEntryCreateBehavior;
+
         private CancellationToken CancellationToken => m_cancellationSource.Token;
         private string m_requestId;
 
@@ -63,10 +69,12 @@ namespace Tool.SymbolDaemon
         }
 
         /// <nodoc />
-        public VsoSymbolClient(ILogger logger, SymbolConfig config)
+        public VsoSymbolClient(ILogger logger, SymbolConfig config, Client apiClient)
         {
             m_logger = logger;
+            m_apiClient = apiClient;
             m_config = config;
+            m_debugEntryCreateBehavior = config.DebugEntryCreateBehavior;
             m_cancellationSource = new CancellationTokenSource();
 
             m_logger.Info(I($"[{nameof(VsoSymbolClient)}] Using drop config: {JsonConvert.SerializeObject(m_config)}"));
@@ -124,11 +132,42 @@ namespace Tool.SymbolDaemon
 
             await EnsureRequestIdInitalizedAsync();
 
-            var result = await m_symbolClient.CreateRequestDebugEntriesAsync(
-                RequestId,
-                symbolFile.DebugEntries.Select(e => CreateDebugEntry(e)),
-                DefaultDebugEntryCreateBehavior,
-                CancellationToken);
+            List<DebugEntry> result;
+
+            try
+            {
+                result = await m_symbolClient.CreateRequestDebugEntriesAsync(
+                    RequestId,
+                    symbolFile.DebugEntries.Select(e => CreateDebugEntry(e)),
+                    DebugEntryCreateBehavior.ThrowIfExists,
+                    CancellationToken);
+            }
+            catch (DebugEntryExistsException)
+            {
+                string message = $"[SymbolDaemon] File: '{symbolFile.FullFilePath}' caused collision. " +
+                    (m_debugEntryCreateBehavior == DebugEntryCreateBehavior.ThrowIfExists 
+                        ? string.Empty 
+                        : $"SymbolDaemon will retry creating debug entry with {m_debugEntryCreateBehavior} behavior");
+
+                // Log a warning message in BuildXL log file
+                Analysis.IgnoreResult(await m_apiClient.LogMessage(message, isWarning: true));
+ 
+                if (m_debugEntryCreateBehavior == DebugEntryCreateBehavior.ThrowIfExists)
+                {
+                    // Log an error message in SymbolDaemon log file
+                    m_logger.Error(message);
+                    throw new DebugEntryExistsException(message);
+                }
+
+                // Log a warning message in SymbolDaemon log file
+                m_logger.Warning(message);
+
+                result = await m_symbolClient.CreateRequestDebugEntriesAsync(
+                    RequestId,
+                    symbolFile.DebugEntries.Select(e => CreateDebugEntry(e)),
+                    m_debugEntryCreateBehavior,
+                    CancellationToken);
+            }
 
             var entriesWithMissingBlobs = result.Where(e => e.Status == DebugEntryStatus.BlobMissing).ToList();
 
@@ -154,7 +193,7 @@ namespace Tool.SymbolDaemon
                 entriesWithMissingBlobs = await m_symbolClient.CreateRequestDebugEntriesAsync(
                     RequestId,
                     entriesWithMissingBlobs,
-                    DefaultDebugEntryCreateBehavior,
+                    m_debugEntryCreateBehavior,
                     CancellationToken);
 
                 Contract.Assert(entriesWithMissingBlobs.All(e => e.Status != DebugEntryStatus.BlobMissing), "Entries with non-success code are present.");

--- a/Public/Src/Utilities/Instrumentation/Tracing/Statistics.resx
+++ b/Public/Src/Utilities/Instrumentation/Tracing/Statistics.resx
@@ -1,5 +1,110 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
@@ -46,13 +151,13 @@
     <value>DiskAvailableMBExecutionStart</value>
   </data>
   <data name="ApiTotalMaterializeFileCalls" xml:space="preserve">
-    <value>DominoApiTotalMaterializeFileCalls</value>
+    <value>BuildXLApiTotalMaterializeFileCalls</value>
   </data>
   <data name="ApiTotalReportStatisticsCalls" xml:space="preserve">
-    <value>DominoApiTotalReportStatisticsCalls</value>
+    <value>BuildXLApiTotalReportStatisticsCalls</value>
   </data>
   <data name="ApiTotalGetSealedDirectoryContentCalls" xml:space="preserve">
-    <value>DominoApiTotalGetSealedDirectoryContentCalls</value>
+    <value>BuildXLApiTotalGetSealedDirectoryContentCalls</value>
   </data>
   <data name="DropTrackerOverhangMs" xml:space="preserve">
     <value>DropTrackerOverhangMs</value>
@@ -176,5 +281,8 @@
   </data>
   <data name="AppHostInitializationDurationMs" xml:space="preserve">
     <value>AppHostInitializationDurationMs</value>
+  </data>
+  <data name="ApiTotalLogMessageCalls" xml:space="preserve">
+    <value>BuildXLApiTotalLogMessageCalls</value>
   </data>
 </root>

--- a/Public/Src/Utilities/Ipc/ExternalApi/Client.cs
+++ b/Public/Src/Utilities/Ipc/ExternalApi/Client.cs
@@ -55,6 +55,14 @@ namespace BuildXL.Ipc.ExternalApi
         }
 
         /// <summary>
+        /// Log a verbose or warning message on BuildXL side
+        /// </summary>
+        public Task<Possible<bool>> LogMessage(string message, bool isWarning = false)
+        {
+            return ExecuteCommand(new LogMessageCommand(message, isWarning));
+        }
+
+        /// <summary>
         /// Arbitrary statistics that BuildXL should report (in its .stats file).
         /// </summary>
         public Task<Possible<bool>> ReportStatistics(IDictionary<string, long> stats)

--- a/Public/Src/Utilities/Ipc/ExternalApi/Commands/Command.cs
+++ b/Public/Src/Utilities/Ipc/ExternalApi/Commands/Command.cs
@@ -68,6 +68,8 @@ namespace BuildXL.Ipc.ExternalApi.Commands
                         return ReportStatisticsCommand.InternalDeserialize(reader);
                     case nameof(GetSealedDirectoryContentCommand):
                         return GetSealedDirectoryContentCommand.InternalDeserialize(reader);
+                    case nameof(LogMessageCommand):
+                        return LogMessageCommand.InternalDeserialize(reader);
                     default:
                         Contract.Assert(false, "unrecognized command type name: " + typeName);
                         return null;

--- a/Public/Src/Utilities/Ipc/ExternalApi/Commands/LogMessageCommand.cs
+++ b/Public/Src/Utilities/Ipc/ExternalApi/Commands/LogMessageCommand.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.ContractsLight;
+using System.IO;
+
+namespace BuildXL.Ipc.ExternalApi.Commands
+{
+    /// <summary>
+    /// Command corresponding to the <see cref="Client.LogMessage"/> API operation.
+    /// </summary>
+    public sealed class LogMessageCommand : Command<bool>
+    {
+        /// <summary>Nessage to be logged.</summary>
+        public string Message { get; }
+
+        /// <summary>Whether the message is to be logged as a warning or verbose.</summary>
+        public bool IsWarning { get; }
+
+        /// <nodoc />
+        public LogMessageCommand(string message, bool isWarning)
+        {
+            Contract.Requires(!string.IsNullOrWhiteSpace(message));
+
+            Message = message;
+            IsWarning = isWarning;
+        }
+
+        /// <inheritdoc />
+        public override bool TryParseResult(string result, out bool commandResult)
+        {
+            commandResult = false;
+            return bool.TryParse(result, out commandResult);
+        }
+
+        /// <inheritdoc />
+        public override string RenderResult(bool commandResult)
+        {
+            return commandResult.ToString();
+        }
+
+        internal override void InternalSerialize(BinaryWriter writer)
+        {
+            writer.Write(Message);
+            writer.Write(IsWarning);
+        }
+
+        internal static Command InternalDeserialize(BinaryReader reader)
+        {
+            var message = reader.ReadString();
+            bool isWarning = reader.ReadBoolean();
+            return new LogMessageCommand(message, isWarning);
+        }
+    }
+}

--- a/Public/Src/Utilities/Utilities/Tracing/EventId.cs
+++ b/Public/Src/Utilities/Utilities/Tracing/EventId.cs
@@ -1046,6 +1046,8 @@ namespace BuildXL.Utilities.Tracing
         ApiServerReportStatisticsExecuted = 12104,
         ApiServerGetSealedDirectoryContentExecuted = 12105,
         ErrorApiServerMaterializeFileFailed = 12106,
+        ApiServerReceivedMessage = 12107,
+        ApiServerReceivedWarningMessage = 12108,
 
         // Copy file cont'd.
         PipCopyFileSourceFileDoesNotExist = 12201,


### PR DESCRIPTION
Collision handling behavior can be specified by the developer: 
(1) DebugEntryCreateBehavior.ThrowIfExists:
     - We log a warning message on both SymbolDaemon and BuildXL log file.
     - We fail the IPC pip.
(2) DebugEntryCreateBehavior.SkipIfExists:
     - We log a warning message on both SymbolDaemon and BuildXL log file.
(3) DebugEntryCreateBehavior.OverwriteIfExists
     - We log a warning message on both SymbolDaemon and BuildXL log file.
     - We retry adding the symbol with OverwriteIfExists behavior.