### PR TITLE
Fallback logic for IsSharedOpaqueOutput on macOS

### DIFF
--- a/Public/Src/Engine/Processes/SharedOpaqueOutputHelper.cs
+++ b/Public/Src/Engine/Processes/SharedOpaqueOutputHelper.cs
@@ -104,7 +104,7 @@ namespace BuildXL.Processes
             private static extern int SetXattr(
                 [MarshalAs(UnmanagedType.LPStr)] string path,
                 [MarshalAs(UnmanagedType.LPStr)] string name,
-                void* value,
+                void *value,
                 ulong size,
                 uint position,
                 int options);
@@ -113,7 +113,7 @@ namespace BuildXL.Processes
             private static extern long GetXattr(
                 [MarshalAs(UnmanagedType.LPStr)] string path,
                 [MarshalAs(UnmanagedType.LPStr)] string name,
-                void* value,
+                void *value,
                 ulong size,
                 uint position,
                 int options);

--- a/Public/Src/Engine/Processes/SharedOpaqueOutputHelper.cs
+++ b/Public/Src/Engine/Processes/SharedOpaqueOutputHelper.cs
@@ -160,6 +160,7 @@ namespace BuildXL.Processes
             /// </summary>
             public static bool IsSharedOpaqueOutput(string expandedPath) => IsSharedOpaqueOutputWithFallback(expandedPath, checkFallback: true);
 
+            // TODO: delete the fallback logic after a successful transition from old to new logic
             private static bool IsSharedOpaqueOutputWithFallback(string expandedPath, bool checkFallback)
             {
                 long value = 0;

--- a/Public/Src/Engine/Processes/SharedOpaqueOutputHelper.cs
+++ b/Public/Src/Engine/Processes/SharedOpaqueOutputHelper.cs
@@ -91,10 +91,10 @@ namespace BuildXL.Processes
 
         private static unsafe class Unix
         {
-            private const string MY_XATTR_NAME = "com.microsoft.buildxl:shared_opaque_output";
+            private const string BXL_SHARED_OPAQUE_XATTR_NAME = "com.microsoft.buildxl:shared_opaque_output";
 
             // arbitrary value; in the future, we could store something more useful here (e.g., the producer PipId or something)
-            private const long MY_XATTR_VALUE = 42;
+            private const long BXL_SHARED_OPAQUE_XATTR_VALUE = 42;
 
             // from xattr.h:
             // #define XATTR_NOFOLLOW   0x0001     /* Don't follow symbolic links */
@@ -122,7 +122,7 @@ namespace BuildXL.Processes
 
             /// <summary>
             /// Flags the given path as being an output under a shared opaque by setting
-            /// <see cref="MY_XATTR_NAME"/> xattr to a <see cref="MY_XATTR_VALUE"/>.
+            /// <see cref="BXL_SHARED_OPAQUE_XATTR_NAME"/> xattr to a <see cref="BXL_SHARED_OPAQUE_XATTR_VALUE"/>.
             /// </summary>
             public static void SetPathAsSharedOpaqueOutput(string expandedPath)
             {
@@ -137,8 +137,8 @@ namespace BuildXL.Processes
                 }
 
                 // set xattr
-                long value = MY_XATTR_VALUE;
-                var err = SetXattr(expandedPath, MY_XATTR_NAME, &value, sizeof(long), 0, XATTR_NOFOLLOW);
+                long value = BXL_SHARED_OPAQUE_XATTR_VALUE;
+                var err = SetXattr(expandedPath, BXL_SHARED_OPAQUE_XATTR_NAME, &value, sizeof(long), 0, XATTR_NOFOLLOW);
                 var xattrErrorCode = err != 0 ? Marshal.GetLastWin32Error() : 0;
 
                 // reset permissions if we changed them
@@ -150,13 +150,13 @@ namespace BuildXL.Processes
                 // throw if neither SetXattr succeeded nor the path is properly marked
                 if (xattrErrorCode != 0 && !IsSharedOpaqueOutputWithFallback(expandedPath, checkFallback: false))
                 {
-                    throw new BuildXLException(I($"Failed to set '{MY_XATTR_NAME}' extended attribute for file '{expandedPath}'. Error: {xattrErrorCode}."));
+                    throw new BuildXLException(I($"Failed to set '{BXL_SHARED_OPAQUE_XATTR_NAME}' extended attribute for file '{expandedPath}'. Error: {xattrErrorCode}."));
                 }
             }
 
             /// <summary>
             /// Checks if the given path is an output under a shared opaque by checking if
-            /// it contains extended attribute by <see cref="MY_XATTR_NAME"/> name.
+            /// it contains extended attribute by <see cref="BXL_SHARED_OPAQUE_XATTR_NAME"/> name.
             /// </summary>
             public static bool IsSharedOpaqueOutput(string expandedPath) => IsSharedOpaqueOutputWithFallback(expandedPath, checkFallback: true);
 
@@ -165,8 +165,8 @@ namespace BuildXL.Processes
             {
                 long value = 0;
                 uint valueSize = sizeof(long);
-                var resultSize = GetXattr(expandedPath, MY_XATTR_NAME, &value, valueSize, 0, XATTR_NOFOLLOW);
-                if (resultSize == valueSize && value == MY_XATTR_VALUE)
+                var resultSize = GetXattr(expandedPath, BXL_SHARED_OPAQUE_XATTR_NAME, &value, valueSize, 0, XATTR_NOFOLLOW);
+                if (resultSize == valueSize && value == BXL_SHARED_OPAQUE_XATTR_VALUE)
                 {
                     return true;
                 }


### PR DESCRIPTION
The fallback logic means checking creation timestamp in addition to checking extended attributes.

This should accommodate smoothly transitioning between older versions (which used creation timestamps only) and newer versions (which use extended attributes).