### PR TITLE
Throw ObjectDisposeException from HashingStreamImpl when disposed.

### DIFF
--- a/Public/Src/Cache/ContentStore/Hashing/ContentHasher.cs
+++ b/Public/Src/Cache/ContentStore/Hashing/ContentHasher.cs
@@ -179,7 +179,7 @@ namespace BuildXL.Cache.ContentStore.Hashing
             private static readonly byte[] EmptyByteArray = new byte[0];
             private static readonly Task<bool> TrueTask = Task.FromResult(true);
 
-            private static readonly Stopwatch Stopwatch = Stopwatch.StartNew();
+            private static readonly Stopwatch Timer = Stopwatch.StartNew();
 
             private readonly ActionBlock<Pool<Buffer>.PoolHandle> _hashingBufferBlock;
 
@@ -393,9 +393,9 @@ namespace BuildXL.Cache.ContentStore.Hashing
 
             private void TransformBlock(byte[] buffer, int offset, int count, byte[] outputBuffer, int outputOffset)
             {
-                var start = Stopwatch.Elapsed;
+                var start = Timer.Elapsed;
                 _hashAlgorithm.TransformBlock(buffer, offset, count, outputBuffer, outputOffset);
-                var elapsed = Stopwatch.Elapsed - start;
+                var elapsed = Timer.Elapsed - start;
                 Interlocked.Add(ref _ticksSpentHashing, elapsed.Ticks);
             }
 

--- a/Public/Src/Cache/ContentStore/Hashing/ContentHasher.cs
+++ b/Public/Src/Cache/ContentStore/Hashing/ContentHasher.cs
@@ -62,10 +62,6 @@ namespace BuildXL.Cache.ContentStore.Hashing
         }
 
         /// <inheritdoc />
-        [SuppressMessage(
-            "Microsoft.Reliability",
-            "CA2000:Dispose objects before losing scope",
-            Justification = "Code is designed to reuse and not dispose of the HashAlgorithm")]
         public HasherToken CreateToken() => new HasherToken(_algorithmsPool.Get());
 
         /// <inheritdoc />
@@ -183,12 +179,13 @@ namespace BuildXL.Cache.ContentStore.Hashing
             private static readonly byte[] EmptyByteArray = new byte[0];
             private static readonly Task<bool> TrueTask = Task.FromResult(true);
 
-            private static readonly Stopwatch _sw = Stopwatch.StartNew();
+            private static readonly Stopwatch Stopwatch = Stopwatch.StartNew();
 
             private readonly ActionBlock<Pool<Buffer>.PoolHandle> _hashingBufferBlock;
 
             private readonly Stream _baseStream;
             private readonly ContentHasher<T> _hasher;
+
             private readonly CryptoStreamMode _streamMode;
             private readonly long _parallelHashingFileSizeBoundary;
             private readonly bool _useParallelHashing;
@@ -275,7 +272,11 @@ namespace BuildXL.Cache.ContentStore.Hashing
                     FinishHash();
                 }
 
-                _hasherHandle.Dispose();
+                if (disposing)
+                {
+                    // Disposing the owning resources only during disposal and not during the finalization.
+                    _hasherHandle.Dispose();
+                }
 
                 Interlocked.Increment(ref _hasher._calls);
             }
@@ -308,24 +309,28 @@ namespace BuildXL.Cache.ContentStore.Hashing
             /// <inheritdoc />
             public override void Flush()
             {
+                ThrowIfDisposed();
                 _baseStream.Flush();
             }
 
             /// <inheritdoc />
             public override long Seek(long offset, SeekOrigin origin)
             {
+                ThrowIfDisposed();
                 return _baseStream.Seek(offset, origin);
             }
 
             /// <inheritdoc />
             public override void SetLength(long value)
             {
+                ThrowIfDisposed();
                 _baseStream.SetLength(value);
             }
 
             /// <inheritdoc />
             public override int Read(byte[] buffer, int offset, int count)
             {
+                ThrowIfDisposed();
                 var bytesRead = _baseStream.Read(buffer, offset, count);
 
                 if (_streamMode == CryptoStreamMode.Read)
@@ -339,6 +344,7 @@ namespace BuildXL.Cache.ContentStore.Hashing
             /// <inheritdoc />
             public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             {
+                ThrowIfDisposed();
                 var bytesRead = await _baseStream.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
 
                 if (_streamMode == CryptoStreamMode.Read)
@@ -387,15 +393,16 @@ namespace BuildXL.Cache.ContentStore.Hashing
 
             private void TransformBlock(byte[] buffer, int offset, int count, byte[] outputBuffer, int outputOffset)
             {
-                var start = _sw.Elapsed;
+                var start = Stopwatch.Elapsed;
                 _hashAlgorithm.TransformBlock(buffer, offset, count, outputBuffer, outputOffset);
-                var elapsed = _sw.Elapsed - start;
+                var elapsed = Stopwatch.Elapsed - start;
                 Interlocked.Add(ref _ticksSpentHashing, elapsed.Ticks);
             }
 
             /// <inheritdoc />
             public override void Write(byte[] buffer, int offset, int count)
             {
+                ThrowIfDisposed();
                 _baseStream.Write(buffer, offset, count);
 
                 if (_streamMode == CryptoStreamMode.Write)
@@ -407,6 +414,7 @@ namespace BuildXL.Cache.ContentStore.Hashing
             /// <inheritdoc />
             public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             {
+                ThrowIfDisposed();
                 await _baseStream.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
 
                 if (_streamMode == CryptoStreamMode.Write)
@@ -437,15 +445,23 @@ namespace BuildXL.Cache.ContentStore.Hashing
             /// <inheritdoc />
             public override TimeSpan TimeSpentHashing => TimeSpan.FromTicks(_ticksSpentHashing);
 
+            private void ThrowIfDisposed()
+            {
+                if (_disposed)
+                {
+                    throw new ObjectDisposedException(nameof(HashingStreamImpl));
+                }
+            }
+
             private sealed class Buffer
             {
-                private static readonly Pool<Buffer> _bufferPool = new Pool<Buffer>(() => new Buffer());
+                private static readonly Pool<Buffer> BufferPool = new Pool<Buffer>(() => new Buffer());
 
                 public byte[] Data { get; private set; } = new byte[0];
 
                 public int Count { get; private set; } = 0;
 
-                public static Pool<Buffer>.PoolHandle GetBuffer() => _bufferPool.Get();
+                public static Pool<Buffer>.PoolHandle GetBuffer() => BufferPool.Get();
 
                 public void CopyFrom(byte[] buffer, int offset, int count)
                 {


### PR DESCRIPTION
This change makes the error that may happen during the "abandoned" copy file more readable.

In some cases, the file copy operation may be canceled from the outside (for instance, by the bandwidth checker). This may cause a different kind of errors because `Stream.CopyTo` procedure may access already disposed streams, and one of the streams may be `HashingStreamImpl` used for on-the-fly file hashing.

Without this change, it was possible to get errors like that:

```
System.AggregateException: One or more errors occurred. ---> System.ObjectDisposedException: Safe handle has been closed
   at System.Runtime.InteropServices.SafeHandle.DangerousAddRef(Boolean& success)
   at System.StubHelpers.StubHelpers.SafeHandleAddRef(SafeHandle pHandle, Boolean& success)
   at Microsoft.Win32.Win32Native.SetFilePointerWin32(SafeFileHandle handle, Int32 lo, Int32* hi, Int32 origin)
   at Microsoft.Win32.Win32Native.SetFilePointer(SafeFileHandle handle, Int64 offset, SeekOrigin origin, Int32& hr)
   at System.IO.FileStream.SeekCore(Int64 offset, SeekOrigin origin)
   at System.IO.FileStream.BeginWriteCore(Byte[] bytes, Int32 offset, Int32 numBytes, AsyncCallback userCallback, Object stateObject)
   at System.IO.Stream.<>c.<BeginEndWriteAsync>b__53_0(Stream stream, ReadWriteParameters args, AsyncCallback callback, Object state)
   at System.Threading.Tasks.TaskFactory`1.FromAsyncTrim[TInstance,TArgs](TInstance thisRef, TArgs args, Func`5 beginMethod, Func`3 endMethod)
   at System.IO.Stream.BeginEndWriteAsync(Byte[] buffer, Int32 offset, Int32 count)
   at System.IO.FileStream.WriteAsync(Byte[] buffer, Int32 offset, Int32 count, CancellationToken cancellationToken)
   at BuildXL.Cache.ContentStore.Hashing.ContentHasher`1.HashingStreamImpl.<WriteAsync>d__38.MoveNext() in \.\Public\Src\Cache\ContentStore\Hashing\ContentHasher.cs:line 410
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.IO.Stream.<CopyToAsyncInternal>d__27.MoveNext()
   --- End of inner exception stack trace ---
---> (Inner Exception #0) System.ObjectDisposedException: Safe handle has been closed
   at System.Runtime.InteropServices.SafeHandle.DangerousAddRef(Boolean& success)
   at System.StubHelpers.StubHelpers.SafeHandleAddRef(SafeHandle pHandle, Boolean& success)
   at Microsoft.Win32.Win32Native.SetFilePointerWin32(SafeFileHandle handle, Int32 lo, Int32* hi, Int32 origin)
   at Microsoft.Win32.Win32Native.SetFilePointer(SafeFileHandle handle, Int64 offset, SeekOrigin origin, Int32& hr)
   at System.IO.FileStream.SeekCore(Int64 offset, SeekOrigin origin)
   at System.IO.FileStream.BeginWriteCore(Byte[] bytes, Int32 offset, Int32 numBytes, AsyncCallback userCallback, Object stateObject)
   at System.IO.Stream.<>c.<BeginEndWriteAsync>b__53_0(Stream stream, ReadWriteParameters args, AsyncCallback callback, Object state)
   at System.Threading.Tasks.TaskFactory`1.FromAsyncTrim[TInstance,TArgs](TInstance thisRef, TArgs args, Func`5 beginMethod, Func`3 endMethod)
   at System.IO.Stream.BeginEndWriteAsync(Byte[] buffer, Int32 offset, Int32 count)
   at System.IO.FileStream.WriteAsync(Byte[] buffer, Int32 offset, Int32 count, CancellationToken cancellationToken)
   at BuildXL.Cache.ContentStore.Hashing.ContentHasher`1.HashingStreamImpl.<WriteAsync>d__38.MoveNext() in \.\Public\Src\Cache\ContentStore\Hashing\ContentHasher.cs:line 410
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.IO.Stream.<CopyToAsyncInternal>d__27.MoveNext()<---
```
Now, we'll be getting a more graceful error from the hasher without trying to access a closed file stream.