### PR TITLE
Deploy pdb files when creating Nuget packages

### DIFF
--- a/Public/Src/Deployment/NugetPackages.dsc
+++ b/Public/Src/Deployment/NugetPackages.dsc
@@ -21,7 +21,7 @@ namespace NugetPackages {
         : r`${qualifier.configuration}/public/pkgs`;
 
     const reducedDeploymentOptions: Managed.Deployment.FlattenOptions = {
-        skipPdb: true,
+        skipPdb: false,
         skipXml: true,
     };
 
@@ -137,7 +137,7 @@ namespace NugetPackages {
     const xldblibrary = !canBuildAllPackagesOnThisHost ? undefined : pack({
         id: `${packageNamePrefix}.Xldb`,
         deployment: {
-            contents: [ 
+            contents: [
                 Nuget.createAssemblyLayout(importFrom("BuildXL.Tools").Xldb.withQualifier(xldbnetcorequalifier).dll),
                 Nuget.createAssemblyLayout(importFrom("BuildXL.Tools").Xldb.Proto.withQualifier(xldbnetcorequalifier).dll),
                 Nuget.createAssemblyLayout(importFrom("BuildXL.Utilities").withQualifier(xldbnetcorequalifier).dll),
@@ -153,7 +153,7 @@ namespace NugetPackages {
                 Nuget.createAssemblyLayout(importFrom("BuildXL.Utilities").Collections.withQualifier(xldbnet472qualifier).dll),
                 Nuget.createAssemblyLayout(importFrom("BuildXL.Utilities").Native.withQualifier(xldbnet472qualifier).dll),
                 Nuget.createAssemblyLayout(importFrom("BuildXL.Utilities").Storage.withQualifier(xldbnet472qualifier).dll),
-            
+
                 {
                     subfolder: r`content`,
                     contents: [
@@ -197,10 +197,10 @@ namespace NugetPackages {
     });
 
     export function pack(args: {
-        id: string, 
-        deployment: Deployment.Definition, 
+        id: string,
+        deployment: Deployment.Definition,
         deploymentOptions?: Managed.Deployment.FlattenOptions,
-        copyContentFiles?: boolean, 
+        copyContentFiles?: boolean,
         dependencies?: (Nuget.Dependency | Managed.ManagedNugetPackage)[]
     }) : File {
 
@@ -212,7 +212,7 @@ namespace NugetPackages {
                     return dep;
                 }
             });
-        
+
         return Nuget.pack({
             metadata:  {
                 id: args.id,


### PR DESCRIPTION
Don't skip pdb files when deploying Nuget packages due to incomplete symbols when debugging.