### PR TITLE
Use checked-in package-lock.json file for npm install

### DIFF
--- a/Public/Sdk/Experimental/NodeJs/node.dsc
+++ b/Public/Sdk/Experimental/NodeJs/node.dsc
@@ -93,10 +93,6 @@ namespace Node {
                 pkgContents = importFrom("NodeJs.osx-x64").extracted;
                 executable = r`node-v8.12.0-darwin-x64/lib/node_modules/npm/bin/npm-cli.js`;
                 break;
-            case "unix":
-                pkgContents = importFrom("NodeJs.linux-x64").extracted;
-                executable = r`node-v8.12.0-linux-arm64/lib/node_modules/npm/bin/npm-cli.js`;
-                break;
             default:
                 Contract.fail(`The current NodeJs package doesn't support the current OS: ${host.os}. Esure you run on a supported OS -or- update the NodeJs package to have the version embdded.`);
         }
@@ -105,7 +101,7 @@ namespace Node {
     }
 
     @@public
-    export function tscCompile(workingDirectory: Directory, dependencies: StaticDirectory[]) : OpaqueDirectory {
+    export function tscCompile(workingDirectory: Directory, dependencies: Transformer.InputArtifact[]) : OpaqueDirectory {
         const outPath = d`${workingDirectory}/out`;
         const arguments: Argument[] = [
             Cmd.argument(Artifact.none(f`${workingDirectory}/node_modules/typescript/lib/tsc.js`)),

--- a/Public/Sdk/Experimental/NodeJs/node.dsc
+++ b/Public/Sdk/Experimental/NodeJs/node.dsc
@@ -93,6 +93,10 @@ namespace Node {
                 pkgContents = importFrom("NodeJs.osx-x64").extracted;
                 executable = r`node-v8.12.0-darwin-x64/lib/node_modules/npm/bin/npm-cli.js`;
                 break;
+            case "unix":
+                pkgContents = importFrom("NodeJs.linux-x64").extracted;
+                executable = r`node-v8.12.0-linux-arm64/lib/node_modules/npm/bin/npm-cli.js`;
+                break;
             default:
                 Contract.fail(`The current NodeJs package doesn't support the current OS: ${host.os}. Esure you run on a supported OS -or- update the NodeJs package to have the version embdded.`);
         }

--- a/Shared/Scripts/bxl.ps1
+++ b/Shared/Scripts/bxl.ps1
@@ -560,7 +560,7 @@ if (!$skipFilter){
 
     if ($Minimal) {
         # filtering by core deployment.
-        $AdditionalBuildXLArguments +=  "/f:(output='$($useDeployment.buildDir)\*'or(output='out\bin\$DeployConfig\Sdk\*')or($CacheOutputFilter))and~($CacheLongRunningFilter)ortag='protobufgenerator'oroutput='cg\*'"
+        $AdditionalBuildXLArguments +=  "/f:(output='$($useDeployment.buildDir)\*'or(output='out\bin\$DeployConfig\Sdk\*')or($CacheOutputFilter))and~($CacheLongRunningFilter)ortag='protobufgenerator'"
     }
 
     if ($Cache) {

--- a/config.dsc
+++ b/config.dsc
@@ -643,7 +643,7 @@ config({
             name: a`CgNpmRoot`,
             path: p`cg/npm`,
             trackSourceFileChanges: true,
-            isWritable: true,
+            isWritable: false,
             isReadable: true
         },
         {


### PR DESCRIPTION
This avoids generating package-lock.json upon every build; given that `npm install` without a lock file is not necessarily deterministic, every build can in theory generate a new package-lock.json.  Instead, when the lock file is explicitly provided, the behavior of `npm install` is fixed and deterministic.
