### PR TITLE
Log diagnostics on failure to get connection string

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/Redis/RedisConnectionMultiplexer.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Redis/RedisConnectionMultiplexer.cs
@@ -36,7 +36,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Redis
             if (!connectionStringResult.Succeeded || string.IsNullOrWhiteSpace(connectionStringResult.ConnectionString))
             {
                 var errorMessage =
-                    $"Failed to get connection string from provider {connectionStringProvider.GetType().Name}. {connectionStringResult.ErrorMessage}.";
+                    $"Failed to get connection string from provider {connectionStringProvider.GetType().Name}. {connectionStringResult.ErrorMessage}. Diagnostics: {connectionStringResult.Diagnostics}";
                 context.Logger.Error(errorMessage);
                 throw new ArgumentException(errorMessage, nameof(connectionStringProvider));
             }


### PR DESCRIPTION
When the executable connection string source fails, we get no logs back, since its output is redirected into the diagnostics of the result