### PR TITLE
Improve time to first pip on workers by having workers download graph while scheduler is initializing/filtering.

### DIFF
--- a/Public/Src/Engine/Dll/Engine.cs
+++ b/Public/Src/Engine/Dll/Engine.cs
@@ -2862,12 +2862,6 @@ namespace BuildXL.Engine
                                 Logger.Log.ErrorUnableToCacheGraphDistributedBuild(loggingContext);
                                 return ConstructScheduleResult.Failure;
                             }
-
-                            // Now that graph is saved, workers can be attached
-                            if (phase.HasFlag(EnginePhases.Execute))
-                            {
-                                m_masterService.EnableDistribution(engineSchedule);
-                            }
                         }
                     }
                 }
@@ -2894,6 +2888,12 @@ namespace BuildXL.Engine
                 if (TestHooks != null)
                 {
                     TestHooks.TempCleanerTempDirectory = m_tempCleaner.TempDirectory;
+                }
+
+                // Now that graph is constructed and saved, workers can be attached
+                if (phase.HasFlag(EnginePhases.Execute))
+                {
+                    m_masterService.EnableDistribution(engineSchedule);
                 }
 
                 if (!engineSchedule.PrepareForBuild(

--- a/Public/Src/Engine/Dll/Engine.cs
+++ b/Public/Src/Engine/Dll/Engine.cs
@@ -1873,16 +1873,9 @@ namespace BuildXL.Engine
 
                                     WorkerService workerservice = null;
 
-                                    if (Configuration.Distribution.BuildRole != DistributedBuildRoles.None)
+                                    if (Configuration.Distribution.BuildRole == DistributedBuildRoles.Worker)
                                     {
-                                        if (Configuration.Distribution.BuildRole == DistributedBuildRoles.Master)
-                                        {
-                                            m_masterService.EnableDistribution(engineSchedule);
-                                        }
-                                        else if (Configuration.Distribution.BuildRole == DistributedBuildRoles.Worker)
-                                        {
-                                            workerservice = m_workerService;
-                                        }
+                                        workerservice = m_workerService;
                                     }
 
                                     var stats = default(ExecuteStatistics);
@@ -2869,6 +2862,12 @@ namespace BuildXL.Engine
                                 Logger.Log.ErrorUnableToCacheGraphDistributedBuild(loggingContext);
                                 return ConstructScheduleResult.Failure;
                             }
+
+                            // Now that graph is saved, workers can be attached
+                            if (phase.HasFlag(EnginePhases.Execute))
+                            {
+                                m_masterService.EnableDistribution(engineSchedule);
+                            }
                         }
                     }
                 }
@@ -2981,7 +2980,7 @@ namespace BuildXL.Engine
             }
         }
 
-#region Logging stats about the build
+        #region Logging stats about the build
 
         private static void LogObjectPoolStats<T>(LoggingContext loggingContext, string poolName, ObjectPool<T> pool) where T : class
         {
@@ -3077,9 +3076,9 @@ namespace BuildXL.Engine
                 });
         }
 
-#endregion
+        #endregion
 
-#region Graph Caching
+        #region Graph Caching
 
         /// <summary>
         /// Determines whether the GraphCaching feature is allowed
@@ -3170,13 +3169,6 @@ namespace BuildXL.Engine
                             mountsImpactingBuild,
                             serializer.PreviousInputsJournalCheckpoint),
                         overrideName: EngineSerializer.PreviousInputsIntermediateFile);
-
-                    // The RunningTimeTable task initializes asynchronously. It needs to complete before the StringTable's serialization starts to avoid races.
-                    // The line below enforces that the lazy initialization has completed.
-                    if (engineSchedule.Scheduler.RunningTimeTableTask != null)
-                    {
-                        Analysis.IgnoreResult(engineSchedule.Scheduler.RunningTimeTableTask.GetAwaiter().GetResult());
-                    }
 
                     // We do not want to concurrently execute the serialization tasks and pips because pips can add new stuff to the PathTable, SymbolTable, and StringTable.
                     var success = engineSchedule.SaveToDiskAsync(serializer, Context).GetAwaiter().GetResult();
@@ -3303,7 +3295,7 @@ namespace BuildXL.Engine
                 checkAllPossiblyChangedPaths: m_rememberAllChangedTrackedInputs);
         }
 
-#endregion
+        #endregion
 
         /// <summary>
         /// Gets the update and delay time for status timers

--- a/Public/Src/Engine/Dll/Engine.cs
+++ b/Public/Src/Engine/Dll/Engine.cs
@@ -2891,7 +2891,7 @@ namespace BuildXL.Engine
                 }
 
                 // Now that graph is constructed and saved, workers can be attached
-                if (phase.HasFlag(EnginePhases.Execute))
+                if (IsDistributedMaster && phase.HasFlag(EnginePhases.Execute))
                 {
                     m_masterService.EnableDistribution(engineSchedule);
                 }

--- a/Public/Src/Engine/Scheduler/Caching/HistoricMetadataCache.cs
+++ b/Public/Src/Engine/Scheduler/Caching/HistoricMetadataCache.cs
@@ -226,7 +226,7 @@ namespace BuildXL.Scheduler.Cache
         /// <summary>
         /// Starting the loading task for the historic metadata cache
         /// </summary>
-        public void StartLoading(bool waitForCompletion)
+        public override void StartLoading(bool waitForCompletion)
         {
             var loadingTask = EnsureLoadedAsync();
             if (waitForCompletion)

--- a/Public/Src/Engine/Scheduler/Caching/PipTwoPhaseCache.cs
+++ b/Public/Src/Engine/Scheduler/Caching/PipTwoPhaseCache.cs
@@ -80,6 +80,13 @@ namespace BuildXL.Scheduler.Cache
         }
 
         /// <summary>
+        /// Attempts to load state need for use of the cache.
+        /// </summary>
+        public virtual void StartLoading(bool waitForCompletion)
+        {
+        }
+
+        /// <summary>
         /// Stores cache descriptor metadata for pip
         /// </summary>
         public virtual async Task<Possible<ContentHash>> TryStoreMetadataAsync(PipCacheDescriptorV2Metadata metadata)

--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -308,9 +308,13 @@ namespace BuildXL.Scheduler
                 worker.SyncResourceMappings(LocalWorker);
             }
 
-            m_workersStatusOperation = OperationTracker.StartOperation(Worker.WorkerStatusParentOperationKind, m_executePhaseLoggingContext);
             m_workers.AddRange(remoteWorkers);
             PipExecutionCounters.AddToCounter(PipExecutorCounter.RemoteWorkerCount, remoteWorkers.Length);
+        }
+
+        private void StartWorkers(LoggingContext loggingContext)
+        {
+            m_workersStatusOperation = OperationTracker.StartOperation(Worker.WorkerStatusParentOperationKind, loggingContext);
 
             // The first of the workers must be local and all others must be remote.
             Contract.Assert(m_workers[0] is LocalWorker && m_workers.Skip(1).All(w => w.IsRemote));
@@ -402,14 +406,7 @@ namespace BuildXL.Scheduler
         private PipRuntimeInfo[] m_pipRuntimeInfos;
 
         private PipRuntimeTimeTable m_runningTimeTable;
-
-        /// <summary>
-        /// Task for lazily initializing the running time table.
-        /// </summary>
-        /// <remarks>
-        /// Exposed for sake of controling when the task has completed.
-        /// </remarks>
-        internal readonly Task<PipRuntimeTimeTable> RunningTimeTableTask;
+        private AsyncLazy<PipRuntimeTimeTable> m_runningTimeTableTask;
 
         /// <summary>
         /// The last node in the currently computed critical path
@@ -419,7 +416,7 @@ namespace BuildXL.Scheduler
         /// <summary>
         /// Historical estimation for duration of each pip, indexed by semi stable hashes
         /// </summary>
-        public PipRuntimeTimeTable RunningTimeTable => (m_runningTimeTable = m_runningTimeTable ?? (RunningTimeTableTask?.Result ?? new PipRuntimeTimeTable()));
+        public PipRuntimeTimeTable RunningTimeTable => (m_runningTimeTable = (m_runningTimeTableTask?.Value ?? new PipRuntimeTimeTable()));
 
         /// <summary>
         /// Nodes that are explicitly scheduled by filtering.
@@ -999,7 +996,7 @@ namespace BuildXL.Scheduler
             string buildEngineFingerprint,
             DirectoryMembershipFingerprinterRuleSet directoryMembershipFingerprinterRules = null,
             ITempCleaner tempCleaner = null,
-            Task<PipRuntimeTimeTable> runningTimeTableTask = null,
+            AsyncLazy<PipRuntimeTimeTable> runningTimeTable = null,
             PerformanceCollector performanceCollector = null,
             string fingerprintSalt = null,
             ContentHash? previousInputsSalt = null,
@@ -1057,7 +1054,7 @@ namespace BuildXL.Scheduler
                 extraFingerprintSalts,
                 m_semanticPathExpander,
                 PipGraph.QueryFileArtifactPipData);
-            RunningTimeTableTask = runningTimeTableTask;
+            m_runningTimeTableTask = runningTimeTable;
 
             // Prepare Root Map redirection table. see m_rootMappings comment on why this is happening here.
             var rootMappings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -4806,6 +4803,13 @@ namespace BuildXL.Scheduler
                     Logger.Log.EndSchedulingPipsWithFilter))
             {
                 InitSchedulerRuntimeState(pm.LoggingContext, schedulerState: schedulerState);
+
+                // Start workers after scheduler runtime state is successfully established
+                if (!HasFailed)
+                {
+                    StartWorkers(loggingContext);
+                }
+
                 InitPipStates(pm.LoggingContext);
 
                 IEnumerable<NodeId> nodesToSchedule;
@@ -4922,6 +4926,11 @@ namespace BuildXL.Scheduler
             {
                 Contract.Requires(loggingContext != null);
 
+                // Start loading data for pip two phase cache and running time table. No need to wait since any operation against the components
+                // will block until the required component is ready.
+                m_pipTwoPhaseCache.StartLoading(waitForCompletion: false);
+                m_runningTimeTableTask.Start();
+
                 InitFileChangeTracker(loggingContext);
                 ProcessFileChanges(loggingContext, schedulerState);
 
@@ -4955,11 +4964,11 @@ namespace BuildXL.Scheduler
                 using (PipExecutionCounters.StartStopwatch(PipExecutorCounter.CreateFileSystemViewDuration))
                 {
                     fileSystemView = FileSystemView.Create(
-                    Context.PathTable,
-                    PipGraph,
-                    m_localDiskContentStore,
-                    maxInitializationDegreeOfParallelism: m_scheduleConfiguration.MaxProcesses,
-                    inferNonExistenceBasedOnParentPathInRealFileSystem: m_scheduleConfiguration.InferNonExistenceBasedOnParentPathInRealFileSystem);
+                        Context.PathTable,
+                        PipGraph,
+                        m_localDiskContentStore,
+                        maxInitializationDegreeOfParallelism: m_scheduleConfiguration.MaxProcesses,
+                        inferNonExistenceBasedOnParentPathInRealFileSystem: m_scheduleConfiguration.InferNonExistenceBasedOnParentPathInRealFileSystem);
                 }
 
                 State = new PipExecutionState(

--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -406,7 +406,7 @@ namespace BuildXL.Scheduler
         private PipRuntimeInfo[] m_pipRuntimeInfos;
 
         private PipRuntimeTimeTable m_runningTimeTable;
-        private AsyncLazy<PipRuntimeTimeTable> m_runningTimeTableTask;
+        private readonly AsyncLazy<PipRuntimeTimeTable> m_runningTimeTableTask;
 
         /// <summary>
         /// The last node in the currently computed critical path
@@ -4805,7 +4805,7 @@ namespace BuildXL.Scheduler
                 InitSchedulerRuntimeState(pm.LoggingContext, schedulerState: schedulerState);
 
                 // Start workers after scheduler runtime state is successfully established
-                if (!HasFailed)
+                if (!HasFailed && IsDistributedMaster)
                 {
                     StartWorkers(loggingContext);
                 }
@@ -4929,7 +4929,7 @@ namespace BuildXL.Scheduler
                 // Start loading data for pip two phase cache and running time table. No need to wait since any operation against the components
                 // will block until the required component is ready.
                 m_pipTwoPhaseCache.StartLoading(waitForCompletion: false);
-                m_runningTimeTableTask.Start();
+                m_runningTimeTableTask?.Start();
 
                 InitFileChangeTracker(loggingContext);
                 ProcessFileChanges(loggingContext, schedulerState);

--- a/Public/Src/Engine/UnitTests/Scheduler/TestScheduler.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/TestScheduler.cs
@@ -72,7 +72,7 @@ namespace Test.BuildXL.Scheduler
             VmInitializer vmInitializer = null,
             SchedulerTestHooks testHooks = null) : base(graph, pipQueue, context, fileContentTable, cache,
                 configuration, fileAccessWhitelist, loggingContext, null, directoryMembershipFingerprinterRules,
-                tempCleaner, Task.FromResult<PipRuntimeTimeTable>(runningTimeTable), performanceCollector, fingerprintSalt, previousInputsSalt,
+                tempCleaner, AsyncLazy<PipRuntimeTimeTable>.FromResult(runningTimeTable), performanceCollector, fingerprintSalt, previousInputsSalt,
                 ipcProvider: ipcProvider, 
                 directoryTranslator: directoryTranslator, 
                 journalState: journalState, 

--- a/Public/Src/Utilities/Utilities/AsyncLazy.cs
+++ b/Public/Src/Utilities/Utilities/AsyncLazy.cs
@@ -20,6 +20,20 @@ namespace BuildXL.Utilities
             m_lazyTask = new Lazy<Task<T>>(() => Task.Run(factory));    
         }
 
+        /// <nodoc />
+        private AsyncLazy(T value)
+        {
+            m_lazyTask = new Lazy<Task<T>>(() => Task.FromResult(value));
+        }
+
+        /// <summary>
+        /// Creates an async lazy from the result value
+        /// </summary>
+        public static AsyncLazy<T> FromResult(T value)
+        {
+            return new AsyncLazy<T>(value);
+        }
+
         /// <summary>
         /// Gets the synchronous result of the completion of the async lazy
         /// </summary>

--- a/Public/Src/Utilities/Utilities/AsyncLazy.cs
+++ b/Public/Src/Utilities/Utilities/AsyncLazy.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading.Tasks;
+using BuildXL.Utilities.Tasks;
+
+namespace BuildXL.Utilities
+{
+    /// <summary>
+    /// Represents an async version of <see cref="Lazy{T}"/> which allows starting the underlying task to without waiting on the result
+    /// </summary>
+    public sealed class AsyncLazy<T>
+    {
+        private Lazy<Task<T>> m_lazyTask;
+
+        /// <nodoc />
+        public AsyncLazy(Func<Task<T>> factory)
+        {
+            m_lazyTask = new Lazy<Task<T>>(() => Task.Run(factory));    
+        }
+
+        /// <summary>
+        /// Gets the synchronous result of the completion of the async lazy
+        /// </summary>
+        public T Value => m_lazyTask.Value.GetAwaiter().GetResult();
+
+        /// <summary>
+        /// Starts the asynchronous operation without blocking the current thread of execution
+        /// </summary>
+        public void Start()
+        {
+            m_lazyTask.Value.Forget();
+        }
+    }
+}

--- a/Public/Src/Utilities/Utilities/Lazy.cs
+++ b/Public/Src/Utilities/Utilities/Lazy.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics.ContractsLight;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace BuildXL.Utilities
 {
@@ -22,6 +23,18 @@ namespace BuildXL.Utilities
         {
             Contract.Requires(factory != null);
             return new Lazy<T>(factory, mode);
+        }
+
+        /// <summary>
+        /// Creates instance of <see cref="AsyncLazy{T}"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method simply calls constructor of <see cref="AsyncLazy{T}"/>, but because it is a static method, it will infer generic argument automatically.
+        /// </remarks>
+        public static AsyncLazy<T> CreateAsync<T>(Func<Task<T>> factory)
+        {
+            Contract.Requires(factory != null);
+            return new AsyncLazy<T>(factory);
         }
     }
 }


### PR DESCRIPTION
Improve time to first pip on workers by having workers download graph while scheduler is initializing/filtering. Also improves, time to first pip on master by making historic metadata and historic perf data retrieval lazy and async. For Office Mularchy builds, this results in workers being ready to execute about the same time as the master.  Specifically for master (13.5 min to 11 min) and for worker (17 min to 11 min).