### PR TITLE
Correct PipExecutionPerformanceAnalyzer's pipMemoryUsage counter label

### DIFF
--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/PipExecutionPerformanceAnalyzer.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/PipExecutionPerformanceAnalyzer.cs
@@ -158,7 +158,7 @@ namespace BuildXL.Execution.Analyzer
                 WriteLineIndented(I($"\"executionTimeInMs\" : {performance.ProcessExecutionTime.TotalMilliseconds},"));
                 WriteLineIndented(I($"\"userExecutionTimeInMs\" : {performance.UserTime.TotalMilliseconds},"));
                 WriteLineIndented(I($"\"kernelExecutionTimeInMs\" : {performance.KernelTime.TotalMilliseconds},"));
-                WriteLineIndented(I($"\"peakMemoryUsageInMb\" : {performance.MemoryCounters.PeakVirtualMemoryUsage},"));
+                WriteLineIndented(I($"\"peakMemoryUsageInByte\" : {performance.MemoryCounters.PeakVirtualMemoryUsage},"));
 
                 WriteLineIndented("\"io\" : {");
                 IncrementIndent();


### PR DESCRIPTION
Fixes [AB#1629042](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1629042)