### PR TITLE
Make some filesystemcontentstore traces optional.

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/EventStreaming/EventHubContentLocationEventStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/EventStreaming/EventHubContentLocationEventStore.cs
@@ -13,7 +13,6 @@ using System.Threading.Tasks.Dataflow;
 using BuildXL.Cache.ContentStore.Distributed.Tracing;
 using BuildXL.Cache.ContentStore.Interfaces.Results;
 using BuildXL.Cache.ContentStore.Tracing.Internal;
-using BuildXL.Utilities.Collections;
 using BuildXL.Utilities.Tasks;
 using BuildXL.Utilities.Tracing;
 using Microsoft.Azure.EventHubs;

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/RedisGlobalStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/RedisGlobalStore.cs
@@ -293,7 +293,8 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
 
                     return Result.Success<IReadOnlyList<ContentLocationEntry>>(results);
                 },
-                Counters[GlobalStoreCounters.GetBulk]);
+                Counters[GlobalStoreCounters.GetBulk],
+                traceErrorsOnly: true);
         }
 
         private ContentLocationEntry MergeEntries(ContentLocationEntry entry, ContentLocationEntry originalEntry)

--- a/Public/Src/Cache/ContentStore/Library/Stores/ContentStoreSettings.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/ContentStoreSettings.cs
@@ -82,6 +82,11 @@ namespace BuildXL.Cache.ContentStore.Stores
         /// </summary>
         public bool OverrideUnixFileAccessMode { get; set; } = false;
 
+        /// <summary>
+        /// Whether to trace diagnostic-level messages emitted by <see cref="FileSystemContentStore"/> and <see cref="FileSystemContentStoreInternal"/> like hashing or placing files.
+        /// </summary>
+        public bool TraceFileSystemContentStoreDiagnosticMessages { get; set; } = false;
+
         /// <nodoc />
         public static ContentStoreSettings DefaultSettings { get; } = new ContentStoreSettings();
     }

--- a/Public/Src/Cache/ContentStore/Library/Stores/FileSystemContentStoreInternal.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/FileSystemContentStoreInternal.cs
@@ -9,6 +9,8 @@ using System.Diagnostics.ContractsLight;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Security.AccessControl;
+using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;

--- a/Public/Src/Cache/ContentStore/Library/Stores/FileSystemContentStoreInternal.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/FileSystemContentStoreInternal.cs
@@ -244,7 +244,7 @@ namespace BuildXL.Cache.ContentStore.Stores
             Contract.Requires(fileSystem != null);
             Contract.Requires(clock != null);
 
-            _tracer = new ContentStoreInternalTracer(settings.TraceFileSystemContentStoreDiagnosticMessages);
+            _tracer = new ContentStoreInternalTracer(settings?.TraceFileSystemContentStoreDiagnosticMessages ?? false);
             _hashers = HashInfoLookup.CreateAll();
             int maxContentPathLengthRelativeToCacheRoot = GetMaxContentPathLengthRelativeToCacheRoot();
 

--- a/Public/Src/Cache/ContentStore/Library/Tracing/EvictResult.cs
+++ b/Public/Src/Cache/ContentStore/Library/Tracing/EvictResult.cs
@@ -116,11 +116,17 @@ namespace BuildXL.Cache.ContentStore.Tracing
             return new DeleteResult(DeleteResult.ResultCode.ContentNotDeleted, contentHash, EvictedSize, PinnedSize);
         }
 
+        /// <nodoc />
+        public TimeSpan Age => CreationTime - LastAccessTime;
+
+        /// <nodoc />
+        public TimeSpan? EffectiveAge => CreationTime - EffectiveLastAccessTime;
+
         /// <inheritdoc />
         public override string ToString()
         {
             return Succeeded
-                ? $"Success Size={EvictedSize} Files={EvictedFiles} Pinned={PinnedSize} LastAccessTime={LastAccessTime} Age={CreationTime - LastAccessTime} ReplicaCount={ReplicaCount} EffectiveLastAccessTime={EffectiveLastAccessTime} EffectiveAge={CreationTime - EffectiveLastAccessTime}"
+                ? $"Success Size={EvictedSize} Files={EvictedFiles} Pinned={PinnedSize} LastAccessTime={LastAccessTime} Age={Age} ReplicaCount={ReplicaCount} EffectiveLastAccessTime={EffectiveLastAccessTime} EffectiveAge={EffectiveAge}"
                 : GetErrorString();
         }
     }

--- a/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
@@ -520,6 +520,9 @@ namespace BuildXL.Cache.Host.Configuration
         [DataMember]
         public bool OverrideUnixFileAccessMode { get; set; } = false;
 
+        [DataMember]
+        public bool TraceFileSystemContentStoreDiagnosticMessages { get; set; } = false;
+
         /// <summary>
         /// Valid values: Disabled, InsideRing, OutsideRing, Both (See ProactiveCopyMode enum)
         /// </summary>

--- a/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
@@ -252,7 +252,8 @@ namespace BuildXL.Cache.Host.Service.Internal
                 StartSelfCheckInStartup = settings.StartSelfCheckAtStartup,
                 SelfCheckFrequency = TimeSpan.FromMinutes(settings.SelfCheckFrequencyInMinutes),
                 OverrideUnixFileAccessMode = settings.OverrideUnixFileAccessMode,
-                UseRedundantPutFileShortcut = settings.UseRedundantPutFileShortcut
+                UseRedundantPutFileShortcut = settings.UseRedundantPutFileShortcut,
+                TraceFileSystemContentStoreDiagnosticMessages = settings.TraceFileSystemContentStoreDiagnosticMessages,
             };
         }
 


### PR DESCRIPTION
This PR makes some of the messages from `FileSystemContentStoreInternal` optional (and disabled by default).

For instance, hashing, place file and hard link creation are responsible for about 8% of overall kusto traffic. And now these messages are still available but only when the configuration turns on.