### PR TITLE
Enforce weak fingerprint augmentation for MSBuild-scheduled pips

### DIFF
--- a/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
+++ b/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
@@ -513,6 +513,10 @@ namespace BuildXL.FrontEnd.MsBuild
                 processBuilder.ContainerIsolationLevel = ContainerIsolationLevel.IsolateAllOutputs;
             }
 
+            // We want to enforce the use of weak fingerprint augmentation since input predictions could be not complete/sufficient
+            // to avoid a large number of path sets
+            processBuilder.Options |= Process.Options.EnforceWeakFingerprintAugmentation;
+
             // By default the double write policy is to allow same content double writes.
             processBuilder.DoubleWritePolicy |= m_resolverSettings.DoubleWritePolicy ?? DoubleWritePolicy.AllowSameContentDoubleWrites;
 

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/SchedulingTests/MsBuildProcessBuilderTests.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/SchedulingTests/MsBuildProcessBuilderTests.cs
@@ -67,6 +67,8 @@ namespace Test.BuildXL.FrontEnd.MsBuild
 
             // Undeclared sources are allowed as long as they are true sources
             Assert.True(testProj.AllowUndeclaredSourceReads);
+            // Weak fingerprint augmentation should be enforced
+            Assert.True((testProj.ProcessOptions & Process.Options.EnforceWeakFingerprintAugmentation) != 0);
             // Double writes are allowed as long as the written content is the same
             Assert.True(testProj.DoubleWritePolicy == DoubleWritePolicy.AllowSameContentDoubleWrites);
             // Working directory is the project directory

--- a/Public/Src/Pips/Dll/Operations/Process.Options.cs
+++ b/Public/Src/Pips/Dll/Operations/Process.Options.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using BuildXL.Utilities.Configuration;
+using BuildXL.Utilities.Configuration.Mutable;
 using System;
 
 namespace BuildXL.Pips.Operations
@@ -8,6 +10,20 @@ namespace BuildXL.Pips.Operations
     /// <nodoc />
     public partial class Process
     {
+        /// <summary>
+        /// Process-level default value for <see cref="ICacheConfiguration.AugmentWeakFingerprintRequiredPathCommonalityFactor"/> 
+        /// if fingerprint augmentation is not explicitly set globally and 
+        /// <see cref="Options.EnforceWeakFingerprintAugmentation"/> is on
+        /// </summary>
+        public static double DefaultAugmentWeakFingerprintRequiredPathCommonalityFactor = .4;
+
+        /// <summary>
+        /// Process-level default value for <see cref="ICacheConfiguration.AugmentWeakFingerprintPathSetThreshold"/> 
+        /// if fingerprint augmentation is not explicitly set globally and 
+        /// <see cref="Options.EnforceWeakFingerprintAugmentation"/> is on
+        /// </summary>
+        public static int DefaultAugmentWeakFingerprintPathSetThreshold = 5;
+
         /// <summary>
         /// Flag options controlling process pip behavior.
         /// </summary>
@@ -110,6 +126,14 @@ namespace BuildXL.Pips.Operations
             /// Whether this process require unsafe_GlobalPassthroughEnvVars and unsafe_GlobalUntrackedScopes
             /// </summary>
             RequireGlobalDependencies = 1 << 14,
+
+            /// <summary>
+            /// If the global <see cref="ICacheConfiguration.AugmentWeakFingerprintPathSetThreshold"/> is not 
+            /// set (i.e is equal to zero), this option forces fingerprint augmentation
+            /// for this particular process using defaults specified by <see cref="DefaultAugmentWeakFingerprintPathSetThreshold"/> 
+            /// and <see cref="DefaultAugmentWeakFingerprintRequiredPathCommonalityFactor"/>
+            /// </summary>
+            EnforceWeakFingerprintAugmentation = 1 << 15,
         }
     }
 }

--- a/Public/Src/Pips/Dll/Operations/ProcessExtensions.cs
+++ b/Public/Src/Pips/Dll/Operations/ProcessExtensions.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics.ContractsLight;
 using BuildXL.Utilities;
 using BuildXL.Utilities.Collections;
+using BuildXL.Utilities.Configuration;
 
 namespace BuildXL.Pips.Operations
 {
@@ -152,5 +153,33 @@ namespace BuildXL.Pips.Operations
 
             return ItemResources.Create(semaphoreIncrements);
         }
+
+        /// <summary>
+        /// Returns the global <see cref="ICacheConfiguration.AugmentWeakFingerprintRequiredPathCommonalityFactor"/> 
+        /// if weak fingerprint augmentation is on, or 
+        /// <see cref="Process.DefaultAugmentWeakFingerprintRequiredPathCommonalityFactor"/> if the process pip is 
+        /// configured to enforce weak fingerprint augmentation
+        /// </summary>
+        public static double AugmentWeakFingerprintRequiredPathCommonalityFactor(
+            this Process process, 
+            ICacheConfiguration cacheConfiguration) =>
+            (process.ProcessOptions & Process.Options.EnforceWeakFingerprintAugmentation) != 0 && 
+            cacheConfiguration.AugmentWeakFingerprintPathSetThreshold == 0 ?
+                Process.DefaultAugmentWeakFingerprintRequiredPathCommonalityFactor :
+                cacheConfiguration.AugmentWeakFingerprintRequiredPathCommonalityFactor;
+
+        /// <summary>
+        /// Returns the global <see cref="ICacheConfiguration.AugmentWeakFingerprintPathSetThreshold"/> 
+        /// if weak fingerprint augmentation is on, 
+        /// or <see cref="Process.DefaultAugmentWeakFingerprintPathSetThreshold"/> if the process pip is 
+        /// configured to enforce weak fingerprint augmentation
+        /// </summary>
+        public static int AugmentWeakFingerprintPathSetThreshold(
+            this Process process, 
+            ICacheConfiguration cacheConfiguration) =>
+            (process.ProcessOptions & Process.Options.EnforceWeakFingerprintAugmentation) != 0 && 
+            cacheConfiguration.AugmentWeakFingerprintPathSetThreshold == 0 ?
+                Process.DefaultAugmentWeakFingerprintPathSetThreshold :
+                cacheConfiguration.AugmentWeakFingerprintPathSetThreshold;
     }
 }

--- a/Public/Src/Tools/Tool.MsBuildGraphBuilder/MsBuildGraphBuilder.cs
+++ b/Public/Src/Tools/Tool.MsBuildGraphBuilder/MsBuildGraphBuilder.cs
@@ -357,10 +357,9 @@ namespace MsBuildGraphBuilderTool
                 ProjectInstance projectInstance = msBuildNode.ProjectInstance;
                 Project project = projectInstanceToProjectCache[projectInstance];
 
-                var inputFilePredictions = new List<string>();
                 var outputFolderPredictions = new List<string>();
 
-                var predictionCollector = new MsBuildPredictionCollector(inputFilePredictions, outputFolderPredictions, predictionFailures);
+                var predictionCollector = new MsBuildOutputPredictionCollector(outputFolderPredictions, predictionFailures);
                 try
                 {
                     // Again, be defensive when using arbitrary predictors
@@ -387,11 +386,16 @@ namespace MsBuildGraphBuilderTool
                     return;
                 }
 
+                // The project file itself and all its imports are considered inputs to this project.
+                // Predicted inputs are not actually used.
+                var inputs = new List<string>() { project.FullPath };
+                inputs.AddRange(project.Imports.Select(i => i.ImportedProject.FullPath));
+
                 projectNodes[i] = new ProjectWithPredictions(
                     projectInstance.FullPath,
                     projectInstance.GetItems(ProjectReferenceTargets).Count > 0,
                     globalProperties,
-                    inputFilePredictions,
+                    inputs,
                     outputFolderPredictions);
 
                 // If projects not implementing the target protocol are blocked, then the list of computed targets is final. So we set it right here

--- a/Public/Src/Tools/Tool.MsBuildGraphBuilder/MsBuildOutputPredictionCollector.cs
+++ b/Public/Src/Tools/Tool.MsBuildGraphBuilder/MsBuildOutputPredictionCollector.cs
@@ -12,38 +12,32 @@ using Microsoft.Build.Prediction;
 namespace MsBuildGraphBuilderTool
 {
     /// <summary>
-    /// Collects predictions from the MSBuild prediction library.
+    /// Collects output predictions from the MSBuild prediction library.
     /// </summary>
     /// <remarks>
-    /// This validates the predicted inputs and outputs, in case the predictor is not working properly
+    /// This validates the predicted outputs, in case the predictor is not working properly
     /// </remarks>
-    public sealed class MsBuildPredictionCollector : IProjectPredictionCollector
+    public sealed class MsBuildOutputPredictionCollector : IProjectPredictionCollector
     {
         private readonly ConcurrentQueue<(string predictorName, string failure)> m_predictionFailures;
-
-        private readonly ICollection<string> m_inputFilePredictions;
 
         private readonly ICollection<string> m_outputFolderPredictions;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="MsBuildPredictionCollector"/> class.
+        /// Initializes a new instance of the <see cref="MsBuildOutputPredictionCollector"/> class.
         /// </summary>
         /// <remarks>
         /// The provided collections will be added to by this collector as predictions (or prediction errors) happen.
         /// </remarks>
-        /// <param name="inputFilePredictions">A collection of input file predictions the collector should add to as needed.</param>
         /// <param name="outputFolderPredictions">A collection of output folder predictions the collector should add to as needed.</param>
         /// <param name="predictionFailures">A collection of prediction failures the collector should add to as needed.</param>
-        public MsBuildPredictionCollector(
-            ICollection<string> inputFilePredictions,
+        public MsBuildOutputPredictionCollector(
             ICollection<string> outputFolderPredictions,
             ConcurrentQueue<(string predictorName, string failure)> predictionFailures)
         {
-            Contract.Assert(inputFilePredictions != null);
             Contract.Assert(outputFolderPredictions != null);
             Contract.Assert(predictionFailures != null);
 
-            m_inputFilePredictions = inputFilePredictions;
             m_outputFolderPredictions = outputFolderPredictions;
             m_predictionFailures = predictionFailures;
         }
@@ -51,31 +45,13 @@ namespace MsBuildGraphBuilderTool
         /// <inheritdoc/>
         public void AddInputFile(string path, string projectDirectory, string predictorName)
         {
-            if (!TryValidatePrediction(path, projectDirectory, predictorName, out string absolutePath))
-            {
-                return;
-            }
-
-            m_inputFilePredictions.Add(absolutePath);
+            // We don't collect inputs
         }
 
         /// <inheritdoc/>
         public void AddInputDirectory(string path, string projectDirectory, string predictorName)
         {
-            if (!TryValidatePrediction(path, projectDirectory, predictorName, out string absolutePath))
-            {
-                return;
-            }
-
-            if (Directory.Exists(absolutePath))
-            {
-                FileUtilities.EnumerateFiles(
-                    absolutePath,
-                    false,
-                    "*",
-                    (dir, fileName, attrs, length) => m_inputFilePredictions.Add(Path.Combine(dir, fileName)));
-            }
-            // TODO: Can we do anything to flag that the input prediction is not going to be used?
+            // We don't collect input directories
         }
 
         /// <inheritdoc/>

--- a/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildPredictionCollectorTests.cs
+++ b/Public/Src/Tools/UnitTests/MsBuildGraphBuilder/MsBuildPredictionCollectorTests.cs
@@ -20,171 +20,16 @@ namespace Test.ProjectGraphBuilder
         }
 
         [Fact]
-        public void AddInputFileHandlesAbsolutePaths()
-        {
-            string absolutePath = Path.Combine(TemporaryDirectory, Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
-
-            var inputFilePredictions = new List<string>();
-            var outputFolderPredictions = new List<string>();
-            var predictionFailures = new ConcurrentQueue<(string predictorName, string failure)>();
-            var collector = new MsBuildPredictionCollector(inputFilePredictions, outputFolderPredictions, predictionFailures);
-
-            collector.AddInputFile(absolutePath, TemporaryDirectory, "Mock");
-
-            Assert.Equal(1, inputFilePredictions.Count);
-            Assert.Contains(absolutePath, inputFilePredictions);
-
-            Assert.Equal(0, outputFolderPredictions.Count);
-
-            Assert.Equal(0, predictionFailures.Count);
-        }
-
-        [Fact]
-        public void AddInputFileHandlesRelativePaths()
-        {
-            string relativePath = Path.Combine(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
-            string absolutePath = Path.Combine(TemporaryDirectory, relativePath);
-
-            var inputFilePredictions = new List<string>();
-            var outputFolderPredictions = new List<string>();
-            var predictionFailures = new ConcurrentQueue<(string predictorName, string failure)>();
-            var collector = new MsBuildPredictionCollector(inputFilePredictions, outputFolderPredictions, predictionFailures);
-
-            collector.AddInputFile(relativePath, TemporaryDirectory, "Mock");
-
-            Assert.Equal(1, inputFilePredictions.Count);
-            Assert.Contains(absolutePath, inputFilePredictions);
-
-            Assert.Equal(0, outputFolderPredictions.Count);
-
-            Assert.Equal(0, predictionFailures.Count);
-        }
-
-        [Fact]
-        public void AddInputFileHandlesBadPaths()
-        {
-            var inputFilePredictions = new List<string>();
-            var outputFolderPredictions = new List<string>();
-            var predictionFailures = new ConcurrentQueue<(string predictorName, string failure)>();
-            var collector = new MsBuildPredictionCollector(inputFilePredictions, outputFolderPredictions, predictionFailures);
-
-            collector.AddInputFile("!@#$%^&*()\0", TemporaryDirectory, "Mock");
-
-            Assert.Equal(0, inputFilePredictions.Count);
-
-            Assert.Equal(0, outputFolderPredictions.Count);
-
-            Assert.Equal(1, predictionFailures.Count);
-            Assert.Equal("Mock", predictionFailures.Single().predictorName);
-            Assert.Contains("!@#$%^&*()\0", predictionFailures.Single().failure);
-        }
-
-        [Fact]
-        public void AddInputDirectoryHandlesAbsolutePaths()
-        {
-            string absoluteDirectoryPath = Path.Combine(TemporaryDirectory, Guid.NewGuid().ToString());
-            string absoluteFilePath1 = Path.Combine(absoluteDirectoryPath, Guid.NewGuid().ToString());
-            string absoluteFilePath2 = Path.Combine(absoluteDirectoryPath, Guid.NewGuid().ToString());
-
-            Directory.CreateDirectory(absoluteDirectoryPath);
-            File.WriteAllText(absoluteFilePath1, Guid.NewGuid().ToString());
-            File.WriteAllText(absoluteFilePath2, Guid.NewGuid().ToString());
-
-            var inputFilePredictions = new List<string>();
-            var outputFolderPredictions = new List<string>();
-            var predictionFailures = new ConcurrentQueue<(string predictorName, string failure)>();
-            var collector = new MsBuildPredictionCollector(inputFilePredictions, outputFolderPredictions, predictionFailures);
-
-            collector.AddInputDirectory(absoluteDirectoryPath, TemporaryDirectory, "Mock");
-
-            Assert.Equal(2, inputFilePredictions.Count);
-            Assert.Contains(absoluteFilePath1, inputFilePredictions);
-            Assert.Contains(absoluteFilePath2, inputFilePredictions);
-
-            Assert.Equal(0, outputFolderPredictions.Count);
-
-            Assert.Equal(0, predictionFailures.Count);
-        }
-
-        [Fact]
-        public void AddInputDirectoryHandlesRelativePaths()
-        {
-            string relativeDirectoryPath = Path.Combine(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
-            string absoluteDirectoryPath = Path.Combine(TemporaryDirectory, relativeDirectoryPath);
-            string absoluteFilePath1 = Path.Combine(absoluteDirectoryPath, Guid.NewGuid().ToString());
-            string absoluteFilePath2 = Path.Combine(absoluteDirectoryPath, Guid.NewGuid().ToString());
-
-            Directory.CreateDirectory(absoluteDirectoryPath);
-            File.WriteAllText(absoluteFilePath1, Guid.NewGuid().ToString());
-            File.WriteAllText(absoluteFilePath2, Guid.NewGuid().ToString());
-
-            var inputFilePredictions = new List<string>();
-            var outputFolderPredictions = new List<string>();
-            var predictionFailures = new ConcurrentQueue<(string predictorName, string failure)>();
-            var collector = new MsBuildPredictionCollector(inputFilePredictions, outputFolderPredictions, predictionFailures);
-
-            collector.AddInputDirectory(relativeDirectoryPath, TemporaryDirectory, "Mock");
-
-            Assert.Equal(2, inputFilePredictions.Count);
-            Assert.Contains(absoluteFilePath1, inputFilePredictions);
-            Assert.Contains(absoluteFilePath2, inputFilePredictions);
-
-            Assert.Equal(0, outputFolderPredictions.Count);
-
-            Assert.Equal(0, predictionFailures.Count);
-        }
-
-        [Fact]
-        public void AddInputDirectoryHandlesMissingPaths()
-        {
-            string absoluteDirectoryPath = Path.Combine(TemporaryDirectory, Guid.NewGuid().ToString());
-
-            var inputFilePredictions = new List<string>();
-            var outputFolderPredictions = new List<string>();
-            var predictionFailures = new ConcurrentQueue<(string predictorName, string failure)>();
-            var collector = new MsBuildPredictionCollector(inputFilePredictions, outputFolderPredictions, predictionFailures);
-
-            collector.AddInputDirectory(absoluteDirectoryPath, TemporaryDirectory, "Mock");
-
-            // The folder didn't exist, so ignore the prediction
-            Assert.Equal(0, inputFilePredictions.Count);
-            Assert.Equal(0, outputFolderPredictions.Count);
-            Assert.Equal(0, predictionFailures.Count);
-        }
-
-        [Fact]
-        public void AddInputDirectoryHandlesBadPaths()
-        {
-            var inputFilePredictions = new List<string>();
-            var outputFolderPredictions = new List<string>();
-            var predictionFailures = new ConcurrentQueue<(string predictorName, string failure)>();
-            var collector = new MsBuildPredictionCollector(inputFilePredictions, outputFolderPredictions, predictionFailures);
-
-            collector.AddInputDirectory("!@#$%^&*()\0", TemporaryDirectory, "Mock");
-
-            Assert.Equal(0, inputFilePredictions.Count);
-
-            Assert.Equal(0, outputFolderPredictions.Count);
-
-            Assert.Equal(1, predictionFailures.Count);
-            Assert.Equal("Mock", predictionFailures.Single().predictorName);
-            Assert.Contains("!@#$%^&*()\0", predictionFailures.Single().failure);
-        }
-
-        [Fact]
         public void AddOutputFileHandlesAbsolutePaths()
         {
             string absoluteDirectoryPath = Path.Combine(TemporaryDirectory, Guid.NewGuid().ToString());
             string absoluteFilePath = Path.Combine(absoluteDirectoryPath, Guid.NewGuid().ToString());
 
-            var inputFilePredictions = new List<string>();
             var outputFolderPredictions = new List<string>();
             var predictionFailures = new ConcurrentQueue<(string predictorName, string failure)>();
-            var collector = new MsBuildPredictionCollector(inputFilePredictions, outputFolderPredictions, predictionFailures);
+            var collector = new MsBuildOutputPredictionCollector(outputFolderPredictions, predictionFailures);
 
             collector.AddOutputFile(absoluteFilePath, TemporaryDirectory, "Mock");
-
-            Assert.Equal(0, inputFilePredictions.Count);
 
             Assert.Equal(1, outputFolderPredictions.Count);
             Assert.Contains(absoluteDirectoryPath, outputFolderPredictions);
@@ -199,14 +44,11 @@ namespace Test.ProjectGraphBuilder
             string relativeFilePath = Path.Combine(relativeDirectoryPath, Guid.NewGuid().ToString());
             string absoluteDirectoryPath = Path.Combine(TemporaryDirectory, relativeDirectoryPath);
 
-            var inputFilePredictions = new List<string>();
             var outputFolderPredictions = new List<string>();
             var predictionFailures = new ConcurrentQueue<(string predictorName, string failure)>();
-            var collector = new MsBuildPredictionCollector(inputFilePredictions, outputFolderPredictions, predictionFailures);
+            var collector = new MsBuildOutputPredictionCollector(outputFolderPredictions, predictionFailures);
 
             collector.AddOutputFile(relativeFilePath, TemporaryDirectory, "Mock");
-
-            Assert.Equal(0, inputFilePredictions.Count);
 
             Assert.Equal(1, outputFolderPredictions.Count);
             Assert.Contains(absoluteDirectoryPath, outputFolderPredictions);
@@ -217,14 +59,11 @@ namespace Test.ProjectGraphBuilder
         [Fact]
         public void AddOutputFileHandlesBadPaths()
         {
-            var inputFilePredictions = new List<string>();
             var outputFolderPredictions = new List<string>();
             var predictionFailures = new ConcurrentQueue<(string predictorName, string failure)>();
-            var collector = new MsBuildPredictionCollector(inputFilePredictions, outputFolderPredictions, predictionFailures);
+            var collector = new MsBuildOutputPredictionCollector(outputFolderPredictions, predictionFailures);
 
             collector.AddOutputFile("!@#$%^&*()\0", TemporaryDirectory, "Mock");
-
-            Assert.Equal(0, inputFilePredictions.Count);
 
             Assert.Equal(0, outputFolderPredictions.Count);
 
@@ -238,14 +77,11 @@ namespace Test.ProjectGraphBuilder
         {
             string absoluteDirectoryPath = Path.Combine(TemporaryDirectory, Guid.NewGuid().ToString());
 
-            var inputFilePredictions = new List<string>();
             var outputFolderPredictions = new List<string>();
             var predictionFailures = new ConcurrentQueue<(string predictorName, string failure)>();
-            var collector = new MsBuildPredictionCollector(inputFilePredictions, outputFolderPredictions, predictionFailures);
+            var collector = new MsBuildOutputPredictionCollector(outputFolderPredictions, predictionFailures);
 
             collector.AddOutputDirectory(absoluteDirectoryPath, TemporaryDirectory, "Mock");
-
-            Assert.Equal(0, inputFilePredictions.Count);
 
             Assert.Equal(1, outputFolderPredictions.Count);
             Assert.Contains(absoluteDirectoryPath, outputFolderPredictions);
@@ -259,14 +95,11 @@ namespace Test.ProjectGraphBuilder
             string relativeDirectoryPath = Path.Combine(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
             string absoluteDirectoryPath = Path.Combine(TemporaryDirectory, relativeDirectoryPath);
 
-            var inputFilePredictions = new List<string>();
             var outputFolderPredictions = new List<string>();
             var predictionFailures = new ConcurrentQueue<(string predictorName, string failure)>();
-            var collector = new MsBuildPredictionCollector(inputFilePredictions, outputFolderPredictions, predictionFailures);
+            var collector = new MsBuildOutputPredictionCollector(outputFolderPredictions, predictionFailures);
 
             collector.AddOutputDirectory(relativeDirectoryPath, TemporaryDirectory, "Mock");
-
-            Assert.Equal(0, inputFilePredictions.Count);
 
             Assert.Equal(1, outputFolderPredictions.Count);
             Assert.Contains(absoluteDirectoryPath, outputFolderPredictions);
@@ -277,14 +110,11 @@ namespace Test.ProjectGraphBuilder
         [Fact]
         public void AddOutputDirectoryHandlesBadPaths()
         {
-            var inputFilePredictions = new List<string>();
             var outputFolderPredictions = new List<string>();
             var predictionFailures = new ConcurrentQueue<(string predictorName, string failure)>();
-            var collector = new MsBuildPredictionCollector(inputFilePredictions, outputFolderPredictions, predictionFailures);
+            var collector = new MsBuildOutputPredictionCollector(outputFolderPredictions, predictionFailures);
 
             collector.AddOutputDirectory("!@#$%^&*()\0", TemporaryDirectory, "Mock");
-
-            Assert.Equal(0, inputFilePredictions.Count);
 
             Assert.Equal(0, outputFolderPredictions.Count);
 

--- a/Public/Src/Tools/Xldb.Proto/Enums/Options.proto
+++ b/Public/Src/Tools/Xldb.Proto/Enums/Options.proto
@@ -27,6 +27,7 @@ enum Options{
 
     // (1 << 14) | AllowPreserveOutputs
     IncrementalTool = 16400;
-    RequireGlobalDependencies =32768;
+    RequireGlobalDependencies = 32768;
 
+    EnforceWeakFingerprintAugmentation = 65536;
 }


### PR DESCRIPTION
Many times MSBuild predictors report inputs that are actually outputs. Even though there are some heuristics in place to avoid this problem, we keep hitting this issue and the end user has no easy way to fix the problem.
This PR makes the MSBuild graph builder tool stop using input predictions and just keep inputs to be the associated MSBuild specs for a given project. As a compensating change, and to avoid reaching a too large number of path set candidates (as a result of weakening the weak fingerprint), all MSBuild-scheduled pips now enforce the use of 3-way cache lookup.

* Allow to enforce weak fingerprint augmentation at the pip level when not globally enforced, by using process level defaults
* Enforce fingerprint augmentation for all MSBuild-scheduled pips. 
* Stop depending on input predictions for MSBuild, and only use predictors for determining output cones. 