### PR TITLE
Bug fix for initializing Lazy instance concurrently

### DIFF
--- a/Public/Src/Engine/Scheduler/RunnablePipPerformanceInfo.cs
+++ b/Public/Src/Engine/Scheduler/RunnablePipPerformanceInfo.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Threading;
 using BuildXL.Scheduler.WorkDispatcher;
 
 namespace BuildXL.Scheduler
@@ -63,7 +64,7 @@ namespace BuildXL.Scheduler
             QueueRequestDurations = new Lazy<TimeSpan[]>(() => new TimeSpan[(int)PipExecutionStep.Done + 1], isThreadSafe: false);
             SendRequestDurations = new Lazy<TimeSpan[]>(() => new TimeSpan[(int)PipExecutionStep.Done + 1], isThreadSafe: false);
             QueueDurations = new Lazy<TimeSpan[]>(() => new TimeSpan[(int)DispatcherKind.Materialize + 1], isThreadSafe: false);
-            Workers = new Lazy<uint[]>(() => new uint[(int)PipExecutionStep.Done + 1], isThreadSafe: false);
+            Workers = new Lazy<uint[]>(() => new uint[(int)PipExecutionStep.Done + 1], LazyThreadSafetyMode.PublicationOnly);
         }
 
         internal void Enqueued(DispatcherKind kind)


### PR DESCRIPTION
Fixes [AB#1604569](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1604569)

Bug: 

System.InvalidOperationException: ValueFactory attempted to access the Value property of this instance.
   at void System.Lazy<T>.ViaFactory(LazyThreadSafetyMode mode)
   at T System.Lazy<T>.CreateValue()
   at string BuildXL.Scheduler.Scheduler.GetProducerInfoForFailedMaterializeFile(in FileArtifact artifact) in \.\Public\Src\Engine\Scheduler\Scheduler.cs:line 4226
   at void BuildXL.Scheduler.Tracing.MasterSpecificExecutionLogTarget.CacheMaterializationError(CacheMaterializationErrorEventData data)+(ValueTuple<FileArtifact, ContentHash> f) => { } in \.\Public\Src\Engine\Scheduler\Tracing\MasterSpecificExecutionLogTarget.cs:line 52
   at bool System.Linq.Enumerable+SelectEnumerableIterator<TSource, TResult>.MoveNext()
   at bool System.Linq.Enumerable+ConcatIterator<TSource>.MoveNext()
   at string string.Join(string separator, IEnumerable<string> values)
