### PR TITLE
Add packages.config as temporary solution to run tests in VS

### DIFF
--- a/Public/Src/Cache/ContentStore/DistributedTest/packages.config
+++ b/Public/Src/Cache/ContentStore/DistributedTest/packages.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <!-- Even though this file is not used by Visual Studio to fetch NuGet
+  packages, it is necessary to tell the VS test discoverer it nees to look for
+  xunit based unit tests. -->
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
+</packages>

--- a/Public/Src/Cache/ContentStore/GrpcTest/packages.config
+++ b/Public/Src/Cache/ContentStore/GrpcTest/packages.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <!-- Even though this file is not used by Visual Studio to fetch NuGet
+  packages, it is necessary to tell the VS test discoverer it nees to look for
+  xunit based unit tests. -->
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
+</packages>

--- a/Public/Src/Cache/ContentStore/InterfacesTest/packages.config
+++ b/Public/Src/Cache/ContentStore/InterfacesTest/packages.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <!-- Even though this file is not used by Visual Studio to fetch NuGet
+  packages, it is necessary to tell the VS test discoverer it nees to look for
+  xunit based unit tests. -->
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
+</packages>

--- a/Public/Src/Cache/ContentStore/Test/packages.config
+++ b/Public/Src/Cache/ContentStore/Test/packages.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <!-- Even though this file is not used by Visual Studio to fetch NuGet
+  packages, it is necessary to tell the VS test discoverer it nees to look for
+  xunit based unit tests. -->
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
+</packages>

--- a/Public/Src/Cache/DistributedCache.Host/Test/packages.config
+++ b/Public/Src/Cache/DistributedCache.Host/Test/packages.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <!-- Even though this file is not used by Visual Studio to fetch NuGet
+  packages, it is necessary to tell the VS test discoverer it nees to look for
+  xunit based unit tests. -->
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
+</packages>

--- a/Public/Src/Cache/MemoizationStore/DistributedTest/packages.config
+++ b/Public/Src/Cache/MemoizationStore/DistributedTest/packages.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <!-- Even though this file is not used by Visual Studio to fetch NuGet
+  packages, it is necessary to tell the VS test discoverer it nees to look for
+  xunit based unit tests. -->
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
+</packages>

--- a/Public/Src/Cache/MemoizationStore/InterfacesTest/packages.config
+++ b/Public/Src/Cache/MemoizationStore/InterfacesTest/packages.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <!-- Even though this file is not used by Visual Studio to fetch NuGet
+  packages, it is necessary to tell the VS test discoverer it nees to look for
+  xunit based unit tests. -->
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
+</packages>

--- a/Public/Src/Cache/MemoizationStore/Test/packages.config
+++ b/Public/Src/Cache/MemoizationStore/Test/packages.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <!-- Even though this file is not used by Visual Studio to fetch NuGet
+  packages, it is necessary to tell the VS test discoverer it nees to look for
+  xunit based unit tests. -->
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
+</packages>

--- a/Public/Src/Cache/MemoizationStore/VstsTest/packages.config
+++ b/Public/Src/Cache/MemoizationStore/VstsTest/packages.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <!-- Even though this file is not used by Visual Studio to fetch NuGet
+  packages, it is necessary to tell the VS test discoverer it nees to look for
+  xunit based unit tests. -->
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
These files will enable us to run tests directly in VS.

The VS solution generation is flawed: it will attempt to rite these files when the ProcessType is XUnit, but the process type can never be XUnit.

This should be a temporary solution while the solution-generating logic is fixed