### PR TITLE
Improvements in memory-based scheduler throttling

### DIFF
--- a/Public/Src/Engine/Processes/ExternalSandboxedProcess.cs
+++ b/Public/Src/Engine/Processes/ExternalSandboxedProcess.cs
@@ -52,7 +52,7 @@ namespace BuildXL.Processes
         public virtual string GetAccessedFileName(ReportedFileAccess reportedFileAccess) => null;
 
         /// <inheritdoc />
-        public abstract ulong? GetActivePeakMemoryUsage();
+        public abstract ulong? GetActivePeakWorkingSet();
 
         /// <inheritdoc />
         public virtual long GetDetoursMaxHeapSize() => 0;

--- a/Public/Src/Engine/Processes/ExternalToolSandboxedProcess.cs
+++ b/Public/Src/Engine/Processes/ExternalToolSandboxedProcess.cs
@@ -57,7 +57,7 @@ namespace BuildXL.Processes
         }
 
         /// <inheritdoc />
-        public override ulong? GetActivePeakMemoryUsage() => m_processExecutor?.GetActivePeakMemoryUsage();
+        public override ulong? GetActivePeakWorkingSet() => m_processExecutor?.GetActivePeakWorkingSet();
 
         /// <inheritdoc />
         public override async Task<SandboxedProcessResult> GetResultAsync()

--- a/Public/Src/Engine/Processes/ExternalVMSandboxedProcess.cs
+++ b/Public/Src/Engine/Processes/ExternalVMSandboxedProcess.cs
@@ -67,7 +67,7 @@ namespace BuildXL.Processes
         }
 
         /// <inheritdoc />
-        public override ulong? GetActivePeakMemoryUsage() => m_processExecutor?.GetActivePeakMemoryUsage();
+        public override ulong? GetActivePeakWorkingSet() => m_processExecutor?.GetActivePeakWorkingSet();
 
         /// <inheritdoc />
         [SuppressMessage("AsyncUsage", "AsyncFixer02:MissingAsyncOpportunity")]

--- a/Public/Src/Engine/Processes/ISandboxedProcess.cs
+++ b/Public/Src/Engine/Processes/ISandboxedProcess.cs
@@ -24,11 +24,11 @@ namespace BuildXL.Processes
         /// </summary>
         /// <param name="reportedFileAccess">The file access object on which to get the path location.</param>
         string GetAccessedFileName(ReportedFileAccess reportedFileAccess);
-        
+
         /// <summary>
-        /// Gets the peak memory usage while the process is active. If the process exits, the peak memory usage is considered null.
+        /// Gets the peak working set while the process is active. If the process exits, the peak working set is considered null.
         /// </summary>
-        ulong? GetActivePeakMemoryUsage();
+        ulong? GetActivePeakWorkingSet();
 
         /// <summary>
         /// Gets the maximum heap size of the sandboxed process.

--- a/Public/Src/Engine/Processes/SandboxedProcessMac.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessMac.cs
@@ -173,7 +173,7 @@ namespace BuildXL.Processes
             }
 
             // get memory usage for the process tree
-            m_perfAggregator.PeakMemoryBytes.RegisterSample(Dispatch.GetActivePeakMemoryUsage(default, ProcessId));
+            m_perfAggregator.PeakMemoryBytes.RegisterSample(Dispatch.GetActivePeakWorkingSet(default, ProcessId));
         }
 
         /// <inheritdoc />
@@ -411,7 +411,7 @@ namespace BuildXL.Processes
                         ReadTransferCount = Convert.ToUInt64(m_perfAggregator.DiskBytesRead.Total),
                         WriteTransferCount = Convert.ToUInt64(m_perfAggregator.DiskBytesWritten.Total)
                     }),
-                    PeakMemoryUsage = Convert.ToUInt64(m_perfAggregator.PeakMemoryBytes.Maximum),
+                    PeakWorkingSet = Convert.ToUInt64(m_perfAggregator.PeakMemoryBytes.Maximum),
                     KernelTime = TimeSpan.FromMilliseconds(m_perfAggregator.JobKernelTimeMs.Latest),
                     UserTime = TimeSpan.FromMilliseconds(m_perfAggregator.JobUserTimeMs.Latest),
                 };

--- a/Public/Src/Engine/Processes/SandboxedProcessMac.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessMac.cs
@@ -14,6 +14,7 @@ using BuildXL.Interop;
 using BuildXL.Interop.MacOS;
 using BuildXL.Native.IO;
 using BuildXL.Native.Processes;
+using BuildXL.Pips;
 using BuildXL.Utilities;
 using BuildXL.Utilities.Tasks;
 using JetBrains.Annotations;
@@ -411,7 +412,7 @@ namespace BuildXL.Processes
                         ReadTransferCount = Convert.ToUInt64(m_perfAggregator.DiskBytesRead.Total),
                         WriteTransferCount = Convert.ToUInt64(m_perfAggregator.DiskBytesWritten.Total)
                     }),
-                    PeakWorkingSet = Convert.ToUInt64(m_perfAggregator.PeakMemoryBytes.Maximum),
+                    MemoryCounters = new ProcessMemoryCounters(0, Convert.ToUInt64(m_perfAggregator.PeakMemoryBytes.Maximum), 0),
                     KernelTime = TimeSpan.FromMilliseconds(m_perfAggregator.JobKernelTimeMs.Latest),
                     UserTime = TimeSpan.FromMilliseconds(m_perfAggregator.JobUserTimeMs.Latest),
                 };

--- a/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
@@ -399,11 +399,11 @@ namespace BuildXL.Processes
         }
 
         /// <summary>
-        /// <see cref="SandboxedProcess.GetActivePeakMemoryUsage"/>
+        /// <see cref="SandboxedProcess.GetActivePeakWorkingSet"/>
         /// </summary>
-        public ulong? GetActivePeakMemoryUsage()
+        public ulong? GetActivePeakWorkingSet()
         {
-            return m_activeProcess?.GetActivePeakMemoryUsage();
+            return m_activeProcess?.GetActivePeakWorkingSet();
         }
 
         private static Task<Regex> GetRegexAsync(ExpandedRegexDescriptor descriptor)

--- a/Public/Src/Engine/Processes/UnSandboxedProcess.cs
+++ b/Public/Src/Engine/Processes/UnSandboxedProcess.cs
@@ -180,7 +180,7 @@ namespace BuildXL.Processes
         public string GetAccessedFileName(ReportedFileAccess reportedFileAccess) => null;
 
         /// <inheritdoc />
-        public ulong? GetActivePeakMemoryUsage()
+        public ulong? GetActivePeakWorkingSet()
         {
             try
             {
@@ -189,7 +189,7 @@ namespace BuildXL.Processes
                     return null;
                 }
 
-                return Dispatch.GetActivePeakMemoryUsage(Process.Handle, ProcessId);
+                return Dispatch.GetActivePeakWorkingSet(Process.Handle, ProcessId);
             }
 #pragma warning disable ERP022 // Unobserved exception in generic exception handler
             catch

--- a/Public/Src/Engine/Scheduler/Distribution/ChooseWorkerCpu.cs
+++ b/Public/Src/Engine/Scheduler/Distribution/ChooseWorkerCpu.cs
@@ -57,8 +57,11 @@ namespace BuildXL.Scheduler.Distribution
         public RunnablePip LastBlockedPip { get; private set; }
 
         /// <summary>
-        /// The last resource limiting acquisition of a worker
+        /// The last resource limiting acquisition of a worker. 
         /// </summary>
+        /// <remarks>
+        /// If it is null, there is no resource limiting the worker.
+        /// </remarks>
         public WorkerResource? LastLimitingResource { get; set; }
 
         /// <summary>
@@ -147,7 +150,6 @@ namespace BuildXL.Scheduler.Distribution
                     {
                         m_lastIterationBlockedPip = runnablePip;
                         LastBlockedPip = runnablePip;
-                        LastLimitingResource = limitingResource;
                         var limitingResourceCount = m_limitingResourceCounts.GetOrAdd(limitingResource.Value, k => new BoxRef<int>());
                         limitingResourceCount.Value++;
                     }
@@ -155,6 +157,9 @@ namespace BuildXL.Scheduler.Distribution
                     {
                         m_lastIterationBlockedPip = null;
                     }
+                    
+                    // If a worker is successfully chosen, then the limiting resouce would be null.
+                    LastLimitingResource = limitingResource;
 
                     m_chooseTime += TimestampUtilities.Timestamp - startTime;
                     return chosenWorker;

--- a/Public/Src/Engine/Scheduler/Distribution/Worker.cs
+++ b/Public/Src/Engine/Scheduler/Distribution/Worker.cs
@@ -187,7 +187,6 @@ namespace BuildXL.Scheduler.Distribution
         /// </summary>
         public int? ActualCommitTotalMB;
 
-
         /// <summary>
         /// Gets the estimate RAM usage on the machine
         /// </summary>

--- a/Public/Src/Engine/Scheduler/ExecutionResult.cs
+++ b/Public/Src/Engine/Scheduler/ExecutionResult.cs
@@ -621,7 +621,9 @@ namespace BuildXL.Scheduler
                             ioCounters: jobAccounting.IO,
                             userTime: jobAccounting.UserTime,
                             kernelTime: jobAccounting.KernelTime,
-                            peakMemoryUsage: jobAccounting.PeakMemoryUsage,
+                            peakVirtualMemoryUsage: jobAccounting.PeakVirtualMemoryUsage,
+                            peakWorkingSet: jobAccounting.PeakWorkingSet,
+                            peakPagefileUsage: jobAccounting.PeakPagefileUsage,
                             numberOfProcesses: jobAccounting.NumberOfProcesses,
                             workerId: 0);
                     }

--- a/Public/Src/Engine/Scheduler/ExecutionResult.cs
+++ b/Public/Src/Engine/Scheduler/ExecutionResult.cs
@@ -621,9 +621,7 @@ namespace BuildXL.Scheduler
                             ioCounters: jobAccounting.IO,
                             userTime: jobAccounting.UserTime,
                             kernelTime: jobAccounting.KernelTime,
-                            peakVirtualMemoryUsage: jobAccounting.PeakVirtualMemoryUsage,
-                            peakWorkingSet: jobAccounting.PeakWorkingSet,
-                            peakPagefileUsage: jobAccounting.PeakPagefileUsage,
+                            memoryCounters: jobAccounting.MemoryCounters,
                             numberOfProcesses: jobAccounting.NumberOfProcesses,
                             workerId: 0);
                     }

--- a/Public/Src/Engine/Scheduler/PipExecutor.cs
+++ b/Public/Src/Engine/Scheduler/PipExecutor.cs
@@ -1541,7 +1541,7 @@ namespace BuildXL.Scheduler
                                         processDescription,
                                         (long)(operationContext.Duration?.TotalMilliseconds ?? -1),
                                         peakMemoryMb:
-                                            (int)ByteSizeFormatter.ToMegabytes((long)(result.JobAccountingInformation?.PeakVirtualMemoryUsage ?? 0)),
+                                            (int)ByteSizeFormatter.ToMegabytes((long)(result.JobAccountingInformation?.MemoryCounters.PeakWorkingSet ?? 0)),
                                         expectedMemoryMb: expectedRamUsageMb,
                                         cancelMilliseconds: (int)(cancelTime?.TotalMilliseconds ?? 0));
                                 }

--- a/Public/Src/Engine/Scheduler/PipExecutor.cs
+++ b/Public/Src/Engine/Scheduler/PipExecutor.cs
@@ -1385,7 +1385,7 @@ namespace BuildXL.Scheduler
                                         using (operationContext.StartAsyncOperation(PipExecutorCounter.QueryRamUsageDuration))
                                         {
                                             lastObservedPeakRamUsage =
-                                                (int)ByteSizeFormatter.ToMegabytes((long)(executor.GetActivePeakMemoryUsage() ?? 0));
+                                                (int)ByteSizeFormatter.ToMegabytes((long)(executor.GetActivePeakWorkingSet() ?? 0));
                                         }
 
                                         return lastObservedPeakRamUsage;
@@ -1541,7 +1541,7 @@ namespace BuildXL.Scheduler
                                         processDescription,
                                         (long)(operationContext.Duration?.TotalMilliseconds ?? -1),
                                         peakMemoryMb:
-                                            (int)ByteSizeFormatter.ToMegabytes((long)(result.JobAccountingInformation?.PeakMemoryUsage ?? 0)),
+                                            (int)ByteSizeFormatter.ToMegabytes((long)(result.JobAccountingInformation?.PeakVirtualMemoryUsage ?? 0)),
                                         expectedMemoryMb: expectedRamUsageMb,
                                         cancelMilliseconds: (int)(cancelTime?.TotalMilliseconds ?? 0));
                                 }

--- a/Public/Src/Engine/Scheduler/PipHistoricPerfData.cs
+++ b/Public/Src/Engine/Scheduler/PipHistoricPerfData.cs
@@ -58,7 +58,8 @@ namespace BuildXL.Scheduler
 
             m_entryTimeToLive = DefaultTimeToLive;
             DurationInMs = (uint)Math.Min(uint.MaxValue, Math.Max(1, executionPerformance.ProcessExecutionTime.TotalMilliseconds));
-            PeakMemoryInKB = (uint)Math.Min(uint.MaxValue, executionPerformance.PeakMemoryUsage / 1024);
+            // For historical ram usage, we record the peak working set instead of the virtual memory due to the precision.
+            PeakMemoryInKB = (uint)Math.Min(uint.MaxValue, executionPerformance.PeakWorkingSet / 1024);
             DiskIOInKB = (uint)Math.Min(uint.MaxValue, executionPerformance.IO.GetAggregateIO().TransferCount / 1024);
 
             double cpuTime = executionPerformance.KernelTime.TotalMilliseconds + executionPerformance.UserTime.TotalMilliseconds;

--- a/Public/Src/Engine/Scheduler/PipHistoricPerfData.cs
+++ b/Public/Src/Engine/Scheduler/PipHistoricPerfData.cs
@@ -59,7 +59,7 @@ namespace BuildXL.Scheduler
             m_entryTimeToLive = DefaultTimeToLive;
             DurationInMs = (uint)Math.Min(uint.MaxValue, Math.Max(1, executionPerformance.ProcessExecutionTime.TotalMilliseconds));
             // For historical ram usage, we record the peak working set instead of the virtual memory due to the precision.
-            PeakMemoryInKB = (uint)Math.Min(uint.MaxValue, executionPerformance.PeakWorkingSet / 1024);
+            PeakMemoryInKB = (uint)Math.Min(uint.MaxValue, executionPerformance.MemoryCounters.PeakWorkingSet / 1024);
             DiskIOInKB = (uint)Math.Min(uint.MaxValue, executionPerformance.IO.GetAggregateIO().TransferCount / 1024);
 
             double cpuTime = executionPerformance.KernelTime.TotalMilliseconds + executionPerformance.UserTime.TotalMilliseconds;

--- a/Public/Src/Engine/Scheduler/PipHistoricPerfData.cs
+++ b/Public/Src/Engine/Scheduler/PipHistoricPerfData.cs
@@ -61,10 +61,7 @@ namespace BuildXL.Scheduler
             // For historical ram usage, we record the peak working set instead of the virtual memory due to the precision.
             PeakMemoryInKB = (uint)Math.Min(uint.MaxValue, executionPerformance.MemoryCounters.PeakWorkingSet / 1024);
             DiskIOInKB = (uint)Math.Min(uint.MaxValue, executionPerformance.IO.GetAggregateIO().TransferCount / 1024);
-
-            double cpuTime = executionPerformance.KernelTime.TotalMilliseconds + executionPerformance.UserTime.TotalMilliseconds;
-            double processorPercentage = DurationInMs == 0 ? 0 : cpuTime / DurationInMs;
-            ProcessorsInPercents = (ushort)Math.Min(ushort.MaxValue, processorPercentage * 100.0);
+            ProcessorsInPercents = executionPerformance.ProcessorsInPercents;
         }
 
         private PipHistoricPerfData(byte timeToLive, uint durationInMs, uint peakMemoryInKB, ushort processorsInPercents, uint diskIOInKB)

--- a/Public/Src/Engine/Scheduler/ProcessResourceManager.cs
+++ b/Public/Src/Engine/Scheduler/ProcessResourceManager.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.ContractsLight;
 using System.Threading;
 using System.Threading.Tasks;
 using BuildXL.Pips;
+using BuildXL.Utilities;
 using BuildXL.Utilities.Tasks;
 
 namespace BuildXL.Scheduler
@@ -139,6 +140,7 @@ namespace BuildXL.Scheduler
             }
 
             using (scope)
+            using (new StoppableTimer(() => scope.RefreshRamUsage(), 0, 2000))
             {
                 var result = await execute(scope.Token, registerQueryRamUsageMb: scope.RegisterQueryRamUsageMb);
                 scope.Complete();

--- a/Public/Src/Engine/Scheduler/ProcessRunnablePip.cs
+++ b/Public/Src/Engine/Scheduler/ProcessRunnablePip.cs
@@ -48,6 +48,11 @@ namespace BuildXL.Scheduler
         public int? ExpectedRamUsageMb;
 
         /// <summary>
+        /// The expected historical duration of the pip
+        /// </summary>
+        public ulong? ExpectedDurationMs;
+
+        /// <summary>
         /// SemaphoreResources
         /// </summary>
         public ItemResources? Resources { get; private set; }

--- a/Public/Src/Engine/Scheduler/RunnablePip.cs
+++ b/Public/Src/Engine/Scheduler/RunnablePip.cs
@@ -470,7 +470,9 @@ namespace BuildXL.Scheduler
                         ioCounters: performanceInformation.IO,
                         userTime: performanceInformation.UserTime,
                         kernelTime: performanceInformation.KernelTime,
-                        peakMemoryUsage: performanceInformation.PeakMemoryUsage,
+                        peakVirtualMemoryUsage: performanceInformation.PeakVirtualMemoryUsage,
+                        peakWorkingSet: performanceInformation.PeakWorkingSet,
+                        peakPagefileUsage: performanceInformation.PeakPagefileUsage,
                         numberOfProcesses: performanceInformation.NumberOfProcesses,
                         workerId: performanceInformation.WorkerId);
                 }
@@ -489,7 +491,9 @@ namespace BuildXL.Scheduler
                             ioCounters: default(IOCounters),
                             userTime: TimeSpan.Zero,
                             kernelTime: TimeSpan.Zero,
-                            peakMemoryUsage: 0,
+                            peakVirtualMemoryUsage: 0,
+                            peakWorkingSet: 0,
+                            peakPagefileUsage: 0,
                             numberOfProcesses: 0,
                             workerId: 0);
                 }

--- a/Public/Src/Engine/Scheduler/RunnablePip.cs
+++ b/Public/Src/Engine/Scheduler/RunnablePip.cs
@@ -470,9 +470,7 @@ namespace BuildXL.Scheduler
                         ioCounters: performanceInformation.IO,
                         userTime: performanceInformation.UserTime,
                         kernelTime: performanceInformation.KernelTime,
-                        peakVirtualMemoryUsage: performanceInformation.PeakVirtualMemoryUsage,
-                        peakWorkingSet: performanceInformation.PeakWorkingSet,
-                        peakPagefileUsage: performanceInformation.PeakPagefileUsage,
+                        memoryCounters: performanceInformation.MemoryCounters,
                         numberOfProcesses: performanceInformation.NumberOfProcesses,
                         workerId: performanceInformation.WorkerId);
                 }
@@ -491,9 +489,7 @@ namespace BuildXL.Scheduler
                             ioCounters: default(IOCounters),
                             userTime: TimeSpan.Zero,
                             kernelTime: TimeSpan.Zero,
-                            peakVirtualMemoryUsage: 0,
-                            peakWorkingSet: 0,
-                            peakPagefileUsage: 0,
+                            memoryCounters: new ProcessMemoryCounters(0, 0, 0),
                             numberOfProcesses: 0,
                             workerId: 0);
                 }

--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -3666,12 +3666,14 @@ namespace BuildXL.Scheduler
                             int peakVirtualMemoryUsageMb = executionResult.PerformanceInformation.MemoryCounters.PeakVirtualMemoryUsageMb;
                             int peakWorkingSetMb = executionResult.PerformanceInformation.MemoryCounters.PeakWorkingSetMb;
                             int peakPagefileUsageMb = executionResult.PerformanceInformation.MemoryCounters.PeakPagefileUsageMb;
-
-                            Logger.Log.PeakMemoryUsage(
+                            RunningTimeTable[123].
+                            Logger.Log.ProcessPipExecutionInfo(
                                 operationContext, 
                                 runnablePip.Description,
                                 (int)executionResult.PerformanceInformation.NumberOfProcesses,
+                                (int)((processRunnable.ExpectedDurationMs ?? 0) / 1000),
                                 (int)executionResult.PerformanceInformation.ProcessExecutionTime.TotalSeconds,
+                                executionResult.PerformanceInformation.ProcessorsInPercents,
                                 runnablePip.Worker.DefaultMemoryUsagePerProcess, 
                                 expectedRamUsage,
                                 peakVirtualMemoryUsageMb,
@@ -4193,6 +4195,8 @@ namespace BuildXL.Scheduler
                     {
                         runnableProcess.ExpectedRamUsageMb = (int)(perfData.PeakMemoryInKB / 1024);
                     }
+
+                    runnableProcess.ExpectedDurationMs = perfData.DurationInMs;
                 }
 
                 // Find the estimated setup time for the pip on each builder.

--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -231,7 +231,7 @@ namespace BuildXL.Scheduler
         /// There is at least one worker in the list of workers: LocalWorker.
         /// LocalWorker must be at the beginning of the list. All other workers must be remote.
         /// </remarks>
-        public IEnumerable<Worker> Workers => m_workers;
+        public IList<Worker> Workers => m_workers;
 
         private AllWorker m_allWorker;
 
@@ -823,6 +823,10 @@ namespace BuildXL.Scheduler
         #endregion
 
         #region Statistics
+
+        private long m_totalPeakVirtualMemoryUsageMb;
+        private long m_totalPeakWorkingSetMb;
+        private long m_totalPeakPagefileUsageMb;
 
         private readonly object m_statusLock = new object();
 
@@ -1719,6 +1723,10 @@ namespace BuildXL.Scheduler
                 statistics.Add(string.Format(perfStatsName, "SendRequest", (PipExecutionStep)i), totalSendRequestDurations[i]);
             }
 
+            statistics.Add("TotalPeakMemoryUsage", m_totalPeakVirtualMemoryUsageMb);
+            statistics.Add("TotalPeakWorkingSet", m_totalPeakWorkingSetMb);
+            statistics.Add("TotalPeakPagefileUsage", m_totalPeakPagefileUsageMb);
+
             BuildXL.Tracing.Logger.Log.BulkStatistic(loggingContext, statistics);
 
             return new SchedulerPerformanceInfo
@@ -1773,7 +1781,8 @@ namespace BuildXL.Scheduler
             {
                 { "Cpu Percent", data => data.CpuPercent },
                 { "Mem Percent", data => data.RamPercent },
-                { "Mem MB", data => data.MachineRamUtilizationMB },
+                { "Used Mem MB", data => data.MachineRamUtilizationMB },
+                { "Free Mem MB", data => data.MachineAvailableRamMB },
                 { "Commit Percent", data => data.CommitPercent },
                 { "Commit MB", data => data.CommitTotalMB },
                 { "NetworkBandwidth", data => m_perfInfo.MachineBandwidth },
@@ -1858,7 +1867,11 @@ namespace BuildXL.Scheduler
                         rows.Add(I($"W{worker.WorkerId} Used Ipc Slots"), _ => worker.AcquiredIpcSlots, includeInSnapshot: false);
                         rows.Add(I($"W{worker.WorkerId} Waiting BuildRequests Count"), _ => worker.WaitingBuildRequestsCount, includeInSnapshot: false);
                         rows.Add(I($"W{worker.WorkerId} Total RAM Mb"), _ => worker.TotalMemoryMb ?? 0, includeInSnapshot: false);
-                        rows.Add(I($"W{worker.WorkerId} ~Free RAM Mb"), _ => worker.EstimatedAvailableRamMb, includeInSnapshot: false);
+                        rows.Add(I($"W{worker.WorkerId} Estimated Free RAM Mb"), _ => worker.EstimatedAvailableRamMb, includeInSnapshot: false);
+                        rows.Add(I($"W{worker.WorkerId} Actual Free RAM Mb"), _ => worker.ActualAvailableMemoryMb ?? 0, includeInSnapshot: false);
+                        rows.Add(I($"W{worker.WorkerId} Actual Commit Total Mb"), _ => worker.ActualCommitTotalMB ?? 0, includeInSnapshot: false);
+                        rows.Add(I($"W{worker.WorkerId} Actual Commit Percent"), _ => worker.ActualCommitPercent ?? 0, includeInSnapshot: false);
+
                         rows.Add(I($"W{worker.WorkerId} Status"), _ => worker.Status, includeInSnapshot: false);
 
                         var snapshot = worker.PipStateSnapshot;
@@ -2031,6 +2044,7 @@ namespace BuildXL.Scheduler
                     ProcessWorkingSetMB = m_perfInfo.ProcessWorkingSetMB,
                     RamPercent = m_perfInfo.RamUsagePercentage ?? 0,
                     MachineRamUtilizationMB = (m_perfInfo.TotalRamMb.HasValue && m_perfInfo.AvailableRamMb.HasValue) ? m_perfInfo.TotalRamMb.Value - m_perfInfo.AvailableRamMb.Value : 0,
+                    MachineAvailableRamMB = m_perfInfo.AvailableRamMb ?? 0,
                     CommitPercent = m_perfInfo.CommitUsagePercentage ?? 0,
                     CommitTotalMB = m_perfInfo.CommitTotalMb ?? 0,
                     CpuWaiting = m_pipQueue.GetNumQueuedByKind(DispatcherKind.CPU),
@@ -3598,7 +3612,7 @@ namespace BuildXL.Scheduler
                             // Use the max of the observed peak memory and the worker's expected RAM usage for the pip
                             var expectedRamUsageMb = Math.Max(
                                     worker.GetExpectedRamUsageMb(processRunnable),
-                                    Math.Max(1, executionResult.PerformanceInformation?.PeakMemoryUsageMb ?? 0));
+                                    Math.Max(1, executionResult.PerformanceInformation?.PeakWorkingSetMb ?? 0));
 
                             processRunnable.ExpectedRamUsageMb = expectedRamUsageMb;
 
@@ -3647,6 +3661,23 @@ namespace BuildXL.Scheduler
 
                         if (!IsDistributedWorker)
                         {
+                            var expectedRamUsage = runnablePip.Worker.GetExpectedRamUsageMb((ProcessRunnablePip)runnablePip);
+                            
+                            Logger.Log.PeakMemoryUsage(
+                                operationContext, 
+                                runnablePip.Description,
+                                (int)executionResult.PerformanceInformation.NumberOfProcesses,
+                                (int)executionResult.PerformanceInformation.ProcessExecutionTime.TotalSeconds,
+                                runnablePip.Worker.DefaultMemoryUsagePerProcess, 
+                                expectedRamUsage,
+                                executionResult.PerformanceInformation.PeakVirtualMemoryUsageMb,
+                                executionResult.PerformanceInformation.PeakWorkingSetMb,
+                                executionResult.PerformanceInformation.PeakPagefileUsageMb);
+
+                            m_totalPeakVirtualMemoryUsageMb += executionResult.PerformanceInformation.PeakVirtualMemoryUsageMb;
+                            m_totalPeakWorkingSetMb += executionResult.PerformanceInformation.PeakWorkingSetMb;
+                            m_totalPeakPagefileUsageMb += executionResult.PerformanceInformation.PeakPagefileUsageMb;
+
                             // File violation analysis needs to happen on the master as it relies on
                             // graph-wide data such as detecting duplicate
                             executionResult = PipExecutor.AnalyzeFileAccessViolations(

--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -3666,7 +3666,7 @@ namespace BuildXL.Scheduler
                             int peakVirtualMemoryUsageMb = executionResult.PerformanceInformation.MemoryCounters.PeakVirtualMemoryUsageMb;
                             int peakWorkingSetMb = executionResult.PerformanceInformation.MemoryCounters.PeakWorkingSetMb;
                             int peakPagefileUsageMb = executionResult.PerformanceInformation.MemoryCounters.PeakPagefileUsageMb;
-                            RunningTimeTable[123].
+
                             Logger.Log.ProcessPipExecutionInfo(
                                 operationContext, 
                                 runnablePip.Description,

--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -3662,7 +3662,11 @@ namespace BuildXL.Scheduler
                         if (!IsDistributedWorker)
                         {
                             var expectedRamUsage = runnablePip.Worker.GetExpectedRamUsageMb((ProcessRunnablePip)runnablePip);
-                            
+
+                            int peakVirtualMemoryUsageMb = executionResult.PerformanceInformation.MemoryCounters.PeakVirtualMemoryUsageMb;
+                            int peakWorkingSetMb = executionResult.PerformanceInformation.MemoryCounters.PeakWorkingSetMb;
+                            int peakPagefileUsageMb = executionResult.PerformanceInformation.MemoryCounters.PeakPagefileUsageMb;
+
                             Logger.Log.PeakMemoryUsage(
                                 operationContext, 
                                 runnablePip.Description,
@@ -3670,13 +3674,13 @@ namespace BuildXL.Scheduler
                                 (int)executionResult.PerformanceInformation.ProcessExecutionTime.TotalSeconds,
                                 runnablePip.Worker.DefaultMemoryUsagePerProcess, 
                                 expectedRamUsage,
-                                executionResult.PerformanceInformation.PeakVirtualMemoryUsageMb,
-                                executionResult.PerformanceInformation.PeakWorkingSetMb,
-                                executionResult.PerformanceInformation.PeakPagefileUsageMb);
+                                peakVirtualMemoryUsageMb,
+                                peakWorkingSetMb,
+                                peakPagefileUsageMb);
 
-                            m_totalPeakVirtualMemoryUsageMb += executionResult.PerformanceInformation.PeakVirtualMemoryUsageMb;
-                            m_totalPeakWorkingSetMb += executionResult.PerformanceInformation.PeakWorkingSetMb;
-                            m_totalPeakPagefileUsageMb += executionResult.PerformanceInformation.PeakPagefileUsageMb;
+                            m_totalPeakVirtualMemoryUsageMb += peakVirtualMemoryUsageMb;
+                            m_totalPeakWorkingSetMb += peakWorkingSetMb;
+                            m_totalPeakPagefileUsageMb += peakPagefileUsageMb;
 
                             // File violation analysis needs to happen on the master as it relies on
                             // graph-wide data such as detecting duplicate

--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -3612,7 +3612,7 @@ namespace BuildXL.Scheduler
                             // Use the max of the observed peak memory and the worker's expected RAM usage for the pip
                             var expectedRamUsageMb = Math.Max(
                                     worker.GetExpectedRamUsageMb(processRunnable),
-                                    Math.Max(1, executionResult.PerformanceInformation?.PeakWorkingSetMb ?? 0));
+                                    Math.Max(1, executionResult.PerformanceInformation?.MemoryCounters.PeakWorkingSetMb ?? 0));
 
                             processRunnable.ExpectedRamUsageMb = expectedRamUsageMb;
 

--- a/Public/Src/Engine/Scheduler/Tracing/ExecutionLog.Events.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/ExecutionLog.Events.cs
@@ -1146,6 +1146,11 @@ namespace BuildXL.Scheduler.Tracing
         public int MachineRamUtilizationMB;
 
         /// <summary>
+        /// Available Ram in MB
+        /// </summary>
+        public int MachineAvailableRamMB;
+
+        /// <summary>
         /// Percentage of available commit used. Note if the machine has an expandable page file, this is based on the
         /// current size not necessarily the maximum size. So even if this hits 100%, the machine may still be able to
         /// commit more as the page file expands.
@@ -1276,6 +1281,11 @@ namespace BuildXL.Scheduler.Tracing
             {
                 writer.Write(pipsSucceeded);
             }
+
+            writer.Write(MachineRamUtilizationMB);
+            writer.Write(MachineAvailableRamMB);
+            writer.Write(CommitPercent);
+            writer.Write(CommitTotalMB);
         }
 
         /// <inheritdoc />
@@ -1321,6 +1331,11 @@ namespace BuildXL.Scheduler.Tracing
             {
                 PipsSucceededAllTypes[i] = reader.ReadInt64();
             }
+
+            MachineRamUtilizationMB = reader.ReadInt32();
+            MachineAvailableRamMB = reader.ReadInt32();
+            CommitPercent = reader.ReadInt32();
+            CommitTotalMB = reader.ReadInt32();
         }
     }
 

--- a/Public/Src/Engine/Scheduler/Tracing/Log.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/Log.cs
@@ -4507,13 +4507,13 @@ namespace BuildXL.Scheduler.Tracing
         public abstract void PipSourceDependencyCannotBeHashed(LoggingContext context, string filePath, string pipDescription);
 
         [GeneratedEvent(
-            (ushort)LogEventId.PeakMemoryUsage,
+            (ushort)LogEventId.ProcessPipExecutionInfo,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,
             Keywords = (int)Keywords.UserMessage,
             EventTask = (ushort)Tasks.PipExecutor,
-            Message = "[{pipDescription}] NumProcesses: {numProcesses}, DurationSeconds: {durationSec}, DefaultMemoryUsageMb: {defaultMemoryUsageMb}, ExpectedMemoryUsageMb: {expectedMemoryUsageMb}, PeakVirtualMemoryMb: {peakVirtualMemoryMb}, PeakWorkingSetMb: {peakWorkingSetMb}, PeakPagefileUsageMb: {peakPagefileUsageMb}")]
-        internal abstract void PeakMemoryUsage(LoggingContext loggingContext, string pipDescription, int numProcesses, int durationSec, int defaultMemoryUsageMb, int expectedMemoryUsageMb, int peakVirtualMemoryMb, int peakWorkingSetMb, int peakPagefileUsageMb);
+            Message = "[{pipDescription}] NumProcesses: {numProcesses}, ExpectedDurationSec: {expectedDurationSec}, ActualDurationSec: {actualDurationSec}, ProcessorUseInPercents: {processorUseInPercents}, DefaultMemoryUsageMb: {defaultMemoryUsageMb}, ExpectedMemoryUsageMb: {expectedMemoryUsageMb}, PeakVirtualMemoryMb: {peakVirtualMemoryMb}, PeakWorkingSetMb: {peakWorkingSetMb}, PeakPagefileUsageMb: {peakPagefileUsageMb}")]
+        internal abstract void ProcessPipExecutionInfo(LoggingContext loggingContext, string pipDescription, int numProcesses, int expectedDurationSec, int actualDurationSec, int processorUseInPercents, int defaultMemoryUsageMb, int expectedMemoryUsageMb, int peakVirtualMemoryMb, int peakWorkingSetMb, int peakPagefileUsageMb);
     }
 }
 #pragma warning restore CA1823 // Unused field

--- a/Public/Src/Engine/Scheduler/Tracing/Log.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/Log.cs
@@ -321,7 +321,6 @@ namespace BuildXL.Scheduler.Tracing
             Message = "[{pipDescription}] Adding augmenting path set '{pathSetHash}' with '{pathCount}' (from {pathSetCount} path sets with min {minPathCount} and max {maxPathCount} paths). Weak fingerprint={weakFingerprint}. Result={result}.")]
         internal abstract void AddAugmentingPathSet(LoggingContext loggingContext, string pipDescription, string weakFingerprint, string pathSetHash, int pathCount, int pathSetCount, int minPathCount, int maxPathCount, string result);
 
-
         [GeneratedEvent(
             (ushort)EventId.PipFailedDueToServicesFailedToRun,
             EventGenerators = EventGenerators.LocalOnly,
@@ -4506,6 +4505,15 @@ namespace BuildXL.Scheduler.Tracing
             EventTask = (ushort)Tasks.PipInputAssertions,
             Message = "Source dependency for file at path: {filePath} could not be hashed while processing pip: {pipDescription}.")]
         public abstract void PipSourceDependencyCannotBeHashed(LoggingContext context, string filePath, string pipDescription);
+
+        [GeneratedEvent(
+            (ushort)LogEventId.PeakMemoryUsage,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Verbose,
+            Keywords = (int)Keywords.UserMessage,
+            EventTask = (ushort)Tasks.PipExecutor,
+            Message = "[{pipDescription}] NumProcesses: {numProcesses}, DurationSeconds: {durationSec}, DefaultMemoryUsageMb: {defaultMemoryUsageMb}, ExpectedMemoryUsageMb: {expectedMemoryUsageMb}, PeakVirtualMemoryMb: {peakVirtualMemoryMb}, PeakWorkingSetMb: {peakWorkingSetMb}, PeakPagefileUsageMb: {peakPagefileUsageMb}")]
+        internal abstract void PeakMemoryUsage(LoggingContext loggingContext, string pipDescription, int numProcesses, int durationSec, int defaultMemoryUsageMb, int expectedMemoryUsageMb, int peakVirtualMemoryMb, int peakWorkingSetMb, int peakPagefileUsageMb);
     }
 }
 #pragma warning restore CA1823 // Unused field

--- a/Public/Src/Engine/Scheduler/Tracing/LogEventId.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/LogEventId.cs
@@ -149,7 +149,7 @@ namespace BuildXL.Scheduler.Tracing
         PipSourceDependencyCannotBeHashed = 5053,
 
         ProblematicWorkerExit = 5070,
-        PeakMemoryUsage = 5071,
+        ProcessPipExecutionInfo = 5071,
 
         // was DependencyViolationGenericWithRelatedPip_AsError = 25000,
         // was DependencyViolationGeneric_AsError = 25001,

--- a/Public/Src/Engine/Scheduler/Tracing/LogEventId.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/LogEventId.cs
@@ -149,6 +149,7 @@ namespace BuildXL.Scheduler.Tracing
         PipSourceDependencyCannotBeHashed = 5053,
 
         ProblematicWorkerExit = 5070,
+        PeakMemoryUsage = 5071,
 
         // was DependencyViolationGenericWithRelatedPip_AsError = 25000,
         // was DependencyViolationGeneric_AsError = 25001,

--- a/Public/Src/Engine/UnitTests/Processes/SandboxedProcessTest.cs
+++ b/Public/Src/Engine/UnitTests/Processes/SandboxedProcessTest.cs
@@ -266,9 +266,9 @@ namespace Test.BuildXL.Processes
                         "Expected a non-zero user+kernel time.");
                 }
 
-                XAssert.AreNotEqual<ulong>(0, accounting.PeakVirtualMemoryUsage, "Expecting non-zero memory usage");
-                XAssert.AreNotEqual<ulong>(0, accounting.PeakWorkingSet, "Expecting non-zero memory usage");
-                XAssert.AreNotEqual<ulong>(0, accounting.PeakPagefileUsage, "Expecting non-zero pagefile usage");
+                XAssert.AreNotEqual<ulong>(0, accounting.MemoryCounters.PeakVirtualMemoryUsage, "Expecting non-zero memory usage");
+                XAssert.AreNotEqual<ulong>(0, accounting.MemoryCounters.PeakWorkingSet, "Expecting non-zero memory usage");
+                XAssert.AreNotEqual<ulong>(0, accounting.MemoryCounters.PeakPagefileUsage, "Expecting non-zero pagefile usage");
 
                 // Prior to Win10, cmd.exe launched within a job but its associated conhost.exe was exempt from the job.
                 // That changed with Bug #633552

--- a/Public/Src/Engine/UnitTests/Processes/SandboxedProcessTest.cs
+++ b/Public/Src/Engine/UnitTests/Processes/SandboxedProcessTest.cs
@@ -266,7 +266,9 @@ namespace Test.BuildXL.Processes
                         "Expected a non-zero user+kernel time.");
                 }
 
-                XAssert.AreNotEqual<ulong>(0, accounting.PeakMemoryUsage, "Expecting non-zero memory usage");
+                XAssert.AreNotEqual<ulong>(0, accounting.PeakVirtualMemoryUsage, "Expecting non-zero memory usage");
+                XAssert.AreNotEqual<ulong>(0, accounting.PeakWorkingSet, "Expecting non-zero memory usage");
+                XAssert.AreNotEqual<ulong>(0, accounting.PeakPagefileUsage, "Expecting non-zero pagefile usage");
 
                 // Prior to Win10, cmd.exe launched within a job but its associated conhost.exe was exempt from the job.
                 // That changed with Bug #633552

--- a/Public/Src/Engine/UnitTests/Scheduler/PipRunningTimeTableTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/PipRunningTimeTableTests.cs
@@ -78,6 +78,8 @@ namespace Test.BuildXL.Scheduler
                                                         userTime,
                                                         kernelTime,
                                                         peakMemoryUsage,
+                                                        peakMemoryUsage,
+                                                        peakMemoryUsage,
                                                         numberOfProcesses,
                                                         workerId);
                                                     var data = new PipHistoricPerfData(performance);
@@ -127,6 +129,8 @@ namespace Test.BuildXL.Scheduler
                         TimeSpan.FromMilliseconds(execTime),
                         TimeSpan.FromMilliseconds(execTime / 2),
                         1024 * 1024,
+                        1024 * 1024,
+                        1024 * 1024,
                         1,
                         workerId: 0);
 
@@ -166,6 +170,8 @@ namespace Test.BuildXL.Scheduler
                 default(IOCounters),
                 TimeSpan.FromMilliseconds(execTime),
                 TimeSpan.FromMilliseconds(execTime / 2),
+                1024 * 1024,
+                1024 * 1024,
                 1024 * 1024,
                 1,
                 workerId: 0);

--- a/Public/Src/Engine/UnitTests/Scheduler/PipRunningTimeTableTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/PipRunningTimeTableTests.cs
@@ -77,9 +77,7 @@ namespace Test.BuildXL.Scheduler
                                                         ioCounters,
                                                         userTime,
                                                         kernelTime,
-                                                        peakMemoryUsage,
-                                                        peakMemoryUsage,
-                                                        peakMemoryUsage,
+                                                        new ProcessMemoryCounters(peakMemoryUsage, peakMemoryUsage, peakMemoryUsage),
                                                         numberOfProcesses,
                                                         workerId);
                                                     var data = new PipHistoricPerfData(performance);
@@ -128,9 +126,7 @@ namespace Test.BuildXL.Scheduler
                         default(IOCounters),
                         TimeSpan.FromMilliseconds(execTime),
                         TimeSpan.FromMilliseconds(execTime / 2),
-                        1024 * 1024,
-                        1024 * 1024,
-                        1024 * 1024,
+                        new ProcessMemoryCounters(1024 * 1024, 1024 * 1024, 1024 * 1024),
                         1,
                         workerId: 0);
 
@@ -170,9 +166,7 @@ namespace Test.BuildXL.Scheduler
                 default(IOCounters),
                 TimeSpan.FromMilliseconds(execTime),
                 TimeSpan.FromMilliseconds(execTime / 2),
-                1024 * 1024,
-                1024 * 1024,
-                1024 * 1024,
+                new ProcessMemoryCounters(1024 * 1024, 1024 * 1024, 1024 * 1024),
                 1,
                 workerId: 0);
 

--- a/Public/Src/Engine/UnitTests/Scheduler/ProcessExecutionResultSerializerTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/ProcessExecutionResultSerializerTests.cs
@@ -50,6 +50,8 @@ namespace Test.BuildXL.Scheduler
                     TimeSpan.FromMinutes(3),
                     TimeSpan.FromMinutes(3),
                     12324,
+                    12324,
+                    12324,
                     33,
                     7),
                 fingerprint: new WeakContentFingerprint(fingerprint), 
@@ -123,7 +125,10 @@ namespace Test.BuildXL.Scheduler
                 r => r.PerformanceInformation.FileMonitoringViolations.NumFileAccessesWhitelistedButNotCacheable,
                 r => r.PerformanceInformation.UserTime,
                 r => r.PerformanceInformation.KernelTime,
-                r => r.PerformanceInformation.PeakMemoryUsage,
+                r => r.PerformanceInformation.PeakVirtualMemoryUsage,
+                r => r.PerformanceInformation.PeakWorkingSet,
+                r => r.PerformanceInformation.PeakPagefileUsage,
+
                 r => r.PerformanceInformation.NumberOfProcesses,
 
                 r => r.FileAccessViolationsNotWhitelisted.Count,

--- a/Public/Src/Engine/UnitTests/Scheduler/ProcessExecutionResultSerializerTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/ProcessExecutionResultSerializerTests.cs
@@ -49,9 +49,7 @@ namespace Test.BuildXL.Scheduler
                     default(IOCounters),
                     TimeSpan.FromMinutes(3),
                     TimeSpan.FromMinutes(3),
-                    12324,
-                    12324,
-                    12324,
+                    new ProcessMemoryCounters(12324, 12325, 12326),
                     33,
                     7),
                 fingerprint: new WeakContentFingerprint(fingerprint), 
@@ -125,9 +123,9 @@ namespace Test.BuildXL.Scheduler
                 r => r.PerformanceInformation.FileMonitoringViolations.NumFileAccessesWhitelistedButNotCacheable,
                 r => r.PerformanceInformation.UserTime,
                 r => r.PerformanceInformation.KernelTime,
-                r => r.PerformanceInformation.PeakVirtualMemoryUsage,
-                r => r.PerformanceInformation.PeakWorkingSet,
-                r => r.PerformanceInformation.PeakPagefileUsage,
+                r => r.PerformanceInformation.MemoryCounters.PeakVirtualMemoryUsage,
+                r => r.PerformanceInformation.MemoryCounters.PeakWorkingSet,
+                r => r.PerformanceInformation.MemoryCounters.PeakPagefileUsage,
 
                 r => r.PerformanceInformation.NumberOfProcesses,
 

--- a/Public/Src/Pips/Dll/PipExecutionPerformance.cs
+++ b/Public/Src/Pips/Dll/PipExecutionPerformance.cs
@@ -188,14 +188,34 @@ namespace BuildXL.Pips
         public TimeSpan KernelTime { get; }
 
         /// <summary>
-        /// Peak memory usage (in bytes) considering all processes (highest point-in-time sum of the memory usage of the process tree).
+        /// Peak working set (in bytes) considering all processes (highest point-in-time sum of the memory usage of the process tree).
         /// </summary>
-        public ulong PeakMemoryUsage { get; }
+        public ulong PeakWorkingSet { get; }
 
         /// <summary>
-        /// <see cref="PeakMemoryUsage"/> in megabytes
+        /// <see cref="PeakWorkingSet"/> in megabytes
         /// </summary>
-        public int PeakMemoryUsageMb => (int)(PeakMemoryUsage / (1024 * 1024));
+        public int PeakWorkingSetMb => (int)(PeakWorkingSet / (1024 * 1024));
+
+        /// <summary>
+        /// Peak working set (in bytes) considering all processes (highest point-in-time sum of the memory usage of the process tree).
+        /// </summary>
+        public ulong PeakPagefileUsage { get; }
+
+        /// <summary>
+        /// <see cref="PeakPagefileUsage"/> in megabytes
+        /// </summary>
+        public int PeakPagefileUsageMb => (int)(PeakPagefileUsage / (1024 * 1024));
+
+        /// <summary>
+        /// Peak memory usage (in bytes) considering all processes (highest point-in-time sum of the memory usage of the process tree).
+        /// </summary>
+        public ulong PeakVirtualMemoryUsage { get; }
+
+        /// <summary>
+        /// <see cref="PeakVirtualMemoryUsage"/> in megabytes
+        /// </summary>
+        public int PeakVirtualMemoryUsageMb => (int)(PeakVirtualMemoryUsage / (1024 * 1024));
 
         /// <summary>
         /// Number of processes that executed as part of the pip (the entry-point process may start children).
@@ -228,7 +248,9 @@ namespace BuildXL.Pips
             IOCounters ioCounters,
             TimeSpan userTime,
             TimeSpan kernelTime,
-            ulong peakMemoryUsage,
+            ulong peakVirtualMemoryUsage,
+            ulong peakWorkingSet,
+            ulong peakPagefileUsage,
             uint numberOfProcesses,
             uint workerId)
             : base(level, executionStart, executionStop, workerId)
@@ -245,7 +267,9 @@ namespace BuildXL.Pips
             IO = ioCounters;
             UserTime = userTime;
             KernelTime = kernelTime;
-            PeakMemoryUsage = peakMemoryUsage;
+            PeakVirtualMemoryUsage = peakVirtualMemoryUsage;
+            PeakWorkingSet = peakWorkingSet;
+            PeakPagefileUsage = peakPagefileUsage;
             NumberOfProcesses = numberOfProcesses;
         }
 
@@ -281,7 +305,9 @@ namespace BuildXL.Pips
             IO.Serialize(writer);
             writer.Write(UserTime);
             writer.Write(KernelTime);
-            writer.Write(PeakMemoryUsage);
+            writer.Write(PeakVirtualMemoryUsage);
+            writer.Write(PeakWorkingSet);
+            writer.Write(PeakPagefileUsage);
             writer.WriteCompact(NumberOfProcesses);
         }
 
@@ -295,6 +321,9 @@ namespace BuildXL.Pips
             TimeSpan userTime = reader.ReadTimeSpan();
             TimeSpan kernelTime = reader.ReadTimeSpan();
             ulong peakMemoryUsage = reader.ReadUInt64();
+            ulong peakWorkingSet = reader.ReadUInt64();
+            ulong peakPagefileUsage = reader.ReadUInt64();
+
             uint numberOfProcesses = reader.ReadUInt32Compact();
 
             return new ProcessPipExecutionPerformance(
@@ -307,7 +336,9 @@ namespace BuildXL.Pips
                 ioCounters: ioCounters,
                 userTime: userTime,
                 kernelTime: kernelTime,
-                peakMemoryUsage: peakMemoryUsage,
+                peakVirtualMemoryUsage: peakMemoryUsage,
+                peakWorkingSet: peakWorkingSet,
+                peakPagefileUsage: peakPagefileUsage,
                 numberOfProcesses: numberOfProcesses,
                 workerId: workerId);
         }

--- a/Public/Src/Pips/Dll/PipExecutionPerformance.cs
+++ b/Public/Src/Pips/Dll/PipExecutionPerformance.cs
@@ -212,6 +212,11 @@ namespace BuildXL.Pips
         /// </summary>
         public ulong? CacheDescriptorId { get; }
 
+        /// <summary>
+        /// Processor used in % (150 means one processor fully used and the other half used)
+        /// </summary>
+        public ushort ProcessorsInPercents { get; }
+
         /// <nodoc />
         public ProcessPipExecutionPerformance(
             PipExecutionLevel level,
@@ -242,6 +247,11 @@ namespace BuildXL.Pips
             KernelTime = kernelTime;
             MemoryCounters = memoryCounters;
             NumberOfProcesses = numberOfProcesses;
+
+            var durationInMs = (uint)Math.Min(uint.MaxValue, Math.Max(1, ProcessExecutionTime.TotalMilliseconds));
+            double cpuTime = KernelTime.TotalMilliseconds + UserTime.TotalMilliseconds;
+            double processorPercentage = durationInMs == 0 ? 0 : cpuTime / durationInMs;
+            ProcessorsInPercents = (ushort)Math.Min(ushort.MaxValue, processorPercentage * 100.0);
         }
 
         /// <summary>

--- a/Public/Src/Pips/Dll/PipExecutionPerformance.cs
+++ b/Public/Src/Pips/Dll/PipExecutionPerformance.cs
@@ -188,34 +188,9 @@ namespace BuildXL.Pips
         public TimeSpan KernelTime { get; }
 
         /// <summary>
-        /// Peak working set (in bytes) considering all processes (highest point-in-time sum of the memory usage of the process tree).
+        /// Memory counters
         /// </summary>
-        public ulong PeakWorkingSet { get; }
-
-        /// <summary>
-        /// <see cref="PeakWorkingSet"/> in megabytes
-        /// </summary>
-        public int PeakWorkingSetMb => (int)(PeakWorkingSet / (1024 * 1024));
-
-        /// <summary>
-        /// Peak working set (in bytes) considering all processes (highest point-in-time sum of the memory usage of the process tree).
-        /// </summary>
-        public ulong PeakPagefileUsage { get; }
-
-        /// <summary>
-        /// <see cref="PeakPagefileUsage"/> in megabytes
-        /// </summary>
-        public int PeakPagefileUsageMb => (int)(PeakPagefileUsage / (1024 * 1024));
-
-        /// <summary>
-        /// Peak memory usage (in bytes) considering all processes (highest point-in-time sum of the memory usage of the process tree).
-        /// </summary>
-        public ulong PeakVirtualMemoryUsage { get; }
-
-        /// <summary>
-        /// <see cref="PeakVirtualMemoryUsage"/> in megabytes
-        /// </summary>
-        public int PeakVirtualMemoryUsageMb => (int)(PeakVirtualMemoryUsage / (1024 * 1024));
+        public ProcessMemoryCounters MemoryCounters { get; }
 
         /// <summary>
         /// Number of processes that executed as part of the pip (the entry-point process may start children).
@@ -248,9 +223,7 @@ namespace BuildXL.Pips
             IOCounters ioCounters,
             TimeSpan userTime,
             TimeSpan kernelTime,
-            ulong peakVirtualMemoryUsage,
-            ulong peakWorkingSet,
-            ulong peakPagefileUsage,
+            ProcessMemoryCounters memoryCounters,
             uint numberOfProcesses,
             uint workerId)
             : base(level, executionStart, executionStop, workerId)
@@ -267,9 +240,7 @@ namespace BuildXL.Pips
             IO = ioCounters;
             UserTime = userTime;
             KernelTime = kernelTime;
-            PeakVirtualMemoryUsage = peakVirtualMemoryUsage;
-            PeakWorkingSet = peakWorkingSet;
-            PeakPagefileUsage = peakPagefileUsage;
+            MemoryCounters = memoryCounters;
             NumberOfProcesses = numberOfProcesses;
         }
 
@@ -305,9 +276,7 @@ namespace BuildXL.Pips
             IO.Serialize(writer);
             writer.Write(UserTime);
             writer.Write(KernelTime);
-            writer.Write(PeakVirtualMemoryUsage);
-            writer.Write(PeakWorkingSet);
-            writer.Write(PeakPagefileUsage);
+            MemoryCounters.Serialize(writer);
             writer.WriteCompact(NumberOfProcesses);
         }
 
@@ -320,9 +289,7 @@ namespace BuildXL.Pips
             IOCounters ioCounters = IOCounters.Deserialize(reader);
             TimeSpan userTime = reader.ReadTimeSpan();
             TimeSpan kernelTime = reader.ReadTimeSpan();
-            ulong peakMemoryUsage = reader.ReadUInt64();
-            ulong peakWorkingSet = reader.ReadUInt64();
-            ulong peakPagefileUsage = reader.ReadUInt64();
+            ProcessMemoryCounters memoryCounters = ProcessMemoryCounters.Deserialize(reader);
 
             uint numberOfProcesses = reader.ReadUInt32Compact();
 
@@ -336,9 +303,7 @@ namespace BuildXL.Pips
                 ioCounters: ioCounters,
                 userTime: userTime,
                 kernelTime: kernelTime,
-                peakVirtualMemoryUsage: peakMemoryUsage,
-                peakWorkingSet: peakWorkingSet,
-                peakPagefileUsage: peakPagefileUsage,
+                memoryCounters: memoryCounters,
                 numberOfProcesses: numberOfProcesses,
                 workerId: workerId);
         }

--- a/Public/Src/Pips/Dll/ProcessMemoryCounters.cs
+++ b/Public/Src/Pips/Dll/ProcessMemoryCounters.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using BuildXL.Utilities;
+
+namespace BuildXL.Pips
+{
+    /// <summary>
+    /// Memory counters for process pips, representing all child processes
+    /// </summary>
+    public readonly struct ProcessMemoryCounters
+    {
+        /// <summary>
+        /// Peak working set (in bytes) considering all processes (highest point-in-time sum of the memory usage of the process tree).
+        /// </summary>
+        public readonly ulong PeakWorkingSet;
+
+        /// <summary>
+        /// <see cref="PeakWorkingSet"/> in megabytes
+        /// </summary>
+        public int PeakWorkingSetMb => (int)(PeakWorkingSet / (1024 * 1024));
+
+        /// <summary>
+        /// Peak working set (in bytes) considering all processes (highest point-in-time sum of the memory usage of the process tree).
+        /// </summary>
+        public readonly ulong PeakPagefileUsage;
+
+        /// <summary>
+        /// <see cref="PeakPagefileUsage"/> in megabytes
+        /// </summary>
+        public int PeakPagefileUsageMb => (int)(PeakPagefileUsage / (1024 * 1024));
+
+        /// <summary>
+        /// Peak memory usage (in bytes) considering all processes (highest point-in-time sum of the memory usage of the process tree).
+        /// </summary>
+        public readonly ulong PeakVirtualMemoryUsage;
+
+        /// <summary>
+        /// <see cref="PeakVirtualMemoryUsage"/> in megabytes
+        /// </summary>
+        public int PeakVirtualMemoryUsageMb => (int)(PeakVirtualMemoryUsage / (1024 * 1024));
+
+        /// <nodoc />
+        public ProcessMemoryCounters(
+            ulong peakVirtualMemoryUsage,
+            ulong peakWorkingSet,
+            ulong peakPagefileUsage)
+        {
+            PeakVirtualMemoryUsage = peakVirtualMemoryUsage;
+            PeakWorkingSet = peakWorkingSet;
+            PeakPagefileUsage = peakPagefileUsage;
+        }
+
+        /// <nodoc />
+        public void Serialize(BuildXLWriter writer)
+        {
+            writer.Write(PeakVirtualMemoryUsage);
+            writer.Write(PeakWorkingSet);
+            writer.Write(PeakPagefileUsage);
+        }
+
+        /// <nodoc />
+        public static ProcessMemoryCounters Deserialize(BuildXLReader reader)
+        {
+            ulong peakVirtualMemoryUsage = reader.ReadUInt64();
+            ulong peakWorkingSet = reader.ReadUInt64();
+            ulong peakPagefileUsage = reader.ReadUInt64();
+
+            return new ProcessMemoryCounters(peakVirtualMemoryUsage, peakWorkingSet, peakPagefileUsage);
+        }
+    }
+}

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/Xldb/XldbProtobufExtensions.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/Xldb/XldbProtobufExtensions.cs
@@ -109,7 +109,7 @@ namespace BuildXL.Execution.Analyzer
 
                 processPipExecPerformance.UserTime = Google.Protobuf.WellKnownTypes.Duration.FromTimeSpan(performance.UserTime);
                 processPipExecPerformance.KernelTime = Google.Protobuf.WellKnownTypes.Duration.FromTimeSpan(performance.KernelTime);
-                processPipExecPerformance.PeakMemoryUsage = performance.PeakWorkingSet;
+                processPipExecPerformance.PeakMemoryUsage = performance.MemoryCounters.PeakWorkingSet;
                 processPipExecPerformance.NumberOfProcesses = performance.NumberOfProcesses;
 
                 processPipExecPerformance.FileMonitoringViolationCounters = new Xldb.Proto.FileMonitoringViolationCounters()

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/Xldb/XldbProtobufExtensions.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/Xldb/XldbProtobufExtensions.cs
@@ -109,7 +109,7 @@ namespace BuildXL.Execution.Analyzer
 
                 processPipExecPerformance.UserTime = Google.Protobuf.WellKnownTypes.Duration.FromTimeSpan(performance.UserTime);
                 processPipExecPerformance.KernelTime = Google.Protobuf.WellKnownTypes.Duration.FromTimeSpan(performance.KernelTime);
-                processPipExecPerformance.PeakMemoryUsage = performance.PeakMemoryUsage;
+                processPipExecPerformance.PeakMemoryUsage = performance.PeakWorkingSet;
                 processPipExecPerformance.NumberOfProcesses = performance.NumberOfProcesses;
 
                 processPipExecPerformance.FileMonitoringViolationCounters = new Xldb.Proto.FileMonitoringViolationCounters()

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/CosineJsonExport.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/CosineJsonExport.cs
@@ -794,10 +794,10 @@ namespace BuildXL.Execution.Analyzer
                         m_writer.WriteValue(processPerformance.KernelTime.Ticks);
                     }
 
-                    if (processPerformance.PeakWorkingSet != 0)
+                    if (processPerformance.MemoryCounters.PeakWorkingSet != 0)
                     {
                         m_writer.WritePropertyName("peakMemory");
-                        m_writer.WriteValue(processPerformance.PeakWorkingSet);
+                        m_writer.WriteValue(processPerformance.MemoryCounters.PeakWorkingSet);
                     }
 
                     if (processPerformance.IO.GetAggregateIO().TransferCount > 0)

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/CosineJsonExport.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/CosineJsonExport.cs
@@ -794,10 +794,10 @@ namespace BuildXL.Execution.Analyzer
                         m_writer.WriteValue(processPerformance.KernelTime.Ticks);
                     }
 
-                    if (processPerformance.PeakMemoryUsage != 0)
+                    if (processPerformance.PeakWorkingSet != 0)
                     {
                         m_writer.WritePropertyName("peakMemory");
-                        m_writer.WriteValue(processPerformance.PeakMemoryUsage);
+                        m_writer.WriteValue(processPerformance.PeakWorkingSet);
                     }
 
                     if (processPerformance.IO.GetAggregateIO().TransferCount > 0)

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/FailedPipsDumpAnalyzer.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/FailedPipsDumpAnalyzer.cs
@@ -273,7 +273,7 @@ namespace BuildXL.Execution.Analyzer
                             provenance != null ? provenance.OutputValueSymbol.ToString(SymbolTable) : string.Empty);
 
                         var pipPerformance = m_pipPerformance[pip.PipId.Value];
-                        WritePropertyAndValue(writer, "PeakMemoryUsageMb", pipPerformance.PeakMemoryUsageMb.ToString());
+                        WritePropertyAndValue(writer, "PeakMemoryUsageMb", pipPerformance.PeakWorkingSetMb.ToString());
                         WritePropertyAndValue(writer, "NumberOfProcesses", pipPerformance.NumberOfProcesses.ToString());
                         WritePropertyAndValue(
                             writer,

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/FailedPipsDumpAnalyzer.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/FailedPipsDumpAnalyzer.cs
@@ -273,7 +273,7 @@ namespace BuildXL.Execution.Analyzer
                             provenance != null ? provenance.OutputValueSymbol.ToString(SymbolTable) : string.Empty);
 
                         var pipPerformance = m_pipPerformance[pip.PipId.Value];
-                        WritePropertyAndValue(writer, "PeakMemoryUsageMb", pipPerformance.PeakWorkingSetMb.ToString());
+                        WritePropertyAndValue(writer, "PeakMemoryUsageMb", pipPerformance.MemoryCounters.PeakWorkingSetMb.ToString());
                         WritePropertyAndValue(writer, "NumberOfProcesses", pipPerformance.NumberOfProcesses.ToString());
                         WritePropertyAndValue(
                             writer,

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/PipExecutionPerformanceAnalyzer.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/PipExecutionPerformanceAnalyzer.cs
@@ -119,7 +119,7 @@ namespace BuildXL.Execution.Analyzer
                 WriteColumn(Math.Round(performance.IO.WriteCounters.TransferCount / 1024 / 1024 / 1024.0, 1).ToString());
                 WriteColumn(Math.Round(performance.IO.OtherCounters.TransferCount / 1024 / 1024 / 1024.0, 1).ToString());
                 WriteColumn(performance.NumberOfProcesses.ToString());
-                m_writer.Write(performance.PeakWorkingSet.ToString());
+                m_writer.Write(performance.MemoryCounters.PeakWorkingSet.ToString());
 
                 m_writer.WriteLine();
             }
@@ -158,7 +158,7 @@ namespace BuildXL.Execution.Analyzer
                 WriteLineIndented(I($"\"executionTimeInMs\" : {performance.ProcessExecutionTime.TotalMilliseconds},"));
                 WriteLineIndented(I($"\"userExecutionTimeInMs\" : {performance.UserTime.TotalMilliseconds},"));
                 WriteLineIndented(I($"\"kernelExecutionTimeInMs\" : {performance.KernelTime.TotalMilliseconds},"));
-                WriteLineIndented(I($"\"peakMemoryUsageInMb\" : {performance.PeakVirtualMemoryUsage},"));
+                WriteLineIndented(I($"\"peakMemoryUsageInMb\" : {performance.MemoryCounters.PeakVirtualMemoryUsage},"));
 
                 WriteLineIndented("\"io\" : {");
                 IncrementIndent();

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/PipExecutionPerformanceAnalyzer.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/PipExecutionPerformanceAnalyzer.cs
@@ -119,7 +119,7 @@ namespace BuildXL.Execution.Analyzer
                 WriteColumn(Math.Round(performance.IO.WriteCounters.TransferCount / 1024 / 1024 / 1024.0, 1).ToString());
                 WriteColumn(Math.Round(performance.IO.OtherCounters.TransferCount / 1024 / 1024 / 1024.0, 1).ToString());
                 WriteColumn(performance.NumberOfProcesses.ToString());
-                m_writer.Write(performance.PeakMemoryUsage.ToString());
+                m_writer.Write(performance.PeakWorkingSet.ToString());
 
                 m_writer.WriteLine();
             }
@@ -158,7 +158,7 @@ namespace BuildXL.Execution.Analyzer
                 WriteLineIndented(I($"\"executionTimeInMs\" : {performance.ProcessExecutionTime.TotalMilliseconds},"));
                 WriteLineIndented(I($"\"userExecutionTimeInMs\" : {performance.UserTime.TotalMilliseconds},"));
                 WriteLineIndented(I($"\"kernelExecutionTimeInMs\" : {performance.KernelTime.TotalMilliseconds},"));
-                WriteLineIndented(I($"\"peakMemoryUsageInMb\" : {performance.PeakMemoryUsage},"));
+                WriteLineIndented(I($"\"peakMemoryUsageInMb\" : {performance.PeakVirtualMemoryUsage},"));
 
                 WriteLineIndented("\"io\" : {");
                 IncrementIndent();

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/PipGraphExporter.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/PipGraphExporter.cs
@@ -731,10 +731,10 @@ namespace BuildXL.Execution.Analyzer
                         m_writer.WriteValue(processPerformance.KernelTime.Ticks);
                     }
 
-                    if (processPerformance.PeakMemoryUsage != 0)
+                    if (processPerformance.PeakWorkingSet != 0)
                     {
                         m_writer.WritePropertyName("peakMemory");
-                        m_writer.WriteValue(processPerformance.PeakMemoryUsage);
+                        m_writer.WriteValue(processPerformance.PeakWorkingSet);
                     }
 
                     if (processPerformance.IO.GetAggregateIO().TransferCount > 0)

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/PipGraphExporter.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/PipGraphExporter.cs
@@ -731,10 +731,10 @@ namespace BuildXL.Execution.Analyzer
                         m_writer.WriteValue(processPerformance.KernelTime.Ticks);
                     }
 
-                    if (processPerformance.PeakWorkingSet != 0)
+                    if (processPerformance.MemoryCounters.PeakWorkingSet != 0)
                     {
                         m_writer.WritePropertyName("peakMemory");
-                        m_writer.WriteValue(processPerformance.PeakWorkingSet);
+                        m_writer.WriteValue(processPerformance.MemoryCounters.PeakWorkingSet);
                     }
 
                     if (processPerformance.IO.GetAggregateIO().TransferCount > 0)

--- a/Public/Src/Utilities/Interop/Dispatch.cs
+++ b/Public/Src/Utilities/Interop/Dispatch.cs
@@ -88,7 +88,7 @@ namespace BuildXL.Interop
         /// </summary>
         /// <param name="handle">When calling from Windows the SafeProcessHandle is required</param>
         /// <param name="pid">On non-windows systems a process id has to be provided</param>
-        public static ulong? GetActivePeakMemoryUsage(IntPtr handle, int pid)
+        public static ulong? GetActivePeakWorkingSet(IntPtr handle, int pid)
         {
             switch (s_currentOS)
             {
@@ -104,15 +104,33 @@ namespace BuildXL.Interop
                     }
                 default:
                     {
-                        Process.PROCESSMEMORYCOUNTERSEX processMemoryCounters = new Windows.Process.PROCESSMEMORYCOUNTERSEX();
-
-                        if (Process.GetProcessMemoryInfo(handle, processMemoryCounters, processMemoryCounters.cb))
-                        {
-                            return processMemoryCounters.PeakWorkingSetSize;
-                        }
-
-                        return null;
+                        return GetMemoryUsageCounters(handle)?.PeakWorkingSetSize;
                     }
+            }
+        }
+
+        /// <summary>
+        /// Get memory usage with all counters for Windows
+        /// </summary>
+        public static Process.PROCESSMEMORYCOUNTERSEX GetMemoryUsageCounters(IntPtr handle)
+        {
+            switch (s_currentOS)
+            {
+                case OperatingSystem.MacOS:
+                {
+                    return null;
+                }
+                default:
+                {
+                    Process.PROCESSMEMORYCOUNTERSEX processMemoryCounters = new Windows.Process.PROCESSMEMORYCOUNTERSEX();
+
+                    if (Process.GetProcessMemoryInfo(handle, processMemoryCounters, processMemoryCounters.cb))
+                    {
+                        return processMemoryCounters;
+                    }
+
+                    return null;
+                }
             }
         }
     }

--- a/Public/Src/Utilities/Interop/Windows/Process.cs
+++ b/Public/Src/Utilities/Interop/Windows/Process.cs
@@ -185,7 +185,7 @@ namespace BuildXL.Interop.Windows
         }
 
         /// <nodoc />
-        [DllImport(BuildXL.Interop.Libraries.WindowsKernel32, EntryPoint = "GetProcessMemoryInfo", SetLastError = true)]
+        [DllImport(BuildXL.Interop.Libraries.WindowsPsApi, EntryPoint = "GetProcessMemoryInfo", SetLastError = true)]
         public static extern bool GetProcessMemoryInfo(IntPtr handle, [In, Out] PROCESSMEMORYCOUNTERSEX ppsmemCounters, uint cb);
     }
 }

--- a/Public/Src/Utilities/Utilities/AsyncProcessExecutor.cs
+++ b/Public/Src/Utilities/Utilities/AsyncProcessExecutor.cs
@@ -87,7 +87,7 @@ namespace BuildXL.Utilities
         /// <summary>
         /// Gets active peak memory usage.
         /// </summary>
-        public ulong? GetActivePeakMemoryUsage()
+        public ulong? GetActivePeakWorkingSet()
         {
             try
             {
@@ -96,7 +96,7 @@ namespace BuildXL.Utilities
                     return null;
                 }
 
-                return Dispatch.GetActivePeakMemoryUsage(Process.Handle, ProcessId);
+                return Dispatch.GetActivePeakWorkingSet(Process.Handle, ProcessId);
             }
 #pragma warning disable ERP022 // Unobserved exception in generic exception handler
             catch


### PR DESCRIPTION
- Reduced the default memory usage of process pips in case of no historical ram usage info.
- Master is now aware of workers' actual available memory, and commit memory usage.
- Measure working set, pagefile usage of process pips besides virtual memory
- Record working set in the historical perf data table instead of the virtual memory to accurately estimate the available memory in the next builds.  