### PR TITLE
Better error handling for setxattr

### DIFF
--- a/Public/Src/Engine/Processes/SharedOpaqueOutputHelper.cs
+++ b/Public/Src/Engine/Processes/SharedOpaqueOutputHelper.cs
@@ -143,9 +143,10 @@ namespace BuildXL.Processes
             // but later was made a shared opaque output without a content change.
             // Make sure we allow for attribute writing first
             var writeAttributesDenied = !FileUtilities.HasWritableAttributeAccessControl(expandedPath);
+            var writeAttrs = FileSystemRights.WriteAttributes | FileSystemRights.WriteExtendedAttributes;
             if (writeAttributesDenied)
             {
-                FileUtilities.SetFileAccessControl(expandedPath, FileSystemRights.WriteAttributes | FileSystemRights.WriteExtendedAttributes, allow: true);
+                FileUtilities.SetFileAccessControl(expandedPath, writeAttrs, allow: true);
             }
 
             try
@@ -164,7 +165,7 @@ namespace BuildXL.Processes
                 // Restore the attributes as they were originally set
                 if (writeAttributesDenied)
                 {
-                    FileUtilities.SetFileAccessControl(expandedPath, FileSystemRights.WriteAttributes | FileSystemRights.WriteExtendedAttributes, allow: false);
+                    FileUtilities.SetFileAccessControl(expandedPath, writeAttrs, allow: false);
                 }
             }
         }

--- a/Public/Src/Engine/Processes/SharedOpaqueOutputHelper.cs
+++ b/Public/Src/Engine/Processes/SharedOpaqueOutputHelper.cs
@@ -124,11 +124,6 @@ namespace BuildXL.Processes
                 long value = 0;
                 uint valueSize = sizeof(long);
                 var resultSize = GetXattr(expandedPath, MY_XATTR_NAME, &value, valueSize, 0, XATTR_NOFOLLOW);
-                if (resultSize == -1)
-                {
-                    int errorCode = Marshal.GetLastWin32Error();
-                    throw new BuildXLException(I($"Failed to read extended attributes for file '{expandedPath}'. Error: {errorCode}"));
-                }
                 return resultSize == valueSize && value == MY_XATTR_VALUE;
             }
         }

--- a/Public/Src/Utilities/Native/IO/Unix/FileUtilities.Unix.cs
+++ b/Public/Src/Utilities/Native/IO/Unix/FileUtilities.Unix.cs
@@ -668,7 +668,7 @@ namespace BuildXL.Native.IO.Unix
                 currentPermissions &= ~permissions;
             }
 
-            result = SetFilePermissionsForFilePath(path, currentPermissions);
+            result = SetFilePermissionsForFilePath(path, currentPermissions, followSymlink: false);
 
             if (result < 0)
             {

--- a/Public/Src/Utilities/Native/IO/Unix/FileUtilities.Unix.cs
+++ b/Public/Src/Utilities/Native/IO/Unix/FileUtilities.Unix.cs
@@ -668,6 +668,7 @@ namespace BuildXL.Native.IO.Unix
                 currentPermissions &= ~permissions;
             }
 
+            // don't follow symlinks because if we do that we may end up modifying source files via symlink outputs
             result = SetFilePermissionsForFilePath(path, currentPermissions, followSymlink: false);
 
             if (result < 0)


### PR DESCRIPTION
  - check if file has write permissions before attempting to set xattrs
  - log more information with setting/getting xattrs fails

[AB#1607996](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1607996)