### PR TITLE
Make PipHistoricPerfData merge crashes more visible

### DIFF
--- a/Public/Src/Engine/Processes/SandboxedProcessMac.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessMac.cs
@@ -414,7 +414,7 @@ namespace BuildXL.Processes
                         ReadTransferCount = Convert.ToUInt64(m_perfAggregator.DiskBytesRead.Total),
                         WriteTransferCount = Convert.ToUInt64(m_perfAggregator.DiskBytesWritten.Total)
                     }),
-                    PeakMemoryUsage = (ulong)m_perfAggregator.PeakMemoryBytes.Maximum,
+                    PeakMemoryUsage = Convert.ToUInt64(m_perfAggregator.PeakMemoryBytes.Maximum),
                     KernelTime = TimeSpan.FromMilliseconds(m_perfAggregator.JobKernelTimeMs.Latest),
                     UserTime = TimeSpan.FromMilliseconds(m_perfAggregator.JobUserTimeMs.Latest),
                 };

--- a/Public/Src/Engine/Scheduler/PipHistoricPerfData.cs
+++ b/Public/Src/Engine/Scheduler/PipHistoricPerfData.cs
@@ -192,12 +192,12 @@ namespace BuildXL.Scheduler
                 // An asymmetric merge that goes up fast but decreases slowly.
                 if (newData > oldData)
                 {
-                    return (uint)(newData + (ulong) oldData) / 2;
+                    return (uint) ( (((ulong)newData) / 2) + (((ulong)oldData) / 2) );
                 }
 
-                return (uint)((((ulong)oldData * 9) + ((ulong)newData * 1)) / 10);
+                return (uint) ( (((ulong)oldData) * 9 / 10) + (((ulong)newData) / 10) );
             }
-            catch(System.OverflowException ex)
+            catch (System.OverflowException ex)
             {
                 throw new BuildXLException(I($"Failed to merge historic perf data result with old '{oldData} and new {newData}' data values!"), ex);
             }


### PR DESCRIPTION
Remove implicit casts and add some debugging capabilities for historic perf data crashes we are seeing rarely.