### PR TITLE
Consider user profile redirection for MSBuild frontend

### DIFF
--- a/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
+++ b/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
@@ -715,10 +715,6 @@ namespace BuildXL.FrontEnd.MsBuild
 
         private void SetUntrackedFilesAndDirectories(ProcessBuilder processBuilder)
         {
-            // On some machines, the current user and public user desktop.ini are read by Powershell.exe.
-            // Ignore accesses to the user profile and Public common user profile.
-            processBuilder.AddUntrackedDirectoryScope(DirectoryArtifact.CreateWithZeroPartialSealId(PathTable, SpecialFolderUtilities.GetFolderPath(Environment.SpecialFolder.UserProfile)));
-
             if (Engine.TryGetBuildParameter("PUBLIC", m_frontEndName, out string publicDir))
             {             
                 processBuilder.AddUntrackedDirectoryScope(DirectoryArtifact.CreateWithZeroPartialSealId(AbsolutePath.Create(PathTable, publicDir)));

--- a/Public/Src/FrontEnd/Utilities/ValidAbsolutePathEnumerationJsonConverter.cs
+++ b/Public/Src/FrontEnd/Utilities/ValidAbsolutePathEnumerationJsonConverter.cs
@@ -14,6 +14,12 @@ namespace BuildXL.FrontEnd.Utilities
     public class ValidAbsolutePathEnumerationJsonConverter : ReadOnlyJsonConverter<IEnumerable<AbsolutePath>>
     {
         /// <nodoc/>
+        public static ValidAbsolutePathEnumerationJsonConverter Instance = new ValidAbsolutePathEnumerationJsonConverter();
+
+        private ValidAbsolutePathEnumerationJsonConverter()
+        { }
+
+        /// <nodoc/>
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
             var ret = new List<AbsolutePath>();


### PR DESCRIPTION
The user profile can be configured to be redirected so it looks uniform across machines and therefore shared cache scenarios are supported. MSBuild manages to workaround the env var redirection that buildxl implements and gets to the real user profile. This PR catches those cases after MSBuild static graph construction and relocate those paths appropriately.