### PR TITLE
Fix the NRE when logging mem usage

### DIFF
--- a/Public/Src/Engine/Processes/JobObject.cs
+++ b/Public/Src/Engine/Processes/JobObject.cs
@@ -37,7 +37,7 @@ namespace BuildXL.Processes
         /// <summary>
         /// Initial length to get active processes.
         /// </summary>
-        public const int InitialProcessIdListLength = 256; // arbitrary number
+        public const int InitialProcessIdListLength = 1024; // the number needed to make the bufferSizeForProcessIdList 4KB. 
 
         /// <summary>
         /// Nested jobs are only supported on Win8/Server2012 or higher.

--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -3582,9 +3582,7 @@ namespace BuildXL.Scheduler
                         {
                             var perfInfo = executionResult.PerformanceInformation;
 
-                            if (perfInfo != null)
-                            {
-                                m_groupedPipCounters.AddToCounters(
+                            m_groupedPipCounters.AddToCounters(
                                     processRunnable.Process,
                                     new[]
                                     {
@@ -3593,7 +3591,6 @@ namespace BuildXL.Scheduler
                                     },
                                     new[] { (PipCountersByGroup.ExecuteProcessDuration, perfInfo.ProcessExecutionTime) }
                                 );
-                            }
                         }
 
                         // The pip was canceled
@@ -3662,20 +3659,20 @@ namespace BuildXL.Scheduler
 
                         if (!IsDistributedWorker)
                         {
-                            var expectedRamUsage = runnablePip.Worker.GetExpectedRamUsageMb((ProcessRunnablePip)runnablePip);
+                            var expectedRamUsage = worker.GetExpectedRamUsageMb((ProcessRunnablePip)runnablePip);
 
-                            int peakVirtualMemoryUsageMb = executionResult.PerformanceInformation.MemoryCounters.PeakVirtualMemoryUsageMb;
-                            int peakWorkingSetMb = executionResult.PerformanceInformation.MemoryCounters.PeakWorkingSetMb;
-                            int peakPagefileUsageMb = executionResult.PerformanceInformation.MemoryCounters.PeakPagefileUsageMb;
+                            int peakVirtualMemoryUsageMb = executionResult.PerformanceInformation?.MemoryCounters.PeakVirtualMemoryUsageMb ?? 0;
+                            int peakWorkingSetMb = executionResult.PerformanceInformation?.MemoryCounters.PeakWorkingSetMb ?? 0;
+                            int peakPagefileUsageMb = executionResult.PerformanceInformation?.MemoryCounters.PeakPagefileUsageMb ?? 0;
 
                             Logger.Log.ProcessPipExecutionInfo(
                                 operationContext, 
                                 runnablePip.Description,
-                                (int)executionResult.PerformanceInformation.NumberOfProcesses,
+                                (int)(executionResult.PerformanceInformation?.NumberOfProcesses ?? 0),
                                 (int)((processRunnable.ExpectedDurationMs ?? 0) / 1000),
-                                (int)executionResult.PerformanceInformation.ProcessExecutionTime.TotalSeconds,
-                                executionResult.PerformanceInformation.ProcessorsInPercents,
-                                runnablePip.Worker.DefaultMemoryUsagePerProcess, 
+                                (int)(executionResult.PerformanceInformation?.ProcessExecutionTime.TotalSeconds ?? 0),
+                                executionResult.PerformanceInformation?.ProcessorsInPercents ?? 0,
+                                worker.DefaultMemoryUsagePerProcess, 
                                 expectedRamUsage,
                                 peakVirtualMemoryUsageMb,
                                 peakWorkingSetMb,


### PR DESCRIPTION
There are some NRE happening with random line numbers. I suspect that those are related to logging mem usage. 

System.NullReferenceException: Object reference not set to an instance of an object.
   at async Task<PipExecutionStep> BuildXL.Scheduler.Scheduler.ExecutePipStep(RunnablePip runnablePip) in \.\Public\Src\Engine\Scheduler\Scheduler.cs:line 3769

Fixes [AB#1634391](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1634391)

Fixes [AB#1634458](https://dev.azure.com/mseng/1ES/_boards/board/t/MichaelP%20-%20Team/Stories/?workitem=1634458)