### PR TITLE
Ignore files under .pkgrefgen for msbuild-scheduled pips

### DIFF
--- a/Public/Src/FrontEnd/UnitTests/MsBuild/SchedulingTests/MsBuildInputOutputTests.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/SchedulingTests/MsBuildInputOutputTests.cs
@@ -140,9 +140,9 @@ namespace Test.BuildXL.FrontEnd.MsBuild
         }
 
         [Fact]
-        public void GeneratedNugetPropFilesAreUntracked()
+        public void GeneratedNugetFilesAreUntracked()
         {
-            var project = CreateProjectWithPredictions(inputs: CreatePath(@"aPath\Project.csproj.nuget.g.props"));
+            var project = CreateProjectWithPredictions(inputs: CreatePath(@"aProject\.pkgrefgen\aFile", @"anotherProject\.pkrefgen\anotherFile"));
 
             var processInputs = Start()
                 .Add(project)


### PR DESCRIPTION
Nuget restore does not produce deterministic files under the project .pkgrefgen folder, and many times they have absolute paths embedded