### PR TITLE
Remove unnecessary environment var for qtest pip

### DIFF
--- a/Public/Sdk/SelfHost/BuildXL/Tools/QTest/Tool.QTestRunner.dsc
+++ b/Public/Sdk/SelfHost/BuildXL/Tools/QTest/Tool.QTestRunner.dsc
@@ -215,7 +215,6 @@ export function runQTest(args: QTestArguments): Result {
             tempDirectory: qtestRunTempDirectory,
             weight: args.weight,
             environmentVariables: [
-                { name: "[Sdk.BuildXL]qCodeCoverageEnumType", value: qCodeCoverageEnumType },
                 ...(args.qTestEnvironmentVariables || [])
             ],
             disableCacheLookup: Environment.getFlag("[Sdk.BuildXL]qTestForceTest"),


### PR DESCRIPTION
The purpose of adding this environment variable is to make its value in fingerprint, so pips with different values won't get cache hit of each other. But the value is also in the tool command line, which is part of the fingerprint. So adding this environment variable is unnecessary. 