### PR TITLE
Fix access control check with scrubbing in NetCore builds.

### DIFF
--- a/Public/Src/Utilities/Native/IO/Windows/FileUtilities.Win.cs
+++ b/Public/Src/Utilities/Native/IO/Windows/FileUtilities.Win.cs
@@ -1509,7 +1509,6 @@ namespace BuildXL.Native.IO.Windows
             Contract.Requires(!string.IsNullOrWhiteSpace(path));
             path = FileSystemWin.ToLongPathIfExceedMaxPath(path);
 
-#if NET_FRAMEWORK
             FileSystemRights fileSystemRights =
                 FileSystemRights.WriteData |
                 FileSystemRights.AppendData |
@@ -1517,9 +1516,6 @@ namespace BuildXL.Native.IO.Windows
                 FileSystemRights.WriteExtendedAttributes;
 
             return CheckFileSystemRightsForPath(path, fileSystemRights);
-#else
-            return true;
-#endif
         }
 
 
@@ -1529,15 +1525,11 @@ namespace BuildXL.Native.IO.Windows
             Contract.Requires(!string.IsNullOrWhiteSpace(path));
             path = FileSystemWin.ToLongPathIfExceedMaxPath(path);
 
-#if NET_FRAMEWORK
             FileSystemRights fileSystemRights =
                 FileSystemRights.WriteAttributes |
                 FileSystemRights.WriteExtendedAttributes;
 
             return CheckFileSystemRightsForPath(path, fileSystemRights);
-#else
-            return true;
-#endif
         }
 
         private bool CheckFileSystemRightsForPath(string path, FileSystemRights fileSystemRights)

--- a/Public/Src/Utilities/UnitTests/Storage/FileUtilitiesTests.cs
+++ b/Public/Src/Utilities/UnitTests/Storage/FileUtilitiesTests.cs
@@ -1015,7 +1015,7 @@ namespace Test.BuildXL.Storage
 
             FileUtilities.SetFileAccessControl(testFilePath, FileSystemRights.WriteAttributes, false);
             XAssert.IsFalse(FileUtilities.HasWritableAccessControl(testFilePath));
-            XAssert.IsFalse(FileUtilities.HasWritableAttributeAccessControl(testFilePath));
+            XAssert.IsFalse(FileUtilities.HasWritableAttributeAccessControl(testFilePath)); 
         }
 
         private void AssertNonexistent(Possible<PathExistence, NativeFailure> maybeFileExistence)

--- a/Public/Src/Utilities/UnitTests/Storage/Test.BuildXL.Storage.dsc
+++ b/Public/Src/Utilities/UnitTests/Storage/Test.BuildXL.Storage.dsc
@@ -21,6 +21,7 @@ namespace Storage {
             importFrom("BuildXL.Utilities").Storage.dll,
             importFrom("BuildXL.Utilities.Instrumentation").Common.dll,
             importFrom("BuildXL.Utilities").Collections.dll,
+            ...importFrom("BuildXL.Utilities").Native.securityDlls,
         ],
         runtimeContent: [
             dummyWaiterExe


### PR DESCRIPTION
We had the access check in NetCore builds around a condition that always returned true. This is likely an artifact of some earlier version of NetCore that didn't include the API.

Fixes [AB#1617103](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1617103)