### PR TITLE
[macOS] Low memory resource throttling improvements

### DIFF
--- a/Public/Src/Engine/Scheduler/PipExecutor.cs
+++ b/Public/Src/Engine/Scheduler/PipExecutor.cs
@@ -2304,7 +2304,7 @@ namespace BuildXL.Scheduler
                 RunnableFromCacheResult runnableFromCacheResult;
 
                 bool isCacheHit = cacheHitData != null;
-                
+
                 if (!isCacheHit)
                 {
                     var pathSetCount = strongFingerprintComputationList.Count;
@@ -2327,7 +2327,7 @@ namespace BuildXL.Scheduler
                         {
                             ContentHash weakAugmentingPathSetHash = weakAugmentingPathSetHashResult.Result;
 
-                            // Optional (not currently implemented): If augmenting path set already exists (race condition), we 
+                            // Optional (not currently implemented): If augmenting path set already exists (race condition), we
                             // could compute augmented weak fingerprint and perform the cache lookup as above
                             (ObservedInputProcessingResult observedInputProcessingResult, StrongContentFingerprint computedStrongFingerprint)
                                         = await TryComputeStrongFingerprintBasedOnPriorObservedPathSetAsync(
@@ -4421,7 +4421,7 @@ namespace BuildXL.Scheduler
                 declaredArtifactPath = process.DirectoryOutputs[fileOutputData.OpaqueDirectoryIndex].Path;
             }
 
-            return PipArtifacts.IsPreservedOutputByPip(process, declaredArtifactPath, environment.Context.PathTable, environment.Configuration.Sandbox.UnsafeSandboxConfiguration.PreserveOutputsTrustLevel); 
+            return PipArtifacts.IsPreservedOutputByPip(process, declaredArtifactPath, environment.Context.PathTable, environment.Configuration.Sandbox.UnsafeSandboxConfiguration.PreserveOutputsTrustLevel);
         }
 
         private static bool IsRewriteOutputFile(IPipExecutionEnvironment environment, FileArtifact file)

--- a/Public/Src/Engine/Scheduler/PipExecutor.cs
+++ b/Public/Src/Engine/Scheduler/PipExecutor.cs
@@ -1382,7 +1382,7 @@ namespace BuildXL.Scheduler
                                 registerQueryRamUsageMb(
                                     () =>
                                     {
-                                        using (operationContext.StartAsyncOperation(PipExecutorCounter.QueryRamUsageDuration))
+                                        using (counters[PipExecutorCounter.QueryRamUsageDuration].Start())
                                         {
                                             lastObservedPeakRamUsage =
                                                 (int)ByteSizeFormatter.ToMegabytes((long)(executor.GetActivePeakWorkingSet() ?? 0));

--- a/Public/Src/Engine/Scheduler/ProcessResourceManager.cs
+++ b/Public/Src/Engine/Scheduler/ProcessResourceManager.cs
@@ -96,6 +96,23 @@ namespace BuildXL.Scheduler
             }
         }
 
+        /// <summary>
+        /// Updates the ram usage indicators for all cancelable resource scopes
+        /// </summary>
+        public void UpdateRamUsageForResourceScopes()
+        {
+            lock (m_syncLock)
+            {
+                foreach (var scope in m_pipResourceScopes.Values)
+                {
+                    if (scope.CanCancel)
+                    {
+                        scope.RefreshRamUsage();
+                    }
+                }
+            }
+        }
+
         private void FreeResourcesByPreference(
             IComparer<ResourceScope> scopeComparer,
             ref int requiredRam,
@@ -140,7 +157,6 @@ namespace BuildXL.Scheduler
             }
 
             using (scope)
-            using (new StoppableTimer(() => scope.RefreshRamUsage(), 0, 2000))
             {
                 var result = await execute(scope.Token, registerQueryRamUsageMb: scope.RegisterQueryRamUsageMb);
                 scope.Complete();

--- a/Public/Src/Engine/Scheduler/ProcessResourceManager.cs
+++ b/Public/Src/Engine/Scheduler/ProcessResourceManager.cs
@@ -270,7 +270,12 @@ namespace BuildXL.Scheduler
 
             public int QueryRamUsageMb()
             {
-                return m_queryRamUsageMb?.Invoke() ?? 0;
+                if (!m_cancellation.IsCancellationRequested && !m_cancelled && !m_completed && !m_isDisposed)
+                {
+                    return m_queryRamUsageMb?.Invoke() ?? 0;
+                }
+
+                return 0;
             }
 
             public void RefreshRamUsage()

--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -2173,9 +2173,22 @@ namespace BuildXL.Scheduler
             }
 
 #if PLATFORM_OSX
-            Memory.PressureLevel pressureLevel = Memory.PressureLevel.Normal;
-            var result = Memory.GetMemoryPressureLevel(ref pressureLevel) == Dispatch.MACOS_INTEROP_SUCCESS;
-            resourceAvailable &= !(result && (pressureLevel > m_configuration.Schedule.MaximumAllowedMemoryPressureLevel));
+            if (!resourceAvailable)
+            {
+                Memory.PressureLevel pressureLevel = Memory.PressureLevel.Normal;
+                var result = Memory.GetMemoryPressureLevel(ref pressureLevel) == Dispatch.MACOS_INTEROP_SUCCESS;
+                resourceAvailable = !(result && (pressureLevel > m_configuration.Schedule.MaximumAllowedMemoryPressureLevel));
+
+                if (!result)
+                {
+                    Logger.Log.UnableToGetMemoryPressureLevel(
+                            m_executePhaseLoggingContext,
+                            availableRam: perfInfo.AvailableRamMb.Value,
+                            minimumAvailableRam: m_configuration.Schedule.MinimumTotalAvailableRamMb,
+                            ramUtilization: perfInfo.RamUsagePercentage.Value,
+                            maximumRamUtilization: m_configuration.Schedule.MaximumRamUtilizationPercentage);
+                }
+            }
 #endif
 
             if (!resourceAvailable)

--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -2181,7 +2181,7 @@ namespace BuildXL.Scheduler
                 {
                     // If the memory pressure level is not above the configured level but we've infered resources are not available earlier,
                     // we reset the resource availability and override the decision by looking at the current pressure level only!
-                    resourceAvailable = !(pressureLevel > m_configuration.Schedule.MaximumAllowedMemoryPressureLevel));
+                    resourceAvailable = !(pressureLevel > m_configuration.Schedule.MaximumAllowedMemoryPressureLevel);
                 }
                 else
                 {

--- a/Public/Src/Engine/Scheduler/Tracing/Log.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/Log.cs
@@ -1219,7 +1219,7 @@ namespace BuildXL.Scheduler.Tracing
             EventLevel = Level.Verbose,
             Keywords = (int)Keywords.UserMessage,
             EventTask = (ushort)Tasks.Scheduler,
-            Message = "Failed to get the current memory pressure level - resource cancelation will be skipped all together! Available RAM MB: {availableRam} < {minimumAvailableRam})" +
+            Message = "Failed to get the current memory pressure level - resource cancelation will only take /minimumAvailableRam and /maximumRamUtilization into account! Available RAM MB: {availableRam} < {minimumAvailableRam})" +
             " && (used RAM percentage: {ramUtilization} > {maximumRamUtilization}) ")]
         internal abstract void UnableToGetMemoryPressureLevel(
             LoggingContext loggingContext,

--- a/Public/Src/Engine/Scheduler/Tracing/Log.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/Log.cs
@@ -1214,6 +1214,21 @@ namespace BuildXL.Scheduler.Tracing
         internal abstract void PreserveOutputsFailedToMakeOutputPrivate(LoggingContext loggingContext, string pipDescription, string file, string error);
 
         [GeneratedEvent(
+            (ushort)LogEventId.UnableToGetMemoryPressureLevel,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Verbose,
+            Keywords = (int)Keywords.UserMessage,
+            EventTask = (ushort)Tasks.Scheduler,
+            Message = "Failed to get the current memory pressure level - resource cancelation will be skipped all together! Available RAM MB: {availableRam} < {minimumAvailableRam})" +
+            " && (used RAM percentage: {ramUtilization} > {maximumRamUtilization}) ")]
+        internal abstract void UnableToGetMemoryPressureLevel(
+            LoggingContext loggingContext,
+            long availableRam,
+            long minimumAvailableRam,
+            long ramUtilization,
+            long maximumRamUtilization);
+
+        [GeneratedEvent(
             (ushort)LogEventId.StoppingProcessExecutionDueToResourceExhaustion,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,
@@ -3450,7 +3465,7 @@ namespace BuildXL.Scheduler.Tracing
 
         [GeneratedEvent(
             (int)EventId.InvalidMetadataStaticOutputNotFound,
-            EventGenerators = EventGenerators.LocalOnly, 
+            EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Warning,
             Keywords = (int)Keywords.UserMessage,
             EventTask = (int)Tasks.Scheduler,

--- a/Public/Src/Engine/Scheduler/Tracing/LogEventId.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/LogEventId.cs
@@ -79,6 +79,8 @@ namespace BuildXL.Scheduler.Tracing
         HistoricMetadataCacheCloseCalled = 3663,
         HistoricMetadataCacheLoadFailed = 3664,
 
+        UnableToGetMemoryPressureLevel = 3665,
+
         PipCacheMetadataBelongToAnotherPip = 3700,
 
         PipIpcFailedDueToInfrastructureError = 3701,
@@ -138,7 +140,7 @@ namespace BuildXL.Scheduler.Tracing
         AllowedSameContentDoubleWrite = 5044,
 
         InitiateWorkerRelease = 5045,
-        WorkerReleasedEarly = 5046, 
+        WorkerReleasedEarly = 5046,
         DependencyViolationWriteOnExistingFile = 5047,
         FailedToAddFragmentPipToGraph = 5048,
         ExceptionOnAddingFragmentPipToGraph = 5049,


### PR DESCRIPTION
Adjust some resource throttling mechanisms to better model low memory pressure situations on macOS (jetsam interaction). Also fixes a bug recently introduced with a polling timer for memory usage observation.