### PR TITLE
Stop using nested tracing context for proactive copies

### DIFF
--- a/Public/Src/Cache/ContentStore/Library/Tracing/OperationContext.cs
+++ b/Public/Src/Cache/ContentStore/Library/Tracing/OperationContext.cs
@@ -56,6 +56,15 @@ namespace BuildXL.Cache.ContentStore.Tracing.Internal
             return new OperationContext(new Context(TracingContext, id), Token);
         }
 
+        /// <summary>
+        /// Creates new instance with a given <see cref="CancellationToken"/> without creating nested tracing context.
+        /// </summary>
+        public OperationContext WithCancellationToken(CancellationToken linkedCancellationToken)
+        {
+            var token = CancellationTokenSource.CreateLinkedTokenSource(Token, linkedCancellationToken).Token;
+            return new OperationContext(TracingContext, token);
+        }
+
         /// <nodoc />
         public OperationContext CreateNested(CancellationToken linkedCancellationToken)
         {


### PR DESCRIPTION
Using the same tracing context in `RequestCopyFileAsync` to simplify tracing analysis across machines.