### PR TITLE
Add checkpoint to log messages

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/CheckpointManager.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/CheckpointManager.cs
@@ -109,7 +109,9 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                     {
                         ClearIncrementalCheckpointStateIfNeeded(context, successfullyUpdatedIncrementalState);
                     }
-                });
+                },
+                extraStartMessage: $"SequencePoint=[{sequencePoint}]",
+                extraEndMessage: _ => $"SequencePoint=[{sequencePoint}]");
         }
 
         private async Task CreateFullCheckpointAsync(OperationContext context, EventSequencePoint sequencePoint)

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/CheckpointManager.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/CheckpointManager.cs
@@ -349,7 +349,9 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                     {
                         ClearIncrementalCheckpointStateIfNeeded(context, successfullyUpdatedIncrementalState);
                     }
-                });
+                },
+                extraStartMessage: $"CheckpointId=[{checkpointId}]",
+                extraEndMessage: _ => $"CheckpointId=[{checkpointId}]");
         }
 
         private static void RestoreFullCheckpointAsync(AbsolutePath checkpointFile, AbsolutePath extractedCheckpointDirectory)

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabase.cs
@@ -523,7 +523,10 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             {
                 Counters[ContentLocationDatabaseCounters.NumberOfCacheFlushesTriggeredByCheckpoint].Increment();
                 ForceCacheFlush(context);
-                return context.PerformOperation(Tracer, () => SaveCheckpointCore(context, checkpointDirectory));
+                return context.PerformOperation(Tracer,
+                    () => SaveCheckpointCore(context, checkpointDirectory),
+                    extraStartMessage: $"CheckpointDirectory=[{checkpointDirectory}]",
+                    messageFactory: _ => $"CheckpointDirectory=[{checkpointDirectory}]");
             }
         }
 

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabase.cs
@@ -535,7 +535,10 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         {
             using (Counters[ContentLocationDatabaseCounters.RestoreCheckpoint].Start())
             {
-                return context.PerformOperation(Tracer, () => RestoreCheckpointCore(context, checkpointDirectory));
+                return context.PerformOperation(Tracer,
+                    () => RestoreCheckpointCore(context, checkpointDirectory),
+                    extraStartMessage: $"CheckpointDirectory=[{checkpointDirectory}]",
+                    messageFactory: _ => $"CheckpointDirectory=[{checkpointDirectory}]");
             }
         }
 


### PR DESCRIPTION
We currently don't log checkpoint ID when creating or restoring them. This logging will help identifying:

- Which machines are having issues with the checkpoints
- Whether there's a problem with a particular checkpoint
- Whether the problems lie in the RocksDb restore or our replication logic
- Make computation of checkpoint propagation delay more accurate