### PR TITLE
Additional asserts for bug tracking / avoidance in ExecuteNonProcessPipAsync

### DIFF
--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -4058,6 +4058,10 @@ namespace BuildXL.Scheduler
 
         private async Task<PipResult> ExecuteNonProcessPipAsync(RunnablePip runnablePip)
         {
+            Contract.Requires(runnablePip.Pip != null);
+            Contract.Requires(runnablePip.OperationContext.IsValid);
+            Contract.Requires(runnablePip.Environment != null);
+
             var pip = runnablePip.Pip;
             var operationContext = runnablePip.OperationContext;
             var environment = runnablePip.Environment;


### PR DESCRIPTION
Add some more assertions for sanity checking / tracking of an elusive crash we are seeing very rarely happening when executing `ExecuteNonProcessPipAsync(RunnablePip runnablePip)`.