### PR TITLE
Add constructor (ResultBase, string) to implementations of ResultBase

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/BlobCentralStorage.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/BlobCentralStorage.cs
@@ -346,14 +346,14 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         private class AttemptResult : BoolResult
         {
             /// <inheritdoc />
-            private AttemptResult()
-                : base(succeeded: true)
+            public AttemptResult(ResultBase other, string message = null)
+                : base(other, message)
             {
             }
 
             /// <inheritdoc />
-            private AttemptResult(ResultBase other, string message = null)
-                : base(other, message)
+            private AttemptResult()
+                : base(succeeded: true)
             {
             }
 

--- a/Public/Src/Cache/ContentStore/Distributed/Redis/RedisBlobAdapter.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Redis/RedisBlobAdapter.cs
@@ -91,6 +91,12 @@ namespace BuildXL.Cache.ContentStore.Distributed.Redis
                 BlobSize = blobSize;
             }
 
+            /// <nodoc />
+            public PutBlobResult(ResultBase other, string message)
+                : base(other, message)
+            {
+            }
+
             /// <inheritdoc />
             public override string ToString()
             {

--- a/Public/Src/Cache/ContentStore/Distributed/Sessions/DistributedPinResult.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Sessions/DistributedPinResult.cs
@@ -23,6 +23,12 @@ namespace BuildXL.Cache.ContentStore.Distributed.Sessions
         }
 
         /// <nodoc />
+        public DistributedPinResult(ResultBase other, string message)
+            : base(other, message)
+        {
+        }
+
+        /// <nodoc />
         public static DistributedPinResult SuccessByLocalCopy()
         {
             return new DistributedPinResult("Copied locally")

--- a/Public/Src/Cache/ContentStore/Distributed/Sessions/ProactiveCopyResult.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Sessions/ProactiveCopyResult.cs
@@ -25,6 +25,12 @@ namespace BuildXL.Cache.ContentStore.Distributed.Sessions
         {
         }
 
+        /// <nodoc />
+        public ProactiveCopyResult(ResultBase other, string message)
+            : base(other, message)
+        {
+        }
+
         private static string GetErrorMessage(BoolResult ringCopyResult, BoolResult outsideRingCopyResult)
         {
             if (!ringCopyResult.Succeeded || !outsideRingCopyResult.Succeeded)

--- a/Public/Src/Cache/ContentStore/DistributedTest/TestErrorResultConverter.cs
+++ b/Public/Src/Cache/ContentStore/DistributedTest/TestErrorResultConverter.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using BuildXL.Cache.ContentStore.Interfaces.Results;
+using Xunit;
+
+namespace BuildXL.Cache.ContentStore.Distributed.Test
+{
+    public class TestErrorResultConverter
+    {
+        /// <summary>
+        /// Validate that all implementations of ResultBase include the necessary constructor to use the AsResult extension method.
+        /// </summary>
+        [Fact]
+        public void ValidateAsResult()
+        {
+            var resultBaseType = typeof(ResultBase);
+            IEnumerable<Type> resultTypes = AppDomain.CurrentDomain.GetAssemblies()
+                .Where(assembly => assembly.FullName.Contains("BuildXL"))
+                .SelectMany(assembly => assembly.GetTypes())
+                .Where(t => resultBaseType.IsAssignableFrom(t) && !t.IsInterface && !t.IsAbstract && !t.IsGenericType && t.FullName != resultBaseType.FullName && t.Name != "CustomError");
+
+            var testError = new ErrorResult(new Exception(nameof(ValidateAsResult)));
+
+            foreach (Type resultType in resultTypes)
+            {
+                MethodInfo asResultMethod = typeof(ErrorResult).GetMethod(nameof(ErrorResult.AsResult)).MakeGenericMethod(new Type[] { resultType });
+
+                // testError.AsResult<resultType>();
+                asResultMethod.Invoke(testError, null);
+            }
+        }
+    }
+}

--- a/Public/Src/Cache/ContentStore/Interfaces/Distributed/ConnectionStringResult.cs
+++ b/Public/Src/Cache/ContentStore/Interfaces/Distributed/ConnectionStringResult.cs
@@ -64,7 +64,7 @@ namespace BuildXL.Cache.ContentStore.Interfaces.Distributed
         /// <summary>
         /// Initializes a new instance of the <see cref="ConnectionStringResult" /> class.
         /// </summary>
-        private ConnectionStringResult(ResultBase other, string message)
+        public ConnectionStringResult(ResultBase other, string message)
             : base(other, message)
         {
         }

--- a/Public/Src/Cache/ContentStore/Interfaces/Results/DeleteResult.cs
+++ b/Public/Src/Cache/ContentStore/Interfaces/Results/DeleteResult.cs
@@ -90,6 +90,13 @@ namespace BuildXL.Cache.ContentStore.Interfaces.Results
             Code = resultCode;
         }
 
+        /// <nodoc />
+        public DeleteResult(ResultBase other, string message)
+            : base(other, message)
+        {
+            Code = ResultCode.Error;
+        }
+
         /// <summary>
         /// Gets a classification of the result of the call.
         /// </summary>

--- a/Public/Src/Cache/ContentStore/InterfacesTest/Results/ErrorResultConverterTests.cs
+++ b/Public/Src/Cache/ContentStore/InterfacesTest/Results/ErrorResultConverterTests.cs
@@ -52,7 +52,6 @@ namespace BuildXL.Cache.ContentStore.InterfacesTest.Results
 
         private class CustomError : ResultBase
         {
-
         }
     }
 }

--- a/Public/Src/Cache/ContentStore/Library/Tracing/CalibrateResult.cs
+++ b/Public/Src/Cache/ContentStore/Library/Tracing/CalibrateResult.cs
@@ -31,6 +31,12 @@ namespace BuildXL.Cache.ContentStore.Tracing
         {
         }
 
+        /// <nodoc />
+        public CalibrateResult(ResultBase other, string message)
+            : base(other, message)
+        {
+        }
+
         /// <summary>
         ///     Gets size.
         /// </summary>

--- a/Public/Src/Cache/ContentStore/Library/Tracing/EvictResult.cs
+++ b/Public/Src/Cache/ContentStore/Library/Tracing/EvictResult.cs
@@ -52,6 +52,12 @@ namespace BuildXL.Cache.ContentStore.Tracing
         {
         }
 
+        /// <nodoc />
+        public EvictResult(ResultBase other, string message)
+            : base(other, message)
+        {
+        }
+
         /// <summary>
         ///     Gets number of bytes evicted.
         /// </summary>


### PR DESCRIPTION
Extension method `ErrorResult.AsResult<TResult>` expects to convert any given ErrorResult to any implementation of ResultBase. To do this, it uses reflection to find a constructor of TResult which takes a ResultBase and a string. This method is throwing in production because PutBlobResult does not include the necessary constructor. I added a test to ensure that all implementations include this constructor.