### PR TITLE
Update RuntimeContracts to support non-nullable types.

### DIFF
--- a/Public/Sdk/SelfHost/RuntimeContracts/RuntimeContracts.dsc
+++ b/Public/Sdk/SelfHost/RuntimeContracts/RuntimeContracts.dsc
@@ -46,7 +46,7 @@ export function withRuntimeContracts(args: Managed.Arguments, contractsLevel?: C
         tools: {
             csc: {
                 analyzers: [
-                    ...dlls(importFrom("RuntimeContracts.Analyzer").withQualifier({targetFramework: 'netstandard1.3'}).pkg)
+                    ...dlls(importFrom("RuntimeContracts.Analyzer").withQualifier({targetFramework: 'netstandard2.0'}).pkg)
                 ]
             },
         }});
@@ -80,7 +80,7 @@ export function getContractsSymbols(level: ContractsLevel, enableContractsQuanti
 
 /** Returns analyzers dll for RuntimeContracts nuget package. */
 export function getAnalyzers() : Managed.Binary[] {
-    return dlls(importFrom("RuntimeContracts.Analyzer").withQualifier({targetFramework: 'netstandard1.3'}).pkg);
+    return dlls(importFrom("RuntimeContracts.Analyzer").withQualifier({targetFramework: 'netstandard2.0'}).pkg);
 }
 
 function dlls(nugetPackage: NugetPackage): Managed.Binary[] {

--- a/cg/nuget/cgmanifest.json
+++ b/cg/nuget/cgmanifest.json
@@ -2517,7 +2517,7 @@
         "Type": "NuGet",
         "NuGet": {
           "Name": "RuntimeContracts",
-          "Version": "0.1.7.1"
+          "Version": "0.1.9.1"
         }
       }
     },
@@ -2526,7 +2526,7 @@
         "Type": "NuGet",
         "NuGet": {
           "Name": "RuntimeContracts.Analyzer",
-          "Version": "0.1.7.1"
+          "Version": "0.1.9.4"
         }
       }
     },

--- a/config.dsc
+++ b/config.dsc
@@ -46,6 +46,8 @@ config({
             repositories: importFile(f`config.microsoftInternal.dsc`).isMicrosoftInternal
                 ? {
                     "BuildXL.Selfhost": "https://pkgs.dev.azure.com/cloudbuild/_packaging/BuildXL.Selfhost/nuget/v3/index.json",
+                    // Don't check this in. Remove once the packages are visible from the aggregated feed.
+                    "nuget.org" : "http://api.nuget.org/v3/index.json",
                     // Note: From a compliance point of view it is important that MicrosoftInternal has a single feed.
                     // If you need to consume packages make sure they are upstreamed in that feed.
                   }
@@ -68,7 +70,7 @@ config({
                 { id: "Bond.Runtime.CSharp", version: "8.0.0" },
                 { id: "CLAP", version: "4.6" },
 
-                { id: "RuntimeContracts", version: "0.1.7.1" },
+                { id: "RuntimeContracts", version: "0.1.9.1" },
 
                 { id: "Microsoft.NETFramework.ReferenceAssemblies.net451", version: "1.0.0-alpha-5"},
                 { id: "Microsoft.NETFramework.ReferenceAssemblies.net461", version: "1.0.0-alpha-5"},
@@ -98,9 +100,10 @@ config({
                 { id: "Microsoft.CodeQuality.Analyzers", version: "2.3.0-beta1" },
                 { id: "Microsoft.NetFramework.Analyzers", version: "2.3.0-beta1" },
                 { id: "Microsoft.NetCore.Analyzers", version: "2.3.0-beta1" },
+                
                 { id: "AsyncFixer", version: "1.1.5" },
                 { id: "ErrorProne.NET.CoreAnalyzers", version: "0.1.2" },
-                { id: "RuntimeContracts.Analyzer", version: "0.1.7.1" },
+                { id: "RuntimeContracts.Analyzer", version: "0.1.9.4" },
                 { id: "StyleCop.Analyzers", version: "1.1.0-beta004" },
                 { id: "Text.Analyzers", version: "2.3.0-beta1" },
 

--- a/config.dsc
+++ b/config.dsc
@@ -46,8 +46,6 @@ config({
             repositories: importFile(f`config.microsoftInternal.dsc`).isMicrosoftInternal
                 ? {
                     "BuildXL.Selfhost": "https://pkgs.dev.azure.com/cloudbuild/_packaging/BuildXL.Selfhost/nuget/v3/index.json",
-                    // Don't check this in. Remove once the packages are visible from the aggregated feed.
-                    "nuget.org" : "http://api.nuget.org/v3/index.json",
                     // Note: From a compliance point of view it is important that MicrosoftInternal has a single feed.
                     // If you need to consume packages make sure they are upstreamed in that feed.
                   }


### PR DESCRIPTION
This PR updates RuntimeContracts version to the one that supports non-nullable reference types.

Currently, the following code will produce the warning with C# 8 and nullable types enabled:

```csharp
using System.Diagnostics.ContractsLight;
#nullable enable
class FooBar
{
    public void Foo(string s)
    {
        Contract.Requires(s != null);

       int length = s.Length; // Possible NRE
    }
}
```

Even though the `s` parameter is declared to be non-nullable, the compiler sees that there is a null check in some unknown context inside `Contract.Requires`. This fact changes the nullness of the `s` from 'not nullable' to 'potentially nullable' causes a warning on `s.Length`.

The new version of RuntimeContracts supports `RequiresNotNull` and other helper assertions that now can tell the compiler that the reference can't be null.

So now you can do this:

```csharp
using System.Diagnostics.ContractsLight;
#nullable enable
class FooBar
{
    public void Foo(string s)
    {
        Contract.RequiresNotNull(s);

       int length = s.Length; // no warnings
    }

    public void Bar(string? s)
    {
        Contract.RequiresNotNull(s);

       int length = s.Length; // no warning, because 's' is not nullable after Contract.Requires
    }
}
```

Please note, the runtime contracts library also provides a fixer that helps moving from `Contract.Requires(x != null)` to `Contract.RequiresNotNull(x)` via code fixer.