### PR TITLE
Fix BandwidthChecker

### DIFF
--- a/Public/Src/Cache/ContentStore/Library/Utils/BandwidthChecker.cs
+++ b/Public/Src/Cache/ContentStore/Library/Utils/BandwidthChecker.cs
@@ -83,7 +83,7 @@ namespace BuildXL.Cache.ContentStore.Utils
                     if (copyCompleted)
                     {
                         var result = await copyTask;
-                        var bytesCopied = result.Size ?? previousPosition - startPosition;
+                        var bytesCopied = result.Size ?? (previousPosition - startPosition);
 
                         return (result, bytesCopied);
                     }

--- a/Public/Src/Cache/ContentStore/Library/Utils/BandwidthChecker.cs
+++ b/Public/Src/Cache/ContentStore/Library/Utils/BandwidthChecker.cs
@@ -104,8 +104,8 @@ namespace BuildXL.Cache.ContentStore.Utils
                             copyCancellation.Cancel();
                             traceCopyTaskFailures(copyTask);
 
-                            var result = new CopyFileResult(CopyFileResult.ResultCode.CopyBandwidthTimeoutError, $"Average speed was {currentSpeed}MiB/s - under {minimumSpeedInMbPerSec}MiB/s requirement. Aborting copy with {position} copied");
                             var bytesCopied = position - startPosition;
+                            var result = new CopyFileResult(CopyFileResult.ResultCode.CopyBandwidthTimeoutError, $"Average speed was {currentSpeed}MiB/s - under {minimumSpeedInMbPerSec}MiB/s requirement. Aborting copy with {bytesCopied} bytes copied");
                             return (result, bytesCopied);
                         }
 

--- a/Public/Src/Cache/ContentStore/Library/Utils/BandwidthChecker.cs
+++ b/Public/Src/Cache/ContentStore/Library/Utils/BandwidthChecker.cs
@@ -45,92 +45,77 @@ namespace BuildXL.Cache.ContentStore.Utils
         {
             if (_historicalBandwidthLimitSource != null)
             {
-                var startPosition = destinationStream.Position;
+                var startPosition = tryGetPosition(destinationStream, out var pos) ? pos : 0;
                 var timer = Stopwatch.StartNew();
+                var (result, lastPosition) = await impl();
+                timer.Stop();
 
-                try
-                {
-                    return await impl();
-                }
-                finally
-                {
-                    timer.Stop();
-                    var endPosition = destinationStream.Position;
+                // Bandwidth checker expects speed in MiB/s, so convert it.
+                var bytesCopied = lastPosition - startPosition;
+                var speed = bytesCopied / timer.Elapsed.TotalSeconds / (1024 * 1024);
+                _historicalBandwidthLimitSource.AddBandwidthRecord(speed);
 
-                    // Bandwidth checker expects speed in MiB/s, so convert it.
-                    var bytesCopied = endPosition - startPosition;
-                    var speed = bytesCopied / timer.Elapsed.TotalSeconds / (1024 * 1024);
-                    _historicalBandwidthLimitSource.AddBandwidthRecord(speed);
-                }
+                return result;
             }
             else
             {
-                return await impl();
+                return (await impl()).result;
             }
 
-            async Task<CopyFileResult> impl()
+            async Task<(CopyFileResult result, long lastPosition)> impl()
             {
                 // This method should not fail with exceptions because the resulting task may be left unobserved causing an application to crash
                 // (given that the app is configured to fail on unobserved task exceptions).
                 var minimumSpeedInMbPerSec = _bandwidthLimitSource.GetMinimumSpeedInMbPerSec() * _config.BandwidthLimitMultiplier;
                 minimumSpeedInMbPerSec = Math.Min(minimumSpeedInMbPerSec, _config.MaxBandwidthLimit);
 
-                long previousPosition = 0;
+                long firstPosition = tryGetPosition(destinationStream, out var pos) ? pos : 0;
+                long previousPosition = firstPosition;
                 var copyCompleted = false;
                 using var copyCancellation = CancellationTokenSource.CreateLinkedTokenSource(context.Token);
                 var copyTask = copyTaskFactory(copyCancellation.Token);
 
-                try
+                while (!copyCompleted)
                 {
-                    while (!copyCompleted)
+                    // Wait some time for bytes to be copied
+                    var firstCompletedTask = await Task.WhenAny(copyTask,
+                        Task.Delay(_config.BandwidthCheckInterval, context.Token));
+
+                    copyCompleted = firstCompletedTask == copyTask;
+                    if (copyCompleted)
                     {
-                        // Wait some time for bytes to be copied
-                        var firstCompletedTask = await Task.WhenAny(copyTask,
-                            Task.Delay(_config.BandwidthCheckInterval, context.Token));
+                        var result = await copyTask;
+                        var lastPosition = result.Size.HasValue
+                            ? firstPosition + result.Size.Value
+                            : previousPosition;
 
-                        copyCompleted = firstCompletedTask == copyTask;
-                        if (copyCompleted)
-                        {
-                            return await copyTask;
-                        }
-                        else if (context.Token.IsCancellationRequested)
-                        {
-                            context.Token.ThrowIfCancellationRequested();
-                        }
-
-                        // Copy is not completed and operation has not been canceled, perform
-                        // bandwidth check 
-                        try
-                        {
-                            var position = destinationStream.Position;
-
-                            var receivedMiB = (position - previousPosition) / BytesInMb;
-                            var currentSpeed = receivedMiB / _config.BandwidthCheckInterval.TotalSeconds;
-                            if (currentSpeed == 0 || currentSpeed < minimumSpeedInMbPerSec)
-                            {
-                                return new CopyFileResult(CopyFileResult.ResultCode.CopyBandwidthTimeoutError, $"Average speed was {currentSpeed}MiB/s - under {minimumSpeedInMbPerSec}MiB/s requirement. Aborting copy with {position} copied");
-                            }
-
-                            previousPosition = position;
-                        }
-                        catch (ObjectDisposedException)
-                        {
-                            // If the check task races with the copy completing, it might attempt to check the position of a disposed stream.
-                            // Don't bother logging because the copy completed successfully.
-                        }
+                        return (await copyTask, lastPosition);
+                    }
+                    else if (context.Token.IsCancellationRequested)
+                    {
+                        context.Token.ThrowIfCancellationRequested();
                     }
 
-                    return await copyTask;
-                }
-                finally
-                {
-                    if (!copyCompleted)
+                    // Copy is not completed and operation has not been canceled, perform
+                    // bandwidth check
+                    if (tryGetPosition(destinationStream, out var position))
                     {
-                        // Ensure that we signal the copy to cancel
-                        copyCancellation.Cancel();
-                        traceCopyTaskFailures(copyTask);
+                        var receivedMiB = (position - previousPosition) / BytesInMb;
+                        var currentSpeed = receivedMiB / _config.BandwidthCheckInterval.TotalSeconds;
+                        if (currentSpeed == 0 || currentSpeed < minimumSpeedInMbPerSec)
+                        {
+                            // Ensure that we signal the copy to cancel
+                            copyCancellation.Cancel();
+                            traceCopyTaskFailures(copyTask);
+
+                            return (new CopyFileResult(CopyFileResult.ResultCode.CopyBandwidthTimeoutError, $"Average speed was {currentSpeed}MiB/s - under {minimumSpeedInMbPerSec}MiB/s requirement. Aborting copy with {position} copied"), position);
+                        }
+
+                        previousPosition = position;
                     }
                 }
+
+                return (await copyTask, previousPosition);
 
                 void traceCopyTaskFailures(Task task)
                 {
@@ -148,6 +133,22 @@ namespace BuildXL.Cache.ContentStore.Utils
                             }
                         }
                     });
+                }
+            }
+
+            static bool tryGetPosition(Stream stream, out long position)
+            {
+                try
+                {
+                    position = stream.Position;
+                    return true;
+                }
+                catch (ObjectDisposedException)
+                {
+                    // If the check task races with the copy completing, it might attempt to check the position of a disposed stream.
+                    // Don't bother logging because the copy completed successfully.
+                    position = 0;
+                    return false;
                 }
             }
         }


### PR DESCRIPTION
BandwidthChecker was sometimes failing because it was trying to access the position of the disposed destination stream for calculating the bandwidth.