### PR TITLE
Revert untracking the user profile to what it was before #1032

### DIFF
--- a/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
+++ b/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
@@ -715,6 +715,10 @@ namespace BuildXL.FrontEnd.MsBuild
 
         private void SetUntrackedFilesAndDirectories(ProcessBuilder processBuilder)
         {
+            // On some machines, the current user and public user desktop.ini are read by Powershell.exe.
+            // Ignore accesses to the user profile and Public common user profile.
+            processBuilder.AddUntrackedDirectoryScope(DirectoryArtifact.CreateWithZeroPartialSealId(PathTable, SpecialFolderUtilities.GetFolderPath(Environment.SpecialFolder.UserProfile)));
+
             if (Engine.TryGetBuildParameter("PUBLIC", m_frontEndName, out string publicDir))
             {             
                 processBuilder.AddUntrackedDirectoryScope(DirectoryArtifact.CreateWithZeroPartialSealId(AbsolutePath.Create(PathTable, publicDir)));

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/ExecutionTests/MsBuildGraphConstructionTests.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/ExecutionTests/MsBuildGraphConstructionTests.cs
@@ -237,8 +237,9 @@ namespace Test.BuildXL.FrontEnd.MsBuild
                     .RetrievePipsOfType(PipType.Process)
                     .Single(p => RetrieveProcessArguments((Process)p).Contains(SpecialFolderUtilities.GetFolderPath(Environment.SpecialFolder.UserProfile)));
 
-                // There should be a statically declared input for test.csproj under the redirected profile
-                Assert.Equal(1, testProj.Dependencies.Count(input => 
+                // There shouldn't be a statically declared input for test.csproj under the redirected profile since the user profile has a corresponding mount
+                // with hash source file disabled, so static declarations under it are skipped. But so the declaration was properly redirected
+                Assert.False(testProj.Dependencies.Any(input => 
                     input.Path.IsWithin(PathTable, redirectedProfile) && 
                     input.Path.GetName(PathTable) == PathAtom.Create(StringTable, "test.csproj"))
                     );


### PR DESCRIPTION
The user profile is automatically associated with a system mount with hashSourFile: false. So even though the redirected profile under MSBuild is now honored, we still want to untrack the user profile so we don't add any static inputs under it.