### PR TITLE
Validate SST files during checkpointing

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/BlobCentralStorage.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/BlobCentralStorage.cs
@@ -106,7 +106,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                 AttemptResult result = await TaskUtilities.WithTimeoutAsync(async token =>
                     {
                         var blob = container.GetBlockBlobReference(blobName);
-                        var exists = await blob.ExistsAsync(DefaultBlobStorageRequestOptions, null, token);
+                        var exists = await blob.ExistsAsync(null, null, token);
 
                         if (exists)
                         {
@@ -184,7 +184,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                         async token =>
                         {
                             var blob = await GetBlockBlobReferenceAsync(container, shardId, blobName, token);
-                            var exists = await blob.ExistsAsync(DefaultBlobStorageRequestOptions, null, token);
+                            var exists = await blob.ExistsAsync(null, null, token);
 
                             if (exists)
                             {
@@ -194,7 +194,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                                     $@"Touching blob '{_configuration.ContainerName}\{blobName}' of size {blob.Properties.Length} with access time {now} for shard #{shardId}.");
                                 blob.Metadata[LastAccessedMetadataName] = now.ToReadableString();
 
-                                await blob.SetMetadataAsync(null, DefaultBlobStorageRequestOptions, null, token);
+                                await blob.SetMetadataAsync(null, null, null, token);
                             }
                             else
                             {

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/DistributedCentralStorage.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/DistributedCentralStorage.cs
@@ -156,7 +156,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             if (hash != null)
             {
                 // First attempt to place file from content store
-                var placeResult = await _privateCas.PlaceFileAsync(context, hash.Value, targetFilePath, FileAccessMode.Write, FileReplacementMode.ReplaceExisting, FileRealizationMode.CopyNoVerify, pinRequest: null);
+                var placeResult = await _privateCas.PlaceFileAsync(context, hash.Value, targetFilePath, FileAccessMode.Write, FileReplacementMode.ReplaceExisting, FileRealizationMode.Copy, pinRequest: null);
                 if (placeResult.IsPlaced())
                 {
                     return Result.Success(new ContentHashWithSize(hash.Value, placeResult.FileSize));
@@ -167,7 +167,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                 if (putResult.Succeeded)
                 {
                     // Lastly, try to place again now that file is copied to CAS
-                    placeResult = await _privateCas.PlaceFileAsync(context, hash.Value, targetFilePath, FileAccessMode.Write, FileReplacementMode.ReplaceExisting, FileRealizationMode.CopyNoVerify, pinRequest: null).ThrowIfFailure();
+                    placeResult = await _privateCas.PlaceFileAsync(context, hash.Value, targetFilePath, FileAccessMode.Write, FileReplacementMode.ReplaceExisting, FileRealizationMode.Copy, pinRequest: null).ThrowIfFailure();
 
                     Counters[CentralStorageCounters.TryGetFileFromPeerSucceeded].Increment();
                     return Result.Success(new ContentHashWithSize(hash.Value, placeResult.FileSize));


### PR DESCRIPTION
In all error cases in CBTest, we obtain the file properly from remote storage, but RocksDb fails to start anyways due to corruption. The only explanation I can find is that we are not checking that its hash matches after copying. Another idea worth exploring is if we can simply hard link the files instead, so as to avoid that additional hash check. I _think_ it should be OK as long as we keep the files pinned for as long as the checkpoint is in use, but I'm not sure how to verify.

This also adds checks for Azure Blob downloads, as they don't check by default. One thing to keep in mind is that, **by default, the blob client will use a single thread; we may want to change this**. This latter change does not come from observations, but as a matter of principle.