### PR TITLE
Improve minimum eviction times

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
@@ -1105,6 +1105,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             IReadOnlyList<ContentHashWithLastAccessTime> contentHashes)
         {
             Contract.Requires(contentHashes != null);
+            Contract.Requires(contentHashes.Count > 0);
 
             var postInitializationResult = EnsureInitializedAsync().GetAwaiter().GetResult();
             if (!postInitializationResult)
@@ -1112,11 +1113,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                 return new Result<IReadOnlyList<ContentHashWithLastAccessTimeAndReplicaCount>>(postInitializationResult);
             }
 
-            if (contentHashes.Count == 0)
-            {
-                return CollectionUtilities.EmptyArray<ContentHashWithLastAccessTimeAndReplicaCount>();
-            }
-
+            // This is required because the code inside could throw.
             return context.PerformOperation(
                 Tracer,
                 () =>
@@ -1161,7 +1158,8 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                     }
 
                     return Result.Success<IReadOnlyList<ContentHashWithLastAccessTimeAndReplicaCount>>(effectiveLastAccessTimes);
-                }, Counters[ContentLocationStoreCounters.GetEffectiveLastAccessTimes]);
+                }, Counters[ContentLocationStoreCounters.GetEffectiveLastAccessTimes],
+                traceOperationStarted: false);
         }
 
         /// <summary>

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
@@ -1130,7 +1130,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                         int replicaCount = 1;
                         DateTime? effectiveLastAccessTime = null;
 
-                        if (TryGetContentLocations(context, contentHash.ContentHash, out var entry))
+                        if (TryGetContentLocations(context, contentHash.Hash, out var entry))
                         {
                             // Use the latest last access time between LLS and local last access time
                             DateTime distributedLastAccessTime = entry.LastAccessTimeUtc.ToDateTime();
@@ -1157,7 +1157,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                             Counters[ContentLocationStoreCounters.EffectiveLastAccessTimeLookupMiss].Increment();
                         }
 
-                        effectiveLastAccessTimes.Add(new ContentHashWithLastAccessTimeAndReplicaCount(contentHash.ContentHash, lastAccessTime, replicaCount, effectiveLastAccessTime: effectiveLastAccessTime ?? lastAccessTime));
+                        effectiveLastAccessTimes.Add(new ContentHashWithLastAccessTimeAndReplicaCount(contentHash.Hash, lastAccessTime, replicaCount, effectiveLastAccessTime: effectiveLastAccessTime ?? lastAccessTime));
                     }
 
                     return Result.Success<IReadOnlyList<ContentHashWithLastAccessTimeAndReplicaCount>>(effectiveLastAccessTimes);

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
@@ -1130,7 +1130,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                         int replicaCount = 1;
                         DateTime? effectiveLastAccessTime = null;
 
-                        if (TryGetContentLocations(context, contentHash.Hash, out var entry))
+                        if (TryGetContentLocations(context, contentHash.ContentHash, out var entry))
                         {
                             // Use the latest last access time between LLS and local last access time
                             DateTime distributedLastAccessTime = entry.LastAccessTimeUtc.ToDateTime();
@@ -1138,7 +1138,6 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
 
                             // TODO[LLS]: Maybe some machines should be primary replicas for the content and not prioritize deletion (bug 1365340)
                             // just because there are many replicas
-
                             replicaCount = entry.Locations.Count;
 
                             // Incorporate both replica count and size into an evictability metric.
@@ -1158,7 +1157,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                             Counters[ContentLocationStoreCounters.EffectiveLastAccessTimeLookupMiss].Increment();
                         }
 
-                        effectiveLastAccessTimes.Add(new ContentHashWithLastAccessTimeAndReplicaCount(contentHash.Hash, lastAccessTime, replicaCount, effectiveLastAccessTime: effectiveLastAccessTime ?? lastAccessTime));
+                        effectiveLastAccessTimes.Add(new ContentHashWithLastAccessTimeAndReplicaCount(contentHash.ContentHash, lastAccessTime, replicaCount, effectiveLastAccessTime: effectiveLastAccessTime ?? lastAccessTime));
                     }
 
                     return Result.Success<IReadOnlyList<ContentHashWithLastAccessTimeAndReplicaCount>>(effectiveLastAccessTimes);

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStoreConfiguration.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStoreConfiguration.cs
@@ -116,13 +116,13 @@ namespace BuildXL.Cache.ContentStore.Distributed
         /// <summary>
         /// Estimated decay time for content re-use.
         /// </summary>
-        /// <remarks><para>This is used in the opitmal distributed eviction algorithm.</para></remarks>
+        /// <remarks><para>This is used in the optimal distributed eviction algorithm.</para></remarks>
         public TimeSpan ContentLifetime { get; set; } = TimeSpan.FromDays(0.5);
 
         /// <summary>
         /// Estimated chance of a content not being available on a machine in the distributed pool.
         /// </summary>
-        /// <remarks><para>This is used in the opitmal distributed eviction algorithm.</para></remarks>
+        /// <remarks><para>This is used in the optimal distributed eviction algorithm.</para></remarks>
         public double MachineRisk { get; set; } = 0.1;
 
         /// <summary>

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/NuCacheCollectionUtilities.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/NuCacheCollectionUtilities.cs
@@ -230,26 +230,22 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             }
         }
 
-        /// <summary>
-        /// Takes an enumerable and takes n=pageSize elements from it. Processess the elements with a query, and inserts
-        /// them into a priority queue. It will then continue yielding elements of the queue, until it has less than
-        /// n elements, at which point it will take another n elements from the original enumerable and repeat the
-        /// process, adding them to the same priority queue. This process repeats until the original enumerable has no
-        /// more elements.
-        /// </summary>
-        public static IEnumerable<T> QueryAndOrderInPages<T>(this IEnumerable<T> original, int pageSize, Comparer<T> comparer, Func<List<T>, IEnumerable<T>> query, float? takeoutFraction = null, int poolMultiplier = 2)
+
+        /// <nodoc />
+        /// <remarks>
+        /// If <paramref name="poolSize"/> = <paramref name="pageSize"/>, the algorithm fills up the entire pool and
+        /// evicts a fraction of it in every iteration.
+        /// </remarks>
+        public static IEnumerable<T> ApproximateSort<T>(this IEnumerable<T> original, Comparer<T> comparer, Func<List<T>, IEnumerable<T>> query, int poolSize, int pageSize, float removalFraction)
         {
-            Contract.Requires(pageSize > 0);
-            Contract.Requires(takeoutFraction == null || (takeoutFraction > 0 && takeoutFraction <= 1));
-            Contract.Requires(poolMultiplier > 0);
+            Contract.Requires(poolSize > 0);
+            Contract.Requires(pageSize > 0 && pageSize <= poolSize);
+            Contract.Requires(removalFraction > 0 && removalFraction <= 1);
 
-            var poolSize = Math.Max(pageSize * poolMultiplier, pageSize);
-
-            // We either take the fraction given, or a single page at a time
-            var removalFraction = takeoutFraction ?? (1 / poolMultiplier);
+            // The pool holds up to `poolSize` candidates sorted by the comparer
+            var pool = new PriorityQueue<T>(poolSize, comparer);
 
             var source = original.GetEnumerator();
-            var pool = new PriorityQueue<T>(poolSize, comparer);
             var sourceHasItems = true;
 
             while (true)
@@ -257,9 +253,8 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                 if (sourceHasItems && pool.Count < poolSize)
                 {
                     // In this branch, we fill the queue up to maximum capacity by querying in batches of size at most
-                    // `pageSize`. Notice that this may be run up to `poolMultiplier` times in a row before producing
-                    // any results.
-                    var batchSize = Math.Min(poolSize - pool.Count, pageSize);
+                    // `pageSize`.
+                    int batchSize = Math.Min(poolSize - pool.Count, pageSize);
 
                     var batch = new List<T>(batchSize);
                     while (batch.Count < batch.Capacity && source.MoveNext())
@@ -280,36 +275,31 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                         sourceHasItems = false;
                     }
                 }
-                else if (pool.Count == 0)
+
+                if (pool.Count == 0)
                 {
                     Contract.Assert(!sourceHasItems);
                     yield break;
                 }
+
+                int minimumYieldSize;
+                if (sourceHasItems)
+                {
+                    minimumYieldSize = (int)Math.Floor(removalFraction * pool.Count);
+                    // To guarantee termination, we always yield at least one element
+                    minimumYieldSize = Math.Max(minimumYieldSize, 1);
+                }
                 else
                 {
-                    Contract.Assert(pool.Count > 0);
+                    // If the enumerator has no elements left, we know that the queue has the best order possible,
+                    // so we yield everything.
+                    minimumYieldSize = pool.Count;
+                }
 
-                    int minimumYieldSize;
-                    if (!sourceHasItems)
-                    {
-                        // If the enumerator has no elements left, we know that the queue has the best order possible,
-                        // so we yield everything.
-                        minimumYieldSize = pool.Count;
-                    }
-                    else
-                    {
-                        minimumYieldSize = (int)Math.Floor(removalFraction * pool.Count);
-                        // To guarantee termination, we always yield at least one element
-                        minimumYieldSize = Math.Max(minimumYieldSize, 1);
-                        // Never yield more than one page of results. This is about maintaining baseline accuracy for very large fractions.
-                        minimumYieldSize = Math.Min(minimumYieldSize, pageSize);
-                    }
-
-                    Contract.Assert(minimumYieldSize <= pool.Count);
-                    for (var i = 0; i < minimumYieldSize; ++i) {
-                        yield return pool.Top;
-                        pool.Pop();
-                    }
+                for (var i = 0; i < minimumYieldSize; ++i)
+                {
+                    yield return pool.Top;
+                    pool.Pop();
                 }
             }
         }

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/NuCacheCollectionUtilities.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/NuCacheCollectionUtilities.cs
@@ -239,9 +239,9 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         /// </summary>
         public static IEnumerable<T> QueryAndOrderInPages<T>(this IEnumerable<T> original, int pageSize, Comparer<T> comparer, Func<List<T>, IEnumerable<T>> query, float? takeoutFraction = null, int poolMultiplier = 2)
         {
-            Contract.Assert(pageSize > 0);
-            Contract.Assert(takeoutFraction == null || (takeoutFraction > 0 && takeoutFraction <= 1));
-            Contract.Assert(poolMultiplier > 0);
+            Contract.Requires(pageSize > 0);
+            Contract.Requires(takeoutFraction == null || (takeoutFraction > 0 && takeoutFraction <= 1));
+            Contract.Requires(poolMultiplier > 0);
 
             var poolSize = Math.Max(pageSize * poolMultiplier, pageSize);
 

--- a/Public/Src/Cache/ContentStore/Distributed/Redis/RedisContentLocationStoreConfiguration.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Redis/RedisContentLocationStoreConfiguration.cs
@@ -77,20 +77,29 @@ namespace BuildXL.Cache.ContentStore.Distributed.Redis
         public long MaxBlobCapacity { get; set; } = 1024 * 1024 * 1024;
 
         /// <summary>
-        /// Number of records to compute evictability at once for. This determines -and delimits- how much we hit LLS
-        /// at once. The larger this number is, the more taxing eviction is to LLS, but also the more accurate it is.
+        /// Amount of entries to compute evictability metric for in a single pass. The larger this is, the faster the
+        /// candidate pool fills up, but also the slower it is to produce a candidate. Helps control how fast we need
+        /// to produce candidates.
         /// </summary>
         public int EvictionWindowSize { get; set; } = 500;
 
         /// <summary>
-        /// Amount of pages to compute evictability metric for before determining eviction order. The larger this is,
+        /// Amount of entries to compute evictability metric for before determining eviction order. The larger this is,
         /// the slower and more resources eviction takes, but also the more accurate it becomes.
         /// </summary>
         /// <remarks>
-        /// When running eviction, up to <see cref="EvictionWindowSize"/> * <see cref="MaximumEvictionPoolMultiplier"/>
-        /// may be kept in memory at any time.
+        /// Two pools are kept in memory at the same time, so we effectively keep double the amount of data in memory.
         /// </remarks>
-        public int MaximumEvictionPoolMultiplier { get; set; } = 2;
+        public int EvictionPoolSize { get; set; } = 5000;
+
+        /// <summary>
+        /// Fraction of the pool considered trusted to be in the accurate order.
+        /// </summary>
+        /// <remarks>
+        /// Estimated by looking into the percentage of files we remove of the total content store. Means we remove
+        /// at most 76 entries per iteration when we stabilize.
+        /// </remarks>
+        public float EvictionRemovalFraction { get; set; } = 0.015355f;
 
         /// <summary>
         /// Returns true if Redis can be used for storing small files.

--- a/Public/Src/Cache/ContentStore/Distributed/Redis/RedisContentLocationStoreConfiguration.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Redis/RedisContentLocationStoreConfiguration.cs
@@ -77,9 +77,20 @@ namespace BuildXL.Cache.ContentStore.Distributed.Redis
         public long MaxBlobCapacity { get; set; } = 1024 * 1024 * 1024;
 
         /// <summary>
-        /// Indicates the window size for executing eviction.
+        /// Number of records to compute evictability at once for. This determines -and delimits- how much we hit LLS
+        /// at once. The larger this number is, the more taxing eviction is to LLS, but also the more accurate it is.
         /// </summary>
         public int EvictionWindowSize { get; set; } = 500;
+
+        /// <summary>
+        /// Amount of pages to compute evictability metric for before determining eviction order. The larger this is,
+        /// the slower and more resources eviction takes, but also the more accurate it becomes.
+        /// </summary>
+        /// <remarks>
+        /// When running eviction, up to <see cref="EvictionWindowSize"/> * <see cref="MaximumEvictionPoolMultiplier"/>
+        /// may be kept in memory at any time.
+        /// </remarks>
+        public int MaximumEvictionPoolMultiplier { get; set; } = 2;
 
         /// <summary>
         /// Returns true if Redis can be used for storing small files.

--- a/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentStore.cs
@@ -487,7 +487,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
         }
 
         /// <nodoc />
-        public IEnumerable<IReadOnlyList<ContentHashWithLastAccessTimeAndReplicaCount>> GetLruPages(Context context, IReadOnlyList<ContentHashWithLastAccessTimeAndReplicaCount> contentHashesWithInfo)
+        public IEnumerable<ContentHashWithLastAccessTimeAndReplicaCount> GetHashesInEvictionOrder(Context context, IReadOnlyList<ContentHashWithLastAccessTimeAndReplicaCount> contentHashesWithInfo)
         {
             // Ensure startup was called then wait for it to complete successfully (or error)
             // This logic is important to avoid runtime errors when, for instance, QuotaKeeper tries
@@ -498,7 +498,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
             Contract.Assert(_contentLocationStore is IDistributedLocationStore);
             if (_contentLocationStore is IDistributedLocationStore distributedStore)
             {
-                return distributedStore.GetLruPages(context, contentHashesWithInfo);
+                return distributedStore.GetHashesInEvictionOrder(context, contentHashesWithInfo);
             }
             else
             {

--- a/Public/Src/Cache/ContentStore/Hashing/ContentHashWithLastAccessTime.cs
+++ b/Public/Src/Cache/ContentStore/Hashing/ContentHashWithLastAccessTime.cs
@@ -13,14 +13,14 @@ namespace BuildXL.Cache.ContentStore.Hashing
         /// <nodoc />
         public ContentHashWithLastAccessTime(ContentHash contentHash, DateTime lastAccessTime)
         {
-            Hash = contentHash;
+            ContentHash = contentHash;
             LastAccessTime = lastAccessTime;
         }
 
         /// <summary>
         ///     Gets the content hash member.
         /// </summary>
-        public ContentHash Hash { get; }
+        public ContentHash ContentHash { get; }
 
         /// <summary>
         ///     Gets the last time the content was accessed.
@@ -30,7 +30,7 @@ namespace BuildXL.Cache.ContentStore.Hashing
         /// <inheritdoc />
         public override string ToString()
         {
-            return $"[ContentHash={Hash} LastAccessTime={LastAccessTime}]";
+            return $"[ContentHash={ContentHash} LastAccessTime={LastAccessTime}]";
         }
     }
 }

--- a/Public/Src/Cache/ContentStore/Hashing/ContentHashWithLastAccessTime.cs
+++ b/Public/Src/Cache/ContentStore/Hashing/ContentHashWithLastAccessTime.cs
@@ -13,14 +13,14 @@ namespace BuildXL.Cache.ContentStore.Hashing
         /// <nodoc />
         public ContentHashWithLastAccessTime(ContentHash contentHash, DateTime lastAccessTime)
         {
-            ContentHash = contentHash;
+            Hash = contentHash;
             LastAccessTime = lastAccessTime;
         }
 
         /// <summary>
         ///     Gets the content hash member.
         /// </summary>
-        public ContentHash ContentHash { get; }
+        public ContentHash Hash { get; }
 
         /// <summary>
         ///     Gets the last time the content was accessed.
@@ -30,7 +30,7 @@ namespace BuildXL.Cache.ContentStore.Hashing
         /// <inheritdoc />
         public override string ToString()
         {
-            return $"[ContentHash={ContentHash} LastAccessTime={LastAccessTime}]";
+            return $"[ContentHash={Hash} LastAccessTime={LastAccessTime}]";
         }
     }
 }

--- a/Public/Src/Cache/ContentStore/Library/Stores/ILocalContentStore.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/ILocalContentStore.cs
@@ -33,7 +33,7 @@ namespace BuildXL.Cache.ContentStore.Stores
     public interface IDistributedLocationStore
     {
         /// <summary>
-        /// Returns true if the instance supports <see cref="GetLruPages"/>.
+        /// Returns true if the instance supports <see cref="GetHashesInEvictionOrder"/>.
         /// </summary>
         bool CanComputeLru { get; }
 
@@ -45,7 +45,7 @@ namespace BuildXL.Cache.ContentStore.Stores
         /// <summary>
         /// Computes content hashes with effective last access time sorted in LRU manner.
         /// </summary>
-        IEnumerable<IReadOnlyList<ContentHashWithLastAccessTimeAndReplicaCount>> GetLruPages(
+        IEnumerable<ContentHashWithLastAccessTimeAndReplicaCount> GetHashesInEvictionOrder(
             Context context,
             IReadOnlyList<ContentHashWithLastAccessTimeAndReplicaCount> contentHashesWithInfo);
     }

--- a/Public/Src/Cache/ContentStore/Library/Stores/QuotaManagement/QuotaKeeperV2.Purger.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/QuotaManagement/QuotaKeeperV2.Purger.cs
@@ -106,7 +106,7 @@ namespace BuildXL.Cache.ContentStore.Stores
             var evictedContent = new List<ContentHash>();
             var distributedStore = _distributedEvictionSettings.DistributedStore;
 
-            foreach (var contentHashInfo in distributedStore.GetLruPages(_context, _contentHashesWithInfo).SelectMany(p => p))
+            foreach (var contentHashInfo in distributedStore.GetHashesInEvictionOrder(_context, _contentHashesWithInfo))
             {
                 if (StopPurging(out var stopReason, out var rule))
                 {

--- a/Public/Src/Cache/ContentStore/Library/Stores/QuotaManagement/QuotaRule.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/QuotaManagement/QuotaRule.cs
@@ -182,7 +182,7 @@ namespace BuildXL.Cache.ContentStore.Stores
             var evictedContent = new List<ContentHash>();
             var distributedStore = _distributedEvictionSettings.DistributedStore;
 
-            foreach (var contentHashInfo in distributedStore.GetLruPages(context, hashesToPurge).SelectMany(p => p))
+            foreach (var contentHashInfo in distributedStore.GetHashesInEvictionOrder(context, hashesToPurge))
             {
                 if (StopPurging(reserveSize, cts, out var stopReason))
                 {

--- a/Public/Src/Cache/ContentStore/Test/Stores/MockDistributedLocationStore.cs
+++ b/Public/Src/Cache/ContentStore/Test/Stores/MockDistributedLocationStore.cs
@@ -27,7 +27,7 @@ namespace ContentStoreTest.Stores
         }
 
         /// <inheritdoc />
-        public IEnumerable<IReadOnlyList<ContentHashWithLastAccessTimeAndReplicaCount>> GetLruPages(Context context, IReadOnlyList<ContentHashWithLastAccessTimeAndReplicaCount> contentHashesWithInfo)
+        public IEnumerable<ContentHashWithLastAccessTimeAndReplicaCount> GetHashesInEvictionOrder(Context context, IReadOnlyList<ContentHashWithLastAccessTimeAndReplicaCount> contentHashesWithInfo)
         {
             yield break;
         }

--- a/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
@@ -201,10 +201,22 @@ namespace BuildXL.Cache.Host.Configuration
         public long MaxBlobCapacity { get; set; } = 1024 * 1024 * 1024;
 
         /// <summary>
-        /// Indicates the window size for executing eviction.
+        /// Number of records to compute evictability at once for. This determines -and delimits- how much we hit LLS
+        /// at once. The larger this number is, the more taxing eviction is to LLS, but also the more accurate it is.
         /// </summary>
         [DataMember]
         public int EvictionWindowSize { get; set; } = 500;
+
+        /// <summary>
+        /// Amount of pages to compute evictability metric for before determining eviction order. The larger this is,
+        /// the slower and more resources eviction takes, but also the more accurate it becomes.
+        /// </summary>
+        /// <remarks>
+        /// When running eviction, up to <see cref="EvictionWindowSize"/> * <see cref="MaximumEvictionPoolMultiplier"/>
+        /// may be kept in memory at any time.
+        /// </remarks>
+        [DataMember]
+        public int MaximumEvictionPoolMultiplier { get; set; } = 2;
 
         private int[] _retryIntervalForCopiesMs =
             new int[]

--- a/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
@@ -201,22 +201,28 @@ namespace BuildXL.Cache.Host.Configuration
         public long MaxBlobCapacity { get; set; } = 1024 * 1024 * 1024;
 
         /// <summary>
-        /// Number of records to compute evictability at once for. This determines -and delimits- how much we hit LLS
-        /// at once. The larger this number is, the more taxing eviction is to LLS, but also the more accurate it is.
+        /// Amount of entries to compute evictability metric for in a single pass. The larger this is, the faster the
+        /// candidate pool fills up, but also the slower it is to produce a candidate. Helps control how fast we need
+        /// to produce candidates.
         /// </summary>
         [DataMember]
         public int EvictionWindowSize { get; set; } = 500;
 
         /// <summary>
-        /// Amount of pages to compute evictability metric for before determining eviction order. The larger this is,
+        /// Amount of entries to compute evictability metric for before determining eviction order. The larger this is,
         /// the slower and more resources eviction takes, but also the more accurate it becomes.
         /// </summary>
         /// <remarks>
-        /// When running eviction, up to <see cref="EvictionWindowSize"/> * <see cref="MaximumEvictionPoolMultiplier"/>
-        /// may be kept in memory at any time.
+        /// Two pools are kept in memory at the same time, so we effectively keep double the amount of data in memory.
         /// </remarks>
         [DataMember]
-        public int MaximumEvictionPoolMultiplier { get; set; } = 2;
+        public int EvictionPoolSize { get; set; } = 5000;
+
+        /// <summary>
+        /// Fraction of the pool considered trusted to be in the accurate order.
+        /// </summary>
+        [DataMember]
+        public float EvictionRemovalFraction { get; set; } = 1.0f / 30.0f;
 
         private int[] _retryIntervalForCopiesMs =
             new int[]

--- a/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
@@ -222,7 +222,7 @@ namespace BuildXL.Cache.Host.Configuration
         /// Fraction of the pool considered trusted to be in the accurate order.
         /// </summary>
         [DataMember]
-        public float EvictionRemovalFraction { get; set; } = 1.0f / 30.0f;
+        public float EvictionRemovalFraction { get; set; } = 0.015355f;
 
         private int[] _retryIntervalForCopiesMs =
             new int[]

--- a/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
@@ -68,7 +68,8 @@ namespace BuildXL.Cache.Host.Service.Internal
                 MaxBlobCapacity = _distributedSettings.MaxBlobCapacity,
                 MaxBlobSize = _distributedSettings.MaxBlobSize,
                 EvictionWindowSize = _distributedSettings.EvictionWindowSize,
-                MaximumEvictionPoolMultiplier = _distributedSettings.MaximumEvictionPoolMultiplier,
+                EvictionPoolSize = _distributedSettings.EvictionPoolSize,
+                EvictionRemovalFraction = _distributedSettings.EvictionRemovalFraction,
                 MemoizationExpiryTime = TimeSpan.FromMinutes(_distributedSettings.RedisMemoizationExpiryTimeMinutes)
             };
 

--- a/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
@@ -68,6 +68,7 @@ namespace BuildXL.Cache.Host.Service.Internal
                 MaxBlobCapacity = _distributedSettings.MaxBlobCapacity,
                 MaxBlobSize = _distributedSettings.MaxBlobSize,
                 EvictionWindowSize = _distributedSettings.EvictionWindowSize,
+                MaximumEvictionPoolMultiplier = _distributedSettings.MaximumEvictionPoolMultiplier,
                 MemoizationExpiryTime = TimeSpan.FromMinutes(_distributedSettings.RedisMemoizationExpiryTimeMinutes)
             };
 


### PR DESCRIPTION
This changes the pooling logic to fetch many times the size of the pool, and evict only a fraction of it that depends on the total content being stored.