### PR TITLE
Add global ContentHasher to save memory

### DIFF
--- a/Public/Src/Cache/ContentStore/Library/Stores/FileSystemContentStoreInternal.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/FileSystemContentStoreInternal.cs
@@ -41,6 +41,7 @@ using RelativePath = BuildXL.Cache.ContentStore.Interfaces.FileSystem.RelativePa
 
 namespace BuildXL.Cache.ContentStore.Stores
 {
+
     /// <summary>
     ///     Callback to update last access time based on external access times.
     /// </summary>
@@ -160,8 +161,6 @@ namespace BuildXL.Cache.ContentStore.Stores
         private readonly AbsolutePath _contentRootDirectory;
         private readonly AbsolutePath _tempFolder;
 
-        private readonly Dictionary<HashType, IContentHasher> _hashers;
-
         /// <summary>
         ///     LockSet used to ensure thread safety on write operations.
         /// </summary>
@@ -247,7 +246,6 @@ namespace BuildXL.Cache.ContentStore.Stores
             Contract.Requires(clock != null);
 
             _tracer = new ContentStoreInternalTracer(settings?.TraceFileSystemContentStoreDiagnosticMessages ?? false);
-            _hashers = HashInfoLookup.CreateAll();
             int maxContentPathLengthRelativeToCacheRoot = GetMaxContentPathLengthRelativeToCacheRoot();
 
             RootPath = rootPath;
@@ -1207,12 +1205,6 @@ namespace BuildXL.Cache.ContentStore.Stores
                         counters.Merge(quotaKeeperCounter.ToCounterSet());
                     }
                 }
-
-                foreach (var kvp in _hashers)
-                {
-                    counters.Merge(kvp.Value.GetCounters(), $"{Component}.{kvp.Key}");
-                }
-
                 return new GetStatsResult(counters);
             });
         }
@@ -1285,7 +1277,7 @@ namespace BuildXL.Cache.ContentStore.Stores
                         return;
                     }
 
-                    var hasher = _hashers[hashFromPath.HashType];
+                    var hasher = ContentHashers.Get(hashFromPath.HashType);
                     ContentHash hashFromContents;
                     using (Stream contentStream = await FileSystem.OpenSafeAsync(
                         contentFile, FileAccess.Read, FileMode.Open, FileShare.Read | FileShare.Delete, FileOptions.SequentialScan, HashingExtensions.HashStreamBufferSize))
@@ -1422,11 +1414,6 @@ namespace BuildXL.Cache.ContentStore.Stores
         protected override void DisposeCore()
         {
             base.DisposeCore();
-
-            foreach (IContentHasher hasher in _hashers.Values)
-            {
-                hasher.Dispose();
-            }
 
             QuotaKeeper?.Dispose();
             _taskTracker?.Dispose();
@@ -1571,7 +1558,7 @@ namespace BuildXL.Cache.ContentStore.Stores
             {
                 long contentSize;
 
-                var hasher = _hashers[hashType];
+                var hasher = ContentHashers.Get(hashType);
                 using (var hashingStream = hasher.CreateReadHashingStream(stream))
                 {
                     pathToTempContent = await WriteToTemporaryFileAsync(context, hashingStream);
@@ -1733,7 +1720,7 @@ namespace BuildXL.Cache.ContentStore.Stores
 
             try
             {
-                ContentHash contentHash = await _hashers[hashType].GetContentHashAsync(stream);
+                ContentHash contentHash = await ContentHashers.Get(hashType).GetContentHashAsync(stream);
                 return new ContentHashWithSize(contentHash, stream.Length);
             }
             catch (Exception e)
@@ -2518,8 +2505,8 @@ namespace BuildXL.Cache.ContentStore.Stores
             FileReplacementMode replacementMode)
         {
             var code = PlaceFileResult.ResultCode.Unknown;
-            var hasher = _hashers[contentHash.HashType];
             ContentHash computedHash = new ContentHash(contentHash.HashType);
+            var hasher = ContentHashers.Get(contentHash.HashType);
 
             using (Stream contentStream =
                 await OpenStreamInternalWithLockAsync(context, contentHash, null, FileShare.Read | FileShare.Delete))

--- a/Public/Src/Cache/ContentStore/Library/Utils/ContentHashers.cs
+++ b/Public/Src/Cache/ContentStore/Library/Utils/ContentHashers.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using BuildXL.Cache.ContentStore.Hashing;
+
+namespace BuildXL.Cache.ContentStore.Utils
+{
+    /// <summary>
+    /// Global instance that contains all <see cref="IContentHasher"/> instances.
+    /// </summary>
+    /// <remarks>
+    /// Each and every content hasher instance contains an expensive set of pooled resources used through the entire application's lifetime.
+    /// To avoid duplication and excessive memory usage, this type provides a global entry point for accessing hasher instances.
+    /// </remarks>
+    public static class ContentHashers
+    {
+        private static readonly Dictionary<HashType, IContentHasher> Hashers = HashInfoLookup.CreateAll();
+
+        /// <summary>
+        /// Returns an instance of <see cref="IContentHasher"/> for a given <paramref name="hashType"/>.
+        /// </summary>
+        /// <remarks>
+        /// The method throws <see cref="InvalidOperationException"/> if a given hash type is not registered in a global map.
+        /// </remarks>
+        public static IContentHasher Get(HashType hashType)
+        {
+            if (Hashers.TryGetValue(hashType, out IContentHasher hasher))
+            {
+                return hasher;
+            }
+
+            throw new InvalidOperationException($"The hasher type '{hashType}' is unknown.");
+        }
+    }
+}


### PR DESCRIPTION
Each `IContentHasher` instance holds a memory pool for `byte[]` and consume reasonable amount of memory (like 1Gb) a steady-state.

Originally, all the hashers were created in two different places: inside `FileSystemContentStoreInteranal` and `DistributedFileCopier` causing excessive memory use.

For instance, in one of the memory, each of these instances was about 1Gb in size and this change will allow us to reuse the hasher saving at least this amount of memory in a steady state.