### PR TITLE
Avoid duplicated error/warning message on Azure DevOps

### DIFF
--- a/Examples/DotNetCoreBuild/src/HelloWorld/hello-world.dsc
+++ b/Examples/DotNetCoreBuild/src/HelloWorld/hello-world.dsc
@@ -33,7 +33,7 @@ export const scriptWithChildProcesses = (() => {
         arguments: [
             Cmd.argument("-c"),
             Cmd.rawArgument('"('), // () creates a subshell, i.e., child process
-            Cmd.argument(Artifact.input(f`/a/b/d`)),
+            Cmd.argument(Artifact.input(f`/usr/bin/touch`)),
             Cmd.argument(Artifact.output(outFile)),
             Cmd.rawArgument(')"')
         ],

--- a/Examples/DotNetCoreBuild/src/HelloWorld/hello-world.dsc
+++ b/Examples/DotNetCoreBuild/src/HelloWorld/hello-world.dsc
@@ -33,7 +33,7 @@ export const scriptWithChildProcesses = (() => {
         arguments: [
             Cmd.argument("-c"),
             Cmd.rawArgument('"('), // () creates a subshell, i.e., child process
-            Cmd.argument(Artifact.input(f`/usr/bin/touch`)),
+            Cmd.argument(Artifact.input(f`/a/b/d`)),
             Cmd.argument(Artifact.output(outFile)),
             Cmd.rawArgument(')"')
         ],

--- a/Public/Src/App/Bxl/Args.cs
+++ b/Public/Src/App/Bxl/Args.cs
@@ -704,9 +704,6 @@ namespace BuildXL
                         OptionHandlerFactory.CreateBoolOption(
                             "adoTaskLogging",
                             sign => loggingConfiguration.OptimizeVsoAnnotationsForAzureDevOps = sign),
-                        OptionHandlerFactory.CreateBoolOption(
-                            "adoWarningErrorLogging",
-                            sign => loggingConfiguration.OptimizeWarningOrErrorAnnotationsForAzureDevOps = sign),
                         OptionHandlerFactory.CreateOption(
                             "outputFileExtensionsForSequentialScanHandleOnHashing",
                             opt => schedulingConfiguration.OutputFileExtensionsForSequentialScanHandleOnHashing.AddRange(CommandLineUtilities.ParseRepeatingPathAtomOption(opt, pathTable.StringTable, ";"))),

--- a/Public/Src/App/Bxl/AzureDevOpsListener.cs
+++ b/Public/Src/App/Bxl/AzureDevOpsListener.cs
@@ -203,8 +203,8 @@ namespace BuildXL
             // report the entire message since Azure DevOps does not yet provide actionalbe information from the metadata.
             body = string.Format(CultureInfo.CurrentCulture, message, args);
 
-            // pip description in the final string only exist when args is not empty
-            if (args.Length > 0)
+            // process pip description for PipProcessError event
+            if (eventData.EventId == (int)EventId.PipProcessError)
             {
                 ProcessCustomPipDescription(ref body, UseCustomPipDescription);
             }
@@ -212,7 +212,6 @@ namespace BuildXL
             builder.Append(";]");
 
             // substitute newlines in the message
-
             var encodedBody = body.Replace("\r", "%0D").Replace("\n", "%0A");
             builder.Append(encodedBody);
 

--- a/Public/Src/App/Bxl/BuildXLApp.cs
+++ b/Public/Src/App/Bxl/BuildXLApp.cs
@@ -1426,7 +1426,7 @@ namespace BuildXL
                     m_noLogMask,
                     onDisabledDueToDiskWriteFailure: OnListenerDisabledDueToDiskWriteFailure,
                     maxStatusPips: m_configuration.FancyConsoleMaxStatusPips,
-                    optimizeForAzureDevOps: m_configuration.OptimizeConsoleOutputForAzureDevOps || m_configuration.OptimizeWarningOrErrorAnnotationsForAzureDevOps);
+                    optimizeForAzureDevOps: m_configuration.OptimizeConsoleOutputForAzureDevOps || m_configuration.OptimizeVsoAnnotationsForAzureDevOps);
 
                 listener.SetBuildViewModel(buildViewModel);
 
@@ -2100,8 +2100,7 @@ namespace BuildXL
 
             if (loggingConfiguration.OptimizeConsoleOutputForAzureDevOps
                 || loggingConfiguration.OptimizeProgressUpdatingForAzureDevOps
-                || loggingConfiguration.OptimizeVsoAnnotationsForAzureDevOps
-                || loggingConfiguration.OptimizeWarningOrErrorAnnotationsForAzureDevOps)
+                || loggingConfiguration.OptimizeVsoAnnotationsForAzureDevOps)
             {
                 // Use a very simple logger for azure devops
                 return new StandardConsole(colorize: false, animateTaskbar: false, supportsOverwriting: false, pathTranslator: translator);

--- a/Public/Src/App/Bxl/ConsoleEventListener.cs
+++ b/Public/Src/App/Bxl/ConsoleEventListener.cs
@@ -410,6 +410,12 @@ namespace BuildXL
         protected override void OnError(EventWrittenEventArgs eventData)
         {
             Interlocked.Increment(ref m_errorsLogged);
+
+            // AzureDevOpsListener has alreday write the event to console, avoid duplication
+            if (m_optimizeForAzureDevOps)
+            {
+                return;
+            }
             
             if (eventData.EventId == (int)EventId.PipProcessError)
             {
@@ -440,6 +446,12 @@ namespace BuildXL
         /// <inheritdoc />
         protected override void OnWarning(EventWrittenEventArgs eventData)
         {
+            // AzureDevOpsListener has alreday write the event to console, avoid duplication
+            if (m_optimizeForAzureDevOps)
+            {
+                return;
+            }
+
             if (eventData.EventId == (int)EventId.PipProcessWarning)
             {
                 string warnings = (string)eventData.Payload[5];

--- a/Public/Src/App/Bxl/ConsoleEventListener.cs
+++ b/Public/Src/App/Bxl/ConsoleEventListener.cs
@@ -524,23 +524,7 @@ namespace BuildXL
         /// <inheritdoc />
         protected override void Output(EventLevel level, int id, string eventName, EventKeywords eventKeywords, string text, bool doNotTranslatePaths = false)
         {
-            var outputText = text.TrimEnd(s_newLineCharArray);
-
-            if (m_optimizeForAzureDevOps)
-            {
-                switch  (level)
-                {
-                    case EventLevel.Critical:
-                    case EventLevel.Error:
-                        outputText = "##[error]" + outputText.Replace("\n", "\n##[error]");
-                        break;
-                    case EventLevel.Warning:
-                        outputText = "##[warning]" + outputText.Replace("\n", "\n##[warning]");
-                        break;
-                }
-            }
-
-            m_console.WriteOutputLine(ConvertLevel(level), outputText);
+            m_console.WriteOutputLine(ConvertLevel(level), text.TrimEnd(s_newLineCharArray));
         }
 
         private void OutputUpdatable(EventLevel level, string standardText, string updatableText, bool onlyIfOverwriteIsSupported)

--- a/Public/Src/App/Bxl/ConsoleEventListener.cs
+++ b/Public/Src/App/Bxl/ConsoleEventListener.cs
@@ -411,7 +411,7 @@ namespace BuildXL
         {
             Interlocked.Increment(ref m_errorsLogged);
 
-            // AzureDevOpsListener has alreday write the event to console, avoid duplication
+            // AzureDevOpsListener has alreday written the event to console, avoid duplication
             if (m_optimizeForAzureDevOps)
             {
                 return;

--- a/Public/Src/Utilities/Configuration/ILoggingConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/ILoggingConfiguration.cs
@@ -328,10 +328,5 @@ namespace BuildXL.Utilities.Configuration
         /// Whether Vso annotations should be optimized for Azure DevOps output.
         /// </summary>
         bool OptimizeVsoAnnotationsForAzureDevOps { get; }
-
-        /// <summary>
-        /// Whether Warning/Error annotations should be optimized for Azure DevOps output.
-        /// </summary>
-        bool OptimizeWarningOrErrorAnnotationsForAzureDevOps { get; }
     }
 }

--- a/Public/Src/Utilities/Configuration/Mutable/LoggingConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/LoggingConfiguration.cs
@@ -128,7 +128,6 @@ namespace BuildXL.Utilities.Configuration.Mutable
             InvocationExpandedCommandLineArguments = template.InvocationExpandedCommandLineArguments;
             OptimizeProgressUpdatingForAzureDevOps = template.OptimizeProgressUpdatingForAzureDevOps;
             OptimizeVsoAnnotationsForAzureDevOps = template.OptimizeVsoAnnotationsForAzureDevOps;
-            OptimizeWarningOrErrorAnnotationsForAzureDevOps = template.OptimizeWarningOrErrorAnnotationsForAzureDevOps;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
OnError and OnWarning event handles write very similar messages both in ConsoleEventListener.cs  and AzureDevOpsListener.cs. This leads to duplicated messages on Azure DevOps console and the coloring of the logs from both messages is confusing. This PR removes writing the error and warning messages in ConsoleEventListener.cs. So there is only single message per error or warning event in Azure devops console.