### PR TITLE
Add retries around SetPathAsSharedOpaqueOutput

### DIFF
--- a/Public/Src/Engine/Processes/SharedOpaqueOutputHelper.cs
+++ b/Public/Src/Engine/Processes/SharedOpaqueOutputHelper.cs
@@ -181,7 +181,12 @@ namespace BuildXL.Processes
         }
 
         private const int MaxNumberOfAttemptsForMarkingSharedOpaqueOutputs = 3;
-        private static readonly TimeSpan SleepDurationBetweenMarkingAttempts = TimeSpan.FromMilliseconds(100);
+        private static readonly TimeSpan SleepDurationBetweenMarkingAttempts = TimeSpan.FromMilliseconds(10);
+
+        private static TimeSpan Multiply(TimeSpan timeSpan, int multiplier)
+        {
+            return TimeSpan.FromMilliseconds(multiplier * timeSpan.TotalMilliseconds);
+        }
 
         /// <summary>
         /// Marks a given path as "shared opaque output"
@@ -207,7 +212,7 @@ namespace BuildXL.Processes
                 // wait a bit between attempts
                 if (attempt > 1)
                 {
-                    System.Threading.Thread.Sleep(SleepDurationBetweenMarkingAttempts);
+                    System.Threading.Thread.Sleep(Multiply(SleepDurationBetweenMarkingAttempts, attempt - 1));
                 }
 
                 try


### PR DESCRIPTION
Retries are needed because: (Win|Unix).SetPathAsSharedOpaqueOutput does something like:
  - check if file has write access rights
  - if it doesn't, give it those rights
  - mark the file as shared opaque output
  - ...

There is a race between checking and setting access rights, so it is possible that here we check its rights, we see that it has the correct rights, then someone else (e.g., the cache) revokes those rights, and so we fail to mark the file as shared opaque output.