### PR TITLE
Materialize IPC pips on the Light queue.

### DIFF
--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -3136,6 +3136,14 @@ namespace BuildXL.Scheduler
                     return DispatcherKind.ChooseWorkerCpu;
 
                 case PipExecutionStep.MaterializeInputs:
+                    if (runnablePip.PipType == PipType.Ipc)
+                    {
+                        // Send IPC pips to light queue to materialize since they don't often materialize much
+                        // and in the worst case they would only contend with other IPC pips
+                        return DispatcherKind.Light;
+                    }
+
+                    return DispatcherKind.Materialize;
                 case PipExecutionStep.MaterializeOutputs:
                 case PipExecutionStep.PostProcess:
                     return DispatcherKind.Materialize;


### PR DESCRIPTION
Materialize IPC pips on the Light queue to unblock them from waiting on long process materializations.