### PR TITLE
Make sure we don't over-register env vars on graph construction for MSBuild-scheduled pips

### DIFF
--- a/Public/Src/FrontEnd/UnitTests/MsBuild/Infrastructure/MsBuildPipExecutionTestBase.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/Infrastructure/MsBuildPipExecutionTestBase.cs
@@ -106,9 +106,9 @@ namespace Test.BuildXL.FrontEnd.MsBuild
         }
 
         /// <inheritdoc/>
-        protected SpecEvaluationBuilder Build(string configExtraArguments)
+        protected SpecEvaluationBuilder Build(string configExtraArguments, string environment = null)
         {
-            return base.Build().Configuration(DefaultMsBuildPrelude(configExtraArguments));
+            return base.Build().Configuration(DefaultMsBuildPrelude(configExtraArguments, environment));
         }
 
         /// <summary>
@@ -298,7 +298,8 @@ config({{
 }});";
 
         private string DefaultMsBuildPrelude(
-            string extraArguments) => $@"
+            string extraArguments,
+            string environment) => $@"
 config({{
     disableDefaultSourceResolver: true,
     resolvers: [
@@ -308,7 +309,7 @@ config({{
             msBuildSearchLocations: [d`{TestDeploymentDir}/{RelativePathToFullframeworkMSBuild}`],
             root: d`.`,
             allowProjectsToNotSpecifyTargetProtocol: true,
-            {DictionaryToExpression("environment", new Dictionary<string, string>())}
+            {(environment != null? $"environment: {environment}," : DictionaryToExpression("environment", new Dictionary<string, string>()))}
             {extraArguments ?? string.Empty}
         }},
     ],

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/Infrastructure/MsBuildPipSchedulingTestBase.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/Infrastructure/MsBuildPipSchedulingTestBase.cs
@@ -140,7 +140,7 @@ namespace Test.BuildXL.FrontEnd.MsBuild.Infrastructure
 
             using (var controller = CreateFrontEndHost(GetDefaultCommandLine(), frontEndFactory, workspaceFactory, moduleRegistry, AbsolutePath.Invalid, out _, out _, requestedQualifiers))
             {
-                resolverSettings.ComputeEnvironment(out var trackedEnv, out var passthroughVars);
+                resolverSettings.ComputeEnvironment(out var trackedEnv, out var passthroughVars, out _);
 
                 var pipConstructor = new PipConstructor(
                     FrontEndContext,

--- a/Public/Src/Utilities/Configuration/Resolvers/IMsBuildResolverSettings.cs
+++ b/Public/Src/Utilities/Configuration/Resolvers/IMsBuildResolverSettings.cs
@@ -178,11 +178,12 @@ namespace BuildXL.Utilities.Configuration
         /// <remarks>
         /// When <see cref="IMsBuildResolverSettings.Environment"/> is null, the current environment is defined as the tracked environment, with no passthroughs
         /// </remarks>
-        public static void ComputeEnvironment(this IMsBuildResolverSettings msBuildResolverSettings, out IDictionary<string, string> trackedEnv, out ICollection<string> passthroughEnv)
+        public static void ComputeEnvironment(this IMsBuildResolverSettings msBuildResolverSettings, out IDictionary<string, string> trackedEnv, out ICollection<string> passthroughEnv, out bool processEnvironmentUsed)
         {
             if (msBuildResolverSettings.Environment == null)
             {
                 var allEnvironmentVariables = Environment.GetEnvironmentVariables();
+                processEnvironmentUsed = true;
                 trackedEnv = new Dictionary<string, string>(allEnvironmentVariables.Count);
                 foreach (var envVar in allEnvironmentVariables.Keys)
                 {
@@ -194,6 +195,7 @@ namespace BuildXL.Utilities.Configuration
                 return;
             }
 
+            processEnvironmentUsed = false;
             var trackedList = new Dictionary<string, string>();
             var passthroughList = new List<string>();
 


### PR DESCRIPTION
Make sure we only register env vars used for graph construction when they actually came from the environment. In the case the variables came from the main config file, do not do any explicit registration and leave it up to the config to register vars as appropriate.