### PR TITLE
Retry when pipe is busy on inheritable pipe creations

### DIFF
--- a/Public/Src/Utilities/Native/IO/NativeIOConstants.cs
+++ b/Public/Src/Utilities/Native/IO/NativeIOConstants.cs
@@ -180,6 +180,11 @@ namespace BuildXL.Native.IO
         /// </summary>
         public const int ErrorTimeout = 0x5B4;
 
+        /// <summary> 
+        /// ERROR_PIPE_BUSY. 
+        /// </summary> 
+        public const int ErrorPipeBusy = 0xE7;
+
         /// <summary>
         /// Infinite timeout.
         /// </summary>

--- a/Public/Src/Utilities/Native/Processes/IProcessUtilities.cs
+++ b/Public/Src/Utilities/Native/Processes/IProcessUtilities.cs
@@ -84,6 +84,9 @@ namespace BuildXL.Native.Processes
         /// <summary><see cref="ProcessUtilities.CreateNamedPipe"/></summary>
         SafeFileHandle CreateNamedPipe(string lpName, PipeOpenMode dwOpenMode, PipeMode dwPipeMode, int nMaxInstances, int nOutBufferSize, int nInBufferSize, int nDefaultTimeout, IntPtr lpSecurityAttributes);
 
+        /// <summary><see cref="ProcessUtilities.WaitNamedPipe"/></summary>
+        bool WaitNamedPipe(string pipeName, uint timeout);
+
         /// <summary><see cref="ProcessUtilities.ApplyDriveMappings"/></summary>
         bool ApplyDriveMappings(PathMapping[] mappings);
 

--- a/Public/Src/Utilities/Native/Processes/ProcessUtilities.cs
+++ b/Public/Src/Utilities/Native/Processes/ProcessUtilities.cs
@@ -214,6 +214,9 @@ namespace BuildXL.Native.Processes
             => s_nativeMethods.CreateNamedPipe(lpName, dwOpenMode, dwPipeMode, nMaxInstances, nOutBufferSize, nInBufferSize, nDefaultTimeout, lpSecurityAttributes);
 
         /// <nodoc />
+        public static bool WaitNamedPipe(string pipeName, uint timeout) => s_nativeMethods.WaitNamedPipe(pipeName, timeout);
+
+        /// <nodoc />
         public static bool ApplyDriveMappings(PathMapping[] mappings)
             => s_nativeMethods.ApplyDriveMappings(mappings);
 

--- a/Public/Src/Utilities/Native/Processes/Unix/ProcessUtilities.Unix.cs
+++ b/Public/Src/Utilities/Native/Processes/Unix/ProcessUtilities.Unix.cs
@@ -139,6 +139,9 @@ namespace BuildXL.Native.Processes.Unix
             => throw new NotImplementedException();
 
         /// <inheritdoc />
+        public bool WaitNamedPipe(string pipeName, uint timeout) => throw new NotImplementedException();
+
+        /// <inheritdoc />
         public bool ApplyDriveMappings(PathMapping[] mappings)
             => throw new NotImplementedException();
 

--- a/Public/Src/Utilities/Native/Processes/Windows/ProcessUtilities.Win.cs
+++ b/Public/Src/Utilities/Native/Processes/Windows/ProcessUtilities.Win.cs
@@ -397,7 +397,7 @@ namespace BuildXL.Native.Processes.Windows
 
         [DllImport(ExternDll.Kernel32, EntryPoint = "WaitNamedPipe", CharSet = CharSet.Unicode, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool ExternWaitNamedPipe(string pipeName, uint timeout);
+        private static extern bool ExternWaitNamedPipe(string pipeName, uint timeout);
 
         [DllImport(ExternDll.BuildXLNatives64, EntryPoint = "RemapDevices", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]

--- a/Public/Src/Utilities/Native/Processes/Windows/ProcessUtilities.Win.cs
+++ b/Public/Src/Utilities/Native/Processes/Windows/ProcessUtilities.Win.cs
@@ -241,6 +241,9 @@ namespace BuildXL.Native.Processes.Windows
             => ExternCreateNamedPipe(lpName, dwOpenMode, dwPipeMode, nMaxInstances, nOutBufferSize, nInBufferSize, nDefaultTimeout, lpSecurityAttributes);
 
         /// <inheritdoc />
+        public bool WaitNamedPipe(string pipeName, uint timeout) => ExternWaitNamedPipe(pipeName, timeout);
+
+        /// <inheritdoc />
         public bool ApplyDriveMappings(PathMapping[] mappings)
         {
             Assert64Process();
@@ -391,6 +394,10 @@ namespace BuildXL.Native.Processes.Windows
             int nInBufferSize,
             int nDefaultTimeout,
             IntPtr lpSecurityAttributes);
+
+        [DllImport(ExternDll.Kernel32, EntryPoint = "WaitNamedPipe", CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool ExternWaitNamedPipe(string pipeName, uint timeout);
 
         [DllImport(ExternDll.BuildXLNatives64, EntryPoint = "RemapDevices", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]


### PR DESCRIPTION
The root cause of the bug is still unknown.

This change doesn't solve the bug, but try to address it by retry. If, after retry, the bug still occurs, then we will reach out to the Windows team.

[AB#1614763](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1614763)