### PR TITLE
Proactive copy even when blob in redis

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentStoreSettings.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentStoreSettings.cs
@@ -179,5 +179,10 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
         /// Name of the blob with the snapshot of the content placement predictions.
         /// </summary>
         public string ContentPlacementPredictionsBlob { get; set; } // Can be null.
+
+        /// <summary>
+        /// Used in tests to inline put blob execution.
+        /// </summary>
+        public bool ShouldInlinePutBlob { get; set; } = false;
     }
 }

--- a/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/LocalLocationStoreDistributedContentTests.cs
+++ b/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/LocalLocationStoreDistributedContentTests.cs
@@ -169,7 +169,8 @@ namespace ContentStoreTest.Distributed.Sessions
                 {
                     RetryIntervalForCopies = DistributedContentSessionTests.DefaultRetryIntervalsForTest,
                     PinConfiguration = PinConfiguration,
-                    ProactiveCopyMode = EnableProactiveCopy ? ProactiveCopyMode.Both : ProactiveCopyMode.Disabled
+                    ProactiveCopyMode = EnableProactiveCopy ? ProactiveCopyMode.Both : ProactiveCopyMode.Disabled,
+                    ShouldInlinePutBlob = true
                 },
                 replicaCreditInMinutes: replicaCreditInMinutes,
                 clock: TestClock,

--- a/Public/Src/Cache/ContentStore/DistributedTest/Sessions/RedisDistributedContentTests.cs
+++ b/Public/Src/Cache/ContentStore/DistributedTest/Sessions/RedisDistributedContentTests.cs
@@ -139,6 +139,7 @@ namespace ContentStoreTest.Distributed.Sessions
                 {
                     RetryIntervalForCopies = DistributedContentSessionTests.DefaultRetryIntervalsForTest,
                     PinConfiguration = PinConfiguration,
+                    ShouldInlinePutBlob = true,
                 },
                 replicaCreditInMinutes: replicaCreditInMinutes,
                 clock: TestClock,
@@ -395,12 +396,10 @@ namespace ContentStoreTest.Distributed.Sessions
                     var fileString = Encoding.Default.GetString(file);
 
                     await session0.PutContentAsync(context, fileString).ShouldBeSuccess();
-                    await Task.Delay(500); // Wait for put blob
                     var counters0 = redisStore0.GetCounters(context).ToDictionaryIntegral();
                     Assert.Equal(1, counters0["RedisContentLocationStore.BlobAdapter.PutBlob.Count"]);
 
                     await session1.PutContentAsync(context, fileString).ShouldBeSuccess();
-                    await Task.Delay(500); // Wait for put blob
                     var counters1 = redisStore1.GetCounters(context).ToDictionaryIntegral();
                     Assert.Equal(1, counters1["RedisContentLocationStore.BlobAdapter.PutBlob.Count"]);
                     Assert.Equal(1, counters1["RedisContentLocationStore.BlobAdapter.SkippedBlobs.Count"]);
@@ -424,7 +423,6 @@ namespace ContentStoreTest.Distributed.Sessions
                     var redisStore1 = (RedisContentLocationStore)session1.ContentLocationStore;
 
                     var putResult = await session0.PutRandomAsync(context, HashType.Vso0, false, 10, CancellationToken.None).ShouldBeSuccess();
-                    await Task.Delay(500); // Wait for put blob
                     var counters0 = redisStore0.GetCounters(context).ToDictionaryIntegral();
                     Assert.Equal(1, counters0["RedisContentLocationStore.BlobAdapter.PutBlob.Count"]);
 

--- a/Public/Src/Cache/ContentStore/DistributedTest/Sessions/RedisDistributedContentTests.cs
+++ b/Public/Src/Cache/ContentStore/DistributedTest/Sessions/RedisDistributedContentTests.cs
@@ -395,10 +395,12 @@ namespace ContentStoreTest.Distributed.Sessions
                     var fileString = Encoding.Default.GetString(file);
 
                     await session0.PutContentAsync(context, fileString).ShouldBeSuccess();
+                    await Task.Delay(500); // Wait for put blob
                     var counters0 = redisStore0.GetCounters(context).ToDictionaryIntegral();
                     Assert.Equal(1, counters0["RedisContentLocationStore.BlobAdapter.PutBlob.Count"]);
 
                     await session1.PutContentAsync(context, fileString).ShouldBeSuccess();
+                    await Task.Delay(500); // Wait for put blob
                     var counters1 = redisStore1.GetCounters(context).ToDictionaryIntegral();
                     Assert.Equal(1, counters1["RedisContentLocationStore.BlobAdapter.PutBlob.Count"]);
                     Assert.Equal(1, counters1["RedisContentLocationStore.BlobAdapter.SkippedBlobs.Count"]);
@@ -422,6 +424,7 @@ namespace ContentStoreTest.Distributed.Sessions
                     var redisStore1 = (RedisContentLocationStore)session1.ContentLocationStore;
 
                     var putResult = await session0.PutRandomAsync(context, HashType.Vso0, false, 10, CancellationToken.None).ShouldBeSuccess();
+                    await Task.Delay(500); // Wait for put blob
                     var counters0 = redisStore0.GetCounters(context).ToDictionaryIntegral();
                     Assert.Equal(1, counters0["RedisContentLocationStore.BlobAdapter.PutBlob.Count"]);
 


### PR DESCRIPTION
Expiry time for blobs in Redis is short (30 mins), so it's possible to put it and, in the same build, be unable to retrieve it from Redis, because it already expired.