### PR TITLE
Restore checkpoint in the background when current checkpoint is not old enough

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/CheckpointManager.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/CheckpointManager.cs
@@ -375,11 +375,11 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             }
             catch (Exception e)
             {
-                _tracer.Debug(context, $"Failed to write latest checkpoint state to disk: {e}");
+                _tracer.Warning(context, $"Failed to write latest checkpoint state to disk: {e}");
             }
         }
 
-        public (string id, DateTime checkpointTime)? GetLatestCheckpointInfo(OperationContext context)
+        public (string checkpointId, DateTime checkpointTime)? GetLatestCheckpointInfo(OperationContext context)
         {
             try
             {

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/CheckpointManager.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/CheckpointManager.cs
@@ -42,6 +42,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         private readonly AbsolutePath _checkpointStagingDirectory;
         private readonly AbsolutePath _incrementalCheckpointDirectory;
         private readonly AbsolutePath _incrementalCheckpointInfoFile;
+        private readonly AbsolutePath _lastCheckpointFile;
 
         private CounterCollection<ContentLocationStoreCounters> Counters { get; }
 
@@ -67,6 +68,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             _fileSystem = new PassThroughFileSystem();
             _checkpointStagingDirectory = configuration.WorkingDirectory / "staging";
             _incrementalCheckpointDirectory = configuration.WorkingDirectory / "incremental";
+            _lastCheckpointFile = configuration.WorkingDirectory / "lastCheckpoint.txt";
             _fileSystem.CreateDirectory(_incrementalCheckpointDirectory);
 
             _incrementalCheckpointInfoFile = _incrementalCheckpointDirectory / "checkpointInfo.txt";
@@ -300,9 +302,10 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         /// <summary>
         /// Restores the checkpoint for a given checkpoint id.
         /// </summary>
-        public Task<BoolResult> RestoreCheckpointAsync(OperationContext context, string checkpointId)
+        public Task<BoolResult> RestoreCheckpointAsync(OperationContext context, CheckpointState checkpointState)
         {
             context = context.CreateNested();
+            var checkpointId = checkpointState.CheckpointId;
             return context.PerformOperationAsync(
                 _tracer,
                 async () =>
@@ -344,7 +347,14 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                             }
 
                             // Restoring the checkpoint
-                            return _database.RestoreCheckpoint(context, extractedCheckpointDirectory);
+                            var result = _database.RestoreCheckpoint(context, extractedCheckpointDirectory);
+
+                            if (result)
+                            {
+                                WriteLatestCheckpointToFile(context, checkpointState);
+                            }
+
+                            return result;
                         }
                     }
                     finally
@@ -354,6 +364,36 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                 },
                 extraStartMessage: $"CheckpointId=[{checkpointId}]",
                 extraEndMessage: _ => $"CheckpointId=[{checkpointId}]");
+        }
+
+        private void WriteLatestCheckpointToFile(OperationContext context, CheckpointState checkpointState)
+        {
+            try
+            {
+                _fileSystem.WriteAllText(_lastCheckpointFile, $"{checkpointState.CheckpointId},{checkpointState.CheckpointTime}");
+            }
+            catch (Exception e)
+            {
+                _tracer.Debug(context, $"Failed to write latest checkpoint state to disk: {e}");
+            }
+        }
+
+        public (string id, DateTime checkpointTime)? GetLatestCheckpointInfo(OperationContext context)
+        {
+            try
+            {
+                var checkpointText = _fileSystem.ReadAllText(_lastCheckpointFile);
+                var segments = checkpointText.Split(',');
+                var id = segments[0];
+                var date = DateTime.Parse(segments[1]);
+
+                return (id, date);
+            }
+            catch (Exception e)
+            {
+                _tracer.Debug(context, $"Failed to read latest checkpoint state from disk: {e}");
+                return null;
+            }
         }
 
         private static void RestoreFullCheckpointAsync(AbsolutePath checkpointFile, AbsolutePath extractedCheckpointDirectory)

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/CheckpointManager.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/CheckpointManager.cs
@@ -351,6 +351,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
 
                             if (result)
                             {
+                                // Save latest checkpoint info to file in case we get restarded and want to know about the previous checkpoint.
                                 WriteLatestCheckpointToFile(context, checkpointState);
                             }
 

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
@@ -605,7 +605,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             if (!force)
             {
                 var latestCheckpoint = _checkpointManager.GetLatestCheckpointInfo(context);
-                var latestCheckpointAge = DateTime.UtcNow - latestCheckpoint?.checkpointTime;
+                var latestCheckpointAge = _clock.UtcNow - latestCheckpoint?.checkpointTime;
                 var shouldRestoreInBackground = latestCheckpointAge < _configuration.Checkpoint.RestoreCheckpointAgeThreshold;
 
                 if (shouldRestoreInBackground)

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
@@ -610,6 +610,11 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
 
                 if (shouldRestoreInBackground)
                 {
+                    if (latestCheckpointAge > _configuration.LocationEntryExpiry)
+                    {
+                        Tracer.Debug(context, $"Checkpoint {latestCheckpoint.Value.id} age is {latestCheckpointAge}, which is larger than location expiry {_configuration.LocationEntryExpiry}");
+                    }
+
                     RestoreCheckpointStateAsync(context, checkpointState, force: true).FireAndForget(context);
                     return BoolResult.Success;
                 }

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStoreConfiguration.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStoreConfiguration.cs
@@ -402,6 +402,11 @@ namespace BuildXL.Cache.ContentStore.Distributed
         /// </summary>
         public TimeSpan RestoreCheckpointInterval { get; set; } = TimeSpan.FromMinutes(10);
 
+        /// <summary>
+        /// Age threshold after which we should eagerly restore checkpoint blocking the caller.
+        /// </summary>
+        public TimeSpan RestoreCheckpointAgeThreshold { get; set; } = TimeSpan.FromMinutes(LocalLocationStoreConfiguration.DefaultLocationEntryExpiry.TotalMinutes / 2);
+
         /// <inheritdoc />
         public CheckpointConfiguration(AbsolutePath workingDirectory) => WorkingDirectory = workingDirectory;
     }

--- a/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/LocalLocationStoreDistributedContentTests.cs
+++ b/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/LocalLocationStoreDistributedContentTests.cs
@@ -1195,7 +1195,8 @@ namespace ContentStoreTest.Distributed.Sessions
                         CreateCheckpointInterval = TimeSpan.FromMinutes(1),
                         RestoreCheckpointInterval = TimeSpan.FromMinutes(1),
                         HeartbeatInterval = Timeout.InfiniteTimeSpan,
-                        MasterLeaseExpiryTime = masterLeaseExpiryTime
+                        MasterLeaseExpiryTime = masterLeaseExpiryTime,
+                        RestoreCheckpointAgeThreshold = TimeSpan.Zero,
                     };
                     config.CentralStore = centralStoreConfiguration;
                 });
@@ -1352,6 +1353,7 @@ namespace ContentStoreTest.Distributed.Sessions
                         RestoreCheckpointInterval = TimeSpan.FromMinutes(1),
                         HeartbeatInterval = Timeout.InfiniteTimeSpan,
                         MasterLeaseExpiryTime = masterLeaseExpiryTime,
+                        RestoreCheckpointAgeThreshold = TimeSpan.Zero,
                     };
                     config.CentralStore = centralStoreConfiguration;
                     config.EventStore.Epoch = $"Epoch:{iteration}";
@@ -2184,6 +2186,7 @@ namespace ContentStoreTest.Distributed.Sessions
                         RestoreCheckpointInterval = TimeSpan.FromMinutes(1),
                         HeartbeatInterval = Timeout.InfiniteTimeSpan,
                         Role = role,
+                        RestoreCheckpointAgeThreshold = TimeSpan.Zero,
                     };
                     config.CentralStore = centralStoreConfiguration;
                 });

--- a/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
@@ -519,6 +519,9 @@ namespace BuildXL.Cache.Host.Configuration
         public int? LocationEntryExpiryMinutes { get; set; }
 
         [DataMember]
+        public int? RestoreCheckpointAgeThresholdMinutes { get; set; }
+
+        [DataMember]
         public int? MachineExpiryMinutes { get; set; }
 
         [DataMember]

--- a/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
@@ -76,6 +76,7 @@ namespace BuildXL.Cache.Host.Service.Internal
             ApplyIfNotNull(_distributedSettings.ReplicaCreditInMinutes, v => redisContentLocationStoreConfiguration.ContentLifetime = TimeSpan.FromMinutes(v));
             ApplyIfNotNull(_distributedSettings.MachineRisk, v => redisContentLocationStoreConfiguration.MachineRisk = v);
             ApplyIfNotNull(_distributedSettings.LocationEntryExpiryMinutes, v => redisContentLocationStoreConfiguration.LocationEntryExpiry = TimeSpan.FromMinutes(v));
+            ApplyIfNotNull(_distributedSettings.RestoreCheckpointAgeThresholdMinutes, v => redisContentLocationStoreConfiguration.Checkpoint.RestoreCheckpointAgeThreshold = TimeSpan.FromMinutes(v));
             ApplyIfNotNull(_distributedSettings.MachineExpiryMinutes, v => redisContentLocationStoreConfiguration.MachineExpiry = TimeSpan.FromMinutes(v));
 
             redisContentLocationStoreConfiguration.ReputationTrackerConfiguration.Enabled = _distributedSettings.IsMachineReputationEnabled;
@@ -337,6 +338,7 @@ namespace BuildXL.Cache.Host.Service.Internal
                 _distributedSettings.ContentLocationWriteMode,
                 value => configuration.WriteMode = (ContentLocationMode)Enum.Parse(typeof(ContentLocationMode), value));
             ApplyIfNotNull(_distributedSettings.LocationEntryExpiryMinutes, value => configuration.LocationEntryExpiry = TimeSpan.FromMinutes(value));
+            ApplyIfNotNull(_distributedSettings.RestoreCheckpointAgeThresholdMinutes, v => configuration.Checkpoint.RestoreCheckpointAgeThreshold = TimeSpan.FromMinutes(v));
 
             var errorBuilder = new StringBuilder();
             var storageCredentials = GetStorageCredentials(secrets, errorBuilder);


### PR DESCRIPTION
This should reduce startup time when a machine is being restarted.