### PR TITLE
Allow specifying host name for ServiceClientContentStore to enable remote control of CASaaS instances on different machines.

### DIFF
--- a/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcClientBase.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcClientBase.cs
@@ -28,7 +28,7 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
         private const string HeartbeatName = "Heartbeat";
         private const int DefaultHeartbeatIntervalMinutes = 1;
 
-        private readonly int _grpcPort;
+        private readonly ServiceClientRpcConfiguration _configuration;
         private readonly TimeSpan _heartbeatInterval;
         private Capabilities _clientCapabilities;
         private Capabilities _serviceCapabilities;
@@ -58,20 +58,20 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
         protected GrpcClientBase(
             IAbsFileSystem fileSystem,
             ServiceClientContentSessionTracer tracer,
-            int grpcPort,
+            ServiceClientRpcConfiguration configuration,
             string scenario,
             Capabilities clientCapabilities,
             TimeSpan? heartbeatInterval = null)
         {
             FileSystem = fileSystem;
             ServiceClientTracer = tracer;
-            _grpcPort = grpcPort;
+            _configuration = configuration;
             Scenario = scenario;
 
             GrpcEnvironment.InitializeIfNeeded();
-            Channel = new Channel(GrpcEnvironment.Localhost, (int)grpcPort, ChannelCredentials.Insecure, GrpcEnvironment.DefaultConfiguration);
+            Channel = new Channel(configuration.GrpcHost ?? GrpcEnvironment.Localhost, configuration.GrpcPort, ChannelCredentials.Insecure, GrpcEnvironment.DefaultConfiguration);
             _clientCapabilities = clientCapabilities;
-            _heartbeatInterval = heartbeatInterval ?? TimeSpan.FromMinutes(DefaultHeartbeatIntervalMinutes);
+            _heartbeatInterval = _configuration.HeartbeatInterval ?? TimeSpan.FromMinutes(DefaultHeartbeatIntervalMinutes);
         }
 
         /// <nodoc />
@@ -220,7 +220,7 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
         {
             try
             {
-                context.Always($"Starting up GRPC client against service on port {_grpcPort} with timeout {waitMs}.");
+                context.Always($"Starting up GRPC client against service on port {_configuration.GrpcPort} with timeout {waitMs}.");
 
                 if (!LocalContentServer.EnsureRunning(context, Scenario, waitMs))
                 {

--- a/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcContentClient.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcContentClient.cs
@@ -44,7 +44,20 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
             string scenario,
             TimeSpan? heartbeatInterval = null,
             Capabilities capabilities = Capabilities.ContentOnly)
-            : base(fileSystem, tracer, grpcPort, scenario, capabilities, heartbeatInterval)
+            : this(tracer, fileSystem, new ServiceClientRpcConfiguration(grpcPort,heartbeatInterval), scenario, capabilities)
+        {
+            GrpcEnvironment.InitializeIfNeeded();
+            Client = new ContentServer.ContentServerClient(Channel);
+        }
+
+        /// <nodoc />
+        public GrpcContentClient(
+            ServiceClientContentSessionTracer tracer,
+            IAbsFileSystem fileSystem,
+            ServiceClientRpcConfiguration configuration,
+            string scenario,
+            Capabilities capabilities = Capabilities.ContentOnly)
+            : base(fileSystem, tracer, configuration, scenario, capabilities)
         {
             GrpcEnvironment.InitializeIfNeeded();
             Client = new ContentServer.ContentServerClient(Channel);

--- a/Public/Src/Cache/ContentStore/Library/Sessions/ServiceClientRpcConfiguration.cs
+++ b/Public/Src/Cache/ContentStore/Library/Sessions/ServiceClientRpcConfiguration.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using BuildXL.Cache.ContentStore.Service.Grpc;
 
 namespace BuildXL.Cache.ContentStore.Sessions
 {
@@ -19,7 +20,12 @@ namespace BuildXL.Cache.ContentStore.Sessions
         /// Gets the GRPC port.
         /// </summary>
         public int GrpcPort { get; }
-        
+
+        /// <summary>
+        /// Gets the GRPC host name. 
+        /// NOTE: Leaving unspecified equates to using localhost
+        /// </summary>
+        public string GrpcHost { get; set; } = GrpcEnvironment.Localhost;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ServiceClientRpcConfiguration"/> class.

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/IntegrationTest.BuildXL.Scheduler.dsc
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/IntegrationTest.BuildXL.Scheduler.dsc
@@ -30,8 +30,8 @@ namespace Scheduler.IntegrationTest {
         assemblyName: "IntegrationTest.BuildXL.Scheduler",
         sources: globR(d`.`, "*.cs"),
         runTestArgs: {
-            parallelGroups: categoriesToRunInParallel
-        },
+                parallelBucketCount: 20,
+            },
         references: [
             Scheduler.dll,
             EngineTestUtilities.dll,


### PR DESCRIPTION
Allow specifying host name for ServiceClientContentStore to enable remote control of CASaaS instances on different machines.