### PR TITLE
Revert "Emit change affected inputs with full paths (#1092)"

### DIFF
--- a/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
@@ -2675,7 +2675,7 @@ namespace BuildXL.Processes
                     m_pip.ChangeAffectedInputListWrittenFile,
                     () => string.Join(
                         Environment.NewLine,
-                        changeAffectedInputs.Select(i => i.ToString(m_pathTable))),
+                        changeAffectedInputs.Select(i => i.GetName(m_pathTable).ToString(m_pathTable.StringTable)).Distinct().OrderBy(n => n)),
                     Tracing.Logger.Log.PipProcessChangeAffectedInputsWrittenFileCreationFailed);
 
         private async Task<bool> WritePipAuxiliaryFileAsync(

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/ChangeAffectedInputTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/ChangeAffectedInputTests.cs
@@ -67,7 +67,7 @@ namespace IntegrationTest.BuildXL.Scheduler
             result.AssertCacheHit(pipA.Process.PipId);
 
             var actualAffectedInput = File.ReadAllText(changeAffectedWrittenFile.ToString(Context.PathTable));
-            var expectedAffectedInput = aOutput.Path.ToString(Context.PathTable);
+            var expectedAffectedInput = aOutput.Path.GetName(Context.PathTable).ToString(Context.PathTable.StringTable);
             XAssert.AreEqual(expectedAffectedInput, actualAffectedInput);
         }
 
@@ -224,8 +224,8 @@ namespace IntegrationTest.BuildXL.Scheduler
             string[] actualAffectedSortedInputs = File.ReadAllLines(changeAffectedWrittenFile.ToString(Context.PathTable)).OrderBy(p => p, StringComparer.InvariantCultureIgnoreCase).ToArray();
             string[] expectedAffectedInputs = 
             { 
-                aOutputFileInOutputSubDir.Path.ToString(Context.PathTable),
-                aOutputFileInOutputeDir.Path.ToString(Context.PathTable)
+                aOutputFileInOutputSubDir.Path.GetName(Context.PathTable).ToString(Context.PathTable.StringTable),
+                aOutputFileInOutputeDir.Path.GetName(Context.PathTable).ToString(Context.PathTable.StringTable) 
             };
 
             string[] expectedAffectedSortedInputs = expectedAffectedInputs.OrderBy(p => p, StringComparer.InvariantCultureIgnoreCase).ToArray();
@@ -294,7 +294,7 @@ namespace IntegrationTest.BuildXL.Scheduler
             if (pipBInputAccessType == InputAccessType.DynamicFileAccess)
             {
                 operations.Add(Operation.ReadFile(aOutputFileInOutputeDir, doNotInfer: true));
-                expectedAffectedInput = bOutFileArtifact.Path.ToString(Context.PathTable);
+                expectedAffectedInput = bOutFileArtifact.Path.GetName(Context.PathTable).ToString(Context.PathTable.StringTable);
             }
             operations.Add(Operation.WriteFile(bOutFileArtifact, doNotInfer: true));
             var pipBuilderB = CreatePipBuilder(operations);
@@ -393,7 +393,7 @@ namespace IntegrationTest.BuildXL.Scheduler
                 else
                 {
                     operations.Add(Operation.ReadFile(copiedFile, doNotInfer: true));
-                    expectedAffectedInput = bOutFileArtifact.Path.ToString(Context.PathTable);
+                    expectedAffectedInput = bOutFileArtifact.Path.GetName(Context.PathTable).ToString(Context.PathTable.StringTable);
                 }
             }
             operations.Add(Operation.WriteFile(bOutFileArtifact, doNotInfer: true));
@@ -452,7 +452,7 @@ namespace IntegrationTest.BuildXL.Scheduler
             RunScheduler().AssertSuccess();
 
             var actualAffectedInput = File.ReadAllText(changeAffectedWrittenFile.ToString(Context.PathTable));
-            XAssert.AreEqual(ArtifactToString(fileInsideSourceDirectory), actualAffectedInput);
+            XAssert.AreEqual(Path.GetFileName(ArtifactToString(fileInsideSourceDirectory)), actualAffectedInput);
         }
     }
 }


### PR DESCRIPTION
This reverts commit d2644a37795639d1b00c674c7d85d9559f6990a0.