### PR TITLE
Add an ability to provide the context for copy file operation.

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
@@ -512,7 +512,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
                     using (Stream possiblyRecordingStream = _contentLocationStore.AreBlobsSupported && hashInfo.Size <= _contentLocationStore.MaxBlobSize && hashInfo.Size >= 0 ? (Stream)new RecordingStream(fileStream, hashInfo.Size) : fileStream)
                     using (HashingStream hashingStream = ContentHashers.Get(hashInfo.ContentHash.HashType).CreateWriteHashingStream(possiblyRecordingStream, hashEntireFileConcurrently ? 1 : _settings.ParallelHashingFileSizeBoundary))
                     {
-                        var copyFileResult = await _remoteFileCopier.CopyToAsync(location, hashingStream, hashInfo.Size, cts);
+                        var copyFileResult = await _remoteFileCopier.CopyToWithOperationContextAsync(new OperationContext(context, cts), location, hashingStream, hashInfo.Size);
                         copyFileResult.TimeSpentHashing = hashingStream.TimeSpentHashing;
 
                         if (copyFileResult.Succeeded)

--- a/Public/Src/Cache/ContentStore/Library/Utils/BandwidthChecker.cs
+++ b/Public/Src/Cache/ContentStore/Library/Utils/BandwidthChecker.cs
@@ -7,7 +7,6 @@ using System.Diagnostics.ContractsLight;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using BuildXL.Cache.ContentStore.Interfaces.Extensions;
 using BuildXL.Cache.ContentStore.Interfaces.Results;
 using BuildXL.Cache.ContentStore.Tracing.Internal;
 using BuildXL.Cache.Host.Configuration;
@@ -36,11 +35,11 @@ namespace BuildXL.Cache.ContentStore.Utils
         }
 
         /// <summary>
-        /// Checks that a copy has a minimum bandwidth, and cancells it otherwise.
+        /// Checks that a copy has a minimum bandwidth, and cancels it otherwise.
         /// </summary>
         /// <param name="context">The context of the operation.</param>
         /// <param name="copyTaskFactory">Function that will trigger the copy.</param>
-        /// <param name="destinationStream">Stream into which the copy is being made. Used to meassure bandwidth.</param>
+        /// <param name="destinationStream">Stream into which the copy is being made. Used to measure bandwidth.</param>
         public async Task<CopyFileResult> CheckBandwidthAtIntervalAsync(OperationContext context, Func<CancellationToken, Task<CopyFileResult>> copyTaskFactory, Stream destinationStream)
         {
             if (_historicalBandwidthLimitSource != null)

--- a/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
@@ -192,7 +192,7 @@ namespace BuildXL.Cache.Host.Service.Internal
                 configurationModel = new ConfigurationModel(new ContentStoreConfiguration(new MaxSizeQuota(namedCacheSettings.CacheSizeQuotaString)));
             }
 
-            var bandwidthCheckedCopier = new BandwidthCheckedCopier<AbsolutePath>(_arguments.Copier, BandwidthChecker.Configuration.FromDistributedContentSettings(_distributedSettings), _logger);
+            var bandwidthCheckedCopier = new BandwidthCheckedCopier(_arguments.Copier, BandwidthChecker.Configuration.FromDistributedContentSettings(_distributedSettings), _logger);
 
             _logger.Debug("Creating a distributed content store for Autopilot");
             var contentStore =


### PR DESCRIPTION
The original `GrpcFileCopier` implementation was using a "global" tracing context that was passed across machines. This some investigations a bit complicated because the tracing Id was propagated across machines as well.

It means that every copy from machine A was traced using the same context and that tracing information appeared from every target machine.

Here is an example of the trace:

```
LocalPreciseTimeStamp	Machine	Message
2019-10-04 14:50:00.5980063	DM3AAP781601316	b3dbd214-93f3-4230-b43a-7a8132c2219f FileSystemContentStore.OpenStream stop 0ms input=[VSO0:15225649D00D1EE91C0E] result=[Success Size=58504 LockWait=0ms]
2019-10-04 14:50:00.5980063	DM3AAP781601316	b3dbd214-93f3-4230-b43a-7a8132c2219f GrpcContentServer.CopyFileAsync stop 0.8139ms. result=[Success]. Hash=VSO0:15225649D00D1EE91C0E, GZip=off.
2019-10-04 14:50:03.8459115	DM3AAPB076E5DFC	b3dbd214-93f3-4230-b43a-7a8132c2219f FileSystemContentStore.OpenStream stop 0ms input=[VSO0:D313FBFE79065915DCD2] result=[Success Size=47896 LockWait=0ms]
2019-10-04 14:50:03.8459115	DM3AAPB076E5DFC	b3dbd214-93f3-4230-b43a-7a8132c2219f GrpcContentServer.CopyFileAsync stop 0.784ms. result=[Success]. Hash=VSO0:D313FBFE79065915DCD2, GZip=off.
2019-10-04 14:50:04.2652936	DM3AAP77EAF5434	b3dbd214-93f3-4230-b43a-7a8132c2219f FileSystemContentStore.OpenStream stop 0ms input=[VSO0:576AC19871A2335CF44E] result=[Success Size=24576 LockWait=0ms]
2019-10-04 14:50:04.2652936	DM3AAP77EAF5434	b3dbd214-93f3-4230-b43a-7a8132c2219f GrpcContentServer.CopyFileAsync stop 0.6413ms. result=[Success]. Hash=VSO0:576AC19871A2335CF44E, GZip=off.
2019-10-04 14:50:04.4370770	DM3AAP7841C2661	b3dbd214-93f3-4230-b43a-7a8132c2219f FileSystemContentStore.OpenStream stop 0ms input=[VSO0:0BACD815834344173475] result=[Success Size=99328 LockWait=0ms]
2019-10-04 14:50:04.4839484	DM3AAP7841C2661	b3dbd214-93f3-4230-b43a-7a8132c2219f GrpcContentServer.CopyFileAsync stop 34.5168ms. result=[Success]. Hash=VSO0:0BACD815834344173475, GZip=off.
2019-10-04 14:50:04.8126379	DM3AAP53665CDE5	b3dbd214-93f3-4230-b43a-7a8132c2219f FileSystemContentStore.OpenStream stop 0ms input=[VSO0:02591AB6006462FF9BF6] result=[Success Size=28160 LockWait=0ms]
2019-10-04 14:50:04.8282189	DM3AAP53665CDE5	b3dbd214-93f3-4230-b43a-7a8132c2219f GrpcContentServer.CopyFileAsync stop 0.7412ms. result=[Success]. Hash=VSO0:02591AB6006462FF9BF6, GZip=off.
2019-10-04 14:50:06.5620348	DM3AAP7841C2661	b3dbd214-93f3-4230-b43a-7a8132c2219f FileSystemContentStore.OpenStream stop 0ms input=[VSO0:E57FC8CA263FAC093959] result=[Success Size=30208 LockWait=0ms]
2019-10-04 14:50:06.5620348	DM3AAP7841C2661	b3dbd214-93f3-4230-b43a-7a8132c2219f GrpcContentServer.CopyFileAsync stop 0.5243ms. result=[Success]. Hash=VSO0:E57FC8CA263FAC093959, GZip=off.
2019-10-04 14:50:07.2338974	DM3AAP7841C2661	b3dbd214-93f3-4230-b43a-7a8132c2219f FileSystemContentStore.OpenStream stop 0ms input=[VSO0:AFCA7F1D1CF96917F9A2] result=[Success Size=23168 LockWait=0ms]
```

This change introduces another *traceable* file copier that takes `OperationContext` as it's first argument.