### PR TITLE
Bump fingerprint version

### DIFF
--- a/Public/Src/Engine/Scheduler/Fingerprints/PipFingerprintingVersion.cs
+++ b/Public/Src/Engine/Scheduler/Fingerprints/PipFingerprintingVersion.cs
@@ -36,7 +36,8 @@ namespace BuildXL.Scheduler.Fingerprints
         /// 60: Save AbsolutePath in the StaticOutputHashes
         /// 62: FileContentInfo - change how length/existence is stored.
         /// 63: IncrementalTool - change reparsepoint probes and enumeration probes to read.
+        /// 65: 64 is already used since 20190903; change in UnsafeOption serialization (partial preserve outputs)
         /// </remarks>
-        TwoPhaseV2 = 64,
+        TwoPhaseV2 = 65,
     }
 }


### PR DESCRIPTION
Need to bump the version due to PR #1009 (it's changed the Unsafe options inside the pathset)