### PR TITLE
Implement slow reconciliation

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabase.cs
@@ -291,7 +291,14 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         /// <summary>
         /// Enumeration filter used by <see cref="ContentLocationDatabase.EnumerateEntriesWithSortedKeys"/> to filter out entries by raw value from a database.
         /// </summary>
-        public delegate bool EnumerationFilter(byte[] value);
+        public class EnumerationFilter
+        {
+            /// <nodoc />
+            public Func<byte[], bool> ShouldEnumerate { get; set; }
+
+            /// <nodoc />
+            public ShortHash? StartingPoint { get; set; }
+        }
 
         /// <nodoc />
         protected abstract IEnumerable<(ShortHash key, ContentLocationEntry entry)> EnumerateEntriesWithSortedKeysFromStorage(

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/EventStreaming/ContentLocationEventStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/EventStreaming/ContentLocationEventStore.cs
@@ -373,7 +373,8 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache.EventStreaming
                         _fileSystem.DeleteFile(reconcileFilePath);
                     }
                 },
-                Counters[PublishReconcile]);
+                Counters[PublishReconcile],
+                extraEndMessage: _ => $"AddedContent={addedContent.Count}, RemovedContent={removedContent.Count}, TotalContent={addedContent.Count + removedContent.Count}");
         }
 
         /// <summary>

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/InMemory/MemoryContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/InMemory/MemoryContentLocationDatabase.cs
@@ -87,13 +87,11 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache.InMemory
             CancellationToken token,
             EnumerationFilter filter = null)
         {
-            foreach (var kvp in _map)
-            {
-                if (filter == null || filter(SerializeContentLocationEntry(kvp.Value)))
-                {
-                    yield return (kvp.Key, kvp.Value);
-                }
-            }
+            return _map
+                .OrderBy(kvp => kvp.Key)
+                .SkipWhile(kvp => filter?.StartingPoint != null && filter.StartingPoint > kvp.Key)
+                .Where(kvp => filter?.ShouldEnumerate == null || filter.ShouldEnumerate?.Invoke(SerializeContentLocationEntry(kvp.Value)) == true)
+                .Select(kvp => (kvp.Key, kvp.Value));
         }
 
         /// <inheritdoc />

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
@@ -1210,7 +1210,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                             var allLocalStoreContent = allLocalStoreContentInfos
                                 .Select(c => (hash: new ShortHash(c.ContentHash), size: c.Size))
                                 .OrderBy(c => c.hash)
-                                .SkipWhile(hashWithSize => hashWithSize.hash < lastProcessedHash)
+                                .SkipWhile(hashWithSize => lastProcessedHash.HasValue && hashWithSize.hash < lastProcessedHash.Value)
                                 .ToList();
 
                             allLocalStoreContentCount = allLocalStoreContent.Count;
@@ -1244,6 +1244,8 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
 
                             Counters[ContentLocationStoreCounters.Reconcile_AddedContent].Add(addedContent.Count);
                             Counters[ContentLocationStoreCounters.Reconcile_RemovedContent].Add(removedContent.Count);
+                            totalAddedContent += addedContent.Count;
+                            totalRemovedContent += removedContent.Count;
 
                             // Only call reconcile if content needs to be updated for machine
                             if (addedContent.Count != 0 || removedContent.Count != 0)

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
@@ -1187,67 +1187,95 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
 
                     token.ThrowIfCancellationRequested();
 
-                    // Pause events in main event store while sending reconciliation events via temporary event store
-                    // to ensure reconciliation does cause some content to be lost due to apply reconciliation changes
-                    // in the wrong order. For instance, if a machine has content [A] and [A] is removed during reconciliation.
-                    // It is possible that remove event could be sent before reconciliation event and the final state
-                    // in the database would still have missing content [A].
-                    using (EventStore.PauseSendingEvents())
+                    var totalAddedContent = 0;
+                    var totalRemovedContent = 0;
+                    var allLocalStoreContentCount = 0;
+                    ShortHash? lastProcessedHash = null;
+                    var isFinished = false;
+
+                    while (!isFinished)
                     {
-                        var allLocalStoreContentInfos = await _localContentStore.GetContentInfoAsync(token);
-                        token.ThrowIfCancellationRequested();
+                        var delayTask = Task.Delay(_configuration.ReconciliationCycleFrequency);
 
-                        var allLocalStoreContent = allLocalStoreContentInfos.Select(c => (hash: new ShortHash(c.ContentHash), size: c.Size)).OrderBy(c => c.hash).ToList();
-
-                        var dbContent = Database.EnumerateSortedHashesWithContentSizeForMachineId(context, LocalMachineId);
-                        token.ThrowIfCancellationRequested();
-
-                        // Diff the two views of the local machines content (left = local store, right = content location db)
-                        // Then send changes as events
-                        var diffedContent = NuCacheCollectionUtilities.DistinctDiffSorted(leftItems: allLocalStoreContent, rightItems: dbContent, t => t.hash);
-
-                        var addedContent = new List<ShortHashWithSize>();
-                        var removedContent = new List<ShortHash>();
-
-                        foreach (var diffItem in diffedContent)
+                        // Pause events in main event store while sending reconciliation events via temporary event store
+                        // to ensure reconciliation does cause some content to be lost due to apply reconciliation changes
+                        // in the wrong order. For instance, if a machine has content [A] and [A] is removed during reconciliation.
+                        // It is possible that remove event could be sent before reconciliation event and the final state
+                        // in the database would still have missing content [A].
+                        using (EventStore.PauseSendingEvents())
                         {
-                            if (diffItem.mode == MergeMode.LeftOnly)
+                            var allLocalStoreContentInfos = await _localContentStore.GetContentInfoAsync(token);
+                            token.ThrowIfCancellationRequested();
+
+                            var allLocalStoreContent = allLocalStoreContentInfos
+                                .Select(c => (hash: new ShortHash(c.ContentHash), size: c.Size))
+                                .OrderBy(c => c.hash)
+                                .SkipWhile(hashWithSize => hashWithSize.hash < lastProcessedHash)
+                                .ToList();
+
+                            allLocalStoreContentCount = allLocalStoreContent.Count;
+
+                            var dbContent = Database.EnumerateSortedHashesWithContentSizeForMachineId(context, LocalMachineId, startingPoint: lastProcessedHash);
+                            token.ThrowIfCancellationRequested();
+
+                            // Diff the two views of the local machines content (left = local store, right = content location db)
+                            // Then send changes as events
+                            var diffedContent = NuCacheCollectionUtilities.DistinctDiffSorted(leftItems: allLocalStoreContent, rightItems: dbContent, t => t.hash);
+                            diffedContent = diffedContent.Take(_configuration.ReconciliationMaxCycleSize);
+
+                            var addedContent = new List<ShortHashWithSize>();
+                            var removedContent = new List<ShortHash>();
+
+                            foreach (var diffItem in diffedContent)
                             {
-                                // Content is not in DB but is in the local store need to send add event
-                                addedContent.Add(new ShortHashWithSize(diffItem.item.hash, diffItem.item.size));
+                                lastProcessedHash = diffItem.item.hash;
+
+                                if (diffItem.mode == MergeMode.LeftOnly)
+                                {
+                                    // Content is not in DB but is in the local store need to send add event
+                                    addedContent.Add(new ShortHashWithSize(diffItem.item.hash, diffItem.item.size));
+                                }
+                                else
+                                {
+                                    // Content is in DB but is not local store need to send remove event
+                                    removedContent.Add(diffItem.item.hash);
+                                }
                             }
-                            else
+
+                            Counters[ContentLocationStoreCounters.Reconcile_AddedContent].Add(addedContent.Count);
+                            Counters[ContentLocationStoreCounters.Reconcile_RemovedContent].Add(removedContent.Count);
+
+                            // Only call reconcile if content needs to be updated for machine
+                            if (addedContent.Count != 0 || removedContent.Count != 0)
                             {
-                                // Content is in DB but is not local store need to send remove event
-                                removedContent.Add(diffItem.item.hash);
+                                // Create separate event store for reconciliation events so they are dispatched first before
+                                // events in normal event store which may be queued during reconciliation operation.
+                                var reconciliationEventStore = CreateEventStore(_configuration);
+
+                                try
+                                {
+                                    await reconciliationEventStore.StartupAsync(context).ThrowIfFailure();
+
+                                    await reconciliationEventStore.ReconcileAsync(context, LocalMachineId, addedContent, removedContent).ThrowIfFailure();
+                                }
+                                finally
+                                {
+                                    await reconciliationEventStore.ShutdownAsync(context).ThrowIfFailure();
+                                }
                             }
+
+                            // Corner case where they are equal and we have finished should be very unlikely.
+                            isFinished = (addedContent.Count + removedContent.Count) != _configuration.ReconciliationMaxCycleSize;
                         }
 
-                        Counters[ContentLocationStoreCounters.Reconcile_AddedContent].Add(addedContent.Count);
-                        Counters[ContentLocationStoreCounters.Reconcile_RemovedContent].Add(removedContent.Count);
-
-                        // Only call reconcile if content needs to be updated for machine
-                        if (addedContent.Count != 0 || removedContent.Count != 0)
+                        if (!isFinished)
                         {
-                            // Create separate event store for reconciliation events so they are dispatched first before
-                            // events in normal event store which may be queued during reconciliation operation.
-                            var reconciliationEventStore = CreateEventStore(_configuration);
-
-                            try
-                            {
-                                await reconciliationEventStore.StartupAsync(context).ThrowIfFailure();
-
-                                await reconciliationEventStore.ReconcileAsync(context, LocalMachineId, addedContent, removedContent).ThrowIfFailure();
-                            }
-                            finally
-                            {
-                                await reconciliationEventStore.ShutdownAsync(context).ThrowIfFailure();
-                            }
+                            await delayTask;
                         }
-
-                        MarkReconciled();
-                        return new ReconciliationResult(addedCount: addedContent.Count, removedCount: removedContent.Count, totalLocalContentCount: allLocalStoreContent.Count);
                     }
+
+                    MarkReconciled();
+                    return new ReconciliationResult(addedCount: totalAddedContent, removedCount: totalRemovedContent, totalLocalContentCount: allLocalStoreContentCount);
                 },
                 Counters[ContentLocationStoreCounters.Reconcile]);
         }

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
@@ -1197,6 +1197,8 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                     {
                         var delayTask = Task.Delay(_configuration.ReconciliationCycleFrequency);
 
+                        Counters[ContentLocationStoreCounters.ReconciliationCycles].Increment();
+
                         // Pause events in main event store while sending reconciliation events via temporary event store
                         // to ensure reconciliation does cause some content to be lost due to apply reconciliation changes
                         // in the wrong order. For instance, if a machine has content [A] and [A] is removed during reconciliation.

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
@@ -1267,7 +1267,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                             }
 
                             // Corner case where they are equal and we have finished should be very unlikely.
-                            isFinished = (addedContent.Count + removedContent.Count) != _configuration.ReconciliationMaxCycleSize;
+                            isFinished = (addedContent.Count + removedContent.Count) < _configuration.ReconciliationMaxCycleSize;
                         }
 
                         if (!isFinished)

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStoreConfiguration.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStoreConfiguration.cs
@@ -158,6 +158,16 @@ namespace BuildXL.Cache.ContentStore.Distributed
         public bool InlinePostInitialization { get; set; }
 
         /// <summary>
+        /// The frequency by which reconciliation cycles should be done.
+        /// </summary>
+        public TimeSpan ReconciliationCycleFrequency { get; set; } = TimeSpan.FromMinutes(30);
+
+        /// <summary>
+        /// The amount of events that should be sent per reconciliation cycle.
+        /// </summary>
+        public int ReconciliationMaxCycleSize { get; set; } = 100000;
+
+        /// <summary>
         /// Gets prefix used for checkpoints key which uniquely identifies a checkpoint lineage (i.e. changing this value indicates
         /// all prior checkpoints/cluster state are discarded and a new set of checkpoints is created)
         /// </summary>

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/RocksDbContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/RocksDbContentLocationDatabase.cs
@@ -467,7 +467,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         {
             var keyBuffer = new List<(ShortHash key, ContentLocationEntry entry)>();
             const int KeysChunkSize = 100000;
-            var startValue = filter?.StartingPoint?.Value.ToByteArray();
+            var startValue = filter?.StartingPoint?.ToByteArray();
             while (!token.IsCancellationRequested)
             {
                 keyBuffer.Clear();

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/RocksDbContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/RocksDbContentLocationDatabase.cs
@@ -467,7 +467,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         {
             var keyBuffer = new List<(ShortHash key, ContentLocationEntry entry)>();
             const int KeysChunkSize = 100000;
-            byte[] startValue = null;
+            var startValue = filter?.StartingPoint?.Value.ToByteArray();
             while (!token.IsCancellationRequested)
             {
                 keyBuffer.Clear();
@@ -495,7 +495,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
 
                                     startValue = null;
                                     byte[] value = null;
-                                    if (filter != null && filter(value = iterator.Value()))
+                                    if (filter?.ShouldEnumerate?.Invoke(value = iterator.Value()) == true)
                                     {
                                         keyBuffer.Add((DeserializeKey(key ?? iterator.Key()), DeserializeContentLocationEntry(value)));
                                     }

--- a/Public/Src/Cache/ContentStore/Distributed/Redis/ContentLocationStoreCounters.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Redis/ContentLocationStoreCounters.cs
@@ -154,5 +154,8 @@ namespace BuildXL.Cache.ContentStore.Distributed.Redis
 
         /// <nodoc />
         IncrementalCheckpointFilesUploadSkipped,
+
+        /// <nodoc />
+        ReconciliationCycles,
     }
 }

--- a/Public/Src/Cache/ContentStore/Hashing/ShortHash.cs
+++ b/Public/Src/Cache/ContentStore/Hashing/ShortHash.cs
@@ -65,6 +65,12 @@ namespace BuildXL.Cache.ContentStore.Hashing
         public static bool operator !=(ShortHash left, ShortHash right) => !left.Equals(right);
 
         /// <nodoc />
+        public static bool operator <(ShortHash left, ShortHash right) => left.CompareTo(right) < 0;
+
+        /// <nodoc />
+        public static bool operator >(ShortHash left, ShortHash right) => left.CompareTo(right) > 0;
+
+        /// <nodoc />
         public static implicit operator ShortHash(ContentHash hash) => new ShortHash(hash);
 
         /// <nodoc />

--- a/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
@@ -388,6 +388,12 @@ namespace BuildXL.Cache.Host.Configuration
         public bool Unsafe_DisableReconciliation { get; set; } = false;
 
         [DataMember]
+        public int ReconciliationCycleFrequencyMinutes { get; set; } = 30;
+
+        [DataMember]
+        public int ReconciliationMaxCycleSize { get; set; } = 100000;
+
+        [DataMember]
         public bool IsContentLocationDatabaseEnabled { get; set; } = false;
 
         [DataMember]

--- a/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
@@ -314,6 +314,9 @@ namespace BuildXL.Cache.Host.Service.Internal
 
             configuration.EnableReconciliation = !_distributedSettings.Unsafe_DisableReconciliation;
 
+            configuration.ReconciliationCycleFrequency = TimeSpan.FromMinutes(_distributedSettings.ReconciliationCycleFrequencyMinutes);
+            configuration.ReconciliationMaxCycleSize = _distributedSettings.ReconciliationMaxCycleSize;
+
             ApplyIfNotNull(_distributedSettings.UseIncrementalCheckpointing, value => configuration.Checkpoint.UseIncrementalCheckpointing = value);
             ApplyIfNotNull(_distributedSettings.IncrementalCheckpointDegreeOfParallelism, value => configuration.Checkpoint.IncrementalCheckpointDegreeOfParallelism = value);
 


### PR DESCRIPTION
Reconciliation when resetting epoch is overloading the master in some cases. Implementing slow reconciliation so that we do this over a large period of time and take load off the master.