### PR TITLE
Use xattrs to mark shared opaque outputs on Mac

### DIFF
--- a/Public/Src/Engine/Processes/SharedOpaqueOutputHelper.cs
+++ b/Public/Src/Engine/Processes/SharedOpaqueOutputHelper.cs
@@ -83,7 +83,9 @@ namespace BuildXL.Processes
         private static unsafe class Unix
         {
             private const string MY_XATTR_NAME = "com.microsoft.buildxl:shared_opaque_output";
-            private const long MY_XATTR_VALUE = 42;
+
+            // arbitrary value; in the future, we could store something more useful here (e.g., the producer PipId or something)
+            private const long MY_XATTR_VALUE = 42; 
 
             private const int XATTR_NOFOLLOW = 1;
 
@@ -100,7 +102,7 @@ namespace BuildXL.Processes
             private static extern long GetXattr(
                 [MarshalAs(UnmanagedType.LPStr)] string path,
                 [MarshalAs(UnmanagedType.LPStr)] string name,
-                void* value,
+                void *value,
                 ulong size,
                 uint position,
                 int options);

--- a/Public/Src/Engine/Processes/SharedOpaqueOutputHelper.cs
+++ b/Public/Src/Engine/Processes/SharedOpaqueOutputHelper.cs
@@ -166,7 +166,7 @@ namespace BuildXL.Processes
             //   - if 'expandedPath' is a symlink pointing to a non-existent file, 'expandedPath' should hence
             //     still be treated as an existent file
             //   - similarly, if 'expandedPath' is a symlink pointing to a directory, it should still be treated as a file
-            bool followSymlink = true;
+            bool followSymlink = !OperatingSystemHelper.IsUnixOS;
 
             // If the file is not there (the check may be happening against a reported write that later got deleted)
             // then there is nothing to do

--- a/Public/Src/Engine/Processes/SharedOpaqueOutputHelper.cs
+++ b/Public/Src/Engine/Processes/SharedOpaqueOutputHelper.cs
@@ -14,6 +14,14 @@ namespace BuildXL.Processes
     /// Utility class for identifying a file as being an output of a shared opaque.
     /// This helps the scrubber to be more precautious when deleting files under shared opaques.
     /// </summary>
+    /// <remarks>
+    /// Currently, we use two different strategies when running on Windows and non-Windows platforms
+    ///   - on Windows, we set a magic timestamp as file's creation (birth) date
+    ///   - on Mac, we set an extended attribute with a special name.
+    /// On Mac, some tools tend to change the timestamps (even the birth date) which is the reason for this.
+    ///
+    /// TODO: eventually we should unify this and use the same mechanism for all platforms, if possible.
+    /// </remarks>
     public static class SharedOpaqueOutputHelper
     {
         private static class Win

--- a/Public/Src/Engine/Processes/SharedOpaqueOutputHelper.cs
+++ b/Public/Src/Engine/Processes/SharedOpaqueOutputHelper.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Runtime.InteropServices;
 using System.Security.AccessControl;
 using BuildXL.Native.IO;
 using BuildXL.Utilities;
@@ -10,31 +11,140 @@ using static BuildXL.Utilities.FormattableStringEx;
 namespace BuildXL.Processes
 {
     /// <summary>
-    /// Utility class for identifying a file as being an output of a shared opaque. This helps the scrubber to be more precautious when deleting files under shared opaques.
+    /// Utility class for identifying a file as being an output of a shared opaque.
+    /// This helps the scrubber to be more precautious when deleting files under shared opaques.
     /// </summary>
     public static class SharedOpaqueOutputHelper
     {
-        /// <summary>
-        /// Flags the given path as being an output under a shared opaque by setting the creation time to <see cref="WellKnownTimestamps.OutputInSharedOpaqueTimestamp"/>
-        /// </summary>
-        /// <exception cref="BuildXLException">When the timestamp cannot be set</exception>
-        public static void SetPathAsSharedOpaqueOutput(string expandedPath)
+        private static class Win
         {
-            try
+            /// <summary>
+            /// Flags the given path as being an output under a shared opaque by setting the creation time to 
+            /// <see cref="WellKnownTimestamps.OutputInSharedOpaqueTimestamp"/>.
+            /// </summary>
+            /// <exception cref="BuildXLException">When the timestamp cannot be set</exception>
+            public static void SetPathAsSharedOpaqueOutput(string expandedPath)
             {
-                // Only the creation time is used to identify a file as the output of a shared opaque
-                FileUtilities.SetFileTimestamps(expandedPath, new FileTimestamps(WellKnownTimestamps.OutputInSharedOpaqueTimestamp));
-            }
-            catch (BuildXLException ex)
-            {
-                // On (unsafe) double writes, a race can occur, we give the other contender a second chance
-                if (IsSharedOpaqueOutput(expandedPath))
+                // In the case of a no replay, this case can happen if the file got into the cache as a static output,
+                // but later was made a shared opaque output without a content change.
+                // Make sure we allow for attribute writing first
+                var writeAttributesDenied = !FileUtilities.HasWritableAttributeAccessControl(expandedPath);
+                if (writeAttributesDenied)
                 {
-                    return;
+                    FileUtilities.SetFileAccessControl(expandedPath, FileSystemRights.WriteAttributes | FileSystemRights.WriteExtendedAttributes, allow: true);
                 }
 
-                // Since these files should be just created outputs, this shouldn't happen and we bail out hard.
-                throw new BuildXLException(I($"Failed to open output file '{expandedPath}' for writing."), ex);
+                try
+                {
+                    // Only the creation time is used to identify a file as the output of a shared opaque
+                    FileUtilities.SetFileTimestamps(expandedPath, new FileTimestamps(WellKnownTimestamps.OutputInSharedOpaqueTimestamp));
+                }
+                catch (BuildXLException ex)
+                {
+                    // On (unsafe) double writes, a race can occur, we give the other contender a second chance
+                    if (IsSharedOpaqueOutput(expandedPath))
+                    {
+                        return;
+                    }
+
+                    // Since these files should be just created outputs, this shouldn't happen and we bail out hard.
+                    throw new BuildXLException(I($"Failed to open output file '{expandedPath}' for writing."), ex);
+                }
+                finally
+                {
+                    // Restore the attributes as they were originally set
+                    if (writeAttributesDenied)
+                    {
+                        FileUtilities.SetFileAccessControl(expandedPath, FileSystemRights.WriteAttributes | FileSystemRights.WriteExtendedAttributes, allow: false);
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Checks if the given path is an output under a shared opaque by verifying whether <see cref="WellKnownTimestamps.OutputInSharedOpaqueTimestamp"/> is the creation time of the file
+            /// </summary>
+            /// <remarks>
+            /// If the given path is a directory, it is always considered part of a shared opaque
+            /// </remarks>
+            public static bool IsSharedOpaqueOutput(string expandedPath)
+            {
+                try
+                {
+                    var creationTime = FileUtilities.GetFileTimestamps(expandedPath).CreationTime;
+                    return creationTime == WellKnownTimestamps.OutputInSharedOpaqueTimestamp;
+                }
+                catch (BuildXLException ex)
+                {
+                    throw new BuildXLException(I($"Failed to open output file '{expandedPath}' for reading."), ex);
+                }
+            }
+        }
+
+        private static unsafe class Unix
+        {
+            private const string MY_XATTR_NAME = "com.microsoft.buildxl:shared_opaque_output";
+            private const long MY_XATTR_VALUE = 42;
+
+            private const int XATTR_NOFOLLOW = 1;
+
+            [DllImport("libc", EntryPoint = "setxattr")]
+            private static extern int SetXattr(
+                [MarshalAs(UnmanagedType.LPStr)] string path,
+                [MarshalAs(UnmanagedType.LPStr)] string name,
+                void *value,
+                ulong size,
+                uint position,
+                int options);
+
+            [DllImport("libc", EntryPoint = "getxattr")]
+            private static extern long GetXattr(
+                [MarshalAs(UnmanagedType.LPStr)] string path,
+                [MarshalAs(UnmanagedType.LPStr)] string name,
+                void* value,
+                ulong size,
+                uint position,
+                int options);
+
+            /// <summary>
+            /// Flags the given path as being an output under a shared opaque by setting
+            /// <see cref="MY_XATTR_NAME"/> xattr to a <see cref="MY_XATTR_VALUE"/>.
+            /// </summary>
+            public static void SetPathAsSharedOpaqueOutput(string expandedPath)
+            {
+                long value = MY_XATTR_VALUE;
+                var err = SetXattr(expandedPath, MY_XATTR_NAME, &value, sizeof(long), 0, XATTR_NOFOLLOW);
+                if (err != 0)
+                {
+                    throw new BuildXLException(I($"Failed to set '{MY_XATTR_NAME}' extended attribute. Error: {err}"));
+                }
+            }
+
+            /// <summary>
+            /// Checks if the given path is an output under a shared opaque by checking if
+            /// it contains extended attribute by <see cref="MY_XATTR_NAME"/> name.
+            /// </summary>
+            public static bool IsSharedOpaqueOutput(string expandedPath)
+            {
+                long value = 0;
+                uint valueSize = sizeof(long);
+                var resultSize = GetXattr(expandedPath, MY_XATTR_NAME, &value, valueSize, 0, XATTR_NOFOLLOW);
+                return resultSize == valueSize && value == MY_XATTR_VALUE;
+            }
+        }
+
+        /// <summary>
+        /// Marks a given path as "shared opaque output"
+        /// </summary>
+        /// <exception cref="BuildXLException">When unsuccessful</exception>
+        public static void SetPathAsSharedOpaqueOutput(string expandedPath)
+        {
+            if (OperatingSystemHelper.IsUnixOS)
+            {
+                Unix.SetPathAsSharedOpaqueOutput(expandedPath);
+            }
+            else
+            {
+                Win.SetPathAsSharedOpaqueOutput(expandedPath);
             }
         }
 
@@ -56,7 +166,7 @@ namespace BuildXL.Processes
             //   - if 'expandedPath' is a symlink pointing to a non-existent file, 'expandedPath' should hence
             //     still be treated as an existent file
             //   - similarly, if 'expandedPath' is a symlink pointing to a directory, it should still be treated as a file
-            bool followSymlink = !OperatingSystemHelper.IsUnixOS;
+            bool followSymlink = true;
 
             // If the file is not there (the check may be happening against a reported write that later got deleted)
             // then there is nothing to do
@@ -74,18 +184,9 @@ namespace BuildXL.Processes
                 return true;
             }
 
-            DateTime creationTime;
-
-            try
-            {
-                creationTime = FileUtilities.GetFileTimestamps(expandedPath).CreationTime;
-            }
-            catch (BuildXLException ex)
-            {
-                throw new BuildXLException(I($"Failed to open output file '{expandedPath}' for reading."), ex);
-            }
-
-            return creationTime == WellKnownTimestamps.OutputInSharedOpaqueTimestamp;
+            return OperatingSystemHelper.IsUnixOS
+                ? Unix.IsSharedOpaqueOutput(expandedPath)
+                : Win.IsSharedOpaqueOutput(expandedPath);
         }
 
         /// <summary>
@@ -93,37 +194,13 @@ namespace BuildXL.Processes
         /// </summary>
         public static void EnforceFileIsSharedOpaqueOutput(string expandedPath)
         {
-            // If the file has the right timestamps already, then there is nothing to do.
+            // If the file is already marked, then there is nothing to do.
             if (IsSharedOpaqueOutput(expandedPath))
             {
                 return;
             }
 
-            // In the case of a no replay, this case can happen if the file got into the cache as a static output, but later was made a shared opaque
-            // output without a content change.
-
-#if PLATFORM_WIN
-            // Make sure we allow for attribute writing first
-            var writeAttributesDenied = !FileUtilities.HasWritableAttributeAccessControl(expandedPath);
-            if (writeAttributesDenied)
-            {
-                FileUtilities.SetFileAccessControl(expandedPath, FileSystemRights.WriteAttributes | FileSystemRights.WriteExtendedAttributes, allow: true);
-            }
-#endif
-            try
-            {
-                SetPathAsSharedOpaqueOutput(expandedPath);
-            }
-            finally
-            {
-#if PLATFORM_WIN
-                // Restore the attributes as they were originally set
-                if (writeAttributesDenied)
-                {
-                    FileUtilities.SetFileAccessControl(expandedPath, FileSystemRights.WriteAttributes | FileSystemRights.WriteExtendedAttributes, allow: false);
-                }
-#endif
-            }
+            SetPathAsSharedOpaqueOutput(expandedPath);
         }
     }
 }

--- a/Public/Src/Engine/Processes/SharedOpaqueOutputHelper.cs
+++ b/Public/Src/Engine/Processes/SharedOpaqueOutputHelper.cs
@@ -95,6 +95,8 @@ namespace BuildXL.Processes
             // arbitrary value; in the future, we could store something more useful here (e.g., the producer PipId or something)
             private const long MY_XATTR_VALUE = 42; 
 
+            // from xattr.h:
+            // #define XATTR_NOFOLLOW   0x0001     /* Don't follow symbolic links */
             private const int XATTR_NOFOLLOW = 1;
 
             [DllImport("libc", EntryPoint = "setxattr")]


### PR DESCRIPTION
The implementation for Windows remains the same and continues to use magic timestamps.

On Mac, instead of timestamps extended attributes are used.  Concretely, a file is a shared opaque output IFF it has a `com.microsoft.buildxl:shared_opaque_output` attribute and it's value is equal to `42` (at some point in the future we could insert a more meaningful value here, e.g., PipId)

[AB#1607996](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1607996)