### PR TITLE
Refactor BandwidthChecker and add more config options

### DIFF
--- a/Public/Src/Cache/ContentStore/App/CopyFile.cs
+++ b/Public/Src/Cache/ContentStore/App/CopyFile.cs
@@ -54,7 +54,7 @@ namespace BuildXL.Cache.ContentStore.App
             {
                 var bandwidthCheckConfig = bandwidthCheckIntervalSeconds > 0
                     ? new BandwidthChecker.Configuration(TimeSpan.FromSeconds(bandwidthCheckIntervalSeconds), minimumBandwidthMbPerSec, maxBandwidthLimit: null, bandwidthLimitMultiplier: null, historicalBandwidthRecordsStored: null)
-                    : BandwidthChecker.Configuration.Default;
+                    : BandwidthChecker.Configuration.Disabled;
 
                 using (var clientCache = new GrpcCopyClientCache(context, bandwidthCheckConfig))
                 using (var rpcClientWrapper = clientCache.CreateAsync(host, grpcPort, useCompressionForCopies).GetAwaiter().GetResult())

--- a/Public/Src/Cache/ContentStore/App/CopyFile.cs
+++ b/Public/Src/Cache/ContentStore/App/CopyFile.cs
@@ -29,9 +29,7 @@ namespace BuildXL.Cache.ContentStore.App
             [Required, Description("Path to destination file")] string destinationPath,
             [Description("Whether or not GZip is enabled"), DefaultValue(false)] bool useCompressionForCopies,
             [Description("File name where the GRPC port can be found when using cache service. 'CASaaS GRPC port' if not specified")] string grpcPortFileName,
-            [Description("The GRPC port"), DefaultValue(0)] int grpcPort,
-            [Description("Interval at which to check the bandwidth. 0 will disable bandwidth checks"), DefaultValue(0)] int bandwidthCheckIntervalSeconds,
-            [Description("Minimum bandwidth required. Null will enable historical bandwidth check."), DefaultValue(null)] double? minimumBandwidthMbPerSec)
+            [Description("The GRPC port"), DefaultValue(0)] int grpcPort)
         {
             Initialize();
 
@@ -52,11 +50,7 @@ namespace BuildXL.Cache.ContentStore.App
 
             try
             {
-                var bandwidthCheckConfig = bandwidthCheckIntervalSeconds > 0
-                    ? new BandwidthChecker.Configuration(TimeSpan.FromSeconds(bandwidthCheckIntervalSeconds), minimumBandwidthMbPerSec, maxBandwidthLimit: null, bandwidthLimitMultiplier: null, historicalBandwidthRecordsStored: null)
-                    : BandwidthChecker.Configuration.Disabled;
-
-                using (var clientCache = new GrpcCopyClientCache(context, bandwidthCheckConfig))
+                using (var clientCache = new GrpcCopyClientCache(context))
                 using (var rpcClientWrapper = clientCache.CreateAsync(host, grpcPort, useCompressionForCopies).GetAwaiter().GetResult())
                 {
                     var rpcClient = rpcClientWrapper.Value;

--- a/Public/Src/Cache/ContentStore/App/CopyFile.cs
+++ b/Public/Src/Cache/ContentStore/App/CopyFile.cs
@@ -10,6 +10,7 @@ using BuildXL.Cache.ContentStore.Interfaces.FileSystem;
 using BuildXL.Cache.ContentStore.Interfaces.Tracing;
 using BuildXL.Cache.ContentStore.Service;
 using BuildXL.Cache.ContentStore.Service.Grpc;
+using BuildXL.Cache.ContentStore.Utils;
 using CLAP;
 using Microsoft.Practices.TransientFaultHandling;
 
@@ -51,11 +52,11 @@ namespace BuildXL.Cache.ContentStore.App
 
             try
             {
-                var copyClientConfig = bandwidthCheckIntervalSeconds > 0
-                    ? new GrpcCopyClient.Configuration(TimeSpan.FromSeconds(bandwidthCheckIntervalSeconds), minimumBandwidthMbPerSec, clientBufferSize: null)
-                    : GrpcCopyClient.Configuration.Default;
+                var bandwidthCheckConfig = bandwidthCheckIntervalSeconds > 0
+                    ? new BandwidthChecker.Configuration(TimeSpan.FromSeconds(bandwidthCheckIntervalSeconds), minimumBandwidthMbPerSec, maxBandwidthLimit: null, bandwidthLimitMultiplier: null, historicalBandwidthRecordsStored: null)
+                    : BandwidthChecker.Configuration.Default;
 
-                using (var clientCache = new GrpcCopyClientCache(context, copyClientConfig))
+                using (var clientCache = new GrpcCopyClientCache(context, bandwidthCheckConfig))
                 using (var rpcClientWrapper = clientCache.CreateAsync(host, grpcPort, useCompressionForCopies).GetAwaiter().GetResult())
                 {
                     var rpcClient = rpcClientWrapper.Value;

--- a/Public/Src/Cache/ContentStore/App/DistributedService.cs
+++ b/Public/Src/Cache/ContentStore/App/DistributedService.cs
@@ -12,6 +12,7 @@ using BuildXL.Cache.ContentStore.Distributed;
 using BuildXL.Cache.ContentStore.Distributed.Utilities;
 using BuildXL.Cache.ContentStore.Service;
 using BuildXL.Cache.ContentStore.Service.Grpc;
+using BuildXL.Cache.ContentStore.Utils;
 using BuildXL.Cache.Host.Configuration;
 using BuildXL.Cache.Host.Service;
 using CLAP;
@@ -67,15 +68,9 @@ namespace BuildXL.Cache.ContentStore.App
                     grpcPort = Helpers.GetGrpcPortFromFile(_logger, grpcPortFileName);
                 }
 
-                var (minimumSpeedInMbPerSec, bandwidthCheckIntervalSeconds) = dcs.GetBandwidthCheckSettings();
-                var copyClientConfig = new GrpcCopyClient.Configuration(
-                    bandwidthCheckInterval: TimeSpan.FromSeconds(bandwidthCheckIntervalSeconds),
-                    minimumBandwidthMbPerSec: minimumSpeedInMbPerSec,
-                    clientBufferSize: bufferSizeForGrpcCopies);
-
                 var grpcCopier = new GrpcFileCopier(
                             context: new Interfaces.Tracing.Context(_logger),
-                            clientConfig: copyClientConfig,
+                            bandwidthCheckConfig: BandwidthChecker.Configuration.FromDistributedContentSettings(dcs),
                             grpcPort: grpcPort,
                             maxGrpcClientCount: dcs.MaxGrpcClientCount,
                             maxGrpcClientAgeMinutes: dcs.MaxGrpcClientAgeMinutes,

--- a/Public/Src/Cache/ContentStore/App/DistributedService.cs
+++ b/Public/Src/Cache/ContentStore/App/DistributedService.cs
@@ -70,7 +70,6 @@ namespace BuildXL.Cache.ContentStore.App
 
                 var grpcCopier = new GrpcFileCopier(
                             context: new Interfaces.Tracing.Context(_logger),
-                            bandwidthCheckConfig: BandwidthChecker.Configuration.FromDistributedContentSettings(dcs),
                             grpcPort: grpcPort,
                             maxGrpcClientCount: dcs.MaxGrpcClientCount,
                             maxGrpcClientAgeMinutes: dcs.MaxGrpcClientAgeMinutes,

--- a/Public/Src/Cache/ContentStore/Distributed/FileSystem/IFileCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/FileSystem/IFileCopier.cs
@@ -20,20 +20,6 @@ namespace BuildXL.Cache.ContentStore.Distributed
         where T : PathBase
     {
         /// <summary>
-        /// Copies a file represented by the path into the destination absolute path
-        /// specified. Overwrites the destination if required.
-        /// </summary>
-        /// <exception cref="CopyFileResult">
-        /// throws the exception if the copy fails because the source path is not available.
-        /// </exception>
-        /// <param name="path">the source opaque path to copy from</param>
-        /// <param name="destinationPath">the destination absolute path to copy into</param>
-        /// <param name="contentSize">size of content</param>
-        /// <param name="overwrite">whether or not to overwrite the destination path if it exists.</param>
-        /// <param name="cancellationToken">the cancellation token</param>
-        Task<CopyFileResult> CopyFileAsync(T path, AbsolutePath destinationPath, long contentSize, bool overwrite, CancellationToken cancellationToken);
-
-        /// <summary>
         /// Copies a file represented by the path into the stream specified.
         /// </summary>
         /// <param name="sourcePath">The source opaque path to copy from.</param>

--- a/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
@@ -548,7 +548,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
                 }
                 else
                 {
-                    return await _remoteFileCopier.CopyFileAsync(location, tempDestinationPath, hashInfo.Size, overwrite: true, cancellationToken: cts);
+                    return await CopyFileAsync(_remoteFileCopier, location, tempDestinationPath, hashInfo.Size, overwrite: true, cancellationToken: cts);
                 }
             }
             catch (Exception ex) when (ex is UnauthorizedAccessException || ex is InvalidOperationException || ex is IOException)
@@ -562,6 +562,30 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
                 // any other exceptions are assumed to be bad remote files.
                 return new CopyFileResult(CopyFileResult.ResultCode.SourcePathError, ex, ex.ToString());
             }
+        }
+
+        /// <summary>
+        /// Override for testing.
+        /// </summary>
+        protected virtual async Task<CopyFileResult> CopyFileAsync(IFileCopier<T> copier, T sourcePath, AbsolutePath destinationPath, long expectedContentSize, bool overwrite, CancellationToken cancellationToken)
+        {
+            const int DefaultBuffersize = 1024 * 80;
+
+            if (!overwrite && File.Exists(destinationPath.Path))
+            {
+                return new CopyFileResult(
+                        CopyFileResult.ResultCode.DestinationPathError,
+                        $"Destination file {destinationPath} exists but overwrite not specified.");
+            }
+
+            var directoryPath = destinationPath.Parent.Path;
+            if (!Directory.Exists(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            using var stream = new FileStream(destinationPath.Path, FileMode.Create, FileAccess.Write, FileShare.None, DefaultBuffersize, FileOptions.SequentialScan);
+            return await copier.CopyToAsync(sourcePath, stream, expectedContentSize, cancellationToken);
         }
 
         private static int GetBufferSize(ContentHashWithSizeAndLocations hashInfo)

--- a/Public/Src/Cache/ContentStore/Distributed/Utilities/BandwidthCheckedCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Utilities/BandwidthCheckedCopier.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.ContractsLight;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using BuildXL.Cache.ContentStore.Interfaces.FileSystem;
+using BuildXL.Cache.ContentStore.Interfaces.Logging;
+using BuildXL.Cache.ContentStore.Interfaces.Results;
+using BuildXL.Cache.ContentStore.Interfaces.Tracing;
+using BuildXL.Cache.ContentStore.Tracing.Internal;
+using BuildXL.Cache.ContentStore.Utils;
+
+namespace BuildXL.Cache.ContentStore.Distributed.Utilities
+{
+    /// <summary>
+    /// File copier that times out copies based on their bandwidths.
+    /// </summary>
+    public class BandwidthCheckedCopier<T> : IFileCopier<T> where T : PathBase
+    {
+        private readonly IFileCopier<T> _inner;
+        private readonly BandwidthChecker _checker;
+        private readonly ILogger _logger;
+
+        /// <nodoc />
+        public BandwidthCheckedCopier(IFileCopier<T> inner, BandwidthChecker.Configuration config, ILogger logger)
+        {
+            _inner = inner;
+            _checker = new BandwidthChecker(config);
+            _logger = logger;
+        }
+
+        /// <inheritdoc />
+        public async Task<CopyFileResult> CopyToAsync(T sourcePath, Stream destinationStream, long expectedContentSize, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var context = new OperationContext(new Context(_logger), cancellationToken); 
+                CopyFileResult result = null;
+                await _checker.CheckBandwidthAtIntervalAsync(context, async token =>
+                {
+                    result = await _inner.CopyToAsync(sourcePath, destinationStream, expectedContentSize, token);
+                }, destinationStream);
+
+                Contract.Assert(result != null);
+                return result;
+            }
+            catch (BandwidthTooLowException e)
+            {
+                return new CopyFileResult(CopyFileResult.ResultCode.CopyBandwidthTimeoutError, e);
+            }
+        }
+    }
+}

--- a/Public/Src/Cache/ContentStore/Distributed/Utilities/DistributedCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Utilities/DistributedCopier.cs
@@ -26,37 +26,6 @@ namespace BuildXL.Cache.ContentStore.Distributed.Utilities
         }
 
         /// <inheritdoc />
-        public async Task<CopyFileResult> CopyFileAsync(AbsolutePath path, AbsolutePath destinationPath, long contentSize, bool overwrite, CancellationToken cancellationToken)
-        {
-            // NOTE: Assumes both source and destination are local
-            Contract.Assert(path.IsLocal);
-            Contract.Assert(destinationPath.IsLocal);
-
-            if (!FileUtilities.Exists(path.Path))
-            {
-                return new CopyFileResult(CopyFileResult.ResultCode.FileNotFoundError, $"Source file {path} doesn't exist.");
-            }
-
-            if (FileUtilities.Exists(destinationPath.Path))
-            {
-                if (!overwrite)
-                {
-                    return new CopyFileResult(
-                        CopyFileResult.ResultCode.DestinationPathError,
-                        $"Destination file {destinationPath} exists but overwrite not specified.");
-                }
-            }
-
-            if (!await FileUtilities.CopyFileAsync(path.Path, destinationPath.Path))
-            {
-                return new CopyFileResult(CopyFileResult.ResultCode.SourcePathError, $"Failed to copy {destinationPath} from {path}");
-            }
-
-            return CopyFileResult.SuccessWithSize(new System.IO.FileInfo(destinationPath.Path).Length);
-
-        }
-
-        /// <inheritdoc />
         public async Task<CopyFileResult> CopyToAsync(AbsolutePath sourcePath, Stream destinationStream, long expectedContentSize, CancellationToken cancellationToken)
         {
             // NOTE: Assumes source is local

--- a/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcFileCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcFileCopier.cs
@@ -14,6 +14,7 @@ using BuildXL.Cache.ContentStore.Interfaces.Tracing;
 using BuildXL.Cache.ContentStore.Interfaces.Utils;
 using BuildXL.Cache.ContentStore.Service.Grpc;
 using BuildXL.Cache.ContentStore.Tracing.Internal;
+using BuildXL.Cache.ContentStore.Utils;
 
 namespace BuildXL.Cache.ContentStore.Distributed.Utilities
 {
@@ -31,13 +32,13 @@ namespace BuildXL.Cache.ContentStore.Distributed.Utilities
         /// <summary>
         /// Constructor for <see cref="GrpcFileCopier"/>.
         /// </summary>
-        public GrpcFileCopier(Context context, GrpcCopyClient.Configuration clientConfig, int grpcPort, int maxGrpcClientCount, int maxGrpcClientAgeMinutes, int grpcClientCleanupDelayMinutes, bool useCompression = false)
+        public GrpcFileCopier(Context context, BandwidthChecker.Configuration bandwidthCheckConfig, int grpcPort, int maxGrpcClientCount, int maxGrpcClientAgeMinutes, int grpcClientCleanupDelayMinutes, bool useCompression = false, int? bufferSize = null)
         {
             _context = context;
             _grpcPort = grpcPort;
             _useCompression = useCompression;
 
-            _clientCache = new GrpcCopyClientCache(context, clientConfig, maxGrpcClientCount, maxGrpcClientAgeMinutes, grpcClientCleanupDelayMinutes);
+            _clientCache = new GrpcCopyClientCache(context, bandwidthCheckConfig, maxGrpcClientCount, maxGrpcClientAgeMinutes, grpcClientCleanupDelayMinutes, bufferSize);
         }
 
         /// <inheritdoc />

--- a/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcFileCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcFileCopier.cs
@@ -32,13 +32,13 @@ namespace BuildXL.Cache.ContentStore.Distributed.Utilities
         /// <summary>
         /// Constructor for <see cref="GrpcFileCopier"/>.
         /// </summary>
-        public GrpcFileCopier(Context context, BandwidthChecker.Configuration bandwidthCheckConfig, int grpcPort, int maxGrpcClientCount, int maxGrpcClientAgeMinutes, int grpcClientCleanupDelayMinutes, bool useCompression = false, int? bufferSize = null)
+        public GrpcFileCopier(Context context, int grpcPort, int maxGrpcClientCount, int maxGrpcClientAgeMinutes, int grpcClientCleanupDelayMinutes, bool useCompression = false, int? bufferSize = null)
         {
             _context = context;
             _grpcPort = grpcPort;
             _useCompression = useCompression;
 
-            _clientCache = new GrpcCopyClientCache(context, bandwidthCheckConfig, maxGrpcClientCount, maxGrpcClientAgeMinutes, grpcClientCleanupDelayMinutes, bufferSize);
+            _clientCache = new GrpcCopyClientCache(context, maxGrpcClientCount, maxGrpcClientAgeMinutes, grpcClientCleanupDelayMinutes, bufferSize);
         }
 
         /// <inheritdoc />
@@ -50,19 +50,6 @@ namespace BuildXL.Cache.ContentStore.Distributed.Utilities
             using (var clientWrapper = await _clientCache.CreateAsync(host, _grpcPort, _useCompression))
             {
                 return await clientWrapper.Value.CheckFileExistsAsync(_context, contentHash);
-            }
-        }
-
-        /// <inheritdoc />
-        public async Task<CopyFileResult> CopyFileAsync(AbsolutePath sourcePath, AbsolutePath destinationPath, long contentSize, bool overwrite, CancellationToken cancellationToken)
-        {
-            // Extract host and contentHash from sourcePath
-            (string host, ContentHash contentHash) = ExtractHostHashFromAbsolutePath(sourcePath);
-
-            // Contact hard-coded port on source
-            using (var clientWrapper = await _clientCache.CreateAsync(host, _grpcPort, _useCompression))
-            {
-                return await clientWrapper.Value.CopyFileAsync(_context, contentHash, destinationPath, cancellationToken);
             }
         }
 

--- a/Public/Src/Cache/ContentStore/DistributedTest/Stores/GrpcCopyContentTests.cs
+++ b/Public/Src/Cache/ContentStore/DistributedTest/Stores/GrpcCopyContentTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using BuildXL.Cache.ContentStore.Distributed.Utilities;
 using BuildXL.Cache.ContentStore.FileSystem;
 using BuildXL.Cache.ContentStore.Hashing;
 using BuildXL.Cache.ContentStore.Interfaces.FileSystem;
@@ -40,7 +39,7 @@ namespace ContentStoreTest.Distributed.Stores
             : base(() => new PassThroughFileSystem(TestGlobal.Logger), TestGlobal.Logger)
         {
             _context = new Context(Logger);
-            _clientCache = new GrpcCopyClientCache(_context, GrpcCopyClient.Configuration.Default, maxClientCount: 65536);
+            _clientCache = new GrpcCopyClientCache(_context, BandwidthChecker.Configuration.Disabled, maxClientCount: 65536);
         }
 
         [Fact]
@@ -98,8 +97,7 @@ namespace ContentStoreTest.Distributed.Stores
         {
             int maxClientCount = 10;
             var clientWrapperList = new List<(ResourceWrapper<GrpcCopyClient> Wrapper, GrpcCopyClient Client)>();
-            var clientConfig = new GrpcCopyClient.Configuration(bandwidthCheckInterval: TimeSpan.FromSeconds(30), minimumBandwidthMbPerSec: null, clientBufferSize: 65536);
-            _clientCache = new GrpcCopyClientCache(_context, clientConfig, maxClientCount: maxClientCount, maxClientAgeMinutes: 63, waitBetweenCleanupMinutes: 30);
+            _clientCache = new GrpcCopyClientCache(_context, BandwidthChecker.Configuration.Disabled, maxClientCount: maxClientCount, maxClientAgeMinutes: 63, waitBetweenCleanupMinutes: 30, bufferSize: 65536);
 
             for (int i = 0; i < maxClientCount; i++)
             {

--- a/Public/Src/Cache/ContentStore/DistributedTest/Stores/GrpcCopyContentTests.cs
+++ b/Public/Src/Cache/ContentStore/DistributedTest/Stores/GrpcCopyContentTests.cs
@@ -39,7 +39,7 @@ namespace ContentStoreTest.Distributed.Stores
             : base(() => new PassThroughFileSystem(TestGlobal.Logger), TestGlobal.Logger)
         {
             _context = new Context(Logger);
-            _clientCache = new GrpcCopyClientCache(_context, BandwidthChecker.Configuration.Disabled, maxClientCount: 65536);
+            _clientCache = new GrpcCopyClientCache(_context, maxClientCount: 65536);
         }
 
         [Fact]
@@ -97,7 +97,7 @@ namespace ContentStoreTest.Distributed.Stores
         {
             int maxClientCount = 10;
             var clientWrapperList = new List<(ResourceWrapper<GrpcCopyClient> Wrapper, GrpcCopyClient Client)>();
-            _clientCache = new GrpcCopyClientCache(_context, BandwidthChecker.Configuration.Disabled, maxClientCount: maxClientCount, maxClientAgeMinutes: 63, waitBetweenCleanupMinutes: 30, bufferSize: 65536);
+            _clientCache = new GrpcCopyClientCache(_context, maxClientCount: maxClientCount, maxClientAgeMinutes: 63, waitBetweenCleanupMinutes: 30, bufferSize: 65536);
 
             for (int i = 0; i < maxClientCount; i++)
             {

--- a/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcCopyClient.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcCopyClient.cs
@@ -29,7 +29,6 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
         private readonly Channel _channel;
         private readonly ContentServer.ContentServerClient _client;
         private readonly int _bufferSize;
-        private readonly BandwidthChecker _bandwidthChecker;
 
         /// <inheritdoc />
         protected override Tracer Tracer { get; } = new Tracer(nameof(GrpcCopyClient));
@@ -39,13 +38,12 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
         /// <summary>
         /// Initializes a new instance of the <see cref="GrpcCopyClient" /> class.
         /// </summary>
-        internal GrpcCopyClient(GrpcCopyClientKey key, int? clientBufferSize, BandwidthChecker.Configuration config)
+        internal GrpcCopyClient(GrpcCopyClientKey key, int? clientBufferSize)
         {
             GrpcEnvironment.InitializeIfNeeded();
             _channel = new Channel(key.Host, key.GrpcPort, ChannelCredentials.Insecure, GrpcEnvironment.DefaultConfiguration);
             _client = new ContentServer.ContentServerClient(_channel);
             _bufferSize = clientBufferSize ?? ContentStore.Grpc.CopyConstants.DefaultBufferSize;
-            _bandwidthChecker = new BandwidthChecker(config);
             Key = key;
         }
 
@@ -205,16 +203,17 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
                 // Copy the content to the target stream.
                 using (targetStream)
                 {
-                    await _bandwidthChecker.CheckBandwidthAtIntervalAsync(
-                        context,
-                        copyTaskFactory: token =>
-                            compression switch
-                            {
-                                CopyCompression.None => StreamContentAsync(targetStream, response.ResponseStream, token),
-                                CopyCompression.Gzip => StreamContentWithCompressionAsync(targetStream, response.ResponseStream, token),
-                                _ => throw new NotSupportedException($"CopyCompression {compression} is not supported.")
-                            },
-                        destinationStream: targetStream);
+                    switch(compression)
+                    {
+                        case CopyCompression.None:
+                            await StreamContentAsync(targetStream, response.ResponseStream, context.Token);
+                            break;
+                        case CopyCompression.Gzip:
+                            await StreamContentWithCompressionAsync(targetStream, response.ResponseStream, context.Token);
+                            break;
+                        default:
+                            throw new NotSupportedException($"CopyCompression {compression} is not supported.");
+                    }
                 }
 
                 return CopyFileResult.Success;

--- a/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcCopyClientCache.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcCopyClientCache.cs
@@ -16,12 +16,13 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
         /// Cache for <see cref="GrpcCopyClient"/>.
         /// </summary>
         /// <param name="context">Content.</param>
-        /// <param name="clientConfig">Configuration for created clients.</param>
+        /// <param name="bandwidthCheckConfig">Bandwidth check configuration for created clients.</param>
         /// <param name="maxClientCount">Maximum number of clients to cache.</param>
         /// <param name="maxClientAgeMinutes">Maximum age of cached clients.</param>
         /// <param name="waitBetweenCleanupMinutes">Minutes to wait between cache purges.</param>
-        public GrpcCopyClientCache(Context context, GrpcCopyClient.Configuration clientConfig, int maxClientCount = 512, int maxClientAgeMinutes = 55, int waitBetweenCleanupMinutes = 17)
-            : base(context, maxClientCount, maxClientAgeMinutes, waitBetweenCleanupMinutes, (key) => new GrpcCopyClient(key, clientConfig))
+        /// <param name="bufferSize">Buffer size used to read files from disk.</param>
+        public GrpcCopyClientCache(Context context, BandwidthChecker.Configuration bandwidthCheckConfig, int maxClientCount = 512, int maxClientAgeMinutes = 55, int waitBetweenCleanupMinutes = 17, int? bufferSize = null)
+            : base(context, maxClientCount, maxClientAgeMinutes, waitBetweenCleanupMinutes, (key) => new GrpcCopyClient(key, bufferSize, bandwidthCheckConfig))
         {
         }
 

--- a/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcCopyClientCache.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcCopyClientCache.cs
@@ -16,13 +16,12 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
         /// Cache for <see cref="GrpcCopyClient"/>.
         /// </summary>
         /// <param name="context">Content.</param>
-        /// <param name="bandwidthCheckConfig">Bandwidth check configuration for created clients.</param>
         /// <param name="maxClientCount">Maximum number of clients to cache.</param>
         /// <param name="maxClientAgeMinutes">Maximum age of cached clients.</param>
         /// <param name="waitBetweenCleanupMinutes">Minutes to wait between cache purges.</param>
         /// <param name="bufferSize">Buffer size used to read files from disk.</param>
-        public GrpcCopyClientCache(Context context, BandwidthChecker.Configuration bandwidthCheckConfig, int maxClientCount = 512, int maxClientAgeMinutes = 55, int waitBetweenCleanupMinutes = 17, int? bufferSize = null)
-            : base(context, maxClientCount, maxClientAgeMinutes, waitBetweenCleanupMinutes, (key) => new GrpcCopyClient(key, bufferSize, bandwidthCheckConfig))
+        public GrpcCopyClientCache(Context context, int maxClientCount = 512, int maxClientAgeMinutes = 55, int waitBetweenCleanupMinutes = 17, int? bufferSize = null)
+            : base(context, maxClientCount, maxClientAgeMinutes, waitBetweenCleanupMinutes, (key) => new GrpcCopyClient(key, bufferSize))
         {
         }
 

--- a/Public/Src/Cache/ContentStore/Library/Utils/BandwidthChecker.cs
+++ b/Public/Src/Cache/ContentStore/Library/Utils/BandwidthChecker.cs
@@ -46,14 +46,21 @@ namespace BuildXL.Cache.ContentStore.Utils
             {
                 var startPosition = destinationStream.Position;
                 var timer = Stopwatch.StartNew();
-                await impl();
-                timer.Stop();
-                var endPosition = destinationStream.Position;
 
-                // Bandwidth checker expects speed in MiB/s, so convert it.
-                var bytesCopied = endPosition - startPosition;
-                var speed = bytesCopied / timer.Elapsed.TotalSeconds / (1024 * 1024);
-                _historicalBandwidthLimitSource.AddBandwidthRecord(speed);
+                try
+                {
+                    await impl();
+                }
+                finally
+                {
+                    timer.Stop();
+                    var endPosition = destinationStream.Position;
+
+                    // Bandwidth checker expects speed in MiB/s, so convert it.
+                    var bytesCopied = endPosition - startPosition;
+                    var speed = bytesCopied / timer.Elapsed.TotalSeconds / (1024 * 1024);
+                    _historicalBandwidthLimitSource.AddBandwidthRecord(speed);
+                }
             }
             else
             {

--- a/Public/Src/Cache/ContentStore/Library/Utils/BandwidthChecker.cs
+++ b/Public/Src/Cache/ContentStore/Library/Utils/BandwidthChecker.cs
@@ -109,7 +109,7 @@ namespace BuildXL.Cache.ContentStore.Utils
                             var currentSpeed = receivedMiB / _config.BandwidthCheckInterval.TotalSeconds;
                             if (currentSpeed == 0 || currentSpeed < minimumSpeedInMbPerSec)
                             {
-                                throw new TimeoutException($"Average speed was {currentSpeed}MiB/s - under {minimumSpeedInMbPerSec}MiB/s requirement. Aborting copy with {position} copied]");
+                                throw new BandwidthTooLowException($"Average speed was {currentSpeed}MiB/s - under {minimumSpeedInMbPerSec}MiB/s requirement. Aborting copy with {position} copied]");
                             }
 
                             previousPosition = position;
@@ -134,7 +134,7 @@ namespace BuildXL.Cache.ContentStore.Utils
         }
 
         /// <nodoc />
-        public struct Configuration
+        public class Configuration
         {
             /// <nodoc />
             public Configuration(TimeSpan bandwidthCheckInterval, double? minimumBandwidthMbPerSec, double? maxBandwidthLimit, double? bandwidthLimitMultiplier, int? historicalBandwidthRecordsStored)
@@ -186,6 +186,16 @@ namespace BuildXL.Cache.ContentStore.Utils
 
             /// <nodoc />
             public int HistoricalBandwidthRecordsStored { get; }
+        }
+    }
+
+    /// <nodoc />
+    public class BandwidthTooLowException : Exception
+    {
+        /// <nodoc />
+        public BandwidthTooLowException(string message)
+            : base(message)
+        {
         }
     }
 }

--- a/Public/Src/Cache/ContentStore/Test/Utils/BandwidthCheckerTests.cs
+++ b/Public/Src/Cache/ContentStore/Test/Utils/BandwidthCheckerTests.cs
@@ -83,7 +83,7 @@ namespace ContentStoreTest.Utils
             using (var stream = new MemoryStream())
             {
                 await Assert.ThrowsAsync(
-                    typeof(TimeoutException),
+                    typeof(BandwidthTooLowException),
                     async () => await checker.CheckBandwidthAtIntervalAsync(_context, token => CopyRandomToStreamAtSpeed(token, stream, totalBytes, actualBandwidth), stream));
             }
         }

--- a/Public/Src/Cache/ContentStore/Test/Utils/BandwidthCheckerTests.cs
+++ b/Public/Src/Cache/ContentStore/Test/Utils/BandwidthCheckerTests.cs
@@ -60,7 +60,8 @@ namespace ContentStoreTest.Utils
             var actualBandwidth = MbPerSec(bytesPerSec: actualBandwidthBytesPerSec);
             var bandwidthLimit = MbPerSec(bytesPerSec: actualBandwidthBytesPerSec / 2); // Lower limit is half actual bandwidth
             var totalBytes = actualBandwidthBytesPerSec * 2;
-            var checker = new BandwidthChecker(new ConstantBandwidthLimit(bandwidthLimit), checkInterval);
+            var checkerConfig = new BandwidthChecker.Configuration(checkInterval, bandwidthLimit, maxBandwidthLimit: null, bandwidthLimitMultiplier: null, historicalBandwidthRecordsStored: null);
+            var checker = new BandwidthChecker(checkerConfig);
 
             using (var stream = new MemoryStream())
             {
@@ -76,7 +77,8 @@ namespace ContentStoreTest.Utils
             var actualBandwidth = MbPerSec(bytesPerSec: actualBandwidthBytesPerSec);
             var bandwidthLimit = MbPerSec(bytesPerSec: actualBandwidthBytesPerSec * 2); // Lower limit is twice actual bandwidth
             var totalBytes = actualBandwidthBytesPerSec * 2;
-            var checker = new BandwidthChecker(new ConstantBandwidthLimit(bandwidthLimit), checkInterval);
+            var checkerConfig = new BandwidthChecker.Configuration(checkInterval, bandwidthLimit, maxBandwidthLimit: null, bandwidthLimitMultiplier: null, historicalBandwidthRecordsStored: null);
+            var checker = new BandwidthChecker(checkerConfig);
 
             using (var stream = new MemoryStream())
             {

--- a/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
@@ -293,13 +293,13 @@ namespace BuildXL.Cache.Host.Configuration
         public int BandwidthCheckIntervalSeconds { get; set; } = 60;
 
         [DataMember]
-        public double? MaxBandwidthLimit { get; } = null;
+        public double MaxBandwidthLimit { get; } = double.MaxValue;
 
         [DataMember]
-        public double? BandwidthLimitMultiplier { get; } = null;
+        public double BandwidthLimitMultiplier { get; } = 1;
 
         [DataMember]
-        public int? HistoricalBandwidthRecordsStored { get; } = null;
+        public int HistoricalBandwidthRecordsStored { get; } = 64;
         #endregion
 
         #region Pin Better

--- a/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
@@ -291,6 +291,15 @@ namespace BuildXL.Cache.Host.Configuration
 
         [DataMember]
         public int BandwidthCheckIntervalSeconds { get; set; } = 60;
+
+        [DataMember]
+        public double? MaxBandwidthLimit { get; } = null;
+
+        [DataMember]
+        public double? BandwidthLimitMultiplier { get; } = null;
+
+        [DataMember]
+        public int? HistoricalBandwidthRecordsStored { get; } = null;
         #endregion
 
         #region Pin Better
@@ -566,13 +575,6 @@ namespace BuildXL.Cache.Host.Configuration
 
             return new RedisContentSecretNames(
                 ConnectionSecretNameMap.Single(kvp => Regex.IsMatch(stampId, kvp.Key, RegexOptions.IgnoreCase)).Value);
-        }
-
-        public Tuple<double?, int> GetBandwidthCheckSettings()
-        {
-            return IsDistributedContentEnabled && IsBandwidthCheckEnabled
-                ? Tuple.Create(MinimumSpeedInMbPerSec, BandwidthCheckIntervalSeconds)
-                : null;
         }
 
         public IReadOnlyDictionary<string, string> GetAutopilotAlternateDriveMap()

--- a/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
@@ -293,13 +293,13 @@ namespace BuildXL.Cache.Host.Configuration
         public int BandwidthCheckIntervalSeconds { get; set; } = 60;
 
         [DataMember]
-        public double MaxBandwidthLimit { get; } = double.MaxValue;
+        public double MaxBandwidthLimit { get; set; } = double.MaxValue;
 
         [DataMember]
-        public double BandwidthLimitMultiplier { get; } = 1;
+        public double BandwidthLimitMultiplier { get; set; } = 1;
 
         [DataMember]
-        public int HistoricalBandwidthRecordsStored { get; } = 64;
+        public int HistoricalBandwidthRecordsStored { get; set; } = 64;
         #endregion
 
         #region Pin Better

--- a/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
@@ -13,8 +13,8 @@ using BuildXL.Cache.ContentStore.Distributed.NuCache.EventStreaming;
 using BuildXL.Cache.ContentStore.Distributed.Redis;
 using BuildXL.Cache.ContentStore.Distributed.Sessions;
 using BuildXL.Cache.ContentStore.Distributed.Stores;
+using BuildXL.Cache.ContentStore.Distributed.Utilities;
 using BuildXL.Cache.ContentStore.FileSystem;
-using BuildXL.Cache.ContentStore.Hashing;
 using BuildXL.Cache.ContentStore.Interfaces.Distributed;
 using BuildXL.Cache.ContentStore.Interfaces.FileSystem;
 using BuildXL.Cache.ContentStore.Interfaces.Logging;
@@ -192,6 +192,8 @@ namespace BuildXL.Cache.Host.Service.Internal
                 configurationModel = new ConfigurationModel(new ContentStoreConfiguration(new MaxSizeQuota(namedCacheSettings.CacheSizeQuotaString)));
             }
 
+            var bandwidthCheckedCopier = new BandwidthCheckedCopier<AbsolutePath>(_arguments.Copier, BandwidthChecker.Configuration.FromDistributedContentSettings(_distributedSettings), _logger);
+
             _logger.Debug("Creating a distributed content store for Autopilot");
             var contentStore =
                 new DistributedContentStore<AbsolutePath>(
@@ -201,7 +203,7 @@ namespace BuildXL.Cache.Host.Service.Internal
                             contentStoreSettings: contentStoreSettings, trimBulkAsync: trimBulk, configurationModel: configurationModel),
                     redisContentLocationStoreFactory,
                     _arguments.Copier,
-                    _arguments.Copier,
+                    bandwidthCheckedCopier,
                     _arguments.PathTransformer,
                     _arguments.CopyRequester,
                     contentAvailabilityGuarantee,

--- a/Public/Src/Cache/DistributedCache.Host/Test/TestSettingSerialization.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Test/TestSettingSerialization.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.Serialization;
-using System.Xml;
 using Xunit;
 
 namespace BuildXL.Cache.Host.Configuration.Test


### PR DESCRIPTION
Refactored so config was exclusive to BandiwdthChecker, instead of also involving GrpcCopier. 

Bandiwidth check, instead of being implemented by each copier, can now be done via a BandwidthCheckedCopier, which can wrap an inner copier.

Added more configurations: MaxBandwidthLimit, BandwidthLimitMultiplier and HistoricalBandwidthRecordsStored.

Additionally, stop catching unnecessary exceptions, and always time out copies if an interval detects that current bandwidth is 0.

Finally, make sure to register bandwidths for failed copies in historical bandwidth check, to better reflect the current status of the system.
