### PR TITLE
Add vnode_write policy callbacks to macOS sandbox

### DIFF
--- a/Public/Src/Engine/Processes/SandboxConnectionKext.cs
+++ b/Public/Src/Engine/Processes/SandboxConnectionKext.cs
@@ -67,7 +67,7 @@ Use the the following command to load/reload the sandbox kernel extension and fi
         /// Until some automation for kernel extension building and deployment is in place, this number has to be kept in sync with the 'CFBundleVersion'
         /// inside the Info.plist file of the kernel extension code base. BuildXL will not work if a version mismatch is detected!
         /// </summary>
-        public const string RequiredKextVersionNumber = "1.99.99";
+        public const string RequiredKextVersionNumber = "2.0.99";
 
         /// <summary>
         /// See TN2420 (https://developer.apple.com/library/archive/technotes/tn2420/_index.html) on how versioning numbers are formatted in the Apple ecosystem

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/BuildXLSandbox.cpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/BuildXLSandbox.cpp
@@ -127,6 +127,8 @@ void BuildXLSandbox::InitializePolicyStructures()
 
         .mpo_vnode_check_create           = Listeners::mpo_vnode_check_create,
 
+        .mpo_vnode_check_write            = Listeners::mpo_vnode_check_write,
+
         .mpo_vnode_check_readlink         = Listeners::mpo_vnode_check_readlink,
     };
 

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Kauth/TrustedBsdHandler.hpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Kauth/TrustedBsdHandler.hpp
@@ -19,6 +19,8 @@ public:
 
     int HandleVNodeCreateEvent(const char *fullPath, const bool isDir, const bool isSymlink);
 
+    int HandleVnodeWrite(vnode_t vnode);
+
     void HandleProcessWantsToFork(const pid_t parentProcessPid);
 
     void HandleProcessFork(const pid_t childProcessPid);

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Listeners.cpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Listeners.cpp
@@ -90,7 +90,6 @@ int Listeners::buildxl_vnode_listener(kauth_cred_t credential,
      * (1) KAUTH_VNODE_ACCESS bit is set (request is advisory rather than authoritative)
      * (2) none of the relevant bits are set
      */
-
     bool isVnodeAccess = HasAnyFlags(action, KAUTH_VNODE_ACCESS);
     bool hasRelevantVnodeBits = HasAnyFlags(action, RELEVANT_KAUTH_VNODE_BITS);
 
@@ -254,4 +253,18 @@ int Listeners::mpo_vnode_check_create(kauth_cred_t cred,
     }
 
     return KERN_SUCCESS;
+}
+
+int Listeners::mpo_vnode_check_write(kauth_cred_t active_cred,
+                                     kauth_cred_t file_cred,
+                                     struct vnode *vp,
+                                     struct label *label)
+{
+    TrustedBsdHandler handler = TrustedBsdHandler((BuildXLSandbox*)g_dispatcher);
+    if (!handler.TryInitializeWithTrackedProcess(proc_selfpid()))
+    {
+        return KERN_SUCCESS;
+    }
+
+    return handler.HandleVnodeWrite(vp);
 }

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Listeners.hpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Listeners.hpp
@@ -92,6 +92,12 @@ public:
     static int mpo_vnode_check_readlink(kauth_cred_t cred,
                                         struct vnode *vp,
                                         struct label *label);
+
+
+    static int mpo_vnode_check_write(kauth_cred_t active_cred,
+                                     kauth_cred_t file_cred,
+                                     struct vnode *vp,
+                                     struct label *label);
 };
 
 #endif /* Listeners_hpp */

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>1.99.99</string>
+	<string>2.0.99</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>BuildXLSandbox</key>

--- a/cg/nuget/cgmanifest.json
+++ b/cg/nuget/cgmanifest.json
@@ -14,35 +14,17 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
-          "Name": "Aria.Cpp.SDK",
-          "Version": "8.5.6"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "ArtifactServices.App.Shared",
-          "Version": "17.150.28901-buildid9382555"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "ArtifactServices.App.Shared.Cache",
-          "Version": "17.150.28901-buildid9382555"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
           "Name": "AsyncFixer",
           "Version": "1.1.5"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "Bond.Core.CSharp",
+          "Version": "8.0.0"
         }
       }
     },
@@ -68,26 +50,8 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
-          "Name": "Bond.Core.CSharp",
-          "Version": "8.0.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
           "Name": "Bond.Runtime.CSharp",
           "Version": "8.0.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "BuildXL.DeviceMap",
-          "Version": "0.0.1"
         }
       }
     },
@@ -106,24 +70,6 @@
         "NuGet": {
           "Name": "BuildXL.Tools.Ninjson",
           "Version": "0.0.6"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "BuildXL.Tracing.AriaTenantToken",
-          "Version": "1.0.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "CB.QTest",
-          "Version": "19.9.6.1149"
         }
       }
     },
@@ -151,51 +97,6 @@
         "NuGet": {
           "Name": "DotNet.Glob",
           "Version": "2.0.3"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "Dotnet-Runtime",
-          "Version": "5.0.2"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "Drop.App.Core",
-          "Version": "17.150.28901-buildid9382555"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "Drop.Client",
-          "Version": "17.150.28901-buildid9382555"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "Drop.RemotableClient",
-          "Version": "17.150.28901-buildid9382555"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "Drop.RemotableClient.Interfaces",
-          "Version": "17.150.28901-buildid9382555"
         }
       }
     },
@@ -322,15 +223,6 @@
         "NuGet": {
           "Name": "ILRepack",
           "Version": "2.0.16"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "ItemStore.Shared",
-          "Version": "17.150.28901-buildid9382555"
         }
       }
     },
@@ -1148,8 +1040,8 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
-          "Name": "Microsoft.CSharp",
-          "Version": "4.3.0"
+          "Name": "Microsoft.CodeAnalysis.Analyzers",
+          "Version": "2.6.3"
         }
       }
     },
@@ -1157,8 +1049,8 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
-          "Name": "Microsoft.CodeAnalysis.Analyzers",
-          "Version": "2.6.3"
+          "Name": "Microsoft.CodeAnalysis.Common",
+          "Version": "2.10.0"
         }
       }
     },
@@ -1176,15 +1068,6 @@
         "Type": "NuGet",
         "NuGet": {
           "Name": "Microsoft.CodeAnalysis.CSharp.Workspaces",
-          "Version": "2.10.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.CodeAnalysis.Common",
           "Version": "2.10.0"
         }
       }
@@ -1256,6 +1139,15 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
+          "Name": "Microsoft.CSharp",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
           "Name": "Microsoft.Data.Edm",
           "Version": "5.8.2"
         }
@@ -1283,15 +1175,6 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
-          "Name": "Microsoft.DiaSymReader.Native",
-          "Version": "1.7.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
           "Name": "Microsoft.Diagnostics.Tracing.EventSource.Redist",
           "Version": "1.1.28"
         }
@@ -1310,8 +1193,26 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
+          "Name": "Microsoft.DiaSymReader.Native",
+          "Version": "1.7.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
           "Name": "Microsoft.DotNet.PlatformAbstractions",
           "Version": "2.1.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "microsoft.dotnet.xunitconsolerunner",
+          "Version": "2.5.1-beta.19270.4"
         }
       }
     },
@@ -1625,15 +1526,6 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
-          "Name": "Microsoft.IO.RecyclableMemoryStream",
-          "Version": "1.2.2"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
           "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
           "Version": "4.5.1"
         }
@@ -1654,6 +1546,51 @@
         "NuGet": {
           "Name": "Microsoft.IdentityModel.Tokens",
           "Version": "5.2.2"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "Microsoft.IO.RecyclableMemoryStream",
+          "Version": "1.2.2"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "Microsoft.Net.Compilers",
+          "Version": "3.0.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "Microsoft.Net.Http",
+          "Version": "2.2.29"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "Microsoft.Net.Http.Headers",
+          "Version": "2.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "Microsoft.NetCore.Analyzers",
+          "Version": "2.3.0-beta1"
         }
       }
     },
@@ -1805,6 +1742,15 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
+          "Name": "Microsoft.NetFramework.Analyzers",
+          "Version": "2.3.0-beta1"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
           "Name": "Microsoft.NETFramework.ReferenceAssemblies.net451",
           "Version": "1.0.0-alpha-5"
         }
@@ -1825,51 +1771,6 @@
         "NuGet": {
           "Name": "Microsoft.NETFramework.ReferenceAssemblies.net472",
           "Version": "1.0.0-alpha-5"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Net.Compilers",
-          "Version": "3.0.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Net.Http",
-          "Version": "2.2.29"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Net.Http.Headers",
-          "Version": "2.2.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.NetCore.Analyzers",
-          "Version": "2.3.0-beta1"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.NetFramework.Analyzers",
-          "Version": "2.3.0-beta1"
         }
       }
     },
@@ -2066,44 +1967,8 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
-          "Name": "Microsoft.VisualStudio.Services.ArtifactServices.Shared",
-          "Version": "17.150.28901-buildid9382555"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.VisualStudio.Services.BlobStore.Client",
-          "Version": "17.150.28901-buildid9382555"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.VisualStudio.Services.BlobStore.Client.Cache",
-          "Version": "17.150.28901-buildid9382555"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
           "Name": "Microsoft.VisualStudio.Services.Client",
-          "Version": "17.150.20190501.2-release"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.VisualStudio.Services.InteractiveClient",
-          "Version": "17.150.20190501.2-release"
+          "Version": "16.148.0-preview"
         }
       }
     },
@@ -2381,15 +2246,6 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
-          "Name": "Microsoft.Windows.Debuggers.SymstoreInterop",
-          "Version": "1.0.1"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
           "Name": "Microsoft.Windows.ProjFS",
           "Version": "1.0.19079.1"
         }
@@ -2417,26 +2273,17 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
-          "Name": "NETStandard.Library",
-          "Version": "2.0.3"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "NLog",
-          "Version": "4.6.6"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
           "Name": "Nerdbank.FullDuplexStream",
           "Version": "1.0.9"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "NETStandard.Library",
+          "Version": "2.0.3"
         }
       }
     },
@@ -2471,8 +2318,8 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
-          "Name": "NodeJs",
-          "Version": "8.12.0-noTest"
+          "Name": "NLog",
+          "Version": "4.6.6"
         }
       }
     },
@@ -2491,15 +2338,6 @@
         "NuGet": {
           "Name": "NuGet.Versioning",
           "Version": "4.6.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "PowerShell.Core",
-          "Version": "6.1.0"
         }
       }
     },
@@ -2527,6 +2365,312 @@
         "NuGet": {
           "Name": "RocksDbSharp",
           "Version": "5.8.0-b20181023.3"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.native.System",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.native.System.Data.SqlClient.sni",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.native.System.IO.Compression",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.native.System.Net.Http",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.native.System.Net.Security",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.native.System.Security.Cryptography.Apple",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.native.System.Security.Cryptography.OpenSsl",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.osx-x64.Microsoft.DotNet.ILCompiler",
+          "Version": "1.0.0-alpha-27527-01"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.osx-x64.Microsoft.NETCore.App",
+          "Version": "2.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.osx-x64.Microsoft.NETCore.DotNetAppHost",
+          "Version": "2.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.osx-x64.Microsoft.NETCore.DotNetHostPolicy",
+          "Version": "2.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.osx-x64.Microsoft.NETCore.DotNetHostPolicy",
+          "Version": "3.0.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver",
+          "Version": "2.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver",
+          "Version": "3.0.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.win-x64.Microsoft.DotNet.ILCompiler",
+          "Version": "1.0.0-alpha-27527-01"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.win-x64.Microsoft.NETCore.App",
+          "Version": "2.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.win-x64.Microsoft.NETCore.DotNetAppHost",
+          "Version": "2.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy",
+          "Version": "2.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy",
+          "Version": "3.0.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.win-x64.Microsoft.NETCore.DotNetHostResolver",
+          "Version": "2.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.win-x64.Microsoft.NETCore.DotNetHostResolver",
+          "Version": "3.0.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.win7-x64.runtime.native.System.Data.SqlClient.sni",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.win7-x86.runtime.native.System.Data.SqlClient.sni",
+          "Version": "4.3.0"
         }
       }
     },
@@ -2570,6 +2714,15 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
+          "Name": "stdole",
+          "Version": "7.0.3303"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
           "Name": "StreamJsonRpc",
           "Version": "1.4.128"
         }
@@ -2581,24 +2734,6 @@
         "NuGet": {
           "Name": "StyleCop.Analyzers",
           "Version": "1.1.0-beta004"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "Symbol.App.Core",
-          "Version": "17.150.28901-buildid9382555"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "Symbol.Client",
-          "Version": "17.150.28901-buildid9382555"
         }
       }
     },
@@ -2804,8 +2939,8 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
-          "Name": "System.Data.SQLite.Core",
-          "Version": "1.0.109.2"
+          "Name": "System.Data.SqlClient",
+          "Version": "4.3.0"
         }
       }
     },
@@ -2813,8 +2948,8 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
-          "Name": "System.Data.SqlClient",
-          "Version": "4.3.0"
+          "Name": "System.Data.SQLite.Core",
+          "Version": "1.0.109.2"
         }
       }
     },
@@ -2966,6 +3101,24 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
+          "Name": "System.IdentityModel.Tokens.Jwt",
+          "Version": "5.2.2"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "System.Interactive.Async",
+          "Version": "3.1.1"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
           "Name": "System.IO",
           "Version": "4.3.0"
         }
@@ -3085,24 +3238,6 @@
         "NuGet": {
           "Name": "System.IO.UnmanagedMemoryStream",
           "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.IdentityModel.Tokens.Jwt",
-          "Version": "5.2.2"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Interactive.Async",
-          "Version": "3.1.1"
         }
       }
     },
@@ -3911,6 +4046,24 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
+          "Name": "System.Xml.XmlDocument",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "System.Xml.XmlSerializer",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
           "Name": "System.Xml.XPath",
           "Version": "4.3.0"
         }
@@ -3938,24 +4091,6 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
-          "Name": "System.Xml.XmlDocument",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Xml.XmlSerializer",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
           "Name": "Text.Analyzers",
           "Version": "2.3.0-beta1"
         }
@@ -3967,6 +4102,24 @@
         "NuGet": {
           "Name": "TransientFaultHandling.Core",
           "Version": "5.1.1209.1"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "Validation",
+          "Version": "2.3.7"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "VisualCppTools.Community.VS2017Layout",
+          "Version": "14.11.25506"
         }
       }
     },
@@ -4064,368 +4217,8 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
-          "Name": "Validation",
-          "Version": "2.3.7"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "VisualCppTools.Community.VS2017Layout",
-          "Version": "14.11.25506"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
           "Name": "WindowsAzure.Storage",
           "Version": "9.3.3"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "WindowsSdk.Corext",
-          "Version": "10.0.16299.1"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "microsoft.dotnet.xunitconsolerunner",
-          "Version": "2.5.1-beta.19270.4"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.native.System",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.native.System.Data.SqlClient.sni",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.native.System.IO.Compression",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.native.System.Net.Http",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.native.System.Net.Security",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.native.System.Security.Cryptography.Apple",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.native.System.Security.Cryptography.OpenSsl",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.osx-x64.BuildXL",
-          "Version": "2.0.1"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.osx-x64.Microsoft.DotNet.ILCompiler",
-          "Version": "1.0.0-alpha-27527-01"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.osx-x64.Microsoft.NETCore.App",
-          "Version": "2.2.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.osx-x64.Microsoft.NETCore.DotNetAppHost",
-          "Version": "2.2.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.osx-x64.Microsoft.NETCore.DotNetHostPolicy",
-          "Version": "2.2.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.osx-x64.Microsoft.NETCore.DotNetHostPolicy",
-          "Version": "3.0.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver",
-          "Version": "2.2.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver",
-          "Version": "3.0.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.win-x64.Microsoft.DotNet.ILCompiler",
-          "Version": "1.0.0-alpha-27527-01"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.win-x64.Microsoft.NETCore.App",
-          "Version": "2.2.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.win-x64.Microsoft.NETCore.DotNetAppHost",
-          "Version": "2.2.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy",
-          "Version": "2.2.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy",
-          "Version": "3.0.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.win-x64.Microsoft.NETCore.DotNetHostResolver",
-          "Version": "2.2.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.win-x64.Microsoft.NETCore.DotNetHostResolver",
-          "Version": "3.0.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.win7-x64.runtime.native.System.Data.SqlClient.sni",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.win7-x86.runtime.native.System.Data.SqlClient.sni",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "stdole",
-          "Version": "7.0.3303"
         }
       }
     },

--- a/cg/nuget/cgmanifest.json
+++ b/cg/nuget/cgmanifest.json
@@ -14,8 +14,8 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
-          "Name": "AsyncFixer",
-          "Version": "1.1.5"
+          "Name": "Aria.Cpp.SDK",
+          "Version": "8.5.6"
         }
       }
     },
@@ -23,8 +23,26 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
-          "Name": "Bond.Core.CSharp",
-          "Version": "8.0.0"
+          "Name": "ArtifactServices.App.Shared",
+          "Version": "17.150.28901-buildid9382555"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "ArtifactServices.App.Shared.Cache",
+          "Version": "17.150.28901-buildid9382555"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "AsyncFixer",
+          "Version": "1.1.5"
         }
       }
     },
@@ -50,8 +68,26 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
+          "Name": "Bond.Core.CSharp",
+          "Version": "8.0.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
           "Name": "Bond.Runtime.CSharp",
           "Version": "8.0.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "BuildXL.DeviceMap",
+          "Version": "0.0.1"
         }
       }
     },
@@ -70,6 +106,24 @@
         "NuGet": {
           "Name": "BuildXL.Tools.Ninjson",
           "Version": "0.0.6"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "BuildXL.Tracing.AriaTenantToken",
+          "Version": "1.0.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "CB.QTest",
+          "Version": "19.9.6.1149"
         }
       }
     },
@@ -97,6 +151,51 @@
         "NuGet": {
           "Name": "DotNet.Glob",
           "Version": "2.0.3"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "Dotnet-Runtime",
+          "Version": "5.0.2"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "Drop.App.Core",
+          "Version": "17.150.28901-buildid9382555"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "Drop.Client",
+          "Version": "17.150.28901-buildid9382555"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "Drop.RemotableClient",
+          "Version": "17.150.28901-buildid9382555"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "Drop.RemotableClient.Interfaces",
+          "Version": "17.150.28901-buildid9382555"
         }
       }
     },
@@ -223,6 +322,15 @@
         "NuGet": {
           "Name": "ILRepack",
           "Version": "2.0.16"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "ItemStore.Shared",
+          "Version": "17.150.28901-buildid9382555"
         }
       }
     },
@@ -1040,8 +1148,8 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
-          "Name": "Microsoft.CodeAnalysis.Analyzers",
-          "Version": "2.6.3"
+          "Name": "Microsoft.CSharp",
+          "Version": "4.3.0"
         }
       }
     },
@@ -1049,8 +1157,8 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
-          "Name": "Microsoft.CodeAnalysis.Common",
-          "Version": "2.10.0"
+          "Name": "Microsoft.CodeAnalysis.Analyzers",
+          "Version": "2.6.3"
         }
       }
     },
@@ -1068,6 +1176,15 @@
         "Type": "NuGet",
         "NuGet": {
           "Name": "Microsoft.CodeAnalysis.CSharp.Workspaces",
+          "Version": "2.10.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "Microsoft.CodeAnalysis.Common",
           "Version": "2.10.0"
         }
       }
@@ -1139,15 +1256,6 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
-          "Name": "Microsoft.CSharp",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
           "Name": "Microsoft.Data.Edm",
           "Version": "5.8.2"
         }
@@ -1175,6 +1283,15 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
+          "Name": "Microsoft.DiaSymReader.Native",
+          "Version": "1.7.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
           "Name": "Microsoft.Diagnostics.Tracing.EventSource.Redist",
           "Version": "1.1.28"
         }
@@ -1193,26 +1310,8 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
-          "Name": "Microsoft.DiaSymReader.Native",
-          "Version": "1.7.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
           "Name": "Microsoft.DotNet.PlatformAbstractions",
           "Version": "2.1.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "microsoft.dotnet.xunitconsolerunner",
-          "Version": "2.5.1-beta.19270.4"
         }
       }
     },
@@ -1526,6 +1625,15 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
+          "Name": "Microsoft.IO.RecyclableMemoryStream",
+          "Version": "1.2.2"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
           "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
           "Version": "4.5.1"
         }
@@ -1546,51 +1654,6 @@
         "NuGet": {
           "Name": "Microsoft.IdentityModel.Tokens",
           "Version": "5.2.2"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.IO.RecyclableMemoryStream",
-          "Version": "1.2.2"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Net.Compilers",
-          "Version": "3.0.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Net.Http",
-          "Version": "2.2.29"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Net.Http.Headers",
-          "Version": "2.2.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.NetCore.Analyzers",
-          "Version": "2.3.0-beta1"
         }
       }
     },
@@ -1742,15 +1805,6 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
-          "Name": "Microsoft.NetFramework.Analyzers",
-          "Version": "2.3.0-beta1"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
           "Name": "Microsoft.NETFramework.ReferenceAssemblies.net451",
           "Version": "1.0.0-alpha-5"
         }
@@ -1771,6 +1825,51 @@
         "NuGet": {
           "Name": "Microsoft.NETFramework.ReferenceAssemblies.net472",
           "Version": "1.0.0-alpha-5"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "Microsoft.Net.Compilers",
+          "Version": "3.0.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "Microsoft.Net.Http",
+          "Version": "2.2.29"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "Microsoft.Net.Http.Headers",
+          "Version": "2.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "Microsoft.NetCore.Analyzers",
+          "Version": "2.3.0-beta1"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "Microsoft.NetFramework.Analyzers",
+          "Version": "2.3.0-beta1"
         }
       }
     },
@@ -1967,8 +2066,44 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
+          "Name": "Microsoft.VisualStudio.Services.ArtifactServices.Shared",
+          "Version": "17.150.28901-buildid9382555"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "Microsoft.VisualStudio.Services.BlobStore.Client",
+          "Version": "17.150.28901-buildid9382555"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "Microsoft.VisualStudio.Services.BlobStore.Client.Cache",
+          "Version": "17.150.28901-buildid9382555"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
           "Name": "Microsoft.VisualStudio.Services.Client",
-          "Version": "16.148.0-preview"
+          "Version": "17.150.20190501.2-release"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "Microsoft.VisualStudio.Services.InteractiveClient",
+          "Version": "17.150.20190501.2-release"
         }
       }
     },
@@ -2246,6 +2381,15 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
+          "Name": "Microsoft.Windows.Debuggers.SymstoreInterop",
+          "Version": "1.0.1"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
           "Name": "Microsoft.Windows.ProjFS",
           "Version": "1.0.19079.1"
         }
@@ -2273,8 +2417,8 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
-          "Name": "Nerdbank.FullDuplexStream",
-          "Version": "1.0.9"
+          "Name": "NETStandard.Library",
+          "Version": "2.0.3"
         }
       }
     },
@@ -2282,8 +2426,17 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
-          "Name": "NETStandard.Library",
-          "Version": "2.0.3"
+          "Name": "NLog",
+          "Version": "4.6.6"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "Nerdbank.FullDuplexStream",
+          "Version": "1.0.9"
         }
       }
     },
@@ -2318,8 +2471,8 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
-          "Name": "NLog",
-          "Version": "4.6.6"
+          "Name": "NodeJs",
+          "Version": "8.12.0-noTest"
         }
       }
     },
@@ -2338,6 +2491,15 @@
         "NuGet": {
           "Name": "NuGet.Versioning",
           "Version": "4.6.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "PowerShell.Core",
+          "Version": "6.1.0"
         }
       }
     },
@@ -2365,312 +2527,6 @@
         "NuGet": {
           "Name": "RocksDbSharp",
           "Version": "5.8.0-b20181023.3"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.native.System",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.native.System.Data.SqlClient.sni",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.native.System.IO.Compression",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.native.System.Net.Http",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.native.System.Net.Security",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.native.System.Security.Cryptography.Apple",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.native.System.Security.Cryptography.OpenSsl",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.osx-x64.Microsoft.DotNet.ILCompiler",
-          "Version": "1.0.0-alpha-27527-01"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.osx-x64.Microsoft.NETCore.App",
-          "Version": "2.2.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.osx-x64.Microsoft.NETCore.DotNetAppHost",
-          "Version": "2.2.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.osx-x64.Microsoft.NETCore.DotNetHostPolicy",
-          "Version": "2.2.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.osx-x64.Microsoft.NETCore.DotNetHostPolicy",
-          "Version": "3.0.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver",
-          "Version": "2.2.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver",
-          "Version": "3.0.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.win-x64.Microsoft.DotNet.ILCompiler",
-          "Version": "1.0.0-alpha-27527-01"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.win-x64.Microsoft.NETCore.App",
-          "Version": "2.2.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.win-x64.Microsoft.NETCore.DotNetAppHost",
-          "Version": "2.2.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy",
-          "Version": "2.2.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy",
-          "Version": "3.0.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.win-x64.Microsoft.NETCore.DotNetHostResolver",
-          "Version": "2.2.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.win-x64.Microsoft.NETCore.DotNetHostResolver",
-          "Version": "3.0.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.win7-x64.runtime.native.System.Data.SqlClient.sni",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.win7-x86.runtime.native.System.Data.SqlClient.sni",
-          "Version": "4.3.0"
         }
       }
     },
@@ -2714,15 +2570,6 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
-          "Name": "stdole",
-          "Version": "7.0.3303"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
           "Name": "StreamJsonRpc",
           "Version": "1.4.128"
         }
@@ -2734,6 +2581,24 @@
         "NuGet": {
           "Name": "StyleCop.Analyzers",
           "Version": "1.1.0-beta004"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "Symbol.App.Core",
+          "Version": "17.150.28901-buildid9382555"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "Symbol.Client",
+          "Version": "17.150.28901-buildid9382555"
         }
       }
     },
@@ -2939,8 +2804,8 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
-          "Name": "System.Data.SqlClient",
-          "Version": "4.3.0"
+          "Name": "System.Data.SQLite.Core",
+          "Version": "1.0.109.2"
         }
       }
     },
@@ -2948,8 +2813,8 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
-          "Name": "System.Data.SQLite.Core",
-          "Version": "1.0.109.2"
+          "Name": "System.Data.SqlClient",
+          "Version": "4.3.0"
         }
       }
     },
@@ -3101,24 +2966,6 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
-          "Name": "System.IdentityModel.Tokens.Jwt",
-          "Version": "5.2.2"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Interactive.Async",
-          "Version": "3.1.1"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
           "Name": "System.IO",
           "Version": "4.3.0"
         }
@@ -3238,6 +3085,24 @@
         "NuGet": {
           "Name": "System.IO.UnmanagedMemoryStream",
           "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "System.IdentityModel.Tokens.Jwt",
+          "Version": "5.2.2"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "System.Interactive.Async",
+          "Version": "3.1.1"
         }
       }
     },
@@ -4046,24 +3911,6 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
-          "Name": "System.Xml.XmlDocument",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Xml.XmlSerializer",
-          "Version": "4.3.0"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
           "Name": "System.Xml.XPath",
           "Version": "4.3.0"
         }
@@ -4091,6 +3938,24 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
+          "Name": "System.Xml.XmlDocument",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "System.Xml.XmlSerializer",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
           "Name": "Text.Analyzers",
           "Version": "2.3.0-beta1"
         }
@@ -4102,24 +3967,6 @@
         "NuGet": {
           "Name": "TransientFaultHandling.Core",
           "Version": "5.1.1209.1"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "Validation",
-          "Version": "2.3.7"
-        }
-      }
-    },
-    {
-      "Component": {
-        "Type": "NuGet",
-        "NuGet": {
-          "Name": "VisualCppTools.Community.VS2017Layout",
-          "Version": "14.11.25506"
         }
       }
     },
@@ -4217,8 +4064,368 @@
       "Component": {
         "Type": "NuGet",
         "NuGet": {
+          "Name": "Validation",
+          "Version": "2.3.7"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "VisualCppTools.Community.VS2017Layout",
+          "Version": "14.11.25506"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
           "Name": "WindowsAzure.Storage",
           "Version": "9.3.3"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "WindowsSdk.Corext",
+          "Version": "10.0.16299.1"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "microsoft.dotnet.xunitconsolerunner",
+          "Version": "2.5.1-beta.19270.4"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.native.System",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.native.System.Data.SqlClient.sni",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.native.System.IO.Compression",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.native.System.Net.Http",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.native.System.Net.Security",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.native.System.Security.Cryptography.Apple",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.native.System.Security.Cryptography.OpenSsl",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.osx-x64.BuildXL",
+          "Version": "2.0.99"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.osx-x64.Microsoft.DotNet.ILCompiler",
+          "Version": "1.0.0-alpha-27527-01"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.osx-x64.Microsoft.NETCore.App",
+          "Version": "2.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.osx-x64.Microsoft.NETCore.DotNetAppHost",
+          "Version": "2.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.osx-x64.Microsoft.NETCore.DotNetHostPolicy",
+          "Version": "2.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.osx-x64.Microsoft.NETCore.DotNetHostPolicy",
+          "Version": "3.0.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver",
+          "Version": "2.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver",
+          "Version": "3.0.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.win-x64.Microsoft.DotNet.ILCompiler",
+          "Version": "1.0.0-alpha-27527-01"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.win-x64.Microsoft.NETCore.App",
+          "Version": "2.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.win-x64.Microsoft.NETCore.DotNetAppHost",
+          "Version": "2.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy",
+          "Version": "2.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy",
+          "Version": "3.0.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.win-x64.Microsoft.NETCore.DotNetHostResolver",
+          "Version": "2.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.win-x64.Microsoft.NETCore.DotNetHostResolver",
+          "Version": "3.0.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.win7-x64.runtime.native.System.Data.SqlClient.sni",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "runtime.win7-x86.runtime.native.System.Data.SqlClient.sni",
+          "Version": "4.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "stdole",
+          "Version": "7.0.3303"
         }
       }
     },

--- a/config.microsoftInternal.dsc
+++ b/config.microsoftInternal.dsc
@@ -11,7 +11,7 @@ export const pkgs = isMicrosoftInternal ? [
     { id: "BuildXL.DeviceMap", version: "0.0.1" },
 
     // Runtime dependencies used for macOS deployments
-    { id: "runtime.osx-x64.BuildXL", version: "2.0.1" },
+    { id: "runtime.osx-x64.BuildXL", version: "2.0.99" },
     { id: "Aria.Cpp.SDK", version: "8.5.6" },
 
     { id: "CB.QTest", version: "19.9.6.1149" },


### PR DESCRIPTION
When using pipes to create files from process runs in scripts (bash, csh, etc) that are sourced at execution time instead of directly executed, the KAuth subsystem does only callback registered listeners for processes execute authorization and never again. Writes that happen this way were not registered by our kext observation mechanics at all. Nor do `mpo_vnode_check_create` policies trigger in this particular case.

After testing a lot of policies, in this case only using the `mpo_vnode_check_write` policy yields the desired result and creates a file write observation correctly.