### PR TITLE
When enforcing shared opaque output timestamps, only check for write attribute ACLs

### DIFF
--- a/Public/Src/Engine/Processes/SharedOpaqueOutputHelper.cs
+++ b/Public/Src/Engine/Processes/SharedOpaqueOutputHelper.cs
@@ -104,7 +104,7 @@ namespace BuildXL.Processes
 
 #if PLATFORM_WIN
             // Make sure we allow for attribute writing first
-            var writeAttributesDenied = !FileUtilities.HasWritableAccessControl(expandedPath);
+            var writeAttributesDenied = !FileUtilities.HasWritableAttributeAccessControl(expandedPath);
             if (writeAttributesDenied)
             {
                 FileUtilities.SetFileAccessControl(expandedPath, FileSystemRights.WriteAttributes | FileSystemRights.WriteExtendedAttributes, allow: true);

--- a/Public/Src/Utilities/Native/IO/FileUtilities.cs
+++ b/Public/Src/Utilities/Native/IO/FileUtilities.cs
@@ -393,6 +393,9 @@ namespace BuildXL.Native.IO
         /// <see cref="IFileUtilities.HasWritableAccessControl(string)"/>
         public static bool HasWritableAccessControl(string path) => s_fileUtilities.HasWritableAccessControl(path);
 
+        /// <see cref="IFileUtilities.HasWritableAttributeAccessControl(string)"/>
+        public static bool HasWritableAttributeAccessControl(string path) => s_fileUtilities.HasWritableAttributeAccessControl(path);
+
         /// <see cref="IFileUtilities.CreateFileStream(string, FileMode, FileAccess, FileShare, FileOptions, bool, bool)"/>
         public static FileStream CreateFileStream(
             string path,

--- a/Public/Src/Utilities/Native/IO/IFileUtilities.cs
+++ b/Public/Src/Utilities/Native/IO/IFileUtilities.cs
@@ -289,6 +289,12 @@ namespace BuildXL.Native.IO
         bool HasWritableAccessControl(string path);
 
         /// <summary>
+        /// Checks the ACL for writable attribute access control.
+        /// </summary>
+        /// <param name="path">The path to the file.</param>
+        bool HasWritableAttributeAccessControl(string path);
+
+        /// <summary>
         /// Returns a new <see cref="FileStream" /> with the given creation mode, access level, and sharing.
         /// </summary>
         /// <remarks>

--- a/Public/Src/Utilities/Native/IO/Unix/FileUtilities.Unix.cs
+++ b/Public/Src/Utilities/Native/IO/Unix/FileUtilities.Unix.cs
@@ -627,6 +627,13 @@ namespace BuildXL.Native.IO.Unix
         }
 
         /// <inheritdoc />
+        public bool HasWritableAttributeAccessControl(string path)
+        {
+            // There is no write attribute specific permissions for unix
+            return HasWritableAccessControl(path);
+        }
+
+        /// <inheritdoc />
         public void SetFileAccessControl(string path, FileSystemRights fileSystemRights, bool allow)
         {
             FilePermissions permissions = 0;

--- a/Public/Src/Utilities/Native/IO/Windows/FileUtilities.Win.cs
+++ b/Public/Src/Utilities/Native/IO/Windows/FileUtilities.Win.cs
@@ -1516,6 +1516,32 @@ namespace BuildXL.Native.IO.Windows
                 FileSystemRights.WriteAttributes |
                 FileSystemRights.WriteExtendedAttributes;
 
+            return CheckFileSystemRightsForPath(path, fileSystemRights);
+#else
+            return true;
+#endif
+        }
+
+
+        /// <inheritdoc />
+        public bool HasWritableAttributeAccessControl(string path)
+        {
+            Contract.Requires(!string.IsNullOrWhiteSpace(path));
+            path = FileSystemWin.ToLongPathIfExceedMaxPath(path);
+
+#if NET_FRAMEWORK
+            FileSystemRights fileSystemRights =
+                FileSystemRights.WriteAttributes |
+                FileSystemRights.WriteExtendedAttributes;
+
+            return CheckFileSystemRightsForPath(path, fileSystemRights);
+#else
+            return true;
+#endif
+        }
+
+        private bool CheckFileSystemRightsForPath(string path, FileSystemRights fileSystemRights)
+        {
             FileInfo fileInfo = new FileInfo(path);
             FileSecurity fileSecurity = fileInfo.GetAccessControl();
             foreach (AuthorizationRule rule in fileSecurity.GetAccessRules(true, true, typeof(SecurityIdentifier)))
@@ -1535,9 +1561,6 @@ namespace BuildXL.Native.IO.Windows
             }
 
             return true;
-#else
-            return true;
-#endif
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
When running low-priv, changing file ACLs is not allowed. This is attempted in the case a shared opaque output has to be flagged with the special timestamp, but the file in question is hardlinked into the cache, and therefore write ACL denied. 
However, the file is only ACL denied for writing data. Changing the file attributes are allowed. This PR relaxes the ACL check so we only check for write attribute capabilities. This prevents us from trying to change the ACLs unnecessarily, and therefore allows low-priv builds to work.