### PR TITLE
Force restore from last checkpoint when content location database is invalidated

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabase.cs
@@ -91,25 +91,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         /// <summary>
         /// Event callback that's triggered when the database is permanently invalidated. 
         /// </summary>
-        public event EventHandler<DatabaseInvalidatedEventArgs> DatabaseInvalidated;
-
-        /// <nodoc />
-        public class DatabaseInvalidatedEventArgs : EventArgs
-        {
-            /// <nodoc />
-            public OperationContext Context { get; }
-
-            /// <nodoc />
-            public Failure<Exception> Failure { get; }
-
-            /// <nodoc />
-            public DatabaseInvalidatedEventArgs(OperationContext context, Failure<Exception> failure)
-            {
-                Contract.Requires(failure != null);
-                Context = context;
-                Failure = failure;
-            }
-        }   
+        public Action<OperationContext, Failure<Exception>> DatabaseInvalidated;
 
         /// <nodoc />
         protected void OnDatabaseInvalidated(OperationContext context, Failure<Exception> failure)
@@ -120,7 +102,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             // nothing can be done to this instance after invalidation: all incoming and ongoing operations should fail
             // (because it is triggered by RocksDb). The only way to resume operation is to reload from a checkpoint,
             // which resets the internal state correctly.
-            DatabaseInvalidated?.Invoke(this, new DatabaseInvalidatedEventArgs(context, failure));
+            DatabaseInvalidated?.Invoke(context, failure);
         }
 
         /// <nodoc />

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
@@ -1268,7 +1268,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             // restores, avoids redundant logging.
             using (_databaseInvalidationGate.AcquireSemaphore(0))
             {
-                Tracer.Error(e.Context, "Content location database has been invalidated. Forcing a restore from the last checkpoint.");
+                Tracer.Error(e.Context, $"Content location database has been invalidated. Forcing a restore from the last checkpoint. Error: {e.Failure.DescribeIncludingInnerFailures()}");
 
                 // There is nothing we can do from here if the checkpoint fails to restore. We will just wait until the
                 // next heartbeat.

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/RocksDbContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/RocksDbContentLocationDatabase.cs
@@ -203,6 +203,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                     },
                     invalidationHandler: failure => {
                         Tracer.Error(context, $"RocksDb critical error caused store invalidation: {failure.DescribeIncludingInnerFailures()}");
+                        OnDatabaseInvalidated(context, failure);
                     },
                     onFailureDeleteExistingStoreAndRetry: _configuration.OnFailureDeleteExistingStoreAndRetry,
                     onStoreReset: failure => {

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/RocksDbContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/RocksDbContentLocationDatabase.cs
@@ -201,10 +201,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                         // By default, rethrow is true iff it is a user error. We invalidate only if it isn't
                         failureEvent.Invalidate = !failureEvent.Rethrow;
                     },
-                    invalidationHandler: failure => {
-                        Tracer.Error(context, $"RocksDb critical error caused store invalidation: {failure.DescribeIncludingInnerFailures()}");
-                        OnDatabaseInvalidated(context, failure);
-                    },
+                    invalidationHandler: failure => OnDatabaseInvalidated(context, failure),
                     onFailureDeleteExistingStoreAndRetry: _configuration.OnFailureDeleteExistingStoreAndRetry,
                     onStoreReset: failure => {
                         Tracer.Error(context, $"RocksDb critical error caused store to reset: {failure.DescribeIncludingInnerFailures()}");

--- a/Public/Src/Cache/ContentStore/Interfaces/Synchronization/SemaphoreSlimToken.cs
+++ b/Public/Src/Cache/ContentStore/Interfaces/Synchronization/SemaphoreSlimToken.cs
@@ -42,6 +42,20 @@ namespace BuildXL.Cache.ContentStore.Interfaces.Synchronization.Internal
             return new SemaphoreSlimToken(semaphore);
         }
 
+        /// <summary>
+        ///     Wait on a SemaphoreSlim and return a token that, when disposed, calls Release() on the SemaphoreSlim.
+        ///     If the deadline is reached, the token is not acquired and a fake disposable is returned.
+        /// </summary>
+        /// <param name="semaphore">The semaphore to wait on</param>
+        /// <param name="millisecondsTimeout">Maximum time to wait for the semaphore, in milliseconds</param>
+        /// <param name="acquired">Whether the semaphore was obtained or not</param>
+        /// <returns>A token that, when disposed, calls Release() on the SemaphoreSlim</returns>
+        public static SemaphoreSlimToken TryWait(SemaphoreSlim semaphore, int millisecondsTimeout, out bool acquired)
+        {
+            acquired = semaphore.Wait(millisecondsTimeout);
+            return new SemaphoreSlimToken(acquired ? semaphore : null);
+        }
+
         /// <inheritdoc />
         public void Dispose()
         {

--- a/Public/Src/Utilities/Utilities/Tasks/TaskUtilities.cs
+++ b/Public/Src/Utilities/Utilities/Tasks/TaskUtilities.cs
@@ -209,7 +209,7 @@ namespace BuildXL.Utilities.Tasks
         /// </summary>
         /// <param name="semaphore">The semaphore to acquire</param>
         /// <param name="millisecondsTimeout">Time to wait to acquire the semaphore</param>
-        public static SemaphoreReleaser AcquireSemaphore(this SemaphoreSlim semaphore, int millisecondsTimeout = Timeout.Infinite)
+        public static SemaphoreReleaser AcquireSemaphore(this SemaphoreSlim semaphore)
         {
             Contract.Requires(semaphore != null);
             semaphore.Wait();

--- a/Public/Src/Utilities/Utilities/Tasks/TaskUtilities.cs
+++ b/Public/Src/Utilities/Utilities/Tasks/TaskUtilities.cs
@@ -208,7 +208,6 @@ namespace BuildXL.Utilities.Tasks
         /// Synchronously acquire a semaphore
         /// </summary>
         /// <param name="semaphore">The semaphore to acquire</param>
-        /// <param name="millisecondsTimeout">Time to wait to acquire the semaphore</param>
         public static SemaphoreReleaser AcquireSemaphore(this SemaphoreSlim semaphore)
         {
             Contract.Requires(semaphore != null);

--- a/Public/Src/Utilities/Utilities/Tasks/TaskUtilities.cs
+++ b/Public/Src/Utilities/Utilities/Tasks/TaskUtilities.cs
@@ -208,7 +208,8 @@ namespace BuildXL.Utilities.Tasks
         /// Synchronously acquire a semaphore
         /// </summary>
         /// <param name="semaphore">The semaphore to acquire</param>
-        public static SemaphoreReleaser AcquireSemaphore(this SemaphoreSlim semaphore)
+        /// <param name="millisecondsTimeout">Time to wait to acquire the semaphore</param>
+        public static SemaphoreReleaser AcquireSemaphore(this SemaphoreSlim semaphore, int millisecondsTimeout = Timeout.Infinite)
         {
             Contract.Requires(semaphore != null);
             semaphore.Wait();


### PR DESCRIPTION
When an event (such as database corruption) triggers a database invalidation, we currently have to wait until the next checkpoint is made available and restored. This PR changes the mechanic so that if this happens, a restore is triggered.

Notice that even though the restore is triggered, it will only happen if there is no other ongoing restore.