### PR TITLE
Do not consider qualifiers when building the log path for MSBuild-scheduled pips

### DIFF
--- a/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
+++ b/Public/Src/FrontEnd/MsBuild/PipConstructor.cs
@@ -226,7 +226,7 @@ namespace BuildXL.FrontEnd.MsBuild
             using (var processBuilder = ProcessBuilder.Create(PathTable, m_context.GetPipDataBuilder()))
             {
                 // Configure the process to add an assortment of settings: arguments, response file, etc.
-                if (!TryConfigureProcessBuilder(processBuilder, pipConstructionHelper, project, qualifierId, out AbsolutePath outputResultCacheFile, out failureDetail))
+                if (!TryConfigureProcessBuilder(processBuilder, pipConstructionHelper, project, out AbsolutePath outputResultCacheFile, out failureDetail))
                 {
                     scheduledProcess = null;
                     return false;
@@ -499,7 +499,6 @@ namespace BuildXL.FrontEnd.MsBuild
             ProcessBuilder processBuilder, 
             PipConstructionHelper pipConstructionHelper, 
             ProjectWithPredictions project,
-            QualifierId qualifierId,
             out AbsolutePath outputResultCacheFile,
             out string failureDetail)
         {
@@ -533,8 +532,7 @@ namespace BuildXL.FrontEnd.MsBuild
             SetUntrackedFilesAndDirectories(processBuilder);
 
             // Add the log directory and its corresponding files
-            var qualifier = m_context.QualifierTable.GetQualifier(qualifierId);
-            AbsolutePath logDirectory = GetLogDirectory(project, qualifier);
+            AbsolutePath logDirectory = GetLogDirectory(project);
             processBuilder.AddOutputFile(logDirectory.Combine(PathTable, "msbuild.log"), FileExistence.Optional);
             processBuilder.AddOutputFile(logDirectory.Combine(PathTable, "msbuild.wrn"), FileExistence.Optional);
             processBuilder.AddOutputFile(logDirectory.Combine(PathTable, "msbuild.err"), FileExistence.Optional);
@@ -746,7 +744,7 @@ namespace BuildXL.FrontEnd.MsBuild
             }
         }
 
-        private AbsolutePath GetLogDirectory(ProjectWithPredictions projectFile, Qualifier qualifier)
+        private AbsolutePath GetLogDirectory(ProjectWithPredictions projectFile)
         {
             var success = Root.TryGetRelative(PathTable, projectFile.FullPath, out var inFolderPathFromEnlistmentRoot);
             Contract.Assert(success);
@@ -759,12 +757,11 @@ namespace BuildXL.FrontEnd.MsBuild
                 .Combine(PathTable, "MSBuild")
                 .Combine(PathTable, inFolderPathFromEnlistmentRoot);
 
-            // Build a string with just the qualifier and global property values (e.g. 'debug-x86'). That should be unique enough.
-            // Projects can be evaluated multiple times with different global properties (but same qualifiers), so just
-            // the qualifier name is not enough
-            List<string> values = qualifier.Values.Select(value => value.ToString(m_context.StringTable))
-                .Union(projectFile.GlobalProperties.Where(kvp => kvp.Key != s_isGraphBuildProperty).Select(kvp => kvp.Value))
-                .Select(value => PipConstructionUtilities.SanitizeStringForSymbol(value))
+            // Build a string with global property values (e.g. 'debug-x86'). That should be unique enough.
+            // Projects can be evaluated multiple times with different global properties
+            List<string> values = projectFile.GlobalProperties
+                .Where(kvp => kvp.Key != s_isGraphBuildProperty)
+                .Select(kvp => PipConstructionUtilities.SanitizeStringForSymbol(kvp.Value))
                 .OrderBy(value => value, StringComparer.Ordinal) // Let's make sure we always produce the same string for the same set of values
                 .ToList();
 

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/SchedulingTests/MsBuildProcessBuilderTests.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/SchedulingTests/MsBuildProcessBuilderTests.cs
@@ -149,6 +149,25 @@ namespace Test.BuildXL.FrontEnd.MsBuild
             Assert.True(key1Key2Project.FileOutputs.SequenceEqual(key2Key1Project.FileOutputs));
         }
 
+        [Fact]
+        public void QualifierDoesNotAffectLogDirectory()
+        {
+            var project1 = CreateProjectWithPredictions("Test.proj", 
+                globalProperties: new GlobalProperties(new Dictionary<string, string> { ["TargetFramework"] = "net472" }));
+            var project2 = CreateProjectWithPredictions("Test.proj");
+
+            var targetFrameworkQualifier = FrontEndContext.QualifierTable.CreateQualifier(
+                new Tuple<StringId, StringId>(StringId.Create(StringTable, "TargetFramework"), StringId.Create(StringTable, "net472")));
+
+            // If the qualifier was affecting the log directory, the path to the log file for both projects would be the same, and therefore
+            // they should fail at scheduling.
+            Start(currentQualifier: targetFrameworkQualifier)
+                .Add(project1)
+                .Add(project2)
+                .ScheduleAll()
+                .AssertSuccess();
+        }
+
         [Theory]
         [InlineData(BuildEnvironmentConstants.MsPdbSrvEndpointEnvVar)]
         [InlineData(BuildEnvironmentConstants.MsBuildLogAsyncEnvVar)]


### PR DESCRIPTION
Global properties + path to project is enough for producing a unique log path. Adding the qualifier may cause projects that are actually not affected by a qualifier to clash with projects where the qualifier became part of its global properties.