### PR TITLE
Support source seal directory for affected input files

### DIFF
--- a/Public/Src/Engine/Dll/Distribution/WorkerService.cs
+++ b/Public/Src/Engine/Dll/Distribution/WorkerService.cs
@@ -747,7 +747,7 @@ namespace BuildXL.Engine.Distribution
                     file = fileArtifactKeyedHash.File;
                 }
 
-                if(fileArtifactKeyedHash.IsSourceAffected)
+                if (fileArtifactKeyedHash.IsSourceAffected)
                 {
                     fileContentManager.SourceChangeAffectedContents.ReportSourceChangedAffectedFile(file.Path);
                 }

--- a/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
@@ -173,7 +173,15 @@ namespace BuildXL.Processes
         /// </summary>
         private ISandboxedProcess m_activeProcess;
 
-        IReadOnlyList<string> m_incrementalToolFragments;
+        /// <summary>
+        /// Fragments of incremental tools.
+        /// </summary>
+        private readonly IReadOnlyList<string> m_incrementalToolFragments;
+
+        /// <summary>
+        /// Inputs affected by file/source changes.
+        /// </summary>
+        private readonly IReadOnlyList<AbsolutePath> m_changeAffectedInputs;
 
         /// <summary>
         /// Whether the process invokes an incremental tool with preserveOutputs mode.
@@ -222,7 +230,8 @@ namespace BuildXL.Processes
             bool isQbuildIntegrated = false,
             VmInitializer vmInitializer = null,
             SubstituteProcessExecutionInfo shimInfo = null,
-            IReadOnlyList<RelativePath> incrementalTools = null)
+            IReadOnlyList<RelativePath> incrementalTools = null,
+            IReadOnlyList<AbsolutePath> changeAffectedInputs = null)
         {
             Contract.Requires(pip != null);
             Contract.Requires(context != null);
@@ -340,14 +349,16 @@ namespace BuildXL.Processes
             if (incrementalTools != null)
             {
                 m_incrementalToolFragments = new List<string>(
-                            incrementalTools.Select(toolSuffix =>
-                                // Append leading separator to ensure suffix only matches valid relative path fragments
-                                Path.DirectorySeparatorChar + toolSuffix.ToString(context.StringTable)));
+                    incrementalTools.Select(toolSuffix =>
+                        // Append leading separator to ensure suffix only matches valid relative path fragments
+                        Path.DirectorySeparatorChar + toolSuffix.ToString(context.StringTable)));
             }
             else
             {
                 m_incrementalToolFragments = new List<string>(Enumerable.Empty<string>());
             }
+
+            m_changeAffectedInputs = changeAffectedInputs;
         }
 
         /// <inheritdoc />
@@ -706,7 +717,7 @@ namespace BuildXL.Processes
         /// <summary>
         /// Runs the process pip (uncached).
         /// </summary>
-        public async Task<SandboxedProcessPipExecutionResult> RunAsync(CancellationToken cancellationToken = default, ISandboxConnection sandboxConnection = null, IReadOnlyCollection<AbsolutePath> changeAffectedInputs = null)
+        public async Task<SandboxedProcessPipExecutionResult> RunAsync(CancellationToken cancellationToken = default, ISandboxConnection sandboxConnection = null)
         {
             try
             {
@@ -725,7 +736,12 @@ namespace BuildXL.Processes
                     return SandboxedProcessPipExecutionResult.PreparationFailure();
                 }
 
-                if (!await PrepareResponseFile())
+                if (!await PrepareResponseFileAsync())
+                {
+                    return SandboxedProcessPipExecutionResult.PreparationFailure();
+                }
+
+                if (!await PrepareChangeAffectedInputListFileAsync(m_changeAffectedInputs))
                 {
                     return SandboxedProcessPipExecutionResult.PreparationFailure();
                 }
@@ -751,11 +767,6 @@ namespace BuildXL.Processes
                     }
 
                     if (!await PrepareOutputsAsync())
-                    {
-                        return SandboxedProcessPipExecutionResult.PreparationFailure();
-                    }
-
-                    if (!await PrepareChangeAffectedInputListFile(changeAffectedInputs))
                     {
                         return SandboxedProcessPipExecutionResult.PreparationFailure();
                     }
@@ -2626,80 +2637,61 @@ namespace BuildXL.Processes
         /// <summary>
         /// If used, response files must be created before executing pips that consume them
         /// </summary>
-        private async Task<bool> PrepareResponseFile()
-        {
-            if (m_pip.ResponseFile.IsValid)
-            {
-                Contract.Assume(m_pip.ResponseFileData.IsValid, "ResponseFile path requires having ResponseFile data");
-                string destination = m_pip.ResponseFile.Path.ToString(m_context.PathTable);
-                string contents = m_pip.ResponseFileData.ToString(m_context.PathTable);
-
-                try
+        private Task<bool> PrepareResponseFileAsync() =>
+            WritePipAuxiliaryFileAsync(
+                m_pip.ResponseFile,
+                () =>
                 {
-                    string directoryName = ExceptionUtilities.HandleRecoverableIOException(
-                        () => Path.GetDirectoryName(destination),
-                        ex => { throw new BuildXLException("Cannot get directory name", ex); });
-
-                    PreparePathForOutputFile(m_pip.ResponseFile.Path);
-                    FileUtilities.CreateDirectory(directoryName);
-
-                    // The target is always overwritten
-                    await FileUtilities.WriteAllTextAsync(destination, contents, Encoding.UTF8);
-                }
-                catch (BuildXLException ex)
-                {
-                    Tracing.Logger.Log.PipProcessResponseFileCreationFailed(
-                        m_loggingContext,
-                        m_pip.SemiStableHash,
-                        m_pip.GetDescription(m_context),
-                        destination,
-                        ex.LogEventErrorCode,
-                        ex.LogEventMessage);
-
-                    return false;
-                }
-            }
-
-            return true;
-        }
+                    Contract.Assume(m_pip.ResponseFileData.IsValid, "ResponseFile path requires having ResponseFile data");
+                    return m_pip.ResponseFileData.ToString(m_context.PathTable);
+                },
+                Tracing.Logger.Log.PipProcessResponseFileCreationFailed);
 
         /// <summary>
         /// ChangeAffectedInputListFile file is created before executing pips that consume it
         /// </summary>
-        private async Task<bool> PrepareChangeAffectedInputListFile(IReadOnlyCollection<AbsolutePath> changeAffectedInputs = null)
+        private Task<bool> PrepareChangeAffectedInputListFileAsync(IReadOnlyCollection<AbsolutePath> changeAffectedInputs = null) =>
+            changeAffectedInputs == null
+                ? Task.FromResult(true)
+                : WritePipAuxiliaryFileAsync(
+                    m_pip.ChangeAffectedInputListWrittenFilePath,
+                    () => string.Join(
+                        Environment.NewLine,
+                        changeAffectedInputs.Select(i => i.GetName(m_pathTable).ToString(m_pathTable.StringTable)).Distinct().OrderBy(n => n)),
+                    Tracing.Logger.Log.PipProcessChangeAffectedInputsWrittenFileCreationFailed);
+
+        private async Task<bool> WritePipAuxiliaryFileAsync(
+            FileArtifact fileArtifact, 
+            Func<string> createContent, 
+            Action<LoggingContext, long, string, string, int, string> logException)
         {
-            // If ChangeAffectedInputListWrittenFilePath is set, write the change affected inputs of the pip to the file.
-            if (changeAffectedInputs != null)
+            if (!fileArtifact.IsValid)
             {
-                string destination = m_pip.ChangeAffectedInputListWrittenFilePath.Path.ToString(m_context.PathTable);
-                try
-                {
-                    string directoryName = ExceptionUtilities.HandleRecoverableIOException(
+                return true;
+            }
+
+            string destination = fileArtifact.Path.ToString(m_context.PathTable);
+
+            try
+            {
+                string directoryName = ExceptionUtilities.HandleRecoverableIOException(
                         () => Path.GetDirectoryName(destination),
                         ex => { throw new BuildXLException("Cannot get directory name", ex); });
+                PreparePathForOutputFile(fileArtifact);
+                FileUtilities.CreateDirectory(directoryName);
+                await FileUtilities.WriteAllTextAsync(destination, createContent(), Encoding.UTF8);
+            }
+            catch (BuildXLException ex)
+            {
+                logException(
+                    m_loggingContext,
+                    m_pip.SemiStableHash,
+                    m_pip.GetDescription(m_context),
+                    destination,
+                    ex.LogEventErrorCode,
+                    ex.LogEventMessage);
 
-                    PreparePathForOutputFile(m_pip.ChangeAffectedInputListWrittenFilePath);
-                    FileUtilities.CreateDirectory(directoryName);
-                    await FileUtilities.WriteAllTextAsync(
-                       destination,
-                       string.Join(
-                           Environment.NewLine,
-                           changeAffectedInputs.Select(i => i.GetName(m_pathTable).ToString(m_pathTable.StringTable)).ToHashSet().OrderBy(n=>n)
-                       ),
-                    System.Text.Encoding.UTF8);
-                }
-                catch (BuildXLException ex)
-                {
-                    Tracing.Logger.Log.PipProcessChangeAffectedInputsWrittenFileCreationFailed(
-                        m_loggingContext,
-                        m_pip.SemiStableHash,
-                        m_pip.GetDescription(m_context),
-                        destination,
-                        ex.LogEventErrorCode,
-                        ex.LogEventMessage);
-
-                    return false;
-                }
+                return false;
             }
 
             return true;

--- a/Public/Src/Engine/Scheduler/Artifacts/FileContentManager.cs
+++ b/Public/Src/Engine/Scheduler/Artifacts/FileContentManager.cs
@@ -94,6 +94,11 @@ namespace BuildXL.Scheduler.Artifacts
         public FileContentStats FileContentStats => m_stats;
 
         /// <summary>
+        /// Gets the file content manager host.
+        /// </summary>
+        public IFileContentManagerHost Host => m_host;
+
+        /// <summary>
         /// Dictionary of number of cache content hits by cache name.
         /// </summary>
         private readonly ConcurrentDictionary<string, int> m_cacheContentSource = new ConcurrentDictionary<string, int>();
@@ -261,7 +266,7 @@ namespace BuildXL.Scheduler.Artifacts
                 m_outputMaterializationExclusionMap.TryAdd(outputMaterializationExclusionRoot.Value, Unit.Void);
             }
 
-            SourceChangeAffectedContents = new SourceChangeAffectedContents(host.Context.PathTable, this);
+            SourceChangeAffectedContents = new SourceChangeAffectedContents(this);
         }
 
         /// <summary>
@@ -385,7 +390,7 @@ namespace BuildXL.Scheduler.Artifacts
                     }
                 }
 
-                return await TryHashArtifacts(operationContext, state, pip.ProcessAllowsUndeclaredSourceReads);
+                return await TryHashArtifactsAsync(operationContext, state, pip.ProcessAllowsUndeclaredSourceReads);
             }
         }
 
@@ -405,11 +410,11 @@ namespace BuildXL.Scheduler.Artifacts
                 // by consumers of the seal directory
                 MarkDirectoryMaterializations(state);
 
-                return await TryHashArtifacts(operationContext, state, pip.ProcessAllowsUndeclaredSourceReads);
+                return await TryHashArtifactsAsync(operationContext, state, pip.ProcessAllowsUndeclaredSourceReads);
             }
         }
 
-        private async Task<Possible<Unit>> TryHashArtifacts(OperationContext operationContext, PipArtifactsState state, bool allowUndeclaredSourceReads)
+        private async Task<Possible<Unit>> TryHashArtifactsAsync(OperationContext operationContext, PipArtifactsState state, bool allowUndeclaredSourceReads)
         {
             var maybeReported = EnumerateAndReportDynamicOutputDirectories(state.PipArtifacts);
 

--- a/Public/Src/Engine/Scheduler/Artifacts/IFileContentManagerHost.cs
+++ b/Public/Src/Engine/Scheduler/Artifacts/IFileContentManagerHost.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using BuildXL.Engine.Cache.Artifacts;
 using BuildXL.Pips;
 using BuildXL.Pips.Operations;
+using BuildXL.Scheduler.Fingerprints;
 using BuildXL.Scheduler.Tracing;
 using BuildXL.Storage;
 using BuildXL.Utilities;
@@ -63,6 +64,11 @@ namespace BuildXL.Scheduler.Artifacts
         /// Gets the seal directory kind for the given directory artifact
         /// </summary>
         SealDirectoryKind GetSealDirectoryKind(DirectoryArtifact directory);
+
+        /// <summary>
+        /// Gets source seal directory info.
+        /// </summary>
+        bool TryGetSourceSealDirectory(DirectoryArtifact directory, out SourceSealWithPatterns sourceSealWithPatterns);
 
         /// <summary>
         /// Gets the scrub flag of a seal directory

--- a/Public/Src/Engine/Scheduler/Fingerprints/ObservedInputProcessor.cs
+++ b/Public/Src/Engine/Scheduler/Fingerprints/ObservedInputProcessor.cs
@@ -192,11 +192,11 @@ namespace BuildXL.Scheduler.Fingerprints
                             {
                                 if (allDirectories)
                                 {
-                                    sourceDirectoriesAllDirectories.Add(new SourceSealWithPatterns(directoryDependency.Path, patterns));
+                                    sourceDirectoriesAllDirectories.Add(new SourceSealWithPatterns(directoryDependency.Path, patterns, false));
                                 }
                                 else
                                 {
-                                    sourceDirectoriesTopDirectoryOnly.Add(new SourceSealWithPatterns(directoryDependency.Path, patterns));
+                                    sourceDirectoriesTopDirectoryOnly.Add(new SourceSealWithPatterns(directoryDependency.Path, patterns, true));
                                 }
                             }
                         }
@@ -242,7 +242,7 @@ namespace BuildXL.Scheduler.Fingerprints
                             for (int j = 0; j < sourceDirectoriesAllDirectories.Count && !underSealedSource; j++)
                             {
                                 var sourceSealWithPatterns = sourceDirectoriesAllDirectories[j];
-                                if (sourceSealWithPatterns.Contains(pathTable, path, isTopDirectoryOnly: false))
+                                if (sourceSealWithPatterns.Contains(pathTable, path))
                                 {
                                     // Note the directories themselves are never part of the seal.
                                     underSealedSource = true;
@@ -390,7 +390,7 @@ namespace BuildXL.Scheduler.Fingerprints
 
                                 ObservedInputAccessCheckFailureAction accessCheckFailureResult = target.OnAccessCheckFailure(
                                     observation,
-                                    fromTopLevelDirectory: sourceDirectoriesTopDirectoryOnly.Any(a => a.Contains(pathTable, path, isTopDirectoryOnly: false)));
+                                    fromTopLevelDirectory: sourceDirectoriesTopDirectoryOnly.Any(a => a.Contains(pathTable, path, isTopDirectoryOnlyOverride: false)));
                                 HandleFailureResult(accessCheckFailureResult, ref status, ref invalid);
                                 continue;
                             }
@@ -412,7 +412,7 @@ namespace BuildXL.Scheduler.Fingerprints
                             {
                                 ObservedInputAccessCheckFailureAction accessCheckFailureResult = target.OnAccessCheckFailure(
                                     observation,
-                                    fromTopLevelDirectory: sourceDirectoriesTopDirectoryOnly.Any(a => a.Contains(pathTable, path, isTopDirectoryOnly: false)));
+                                    fromTopLevelDirectory: sourceDirectoriesTopDirectoryOnly.Any(a => a.Contains(pathTable, path, isTopDirectoryOnlyOverride: false)));
                                 HandleFailureResult(accessCheckFailureResult, ref status, ref invalid);
                                 continue;
                             }
@@ -657,7 +657,7 @@ namespace BuildXL.Scheduler.Fingerprints
 
                             if (!proposed.Path.IsValid)
                             {
-                                Contract.Assume(proposed.Path.IsValid, "Created an ObservedInput with an invalid path in ObservedInputProcessor line 675. Type:" + proposed.Type.ToString());
+                                Contract.Assume(proposed.Path.IsValid, "Created an ObservedInput with an invalid path in ObservedInputProcessor line 660. Type: " + proposed.Type.ToString());
                             }
 
                             switch (proposed.Type)
@@ -1131,7 +1131,7 @@ namespace BuildXL.Scheduler.Fingerprints
         /// Action to perform on access check failure
         /// </summary>
         /// <param name="observation">the observation</param>
-        /// <param name="fromTopLevelDirectory">Whether the observation was nested deeploy under a source sealed directory
+        /// <param name="fromTopLevelDirectory">Whether the observation was nested deeply under a source sealed directory
         /// that is configured as a top only directory. This scenar ends up hitting the sealed directory codepath due
         /// the access being allowed but we want to report it differently.</param>
         ObservedInputAccessCheckFailureAction OnAccessCheckFailure(TObservation observation, bool fromTopLevelDirectory);

--- a/Public/Src/Engine/Scheduler/PipExecutor.cs
+++ b/Public/Src/Engine/Scheduler/PipExecutor.cs
@@ -1337,6 +1337,10 @@ namespace BuildXL.Scheduler
                                     }
                                 });
 
+                            IReadOnlyList<AbsolutePath> changeAffectedInputs = pip.ChangeAffectedInputListWrittenFilePath.IsValid
+                                ? environment.State.FileContentManager.SourceChangeAffectedContents.GetChangeAffectedInputs(pip)
+                                : null;
+
                             int remainingUserRetries = pip.RetryExitCodes.Length > 0 ? configuration.Schedule.ProcessRetries : 0;
                             int remainingInternalSandboxedProcessExecutionFailureRetries = InternalSandboxedProcessExecutionFailureRetryCountMax;
 
@@ -1374,7 +1378,8 @@ namespace BuildXL.Scheduler
                                     remainingUserRetryCount: remainingUserRetries,
                                     vmInitializer: environment.VmInitializer,
                                     tempDirectoryCleaner: environment.TempCleaner,
-                                    incrementalTools: configuration.IncrementalTools);
+                                    incrementalTools: configuration.IncrementalTools,
+                                    changeAffectedInputs: changeAffectedInputs);
 
                                 registerQueryRamUsageMb(
                                     () =>
@@ -1395,11 +1400,7 @@ namespace BuildXL.Scheduler
                                     environment.SetMaxExternalProcessRan();
                                 }
 
-                                IReadOnlyCollection<AbsolutePath> changeAffectedInputs = pip.ChangeAffectedInputListWrittenFilePath.IsValid
-                                    ? environment.State.FileContentManager.SourceChangeAffectedContents.GetChangeAffectedInputs(pip)
-                                    : null;
-
-                                result = await executor.RunAsync(innerResourceLimitCancellationTokenSource.Token, sandboxConnection: environment.SandboxConnection, changeAffectedInputs);
+                                result = await executor.RunAsync(innerResourceLimitCancellationTokenSource.Token, sandboxConnection: environment.SandboxConnection);
 
                                 ++retryCount;
 

--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -2290,14 +2290,16 @@ namespace BuildXL.Scheduler
                 {
                     ReadOnlyArray<FileArtifact> outputContents = ReadOnlyArray<FileArtifact>.Empty;
                     PipResultStatus status = result.Status;
+
                     if (pipType == PipType.CopyFile)
                     {
                         outputContents = new[] { ((CopyFile)runnablePip.Pip).Destination }.ToReadOnlyArray();
                     }
                     else if (runnablePip.ExecutionResult?.OutputContent != null)
                     {
-                        outputContents = runnablePip.ExecutionResult.OutputContent.SelectList(o => o.Item1).ToReadOnlyArray();
+                        outputContents = runnablePip.ExecutionResult.OutputContent.SelectList(o => o.fileArtifact).ToReadOnlyArray();
                     }
+
                     m_fileContentManager.SourceChangeAffectedContents.ReportSourceChangeAffectedFiles(
                         pip,
                         result.DynamicallyObservedFiles,
@@ -5480,6 +5482,20 @@ namespace BuildXL.Scheduler
         SealDirectoryKind IFileContentManagerHost.GetSealDirectoryKind(DirectoryArtifact directory)
         {
             return GetSealDirectoryKind(directory);
+        }
+
+        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes")]
+        bool IFileContentManagerHost.TryGetSourceSealDirectory(DirectoryArtifact directory, out SourceSealWithPatterns sourceSealWithPatterns)
+        {
+            sourceSealWithPatterns = default;
+
+            if (((IPipExecutionEnvironment)this).IsSourceSealedDirectory(directory, out bool allDirectories, out ReadOnlyArray<StringId> patterns))
+            {
+                sourceSealWithPatterns = new SourceSealWithPatterns(directory.Path, patterns, !allDirectories);
+                return true;
+            }
+
+            return false;
         }
 
         [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes")]

--- a/Public/Src/Engine/UnitTests/Scheduler/PipQueueTest.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/PipQueueTest.cs
@@ -532,6 +532,19 @@ namespace Test.BuildXL.Scheduler
                 return SealDirectoryKind.Partial;
             }
 
+            bool IFileContentManagerHost.TryGetSourceSealDirectory(DirectoryArtifact directory, out SourceSealWithPatterns sourceSealWithPatterns)
+            {
+                sourceSealWithPatterns = default;
+
+                if (IsSourceSealedDirectory(directory, out bool allDirectories, out ReadOnlyArray<StringId> patterns))
+                {
+                    sourceSealWithPatterns = new SourceSealWithPatterns(directory.Path, patterns, !allDirectories);
+                    return true;
+                }
+
+                return false;
+            }
+
             PipId IFileContentManagerHost.TryGetProducerId(in FileOrDirectoryArtifact artifact)
             {
                 return PipId.Invalid;

--- a/Public/Src/Engine/UnitTests/Scheduler/SourceSealWithPatternsTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/SourceSealWithPatternsTests.cs
@@ -10,7 +10,7 @@ using BuildXL.Utilities.Collections;
 
 namespace Test.BuildXL.Scheduler
 {
-    public class SourceSealWithPatternsTests : BuildXL.TestUtilities.Xunit.XunitBuildXLTest
+    public class SourceSealWithPatternsTests : XunitBuildXLTest
     {
         public SourceSealWithPatternsTests(ITestOutputHelper output)
             : base(output) { }
@@ -39,7 +39,8 @@ namespace Test.BuildXL.Scheduler
             var pattern4 = StringId.Create(st, "file5.txt");
             var pattern5 = StringId.Create(st, "file1*");
 
-            SourceSealWithPatterns sourceSeal1 = new SourceSealWithPatterns(dir1, ReadOnlyArray<StringId>.From(new[] { pattern1, pattern2 }));
+            SourceSealWithPatterns sourceSeal1 = new SourceSealWithPatterns(dir1, ReadOnlyArray<StringId>.From(new[] { pattern1, pattern2 }), true);
+
             // Wildcard matches everything
             AssertTrue(sourceSeal1.Contains(pt, f1));
             AssertTrue(sourceSeal1.Contains(pt, f2));
@@ -50,10 +51,10 @@ namespace Test.BuildXL.Scheduler
 
             AssertTrue(!sourceSeal1.Contains(pt, nestedf1));
             AssertTrue(!sourceSeal1.Contains(pt, nestedf2));
-            AssertTrue(sourceSeal1.Contains(pt, nestedf1, isTopDirectoryOnly: false));
-            AssertTrue(sourceSeal1.Contains(pt, nestedf2, isTopDirectoryOnly: false));
+            AssertTrue(sourceSeal1.Contains(pt, nestedf1, isTopDirectoryOnlyOverride: false));
+            AssertTrue(sourceSeal1.Contains(pt, nestedf2, isTopDirectoryOnlyOverride: false));
 
-            SourceSealWithPatterns sourceSeal2 = new SourceSealWithPatterns(dir1, ReadOnlyArray<StringId>.From(new[] { pattern3, pattern4, pattern5 }));
+            SourceSealWithPatterns sourceSeal2 = new SourceSealWithPatterns(dir1, ReadOnlyArray<StringId>.From(new[] { pattern3, pattern4, pattern5 }), true);
             // *.cs, file5.txt, file1*
             AssertTrue(sourceSeal2.Contains(pt, f1));
             AssertTrue(!sourceSeal2.Contains(pt, f2));
@@ -63,8 +64,8 @@ namespace Test.BuildXL.Scheduler
             AssertTrue(!sourceSeal2.Contains(pt, f6));
             AssertTrue(!sourceSeal2.Contains(pt, nestedf1));
             AssertTrue(!sourceSeal2.Contains(pt, nestedf2));
-            AssertTrue(!sourceSeal2.Contains(pt, nestedf1, isTopDirectoryOnly: false));
-            AssertTrue(sourceSeal2.Contains(pt, nestedf2, isTopDirectoryOnly: false));
+            AssertTrue(!sourceSeal2.Contains(pt, nestedf1, isTopDirectoryOnlyOverride: false));
+            AssertTrue(sourceSeal2.Contains(pt, nestedf2, isTopDirectoryOnlyOverride: false));
 
         }
 

--- a/Public/Src/Engine/UnitTests/Scheduler/Utils/DummyPipExecutionEnvironment.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/Utils/DummyPipExecutionEnvironment.cs
@@ -607,6 +607,19 @@ namespace Test.BuildXL.Scheduler.Utils
             return SealDirectoryKind.Partial;
         }
 
+        public bool TryGetSourceSealDirectory(DirectoryArtifact directory, out SourceSealWithPatterns sourceSealWithPatterns)
+        {
+            sourceSealWithPatterns = default;
+
+            if (IsSourceSealedDirectory(directory, out bool allDirectories, out ReadOnlyArray<StringId> patterns))
+            {
+                sourceSealWithPatterns = new SourceSealWithPatterns(directory.Path, patterns, !allDirectories);
+                return true;
+            }
+
+            return false;
+        }
+
         public bool ShouldScrubFullSealDirectory(DirectoryArtifact directory)
         {           
             return false;

--- a/Public/Src/Pips/Dll/Builders/ProcessBuilder.cs
+++ b/Public/Src/Pips/Dll/Builders/ProcessBuilder.cs
@@ -419,8 +419,8 @@ namespace BuildXL.Pips.Builders
             Contract.Requires(path.IsValid);
             Contract.Assert(!m_changeAffectedInputListWrittenFile.IsValid, "Value already set");
 
-            AddOutputFile(path, FileExistence.Optional);
-            m_changeAffectedInputListWrittenFile = FileArtifact.CreateOutputFile(path);
+            m_changeAffectedInputListWrittenFile = FileArtifact.CreateSourceFile(path);
+            AddUntrackedFile(path);
         }
 
         /// <nodoc />
@@ -511,14 +511,6 @@ namespace BuildXL.Pips.Builders
         public void SetResponseFileSpecification(ResponseFileSpecification specification)
         {
             m_responseFileSpecification = specification;
-        }
-
-        /// <summary>
-        /// Set the file path that will be used to write the change affected inputs
-        /// </summary>
-        public void SetChangeAffectedInputListWrittenFilePath(FileArtifact path)
-        {
-            m_changeAffectedInputListWrittenFile = path;
         }
 
         private PipData FinishArgumentsAndCreateResponseFileIfNeeded(DirectoryArtifact defaultDirectory)


### PR DESCRIPTION
Besides supporting source seal directory, this change also cleans up previous implementation and tests.
