### PR TITLE
Untrack generated nuget props files for MSBuild-scheduled pips

### DIFF
--- a/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
+++ b/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
@@ -330,6 +330,16 @@ namespace BuildXL.FrontEnd.MsBuild
                     continue;
                 }
 
+                // Nuget restore generates nuget.g.props files that have absolute paths embedded. This blocks shared cache from working when
+                // the project file (and therefore the corresponding .pkgrefgen folder) is placed on machine-dependent folders
+                // Even though untracking this file is not completely safe from a caching perspective, in practice this should be harmless
+                // In this case, we not only skip declaring it as an input, but we also untrack it as well
+                if (buildInput.GetName(PathTable).ToString(PathTable.StringTable).EndsWith("nuget.g.props", StringComparison.OrdinalIgnoreCase))
+                {
+                    processBuilder.AddUntrackedFile(buildInput);
+                    continue;
+                }
+
                 // If any of the predicted inputs is under an untracked directory scope, don't add it as an input
                 if (processBuilder.GetUntrackedDirectoryScopesSoFar().Any(untrackedDirectory => buildInput.IsWithin(PathTable, untrackedDirectory)))
                 {

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/SchedulingTests/MsBuildInputOutputTests.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/SchedulingTests/MsBuildInputOutputTests.cs
@@ -139,6 +139,21 @@ namespace Test.BuildXL.FrontEnd.MsBuild
             XAssert.Equals("input2.txt", input.Path.GetName(PathTable).ToString(PathTable.StringTable));
         }
 
+        [Fact]
+        public void GeneratedNugetPropFilesAreUntracked()
+        {
+            var project = CreateProjectWithPredictions(inputs: CreatePath(@"aPath\Project.csproj.nuget.g.props"));
+
+            var processInputs = Start()
+                .Add(project)
+                .ScheduleAll()
+                .RetrieveSuccessfulProcess(project)
+                .Dependencies;
+
+            // The only source file should be MSBuild.exe
+            processInputs.Single(i => (i.IsSourceFile && i.Path.GetName(PathTable) == PathAtom.Create(StringTable, "MSBuild.exe")));
+        }
+
         private IReadOnlyCollection<AbsolutePath> CreatePath(params string[] paths)
         {
             return paths.Select(path => TestPath.Combine(PathTable, RelativePath.Create(PathTable.StringTable, path))).ToList();


### PR DESCRIPTION
Nuget restore generates nuget.g.props files with absolute paths embedded. This blocks shared cache from working on machines were those paths are not uniform. This PR makes the MSBuild pip construction process to untrack those.