### PR TITLE
TEST (Will not complete)

### DIFF
--- a/Public/Src/Cache/MemoizationStore/Library/Sessions/OneLevelCache.cs
+++ b/Public/Src/Cache/MemoizationStore/Library/Sessions/OneLevelCache.cs
@@ -245,7 +245,7 @@ namespace BuildXL.Cache.MemoizationStore.Sessions
                 var createMemoizationResult = MemoizationStore.CreateReadOnlySession(context, name);
                 if (!createMemoizationResult.Succeeded)
                 {
-                    return new CreateSessionResult<IReadOnlyCacheSession>(createContentResult, "Memoization session creation failed");
+                    return new CreateSessionResult<IReadOnlyCacheSession>(createMemoizationResult, "Memoization session creation failed");
                 }
                 var memoizationReadOnlySession = createMemoizationResult.Session;
 


### PR DESCRIPTION
In order to preserve the provenance of the error, the right variable should be passed to the result if `MemoizationStore.CreateReadOnlySession` fails.