### PR TITLE
Fix "bxl -cache -vs" to do the right thing

### DIFF
--- a/Shared/Scripts/bxl.ps1
+++ b/Shared/Scripts/bxl.ps1
@@ -557,7 +557,7 @@ if (!$skipFilter){
 
     if ($Cache) {
         # Only build Cache code.
-        if ($LongRunningTest) {
+        if ($LongRunningTest -or $Vs) {
             $AdditionalBuildXLArguments += "/f:$AllCacheProjectsFilter"
         }
         elseif ($CacheNuget) {


### PR DESCRIPTION
Previously we ran "bxl -cache /vs /q:DebugNet472 -LongRunningTest" to generate the cache solution

Now we can run "bxl -cache -vs" to achieve the same thing.