### PR TITLE
Lightweight trie implementation

### DIFF
--- a/Public/Src/Engine/Processes/SandboxConnectionKext.cs
+++ b/Public/Src/Engine/Processes/SandboxConnectionKext.cs
@@ -67,7 +67,7 @@ Use the the following command to load/reload the sandbox kernel extension and fi
         /// Until some automation for kernel extension building and deployment is in place, this number has to be kept in sync with the 'CFBundleVersion'
         /// inside the Info.plist file of the kernel extension code base. BuildXL will not work if a version mismatch is detected!
         /// </summary>
-        public const string RequiredKextVersionNumber = "2.2.99";
+        public const string RequiredKextVersionNumber = "2.3.10";
 
         /// <summary>
         /// See TN2420 (https://developer.apple.com/library/archive/technotes/tn2420/_index.html) on how versioning numbers are formatted in the Apple ecosystem

--- a/Public/Src/Engine/Processes/SandboxConnectionKext.cs
+++ b/Public/Src/Engine/Processes/SandboxConnectionKext.cs
@@ -67,7 +67,7 @@ Use the the following command to load/reload the sandbox kernel extension and fi
         /// Until some automation for kernel extension building and deployment is in place, this number has to be kept in sync with the 'CFBundleVersion'
         /// inside the Info.plist file of the kernel extension code base. BuildXL will not work if a version mismatch is detected!
         /// </summary>
-        public const string RequiredKextVersionNumber = "2.3.13";
+        public const string RequiredKextVersionNumber = "2.3.15";
 
         /// <summary>
         /// See TN2420 (https://developer.apple.com/library/archive/technotes/tn2420/_index.html) on how versioning numbers are formatted in the Apple ecosystem

--- a/Public/Src/Engine/Processes/SandboxConnectionKext.cs
+++ b/Public/Src/Engine/Processes/SandboxConnectionKext.cs
@@ -67,7 +67,7 @@ Use the the following command to load/reload the sandbox kernel extension and fi
         /// Until some automation for kernel extension building and deployment is in place, this number has to be kept in sync with the 'CFBundleVersion'
         /// inside the Info.plist file of the kernel extension code base. BuildXL will not work if a version mismatch is detected!
         /// </summary>
-        public const string RequiredKextVersionNumber = "2.3.11";
+        public const string RequiredKextVersionNumber = "2.3.12";
 
         /// <summary>
         /// See TN2420 (https://developer.apple.com/library/archive/technotes/tn2420/_index.html) on how versioning numbers are formatted in the Apple ecosystem

--- a/Public/Src/Engine/Processes/SandboxConnectionKext.cs
+++ b/Public/Src/Engine/Processes/SandboxConnectionKext.cs
@@ -67,7 +67,7 @@ Use the the following command to load/reload the sandbox kernel extension and fi
         /// Until some automation for kernel extension building and deployment is in place, this number has to be kept in sync with the 'CFBundleVersion'
         /// inside the Info.plist file of the kernel extension code base. BuildXL will not work if a version mismatch is detected!
         /// </summary>
-        public const string RequiredKextVersionNumber = "2.3.12";
+        public const string RequiredKextVersionNumber = "2.3.13";
 
         /// <summary>
         /// See TN2420 (https://developer.apple.com/library/archive/technotes/tn2420/_index.html) on how versioning numbers are formatted in the Apple ecosystem

--- a/Public/Src/Engine/Processes/SandboxConnectionKext.cs
+++ b/Public/Src/Engine/Processes/SandboxConnectionKext.cs
@@ -67,7 +67,7 @@ Use the the following command to load/reload the sandbox kernel extension and fi
         /// Until some automation for kernel extension building and deployment is in place, this number has to be kept in sync with the 'CFBundleVersion'
         /// inside the Info.plist file of the kernel extension code base. BuildXL will not work if a version mismatch is detected!
         /// </summary>
-        public const string RequiredKextVersionNumber = "2.3.16";
+        public const string RequiredKextVersionNumber = "2.3.17";
 
         /// <summary>
         /// See TN2420 (https://developer.apple.com/library/archive/technotes/tn2420/_index.html) on how versioning numbers are formatted in the Apple ecosystem

--- a/Public/Src/Engine/Processes/SandboxConnectionKext.cs
+++ b/Public/Src/Engine/Processes/SandboxConnectionKext.cs
@@ -67,7 +67,7 @@ Use the the following command to load/reload the sandbox kernel extension and fi
         /// Until some automation for kernel extension building and deployment is in place, this number has to be kept in sync with the 'CFBundleVersion'
         /// inside the Info.plist file of the kernel extension code base. BuildXL will not work if a version mismatch is detected!
         /// </summary>
-        public const string RequiredKextVersionNumber = "2.3.17";
+        public const string RequiredKextVersionNumber = "2.3.99";
 
         /// <summary>
         /// See TN2420 (https://developer.apple.com/library/archive/technotes/tn2420/_index.html) on how versioning numbers are formatted in the Apple ecosystem

--- a/Public/Src/Engine/Processes/SandboxConnectionKext.cs
+++ b/Public/Src/Engine/Processes/SandboxConnectionKext.cs
@@ -67,7 +67,7 @@ Use the the following command to load/reload the sandbox kernel extension and fi
         /// Until some automation for kernel extension building and deployment is in place, this number has to be kept in sync with the 'CFBundleVersion'
         /// inside the Info.plist file of the kernel extension code base. BuildXL will not work if a version mismatch is detected!
         /// </summary>
-        public const string RequiredKextVersionNumber = "2.3.15";
+        public const string RequiredKextVersionNumber = "2.3.16";
 
         /// <summary>
         /// See TN2420 (https://developer.apple.com/library/archive/technotes/tn2420/_index.html) on how versioning numbers are formatted in the Apple ecosystem

--- a/Public/Src/Engine/Processes/SandboxConnectionKext.cs
+++ b/Public/Src/Engine/Processes/SandboxConnectionKext.cs
@@ -67,7 +67,7 @@ Use the the following command to load/reload the sandbox kernel extension and fi
         /// Until some automation for kernel extension building and deployment is in place, this number has to be kept in sync with the 'CFBundleVersion'
         /// inside the Info.plist file of the kernel extension code base. BuildXL will not work if a version mismatch is detected!
         /// </summary>
-        public const string RequiredKextVersionNumber = "2.3.10";
+        public const string RequiredKextVersionNumber = "2.3.11";
 
         /// <summary>
         /// See TN2420 (https://developer.apple.com/library/archive/technotes/tn2420/_index.html) on how versioning numbers are formatted in the Apple ecosystem

--- a/Public/Src/Engine/Processes/SandboxedProcessMac.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessMac.cs
@@ -230,7 +230,7 @@ namespace BuildXL.Processes
             {
                 // IOException can happen if the process is forcefully killed while we're feeding its std in.
                 // When that happens, instead of crashing, just make sure the process is killed.
-                LogProcessState($"IOException caught while feeding the standard input: {e.Message}");
+                LogProcessState($"IOException caught while feeding the standard input: {e.ToString()}");
                 await KillAsync();
             }
         }

--- a/Public/Src/Sandbox/MacOs/Sandbox/Sandbox.xcodeproj/project.pbxproj
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Sandbox.xcodeproj/project.pbxproj
@@ -167,6 +167,8 @@
 		F5B2522C220CA6C400662376 /* Stopwatch.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F5B2522A220CA6C400662376 /* Stopwatch.hpp */; };
 		F5B25231220CED9800662376 /* SysCtl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5B2522F220CED9800662376 /* SysCtl.cpp */; };
 		F5B25232220CED9800662376 /* SysCtl.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F5B25230220CED9800662376 /* SysCtl.hpp */; };
+		F5BB924D2362646B00864612 /* TrieNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5BB924B2362646B00864612 /* TrieNode.cpp */; };
+		F5BB924E2362646B00864612 /* TrieNode.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F5BB924C2362646B00864612 /* TrieNode.hpp */; };
 		F5D014AA2187C35D00067484 /* OpNames.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5D014A92187C35D00067484 /* OpNames.cpp */; };
 /* End PBXBuildFile section */
 
@@ -355,6 +357,8 @@
 		F5B2522A220CA6C400662376 /* Stopwatch.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Stopwatch.hpp; sourceTree = "<group>"; };
 		F5B2522F220CED9800662376 /* SysCtl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SysCtl.cpp; sourceTree = "<group>"; };
 		F5B25230220CED9800662376 /* SysCtl.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = SysCtl.hpp; sourceTree = "<group>"; };
+		F5BB924B2362646B00864612 /* TrieNode.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TrieNode.cpp; sourceTree = "<group>"; };
+		F5BB924C2362646B00864612 /* TrieNode.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = TrieNode.hpp; sourceTree = "<group>"; };
 		F5D014A92187C35D00067484 /* OpNames.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = OpNames.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -795,6 +799,8 @@
 				F53982E1218226820075EFE2 /* ThreadLocal.hpp */,
 				F577F04E21BEE0270066F2EF /* Trie.cpp */,
 				F577F04F21BEE0270066F2EF /* Trie.hpp */,
+				F5BB924B2362646B00864612 /* TrieNode.cpp */,
+				F5BB924C2362646B00864612 /* TrieNode.hpp */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -836,6 +842,7 @@
 				F58E91C4220B562B0083C57E /* lfds711_list_addonly_singlylinked_ordered_internal.h in Headers */,
 				F54B6ADB21D3E37A00069515 /* ResourceManager.hpp in Headers */,
 				F58E919C220B562B0083C57E /* lfds711_hash_addonly.h in Headers */,
+				F5BB924E2362646B00864612 /* TrieNode.hpp in Headers */,
 				F58E919E220B562B0083C57E /* lfds711_btree_addonly_unbalanced.h in Headers */,
 				F58E919B220B562B0083C57E /* lfds711_queue_bounded_manyproducer_manyconsumer.h in Headers */,
 				F58E9199220B562B0083C57E /* lfds711_porting_abstraction_layer_operating_system.h in Headers */,
@@ -1036,6 +1043,7 @@
 				F58E91C2220B562B0083C57E /* lfds711_queue_bounded_singleproducer_singleconsumer_init.c in Sources */,
 				F58E91C0220B562B0083C57E /* lfds711_queue_bounded_singleproducer_singleconsumer_cleanup.c in Sources */,
 				3C2614AB20D7E85E00488B0B /* PolicyResult_common.cpp in Sources */,
+				F5BB924D2362646B00864612 /* TrieNode.cpp in Sources */,
 				F5044A9320F80DA200F95904 /* ConcurrentDictionary.cpp in Sources */,
 				F5B25231220CED9800662376 /* SysCtl.cpp in Sources */,
 				F58E91D6220B562B0083C57E /* lfds711_queue_bounded_manyproducer_manyconsumer_cleanup.c in Sources */,

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/BuildXLSandbox.cpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/BuildXLSandbox.cpp
@@ -617,8 +617,9 @@ IntrospectResponse BuildXLSandbox::Introspect() const
         .pips                = {0}
     };
 
-    Trie::getUintNodeCounts(&result.counters.numUintTrieNodes, &result.counters.uintTrieSizeMB);
-    Trie::getPathNodeCounts(&result.counters.numPathTrieNodes, &result.counters.pathTrieSizeMB);
+    Trie::getUintNodeCounts(&result.counters.uintNodes);
+    Trie::getPathNodeCounts(&result.counters.pathNodes);
+    Trie::getLightNodeCounts(&result.counters.lightNodes);
 
     ReportCounters *reportCounters = &result.counters.reportCounters;
     reportCounters->freeListSizeMB =

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/BuildXLSandboxShared.hpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/BuildXLSandboxShared.hpp
@@ -158,6 +158,11 @@ typedef struct {
 } ReportCounters;
 
 typedef struct {
+    uint count;
+    double size;
+} CountAndSize;
+
+typedef struct {
     DurationCounter findTrackedProcess;
     DurationCounter setLastLookedUpPath;
     DurationCounter checkPolicy;
@@ -171,10 +176,9 @@ typedef struct {
     Counter numForks;
     Counter numCacheHits;
     Counter numCacheMisses;
-    uint numUintTrieNodes;
-    uint numPathTrieNodes;
-    double uintTrieSizeMB;
-    double pathTrieSizeMB;
+    CountAndSize uintNodes;
+    CountAndSize pathNodes;
+    CountAndSize lightNodes;
 } AllCounters;
 
 typedef struct {

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/CLI/SandboxMonitor/main.cpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/CLI/SandboxMonitor/main.cpp
@@ -69,6 +69,16 @@ string renderCounter(DurationCounter cnt)
     return str.str();
 }
 
+static const uint BytesInAMegabyte = 1 << 20;
+
+string renderCountAndSize(CountAndSize cnt)
+{
+    stringstream str;
+    str << to_string(cnt.count)
+        << " (" << renderDouble((1.0 * cnt.size * cnt.count)/BytesInAMegabyte) << " MB)";
+    return str.str();
+}
+
 string to_string(Counter cnt)         { return to_string(cnt.count()); }
 string to_string(DurationCounter cnt) { return renderCounterMicros(cnt); }
 string to_string(string str)          { return str; }
@@ -344,8 +354,9 @@ int main(int argc, const char * argv[])
                    << ", #HardLink retries: " << to_string(response.counters.numHardLinkRetries)
                    << ", #CoalescedReports: " << to_string(response.counters.reportCounters.numCoalescedReports)
                    << " (" << renderDouble(PERCENT(response.counters.reportCounters.numCoalescedReports.count(), response.counters.reportCounters.totalNumSent.count())) << "%)"
-                   << ", #UintTrieNodes: " << to_string(response.counters.numUintTrieNodes) << " (" << renderDouble(response.counters.uintTrieSizeMB) << " MB)"
-                   << ", #PathTrieNodes: " << to_string(response.counters.numPathTrieNodes) << " (" << renderDouble(response.counters.pathTrieSizeMB) << " MB)"
+                   << ", #UintTrieNodes: " << renderCountAndSize(response.counters.uintNodes)
+                   << ", #PathTrieNodes: " << renderCountAndSize(response.counters.pathNodes)
+                   << ", #LightTrieNodes: " << renderCountAndSize(response.counters.lightNodes)
                    << ", #FreeListNodes: " << to_string(response.counters.reportCounters.freeListNodeCount)
                    << " (" << renderDouble(response.counters.reportCounters.freeListSizeMB) << " MB)"
                    << endl;

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>2.3.17</string>
+	<string>2.3.99</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>BuildXLSandbox</key>

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>2.3.16</string>
+	<string>2.3.17</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>BuildXLSandbox</key>

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>2.3.12</string>
+	<string>2.3.13</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>BuildXLSandbox</key>

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>2.3.13</string>
+	<string>2.3.15</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>BuildXLSandbox</key>

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>2.3.10</string>
+	<string>2.3.11</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>BuildXLSandbox</key>

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>2.3.11</string>
+	<string>2.3.12</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>BuildXLSandbox</key>

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>2.2.99</string>
+	<string>2.3.10</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>BuildXLSandbox</key>

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>2.3.15</string>
+	<string>2.3.16</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>BuildXLSandbox</key>

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/SandboxedPip.hpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/SandboxedPip.hpp
@@ -141,6 +141,11 @@ public:
      */
     inline CacheRecord* cacheLookup(const char *path)
     {
+        if (!g_bxl_enable_cache)
+        {
+            return nullptr;
+        }
+
         OSObject *value = pathCache_->getOrAdd(path, nullptr, CacheRecordFactory);
         return OSDynamicCast(CacheRecord, value);
     }

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/SysCtl.cpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/SysCtl.cpp
@@ -14,7 +14,6 @@ int g_bxl_verbose_logging = 0;
 int g_bxl_enable_cache = 1;
 int g_bxl_enable_light_trie = 1;
 
-
 SYSCTL_INT(_kern,                               // parent
            OID_AUTO,                            // oid
            bxl_enable_counters,                 // name

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/SysCtl.cpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/SysCtl.cpp
@@ -11,6 +11,10 @@ int g_bxl_enable_counters = 0;
 int g_bxl_verbose_logging = 0;
 #endif
 
+int g_bxl_enable_cache = 1;
+int g_bxl_enable_light_trie = 1;
+
+
 SYSCTL_INT(_kern,                               // parent
            OID_AUTO,                            // oid
            bxl_enable_counters,                 // name
@@ -27,14 +31,34 @@ SYSCTL_INT(_kern,
            0,
            "Enable/Disable verbose logging");
 
+SYSCTL_INT(_kern,
+           OID_AUTO,
+           bxl_enable_cache,
+           CTLFLAG_RW,
+           &g_bxl_enable_cache,
+           0,
+           "Enable/Disable access report caching");
+
+SYSCTL_INT(_kern,
+           OID_AUTO,
+           bxl_enable_light_trie,
+           CTLFLAG_RW,
+           &g_bxl_enable_light_trie,
+           0,
+           "Enable/Disable light trie implementation (slighly slower, but uses way less memory)");
+
 void bxl_sysctl_register()
 {
     sysctl_register_oid(&sysctl__kern_bxl_enable_counters);
     sysctl_register_oid(&sysctl__kern_bxl_verbose_logging);
+    sysctl_register_oid(&sysctl__kern_bxl_enable_cache);
+    sysctl_register_oid(&sysctl__kern_bxl_enable_light_trie);
 }
 
 void bxl_sysctl_unregister()
 {
     sysctl_unregister_oid(&sysctl__kern_bxl_enable_counters);
     sysctl_unregister_oid(&sysctl__kern_bxl_verbose_logging);
+    sysctl_unregister_oid(&sysctl__kern_bxl_enable_cache);
+    sysctl_unregister_oid(&sysctl__kern_bxl_enable_light_trie);
 }

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/SysCtl.hpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/SysCtl.hpp
@@ -11,6 +11,8 @@
 
 extern int g_bxl_enable_counters;
 extern int g_bxl_verbose_logging;
+extern int g_bxl_enable_cache;
+extern int g_bxl_enable_light_trie;
 
 void bxl_sysctl_register();
 void bxl_sysctl_unregister();

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/Trie.cpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/Trie.cpp
@@ -529,7 +529,7 @@ void Trie::forEach(void *callbackArgs, for_each_fn callback)
 {
     typedef struct { for_each_fn callback; void *args; } State;
     State state = { .callback = callback, .args = callbackArgs };
-    traverse(/*computeKey*/ kind_ == kUintTrie, /*callbackArgs*/ &state, [](void *s, uint64_t key, Node *node)
+    traverse(/*computeKey*/ kind_ != kPathTrie, /*callbackArgs*/ &state, [](void *s, uint64_t key, Node *node)
              {
                  State *state = (State*)s;
                  OSObject *record = node->record_;

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/Trie.cpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/Trie.cpp
@@ -475,8 +475,6 @@ Node* Trie::findUintNode(uint64_t key, bool createIfMissing)
     Node *currNode = root_;
     while (true)
     {
-        assert(currNode->maxKey_ == 10);
-
         int lsd = key % 10;
         currNode = currNode->findChild(lsd, createIfMissing);
         if (!currNode)

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/Trie.hpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/Trie.hpp
@@ -1,84 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#ifndef PathCache_hpp
-#define PathCache_hpp
+#ifndef Trie_hpp
+#define Trie_hpp
 
-#include <IOKit/IOLib.h>
-#include <IOKit/IOService.h>
-#include "BuildXLSandboxShared.hpp"
+#include "TrieNode.hpp"
 
-#define Node BXL_CLASS(Node)
 #define Trie BXL_CLASS(Trie)
-
-/*!
- * A node in a Trie.
- * Only accessible to its friend class Trie.
- */
-class Node : public OSObject
-{
-    OSDeclareDefaultStructors(Node);
-
-private:
-
-    friend class Trie;
-
-    static uint s_numUintNodes;
-    static uint s_numPathNodes;
-
-    /*!
-     * The value 65 is chosen so that all ASCII characters between 32 (' ') and 122 ('z')
-     * get a unique entry in the 'children_' array.  The formula for mapping a character
-     * ch to an array index is:
-     *
-     *   toupper(ch) - 32
-     */
-    static const uint s_pathNodeMaxKey = 65;
-
-    /*! For 10 digits */
-    static const uint s_uintNodeMaxKey = 10;
-
-    /*! Arbitrary value */
-    OSObject *record_;
-
-    /*! The length of the 'children_' array (i.e., the the number of allocated nodes) */
-    uint maxKey_;
-
-    /*! The key by which the parent can find this node */
-    uint key_;
-
-    /*! Used only when modifying this node's list of children */
-    IORecursiveLock *lock_;
-
-    /*! Pointer to the next sibling. */
-    Node *next_;
-
-    /*! Pointer to the first child node */
-    Node *children_;
-
-    /*!
-     * Checks if a child node of 'node' exists at position 'idx'.
-     * If no such child node exists and 'createIfMissing' is true,
-     * a new child node is created and saved at position 'idx'.
-     *
-     * @param key Must be between 0 (inclusive) and 'node.maxKey_' (exclusive); otherwise this method returns NULL
-     * @param createIfMissing When true, this method creates a new child node at position 'idx' if one doesn't already exist.
-     * @result True IFF this node contains a child node with key 'key' after this method returns.
-     */
-    Node* findChild(uint key, bool createIfMissing, IORecursiveLock *lock = nullptr);
-
-    bool init(uint numChildren, uint key);
-    static Node* create(uint numChildren, uint key);
-
-    static Node* createUintNode(uint key) { return create(s_uintNodeMaxKey, key); }
-    static Node* createPathNode(uint key) { return create(s_pathNodeMaxKey, key); }
-
-protected:
-
-    void free() override;
-};
-
-// ================================== class Trie ==================================
 
 /*!
  * A thread-safe, lock-free, dictionary implementation.
@@ -136,7 +64,6 @@ private:
     }
 
     typedef enum { kUintTrie, kPathTrie } TrieKind;
-    typedef void (*traverse_fn)(Trie*, void*, uint64_t key, Node*);
 
     /*! The root of the tree. */
     Node *root_;
@@ -401,4 +328,4 @@ public:
     static Trie* createPathTrie() { return create(kPathTrie); }
 };
 
-#endif /* PathCache_hpp */
+#endif /* Trie_hpp */

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/Trie.hpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/Trie.hpp
@@ -62,7 +62,7 @@ public:
 
     static void getLightNodeCounts(CountAndSize *cnt)
     {
-        cnt->count = NodeLight::metaClass->getInstanceCount();
+        cnt->count = Node::s_numLightNodes; //  NodeLight::metaClass->getInstanceCount();
         cnt->size = sizeof(NodeLight);
     }
 
@@ -76,9 +76,9 @@ private:
 
     uint mergeKindAndImpl(TrieKind knd, TrieImpl impl) { return kKindBitMask * knd + kImplBitMask * impl; }
 
-    bool isUintTrie()  { return (kind_ & kKindBitMask) == 0; }
+    bool isUintTrie()  { return (kind_ & kKindBitMask) == kUintTrie; }
     bool isPathTrie()  { return !isUintTrie(); }
-    bool isFastTrie()  { return (kind_ & kImplBitMask) == 0; }
+    bool isFastTrie()  { return (kind_ & kImplBitMask) == kFastTrie; }
     bool isLightTrie() { return !isFastTrie(); }
 
     /*! The root of the tree. */

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/Trie.hpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/Trie.hpp
@@ -196,9 +196,8 @@ private:
     /*! Creates either a Uint or a Path node, based on the kind of this trie. */
     Node* createNode(uint key)
     {
-        return kind_ == kUintTrie ? Node::createUintNode(key) :
-               kind_ == kPathTrie ? Node::createPathNode(key) :
-               nullptr;
+        auto maxKey = kind_ == kUintTrie ? Node::s_uintNodeMaxKey : Node::s_pathNodeMaxKey;
+        return NodeLight::create(maxKey, key);
     }
 
     /*!

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/Trie.hpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/Trie.hpp
@@ -62,7 +62,7 @@ public:
 
     static void getLightNodeCounts(CountAndSize *cnt)
     {
-        cnt->count = Node::s_numLightNodes; //  NodeLight::metaClass->getInstanceCount();
+        cnt->count = NodeLight::metaClass->getInstanceCount();
         cnt->size = sizeof(NodeLight);
     }
 

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/TrieNode.cpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/TrieNode.cpp
@@ -4,7 +4,7 @@
 #include "Monitor.hpp"
 #include "TrieNode.hpp"
 
-OSDefineMetaClassAndStructors(Node, OSObject)
+OSDefineMetaClassAndAbstractStructors(Node, OSObject)
 OSDefineMetaClassAndStructors(NodeLight, Node)
 OSDefineMetaClassAndStructors(NodeFast, Node)
 
@@ -113,8 +113,10 @@ void Node::free()
 
 void NodeLight::free()
 {
-    // intentionally not calling OSSafeReleaseNULL on children_ and next_
+    // Intentionally not calling OSSafeReleaseNULL on children_ and next_
     // because Trie is responsible for releasing all its nodes
+    //
+    // If we did try to release children_ and next_ here, we'd exceed max allowed stack depth.
     next_ = nullptr;
     children_ = nullptr;
 

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/TrieNode.cpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/TrieNode.cpp
@@ -1,0 +1,198 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "Monitor.hpp"
+#include "TrieNode.hpp"
+
+#define super OSObject
+
+OSDefineMetaClassAndStructors(Node, OSObject)
+
+uint Node::s_numUintNodes = 0;
+uint Node::s_numPathNodes = 0;
+
+Node* Node::create(uint maxKey, uint key)
+{
+    Node *instance = new Node;
+    if (instance != nullptr)
+    {
+        if (maxKey == s_uintNodeMaxKey)      OSIncrementAtomic(&s_numUintNodes);
+        else if (maxKey == s_pathNodeMaxKey) OSIncrementAtomic(&s_numPathNodes);
+
+        if (!instance->init(maxKey, key))
+        {
+            OSSafeReleaseNULL(instance);
+        }
+    }
+
+    return instance;
+}
+
+bool Node::init(uint maxKey, uint key)
+{
+    if (!super::init())
+    {
+        return false;
+    }
+
+    assert(key < maxKey);
+
+    key_    = key;
+    maxKey_ = maxKey;
+    record_ = nullptr;
+
+    next_     = nullptr;
+    children_ = nullptr;
+
+    lock_ = IORecursiveLockAlloc();
+    if (!lock_)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+void Node::free()
+{
+    // intentionally not calling OSSafeReleaseNULL on children_ and next_
+    // because Trie is responsible for releasing all its nodes
+    next_ = nullptr;
+    children_ = nullptr;
+
+    OSSafeReleaseNULL(record_);
+    IORecursiveLockFree(lock_);
+
+    if (maxKey_ == s_uintNodeMaxKey)      OSDecrementAtomic(&s_numUintNodes);
+    else if (maxKey_ == s_pathNodeMaxKey) OSDecrementAtomic(&s_numPathNodes);
+
+    super::free();
+}
+
+Node* Node::findChild(uint key, bool createIfMissing, IORecursiveLock *lock)
+{
+    if (key < 0 || key >= maxKey_)
+    {
+        return nullptr;
+    }
+
+    Monitor __monitor(lock); // this will only acquire the lock if lock is not null
+
+    Node *prev = nullptr;
+    Node *curr = children_;
+    while (curr != nullptr && curr->key_ != key)
+    {
+        prev = curr;
+        curr = curr->next_;
+    }
+
+    if (curr != nullptr)
+    {
+        // found it
+        assert(curr->key_ == key);
+        return curr;
+    }
+    else if (!createIfMissing)
+    {
+        // didn't find it and shouldn't create it
+        return nullptr;
+    }
+    else if (lock == nullptr)
+    {
+        // didn't find it and didn't acquire lock --> must do it all over again with a lock
+        return findChild(key, createIfMissing, lock_);
+    }
+    else
+    {
+        // didn't find it and we are holding the lock -> create a new node and link it
+        Node *newNode = Node::create(maxKey_, key);
+        if (prev != nullptr)
+        {
+            prev->next_ = newNode;
+        }
+        else
+        {
+            assert(children_ == nullptr);
+            children_ = newNode;
+        }
+        return newNode;
+    }
+}
+
+typedef struct Stack {
+    Node *node;
+    Stack *next;
+    uint32_t depth;
+    uint64_t key;
+} Stack;
+
+static void push(Stack **stack, Node *node, uint64_t path, uint32_t depth)
+{
+    if (node == nullptr) return;
+
+    Stack *top = IONew(Stack, 1);
+    top->node  = node;
+    top->next  = *stack;
+    top->key   = path;
+    top->depth = depth;
+
+    *stack = top;
+}
+
+static Node* pop(Stack **stack)
+{
+    Stack *top = *stack;
+    *stack = top->next;
+    Node *node = top->node;
+    IODelete(top, Stack, 1);
+    return node;
+}
+
+static uint64_t s_pow10[] =
+{
+    1,
+    10,
+    100,
+    1000,
+    10000,
+    100000,
+    1000000,
+    10000000,
+    100000000,
+    1000000000,
+    10000000000,
+    100000000000,
+    1000000000000
+};
+
+static int s_powLen = sizeof(s_pow10)/sizeof(s_pow10[0]);
+
+static uint64_t pow10(int exp)
+{
+    if (exp < s_powLen) return s_pow10[exp];
+    uint64_t result = 1;
+    while (--exp >= 0) result *= 10;
+    return result;
+}
+
+void Node::traverse(bool computeKey, void *callbackArgs, traverse_fn callback)
+{
+    Stack *stack = nullptr;
+    push(&stack, this, /*key*/ 0, /*depth*/ 0);
+    while (stack != nullptr)
+    {
+        uint64_t key = stack->key;
+        uint32_t depth = stack->depth;
+
+        Node *toVisit = pop(&stack);
+        Node *curr = toVisit->children_;
+        while (curr)
+        {
+            push(&stack, curr, computeKey ? (curr->key_ * pow10(depth) + key) : 0, depth + 1);
+            curr = curr->next_;
+        }
+
+        // the callback may deallocate 'curr' node, hence this must be the last statement in this loop
+        callback(callbackArgs, key, toVisit);
+    }
+}

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/TrieNode.hpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/TrieNode.hpp
@@ -22,7 +22,7 @@ typedef void (*traverse_fn)(void*, uint64_t key, Node*);
  */
 class Node : public OSObject
 {
-    OSDeclareDefaultStructors(Node);
+    OSDeclareAbstractStructors(Node);
 
     friend class Trie;
 
@@ -56,10 +56,10 @@ protected:
      * @param createIfMissing When true, this method creates a new child node at position 'idx' if one doesn't already exist.
      * @result True IFF this node contains a child node with key 'key' after this method returns.
      */
-    virtual Node* findChild(uint key, bool createIfMissing) { return nullptr; }
+    virtual Node* findChild(uint key, bool createIfMissing) = 0;
 
     /*! Calls 'callback' for every node in the tree rooted in this node (the traversal is pre-order) */
-    virtual void traverse(bool computeKey, void *callbackArgs, traverse_fn callback) {}
+    virtual void traverse(bool computeKey, void *callbackArgs, traverse_fn callback) = 0;
 
     bool init() override;
     void free() override;
@@ -104,7 +104,7 @@ protected:
     void free() override;
 };
 
-/* =================== class NodeLight ====================== */
+/* =================== class NodeFast ====================== */
 
 class NodeFast : public Node
 {

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/TrieNode.hpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/TrieNode.hpp
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef TrieNode_hpp
+#define TrieNode_hpp
+
+#include <IOKit/IOLib.h>
+#include <IOKit/IOService.h>
+#include "BuildXLSandboxShared.hpp"
+
+#define Node BXL_CLASS(Node)
+#define Trie BXL_CLASS(Trie)
+
+class Node;
+
+typedef void (*traverse_fn)(void*, uint64_t key, Node*);
+
+/*!
+ * A node in a Trie.
+ * Only accessible to its friend class Trie.
+ */
+class Node : public OSObject
+{
+    OSDeclareDefaultStructors(Node);
+
+private:
+
+    friend class Trie;
+
+    static uint s_numUintNodes;
+    static uint s_numPathNodes;
+
+    /*!
+     * The value 65 is chosen so that all ASCII characters between 32 (' ') and 122 ('z')
+     * get a unique entry in the 'children_' array.  The formula for mapping a character
+     * ch to an array index is:
+     *
+     *   toupper(ch) - 32
+     */
+    static const uint s_pathNodeMaxKey = 65;
+
+    /*! For 10 digits */
+    static const uint s_uintNodeMaxKey = 10;
+
+    /*! Arbitrary value */
+    OSObject *record_;
+
+    /*! The length of the 'children_' array (i.e., the the number of allocated nodes) */
+    uint maxKey_;
+
+    /*! The key by which the parent can find this node */
+    uint key_;
+
+    /*! Used only when modifying this node's list of children */
+    IORecursiveLock *lock_;
+
+    /*! Pointer to the next sibling. */
+    Node *next_;
+
+    /*! Pointer to the first child node */
+    Node *children_;
+
+    /*!
+     * Checks if a child node of 'node' exists at position 'idx'.
+     * If no such child node exists and 'createIfMissing' is true,
+     * a new child node is created and saved at position 'idx'.
+     *
+     * @param key Must be between 0 (inclusive) and 'node.maxKey_' (exclusive); otherwise this method returns NULL
+     * @param createIfMissing When true, this method creates a new child node at position 'idx' if one doesn't already exist.
+     * @result True IFF this node contains a child node with key 'key' after this method returns.
+     */
+    Node* findChild(uint key, bool createIfMissing, IORecursiveLock *lock = nullptr);
+
+    bool init(uint numChildren, uint key);
+    static Node* create(uint numChildren, uint key);
+
+    static Node* createUintNode(uint key) { return create(s_uintNodeMaxKey, key); }
+    static Node* createPathNode(uint key) { return create(s_pathNodeMaxKey, key); }
+
+    /*! Calls 'callback' for every node in the trie during a pre-order traversal. */
+    void traverse(bool computeKey, void *callbackArgs, traverse_fn callback);
+
+protected:
+
+    void free() override;
+};
+
+#endif /* TrieNode_hpp */

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/TrieNode.hpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/TrieNode.hpp
@@ -10,6 +10,7 @@
 
 #define Node BXL_CLASS(Node)
 #define NodeLight BXL_CLASS(NodeLight)
+#define NodeFast BXL_CLASS(NodeFast)
 #define Trie BXL_CLASS(Trie)
 
 class Node;
@@ -71,9 +72,6 @@ class NodeLight : public Node
     OSDeclareDefaultStructors(NodeLight);
 
 private:
-    /*! The length of the 'children_' array (i.e., the the number of allocated nodes) */
-    uint maxKey_;
-
     /*! The key by which the parent can find this node */
     uint key_;
 
@@ -88,11 +86,11 @@ private:
 
     NodeLight* findChild(uint key, bool createIfMissing, IORecursiveLock *lock);
 
-    bool init(uint maxKey, uint key);
+    bool init(uint key);
 
 public:
 
-    static NodeLight* create(uint numChildren, uint key);
+    static NodeLight* create(uint key);
 
 protected:
 
@@ -103,6 +101,38 @@ protected:
 
     void traverse(bool computeKey, void *callbackArgs, traverse_fn callback) override;
 
+    void free() override;
+};
+
+/* =================== class NodeLight ====================== */
+
+class NodeFast : public Node
+{
+    OSDeclareDefaultStructors(NodeFast);
+
+private:
+    /*! The length of the 'children_' array (i.e., the the number of allocated nodes) */
+    uint childrenLength_;
+
+    /*! Pre-allocated pointers to all possible children nodes. */
+    NodeFast **children_;
+
+    uint length()     const { return childrenLength_; }
+    NodeFast** children() const { return children_; }
+
+    bool init(uint key);
+
+    static NodeFast* create(uint numChildren);
+
+public:
+
+    static NodeFast* createUintNode() { return create(s_uintNodeMaxKey); }
+    static NodeFast* createPathNode() { return create(s_pathNodeMaxKey); }
+
+protected:
+
+    Node* findChild(uint key, bool createIfMissing) override;
+    void traverse(bool computeKey, void *callbackArgs, traverse_fn callback) override;
     void free() override;
 };
 

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/TrieNode.hpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/TrieNode.hpp
@@ -30,7 +30,6 @@ protected:
 
     static uint s_numUintNodes;
     static uint s_numPathNodes;
-    static uint s_numLightNodes;
 
     /*!
      * The value 65 is chosen so that all ASCII characters between 32 (' ') and 122 ('z')
@@ -61,8 +60,17 @@ protected:
     /*! Calls 'callback' for every node in the tree rooted in this node (the traversal is pre-order) */
     virtual void traverse(bool computeKey, void *callbackArgs, traverse_fn callback) = 0;
 
-    bool init() override;
-    void free() override;
+    bool init() override
+    {
+        record_ = nullptr;
+        return OSObject::init();
+    }
+
+    void free() override
+    {
+        OSSafeReleaseNULL(record_);
+        OSObject::free();
+    }
 };
 
 /* =================== class NodeLight ====================== */

--- a/Public/Src/Sandbox/MacOs/scripts/sandbox-load.sh
+++ b/Public/Src/Sandbox/MacOs/scripts/sandbox-load.sh
@@ -10,10 +10,10 @@ source "$MY_DIR/env.sh"
 declare arg_kextSourceDir=""
 declare arg_kextDeployDir=""
 declare arg_noReload=""
-declare arg_enableCounters="0"
-declare arg_verboseLogging="0"
-declare arg_enableCache="1"
-declare arg_enableLightTrie="1"
+declare arg_enableCounters=""
+declare arg_verboseLogging=""
+declare arg_enableCache=""
+declare arg_enableLightTrie=""
 
 # Prints out BuildXLSandbox bundle id if it is currently loaded, or empty string otherwise.
 function getRunningBuildXLSandboxBundleId { # (bundleId)
@@ -206,7 +206,7 @@ fi
 loadBuildXLSandbox "$finalKextFolder" "$bundleId"
 
 # turn sysctl knobs
-sysctl kern.bxl_enable_counters=$arg_enableCounters
-sysctl kern.bxl_verbose_logging=$arg_verboseLogging
-sysctl kern.bxl_enable_cache=$arg_enableCache
-sysctl kern.bxl_enable_light_trie=$arg_enableLightTrie
+if [[ -n $arg_enableCounters ]];  then sysctl kern.bxl_enable_counters=$arg_enableCounters; fi
+if [[ -n $arg_verboseLogging ]];  then sysctl kern.bxl_verbose_logging=$arg_verboseLogging; fi
+if [[ -n $arg_enableCache ]];     then sysctl kern.bxl_enable_cache=$arg_enableCache; fi
+if [[ -n $arg_enableLightTrie ]]; then sysctl kern.bxl_enable_light_trie=$arg_enableLightTrie; fi

--- a/Public/Src/Sandbox/MacOs/scripts/sandbox-load.sh
+++ b/Public/Src/Sandbox/MacOs/scripts/sandbox-load.sh
@@ -10,8 +10,10 @@ source "$MY_DIR/env.sh"
 declare arg_kextSourceDir=""
 declare arg_kextDeployDir=""
 declare arg_noReload=""
-declare arg_enableCounters=""
-declare arg_verboseLogging=""
+declare arg_enableCounters="0"
+declare arg_verboseLogging="0"
+declare arg_enableCache="1"
+declare arg_enableLightTrie="1"
 
 # Prints out BuildXLSandbox bundle id if it is currently loaded, or empty string otherwise.
 function getRunningBuildXLSandboxBundleId { # (bundleId)
@@ -118,6 +120,14 @@ function parseArgs {
                 arg_verboseLogging="1"
                 shift
                 ;;
+            --disable-cache)
+                arg_enableCache="0"
+                shift
+                ;;
+            --disable-light-trie|--enable-fast-trie)
+                arg_enableLightTrie="0"
+                shift
+                ;;
             *)
                 if [[ $# == 1 && -z $arg_kextSourceDir ]]; then
                     arg_kextSourceDir="$1"
@@ -195,12 +205,8 @@ fi
 # load kext
 loadBuildXLSandbox "$finalKextFolder" "$bundleId"
 
-# enable counters if requested
-if [[ -n $arg_enableCounters ]]; then
-    sysctl kern.bxl_enable_counters=1
-fi
-
-# enable verbose logging if requested
-if [[ -n $arg_verboseLogging ]]; then
-    sysctl kern.bxl_verbose_logging=1
-fi
+# turn sysctl knobs
+sysctl kern.bxl_enable_counters=$arg_enableCounters
+sysctl kern.bxl_verbose_logging=$arg_verboseLogging
+sysctl kern.bxl_enable_cache=$arg_enableCache
+sysctl kern.bxl_enable_light_trie=$arg_enableLightTrie

--- a/Public/Src/Sandbox/MacOs/scripts/sandbox-load.sh.1
+++ b/Public/Src/Sandbox/MacOs/scripts/sandbox-load.sh.1
@@ -7,6 +7,8 @@ sandbox-load \- Load BuildXLSandbox kernel extension for macOS
 [--no-reload]
 [--enable-counters]
 [--verbose-logging]
+[--disable-cache]
+[--disable-light-trie | --enable-fast-trie]
 [--kext] \fIsrc-dir\fR
 .SH DESCRIPTION
 Loads a 'BuildXLSandbox' kernel extension from a given location.
@@ -40,3 +42,11 @@ Optional.  When specified, various performance counters will become enabled.
 .TP
 .BI --verbose-logging
 Optional.  When specified, BuildXLSandbox will log verbose messages to the system log.
+.TP
+.BI --disable-cache
+Optional.  When specified, BuildXLSandbox will not cache any access reports 
+(i.e., every single file access will be reported as it happens).
+.TP
+.BI --enable-fast-trie | --disable-light-trie
+Optional.  When specified, BuildXLSandbox will use a fast but very memory consuming trie
+implementation for its internal dictionaries; othewise (by default), it uses a lightweight trie.

--- a/cg/nuget/cgmanifest.json
+++ b/cg/nuget/cgmanifest.json
@@ -4191,7 +4191,7 @@
         "Type": "NuGet",
         "NuGet": {
           "Name": "runtime.osx-x64.BuildXL",
-          "Version": "2.3.16"
+          "Version": "2.3.17"
         }
       }
     },

--- a/cg/nuget/cgmanifest.json
+++ b/cg/nuget/cgmanifest.json
@@ -4191,7 +4191,7 @@
         "Type": "NuGet",
         "NuGet": {
           "Name": "runtime.osx-x64.BuildXL",
-          "Version": "2.3.13"
+          "Version": "2.3.15"
         }
       }
     },

--- a/cg/nuget/cgmanifest.json
+++ b/cg/nuget/cgmanifest.json
@@ -4191,7 +4191,7 @@
         "Type": "NuGet",
         "NuGet": {
           "Name": "runtime.osx-x64.BuildXL",
-          "Version": "2.3.11"
+          "Version": "2.3.12"
         }
       }
     },

--- a/cg/nuget/cgmanifest.json
+++ b/cg/nuget/cgmanifest.json
@@ -4191,7 +4191,7 @@
         "Type": "NuGet",
         "NuGet": {
           "Name": "runtime.osx-x64.BuildXL",
-          "Version": "2.3.17"
+          "Version": "2.3.99"
         }
       }
     },

--- a/cg/nuget/cgmanifest.json
+++ b/cg/nuget/cgmanifest.json
@@ -4191,7 +4191,7 @@
         "Type": "NuGet",
         "NuGet": {
           "Name": "runtime.osx-x64.BuildXL",
-          "Version": "2.3.12"
+          "Version": "2.3.13"
         }
       }
     },

--- a/cg/nuget/cgmanifest.json
+++ b/cg/nuget/cgmanifest.json
@@ -4191,7 +4191,7 @@
         "Type": "NuGet",
         "NuGet": {
           "Name": "runtime.osx-x64.BuildXL",
-          "Version": "2.2.99"
+          "Version": "2.3.10"
         }
       }
     },

--- a/cg/nuget/cgmanifest.json
+++ b/cg/nuget/cgmanifest.json
@@ -4191,7 +4191,7 @@
         "Type": "NuGet",
         "NuGet": {
           "Name": "runtime.osx-x64.BuildXL",
-          "Version": "2.3.15"
+          "Version": "2.3.16"
         }
       }
     },

--- a/cg/nuget/cgmanifest.json
+++ b/cg/nuget/cgmanifest.json
@@ -4191,7 +4191,7 @@
         "Type": "NuGet",
         "NuGet": {
           "Name": "runtime.osx-x64.BuildXL",
-          "Version": "2.3.10"
+          "Version": "2.3.11"
         }
       }
     },

--- a/config.microsoftInternal.dsc
+++ b/config.microsoftInternal.dsc
@@ -11,7 +11,7 @@ export const pkgs = isMicrosoftInternal ? [
     { id: "BuildXL.DeviceMap", version: "0.0.1" },
 
     // Runtime dependencies used for macOS deployments
-    { id: "runtime.osx-x64.BuildXL", version: "2.3.12" },
+    { id: "runtime.osx-x64.BuildXL", version: "2.3.13" },
     { id: "Aria.Cpp.SDK", version: "8.5.6" },
 
     { id: "CB.QTest", version: "19.10.17.210051" },

--- a/config.microsoftInternal.dsc
+++ b/config.microsoftInternal.dsc
@@ -11,7 +11,7 @@ export const pkgs = isMicrosoftInternal ? [
     { id: "BuildXL.DeviceMap", version: "0.0.1" },
 
     // Runtime dependencies used for macOS deployments
-    { id: "runtime.osx-x64.BuildXL", version: "2.3.16" },
+    { id: "runtime.osx-x64.BuildXL", version: "2.3.17" },
     { id: "Aria.Cpp.SDK", version: "8.5.6" },
 
     { id: "CB.QTest", version: "19.10.17.210051" },

--- a/config.microsoftInternal.dsc
+++ b/config.microsoftInternal.dsc
@@ -11,7 +11,7 @@ export const pkgs = isMicrosoftInternal ? [
     { id: "BuildXL.DeviceMap", version: "0.0.1" },
 
     // Runtime dependencies used for macOS deployments
-    { id: "runtime.osx-x64.BuildXL", version: "2.3.10" },
+    { id: "runtime.osx-x64.BuildXL", version: "2.3.11" },
     { id: "Aria.Cpp.SDK", version: "8.5.6" },
 
     { id: "CB.QTest", version: "19.10.17.210051" },

--- a/config.microsoftInternal.dsc
+++ b/config.microsoftInternal.dsc
@@ -11,7 +11,7 @@ export const pkgs = isMicrosoftInternal ? [
     { id: "BuildXL.DeviceMap", version: "0.0.1" },
 
     // Runtime dependencies used for macOS deployments
-    { id: "runtime.osx-x64.BuildXL", version: "2.3.13" },
+    { id: "runtime.osx-x64.BuildXL", version: "2.3.15" },
     { id: "Aria.Cpp.SDK", version: "8.5.6" },
 
     { id: "CB.QTest", version: "19.10.17.210051" },

--- a/config.microsoftInternal.dsc
+++ b/config.microsoftInternal.dsc
@@ -11,7 +11,7 @@ export const pkgs = isMicrosoftInternal ? [
     { id: "BuildXL.DeviceMap", version: "0.0.1" },
 
     // Runtime dependencies used for macOS deployments
-    { id: "runtime.osx-x64.BuildXL", version: "2.3.11" },
+    { id: "runtime.osx-x64.BuildXL", version: "2.3.12" },
     { id: "Aria.Cpp.SDK", version: "8.5.6" },
 
     { id: "CB.QTest", version: "19.10.17.210051" },

--- a/config.microsoftInternal.dsc
+++ b/config.microsoftInternal.dsc
@@ -11,7 +11,7 @@ export const pkgs = isMicrosoftInternal ? [
     { id: "BuildXL.DeviceMap", version: "0.0.1" },
 
     // Runtime dependencies used for macOS deployments
-    { id: "runtime.osx-x64.BuildXL", version: "2.3.15" },
+    { id: "runtime.osx-x64.BuildXL", version: "2.3.16" },
     { id: "Aria.Cpp.SDK", version: "8.5.6" },
 
     { id: "CB.QTest", version: "19.10.17.210051" },

--- a/config.microsoftInternal.dsc
+++ b/config.microsoftInternal.dsc
@@ -11,7 +11,7 @@ export const pkgs = isMicrosoftInternal ? [
     { id: "BuildXL.DeviceMap", version: "0.0.1" },
 
     // Runtime dependencies used for macOS deployments
-    { id: "runtime.osx-x64.BuildXL", version: "2.2.99" },
+    { id: "runtime.osx-x64.BuildXL", version: "2.3.10" },
     { id: "Aria.Cpp.SDK", version: "8.5.6" },
 
     { id: "CB.QTest", version: "19.10.17.210051" },

--- a/config.microsoftInternal.dsc
+++ b/config.microsoftInternal.dsc
@@ -11,7 +11,7 @@ export const pkgs = isMicrosoftInternal ? [
     { id: "BuildXL.DeviceMap", version: "0.0.1" },
 
     // Runtime dependencies used for macOS deployments
-    { id: "runtime.osx-x64.BuildXL", version: "2.3.17" },
+    { id: "runtime.osx-x64.BuildXL", version: "2.3.99" },
     { id: "Aria.Cpp.SDK", version: "8.5.6" },
 
     { id: "CB.QTest", version: "19.10.17.210051" },


### PR DESCRIPTION
This PR adds an alternative trie implementation, namely using a linked list to represent node children instead of a preallocated array.  When using this new implementation, the kext memory footprint is reduced significantly, even 10x in some large builds.

Two additional sysctl variables are introduced:
  1. `bxl_enable_cache` to control whether access reports are cached inside the kext (on by default)
  2. `bxl_enable_light_trie` to control whether to use this lightweight trie implementation or the old one (on by default)