### PR TITLE
Update macOS Developer Guide for XCode version

### DIFF
--- a/Documentation/Wiki/DeveloperGuide.md
+++ b/Documentation/Wiki/DeveloperGuide.md
@@ -8,6 +8,7 @@ To run BuildXL on macOS you need to install:
 * Microsoft [.NET Core SDK](https://dotnet.microsoft.com/download) for macOS
 * The latest [Mono](https://www.mono-project.com/download/stable/) runtime
 * If you want to run and load the sandbox to enable fully observed and cacheable builds, you also have to [turn off System Integrity Protection](https://developer.apple.com/library/archive/documentation/Security/Conceptual/System_Integrity_Protection_Guide/ConfiguringSystemIntegrityProtection/ConfiguringSystemIntegrityProtection.html) (SIP) on macOS. SIP blocks the installation of the unsigned kernel extension (or Kext) produced by the build.
+* XCode 10.3. Obtanable from https://developer.apple.com/download/more/. After downloading, either adjust this path to where you have placed the tool or put everything into your /Applications folder, renaming the app to 'Xcode_10.3' so the xcodebuild executable can be found
 
 # Performing a build
 `bxl.cmd` (and `./bxl.sh`) are the entry points to building BuildXL. They provide some shorthands for common tasks to prevent developers from needing to specify longer command line options. While most examples below are based off of bxl.cmd for Windows, there will most times be a bxl.sh equivalent for macOS.

--- a/Public/Src/Sandbox/MacOs/scripts/bxl.sh
+++ b/Public/Src/Sandbox/MacOs/scripts/bxl.sh
@@ -32,7 +32,6 @@ function setBxlCmdArgs {
     g_bxlCmdArgs=(
         # some defaults
         /sandboxKind:none
-        /remoteTelemetry+
         /enableIncrementalFrontEnd-
         /useHardLinks-
         # some environment variables

--- a/bxl.sh
+++ b/bxl.sh
@@ -49,7 +49,8 @@ function setMinimal() {
 
 function setInternal() {
     arg_Positional+=("/p:[Sdk.BuildXL]microsoftInternal=1")
-    
+    arg_Positional+=("/remoteTelemetry+")
+
     for arg in "$@" 
     do
         to_lower=`printf '%s\n' "$arg" | awk '{ print tolower($0) }'`


### PR DESCRIPTION
- Include requirement for old Xcode version to DeveloperGuide
- Remove /remotetelemetry+ switch by default for public builds