### PR TITLE
Skip checkpoint restore rather than performing restore asynchronously which could lead to two concurrent restore operations which is not safe.

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/CheckpointManager.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/CheckpointManager.cs
@@ -32,6 +32,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
 
         private const string CheckpointSizeMetricName = "CheckpointSizeBytes";
         private const string IncrementalCheckpointIdSuffix = "|Incremental";
+        private const string CheckpointInfoKey = "CheckpointManager.CheckpointState";
 
         private const string IncrementalCheckpointInfoEntrySeparator = "\n";
 
@@ -42,7 +43,6 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         private readonly AbsolutePath _checkpointStagingDirectory;
         private readonly AbsolutePath _incrementalCheckpointDirectory;
         private readonly AbsolutePath _incrementalCheckpointInfoFile;
-        private readonly AbsolutePath _lastCheckpointFile;
 
         private CounterCollection<ContentLocationStoreCounters> Counters { get; }
 
@@ -68,7 +68,6 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             _fileSystem = new PassThroughFileSystem();
             _checkpointStagingDirectory = configuration.WorkingDirectory / "staging";
             _incrementalCheckpointDirectory = configuration.WorkingDirectory / "incremental";
-            _lastCheckpointFile = configuration.WorkingDirectory / "lastCheckpoint.txt";
             _fileSystem.CreateDirectory(_incrementalCheckpointDirectory);
 
             _incrementalCheckpointInfoFile = _incrementalCheckpointDirectory / "checkpointInfo.txt";
@@ -268,6 +267,9 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                 _tracer.Debug(context, $"Incremental checkpoint state is invalid or corrupted. Deleting '{_incrementalCheckpointInfoFile}'.");
                 _incrementalCheckpointInfo = CollectionUtilities.EmptyDictionary<string, string>();
                 _fileSystem.DeleteFile(_incrementalCheckpointInfoFile);
+
+                // Clear the latest checkpoint state from the db
+                WriteLatestCheckpoint(context, checkpointState: null);
             }
         }
 
@@ -338,24 +340,21 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                             if (isIncrementalCheckpoint)
                             {
                                 var incrementalRestoreResult = await RestoreCheckpointIncrementalAsync(context, checkpointFile, extractedCheckpointDirectory);
-                                successfullyUpdatedIncrementalState = incrementalRestoreResult.Succeeded;
                                 incrementalRestoreResult.ThrowIfFailure();
                             }
                             else
                             {
-                                RestoreFullCheckpointAsync(checkpointFile, extractedCheckpointDirectory);
+                                RestoreFullCheckpoint(checkpointFile, extractedCheckpointDirectory);
                             }
 
                             // Restoring the checkpoint
-                            var result = _database.RestoreCheckpoint(context, extractedCheckpointDirectory);
+                            _database.RestoreCheckpoint(context, extractedCheckpointDirectory).ThrowIfFailure();
 
-                            if (result)
-                            {
-                                // Save latest checkpoint info to file in case we get restarded and want to know about the previous checkpoint.
-                                WriteLatestCheckpointToFile(context, checkpointState);
-                            }
+                            // Save latest checkpoint info to file in case we get restarded and want to know about the previous checkpoint.
+                            WriteLatestCheckpoint(context, checkpointState);
 
-                            return result;
+                            successfullyUpdatedIncrementalState = true;
+                            return BoolResult.Success;
                         }
                     }
                     finally
@@ -367,15 +366,15 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                 extraEndMessage: _ => $"CheckpointId=[{checkpointId}]");
         }
 
-        private void WriteLatestCheckpointToFile(OperationContext context, CheckpointState checkpointState)
+        private void WriteLatestCheckpoint(OperationContext context, CheckpointState? checkpointState)
         {
             try
             {
-                _fileSystem.WriteAllText(_lastCheckpointFile, $"{checkpointState.CheckpointId},{checkpointState.CheckpointTime}");
+                _database.SetGlobalEntry(CheckpointInfoKey, checkpointState == null ? null : $"{checkpointState.Value.CheckpointId},{checkpointState.Value.CheckpointTime}");
             }
             catch (Exception e)
             {
-                _tracer.Warning(context, $"Failed to write latest checkpoint state to disk: {e}");
+                _tracer.Warning(context, $"Failed to write latest checkpoint state '{checkpointState?.ToString()}' to disk: {e}");
             }
         }
 
@@ -383,12 +382,18 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         {
             try
             {
-                var checkpointText = _fileSystem.ReadAllText(_lastCheckpointFile);
-                var segments = checkpointText.Split(',');
-                var id = segments[0];
-                var date = DateTime.Parse(segments[1]);
+                if (_database.TryGetGlobalEntry(CheckpointInfoKey, out var checkpointText))
+                {
+                    var segments = checkpointText.Split(',');
+                    var id = segments[0];
+                    var date = DateTime.Parse(segments[1]);
+                    return (id, date);
+                }
+                else
+                {
+                    return null;
+                }
 
-                return (id, date);
             }
             catch (Exception e)
             {
@@ -397,7 +402,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             }
         }
 
-        private static void RestoreFullCheckpointAsync(AbsolutePath checkpointFile, AbsolutePath extractedCheckpointDirectory)
+        private static void RestoreFullCheckpoint(AbsolutePath checkpointFile, AbsolutePath extractedCheckpointDirectory)
         {
             // Extracting the checkpoint archive
             ZipFile.ExtractToDirectory(checkpointFile.ToString(), extractedCheckpointDirectory.ToString());

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/CheckpointManager.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/CheckpointManager.cs
@@ -374,7 +374,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             }
             catch (Exception e)
             {
-                _tracer.Warning(context, $"Failed to write latest checkpoint state '{checkpointState?.ToString()}' to disk: {e}");
+                _tracer.Warning(context, $"Failed to write latest checkpoint state '{checkpointState?.ToString()}' to database: {e}");
             }
         }
 

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/CheckpointState.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/CheckpointState.cs
@@ -55,7 +55,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Redis
         /// <inheritdoc />
         public override string ToString()
         {
-            return CheckpointAvailable ? CheckpointId : "Unavailable";
+            return CheckpointAvailable ? $"Id={CheckpointId}, Time={CheckpointTime}, StartSeqPt={StartSequencePoint}" : "Unavailable";
 
         }
     }

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabase.cs
@@ -126,6 +126,16 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         }
 
         /// <summary>
+        /// Sets a key to a given value in the global info map
+        /// </summary>
+        public abstract void SetGlobalEntry(string key, string value);
+
+        /// <summary>
+        /// Attempts to get a value from the global info map
+        /// </summary>
+        public abstract bool TryGetGlobalEntry(string key, out string value); 
+
+        /// <summary>
         /// Factory method that creates an instance of a <see cref="ContentLocationDatabase"/> based on an optional <paramref name="configuration"/> instance.
         /// </summary>
         public static ContentLocationDatabase Create(IClock clock, ContentLocationDatabaseConfiguration configuration, Func<IReadOnlyList<MachineId>> getInactiveMachines)

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/InMemory/MemoryContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/InMemory/MemoryContentLocationDatabase.cs
@@ -22,6 +22,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache.InMemory
     public sealed class MemoryContentLocationDatabase : ContentLocationDatabase
     {
         private readonly ConcurrentDictionary<ShortHash, ContentLocationEntry> _map = new ConcurrentDictionary<ShortHash, ContentLocationEntry>();
+        private readonly ConcurrentDictionary<string, string> _globalEntryMap = new ConcurrentDictionary<string, string>();
 
         /// <inheritdoc />
         public MemoryContentLocationDatabase(IClock clock, MemoryContentLocationDatabaseConfiguration configuration, Func<IReadOnlyList<MachineId>> getInactiveMachines)
@@ -35,6 +36,25 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache.InMemory
             // Intentionally doing nothing.
             Tracer.Info(context, "Initializing in-memory content location database.");
             return BoolResult.Success;
+        }
+
+        /// <inheritdoc />
+        public override void SetGlobalEntry(string key, string value)
+        {
+            if (value == null)
+            {
+                _globalEntryMap.TryRemove(key, out _);
+            }
+            else
+            {
+                _globalEntryMap[key] = value;
+            }
+        }
+
+        /// <inheritdoc />
+        public override bool TryGetGlobalEntry(string key, out string value)
+        {
+            return _globalEntryMap.TryGetValue(key, out value);
         }
 
         /// <inheritdoc />

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
@@ -409,7 +409,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
 
                     if (shouldRestore || forceRestore)
                     {
-                        result = await RestoreCheckpointStateAsync(context, checkpointState, force: false);
+                        result = await RestoreCheckpointStateAsync(context, checkpointState);
                         if (!result)
                         {
                             return result;
@@ -517,7 +517,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                 }
             }
         }
-        
+
 
         internal Task<BoolResult> UpdateClusterStateAsync(OperationContext context)
         {
@@ -592,30 +592,26 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             return await _checkpointManager.CreateCheckpointAsync(context, currentSequencePoint);
         }
 
-        private async Task<BoolResult> RestoreCheckpointStateAsync(OperationContext context, CheckpointState checkpointState, bool force = false)
+        private async Task<BoolResult> RestoreCheckpointStateAsync(OperationContext context, CheckpointState checkpointState)
         {
-            var token = context.Token;
+            var latestCheckpoint = _checkpointManager.GetLatestCheckpointInfo(context);
+            var latestCheckpointAge = _clock.UtcNow - latestCheckpoint?.checkpointTime;
 
-            if (!force)
+            // Only skip if this is the first restore and it is sufficiently recent
+            // NOTE: _lastRestoreTime will be set since skipping this operation will return successful result.
+            var shouldSkipRestore = _lastRestoreTime == default
+                && latestCheckpoint != null
+                && latestCheckpoint.Value.checkpointTime.IsRecent(_clock.UtcNow, _configuration.Checkpoint.RestoreCheckpointAgeThreshold);
+
+            if (latestCheckpointAge > _configuration.LocationEntryExpiry)
             {
-                var latestCheckpoint = _checkpointManager.GetLatestCheckpointInfo(context);
-                var latestCheckpointAge = _clock.UtcNow - latestCheckpoint?.checkpointTime;
+                Tracer.Debug(context, $"Checkpoint {latestCheckpoint.Value.checkpointId} age is {latestCheckpointAge}, which is larger than location expiry {_configuration.LocationEntryExpiry}");
+            }
 
-                // Only skip if this is the first restore and it is sufficiently recent
-                var shouldSkipRestore = _lastRestoreTime == default 
-                    && latestCheckpoint != null 
-                    && latestCheckpoint?.checkpointTime.IsRecent(_clock.UtcNow, _configuration.Checkpoint.RestoreCheckpointAgeThreshold) == true;
-
-                if (latestCheckpointAge > _configuration.LocationEntryExpiry)
-                {
-                    Tracer.Debug(context, $"Checkpoint {latestCheckpoint.Value.checkpointId} age is {latestCheckpointAge}, which is larger than location expiry {_configuration.LocationEntryExpiry}");
-                }
-
-                if (shouldSkipRestore)
-                {
-                    Tracer.Debug(context, $"First checkpoint {latestCheckpoint.Value.checkpointId} will be skipped. Age=[{latestCheckpointAge}], Threshold=[{_configuration.Checkpoint.RestoreCheckpointAgeThreshold}]");
-                    return BoolResult.Success;
-                }
+            if (shouldSkipRestore)
+            {
+                Tracer.Debug(context, $"First checkpoint {latestCheckpoint.Value.checkpointId} will be skipped. Age=[{latestCheckpointAge}], Threshold=[{_configuration.Checkpoint.RestoreCheckpointAgeThreshold}]");
+                return BoolResult.Success;
             }
 
             if (checkpointState.CheckpointAvailable)
@@ -647,7 +643,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                     }
                     else
                     {
-                        Task.Run(() => ReconcileAsync(context), token).FireAndForget(context);
+                        Task.Run(() => ReconcileAsync(context), context.Token).FireAndForget(context);
                     }
                 }
             }

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/RocksDbContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/RocksDbContentLocationDatabase.cs
@@ -336,6 +336,39 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         }
 
         /// <inheritdoc />
+        public override void SetGlobalEntry(string key, string value)
+        {
+            _keyValueStore.Use(store =>
+            {
+                if (value == null)
+                {
+                    store.Remove(key, nameof(Columns.ClusterState));
+                }
+                else
+                {
+                    store.Put(key, value, nameof(Columns.ClusterState));
+                }
+            }).ThrowOnError();
+        }
+
+        /// <inheritdoc />
+        public override bool TryGetGlobalEntry(string key, out string value)
+        {
+            value = _keyValueStore.Use(store =>
+            {
+                if (store.TryGetValue(key, out var value, nameof(Columns.ClusterState)))
+                {
+                    return value;
+                }
+                else
+                {
+                    return null;
+                }
+            }).ThrowOnError();
+            return value != null;
+        }
+
+        /// <inheritdoc />
         protected override void UpdateClusterStateCore(OperationContext context, ClusterState clusterState, bool write)
         {
             _keyValueStore.Use(

--- a/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
@@ -76,7 +76,6 @@ namespace BuildXL.Cache.Host.Service.Internal
             ApplyIfNotNull(_distributedSettings.ReplicaCreditInMinutes, v => redisContentLocationStoreConfiguration.ContentLifetime = TimeSpan.FromMinutes(v));
             ApplyIfNotNull(_distributedSettings.MachineRisk, v => redisContentLocationStoreConfiguration.MachineRisk = v);
             ApplyIfNotNull(_distributedSettings.LocationEntryExpiryMinutes, v => redisContentLocationStoreConfiguration.LocationEntryExpiry = TimeSpan.FromMinutes(v));
-            ApplyIfNotNull(_distributedSettings.RestoreCheckpointAgeThresholdMinutes, v => redisContentLocationStoreConfiguration.Checkpoint.RestoreCheckpointAgeThreshold = TimeSpan.FromMinutes(v));
             ApplyIfNotNull(_distributedSettings.MachineExpiryMinutes, v => redisContentLocationStoreConfiguration.MachineExpiry = TimeSpan.FromMinutes(v));
 
             redisContentLocationStoreConfiguration.ReputationTrackerConfiguration.Enabled = _distributedSettings.IsMachineReputationEnabled;


### PR DESCRIPTION
Skip checkpoint restore rather than performing restore asynchronously which could lead to two concurrent restore operations which is not safe.