### PR TITLE
Adding pip output without producer logs error instead of contract violation

### DIFF
--- a/Public/Src/Engine/Scheduler/Tracing/Log.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/Log.cs
@@ -2845,6 +2845,25 @@ namespace BuildXL.Scheduler.Tracing
             string producingPipValueId);
 
         [GeneratedEvent(
+            (int)EventId.InvalidInputSinceInputIsOutputWithNoProducer,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Error,
+            Keywords = (int)(Keywords.UserMessage | Keywords.UserError),
+            EventTask = (int)Tasks.Scheduler,
+            Message =
+                EventConstants.ProvenancePrefix +
+                "The pip '{pipDescription}' cannot be added because its input '{inputFile}' is specified as an output file, but there is no pip producing the output file")]
+        public abstract void ScheduleFailAddPipInvalidInputSinceInputIsOutputWithNoProducer(
+            LoggingContext context,
+            string file,
+            int line,
+            int column,
+            long pipSemiStableHash,
+            string pipDescription,
+            string pipValueId,
+            string inputFile);
+
+        [GeneratedEvent(
             (int)EventId.InvalidTempDirectoryInvalidPath,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Error,

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/TempDirectoryTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/TempDirectoryTests.cs
@@ -16,7 +16,7 @@ using Test.BuildXL.TestUtilities.Xunit;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace IntegrationTest.Domino.Scheduler
+namespace IntegrationTest.BuildXL.Scheduler
 {
     /// <summary>
     /// Tests that validate file access policies and caching behavior
@@ -126,36 +126,22 @@ namespace IntegrationTest.Domino.Scheduler
         /// </summary>
         /// <param name="tempArtifactType"></param>
         [Theory]
-        [InlineData(TempArtifactType.AdditionalTempDirectory)]
-        [InlineData(TempArtifactType.TempDirectory)]
-        [InlineData(TempArtifactType.TempFile)]
-        public void FailOnTempInput(int tempArtifactType)
+        [InlineData(TempArtifactType.AdditionalTempDirectory, EventId.InvalidInputSinceInputIsOutputWithNoProducer)]
+        [InlineData(TempArtifactType.TempDirectory, EventId.InvalidInputSinceInputIsOutputWithNoProducer)]
+        [InlineData(TempArtifactType.TempFile, EventId.InvalidInputSinceCorrespondingOutputIsTemporary)]
+        public void FailOnTempInput(int tempArtifactType, EventId errorEvent)
         {
             // First pip writes a file to its temp directory
             CreateAndSchedulePipWithTemp(tempArtifactType, out var tempOut);
-
-            try
+            
+            // Second pip consumes a file from pipA's temp directory
+            CreateAndSchedulePipBuilder(new Operation[]
             {
-                // Second pip consumes a file from pipA's temp directory
-                CreateAndSchedulePipBuilder(new Operation[]
-                {
                     Operation.ReadFile(tempOut),
                     Operation.WriteFile(CreateOutputFileArtifact())
-                });
-            }
-            catch (System.Exception contractException)
-            {
-#pragma warning disable EPC12 // Suspicious exception handling: only Message property is observed in exception block.
-                // input files in temp directories throw this contract exception
-                contractException.Message.StartsWith("Assumption failed: Output artifact has no producer.");
-#pragma warning restore EPC12 // Suspicious exception handling: only Message property is observed in exception block.
+            });
 
-                // temp files error
-                if (tempArtifactType == TempArtifactType.TempFile)
-                {
-                    AssertErrorEventLogged(EventId.InvalidInputSinceCorrespondingOutputIsTemporary);
-                }
-            }
+            AssertErrorEventLogged(errorEvent);
         }
 
         [Theory]
@@ -486,14 +472,15 @@ namespace IntegrationTest.Domino.Scheduler
             var tempRootPath = tempRoot ?? TempRootPath;
 
             tempFileWritten = CreateOutputFileArtifact(tempRootPath);
-            var pip = CreateAndScheduleTempDirProcess(new Operation[]
-            {
-                Operation.WriteFile(tempFileWritten, doNotInfer: true),
-                Operation.WriteFile(CreateOutputFileArtifact())
-            },
-            tempArtifactType,
-            tempRootPath,
-            tempFileWritten.Path);
+            var pip = CreateAndScheduleTempDirProcess(
+                new Operation[]
+                {
+                    Operation.WriteFile(tempFileWritten, doNotInfer: true),
+                    Operation.WriteFile(CreateOutputFileArtifact())
+                },
+                tempArtifactType,
+                tempRootPath,
+                tempFileWritten.Path);
 
             return pip;
         }

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/TempDirectoryTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/TempDirectoryTests.cs
@@ -133,12 +133,14 @@ namespace IntegrationTest.BuildXL.Scheduler
         {
             // First pip writes a file to its temp directory
             CreateAndSchedulePipWithTemp(tempArtifactType, out var tempOut);
-            
-            // Second pip consumes a file from pipA's temp directory
-            CreateAndSchedulePipBuilder(new Operation[]
+            Assert.Throws<BuildXLTestException>(() =>
             {
+                // Second pip consumes a file from pipA's temp directory
+                CreateAndSchedulePipBuilder(new Operation[]
+                {
                     Operation.ReadFile(tempOut),
                     Operation.WriteFile(CreateOutputFileArtifact())
+                });
             });
 
             AssertErrorEventLogged(errorEvent);

--- a/Public/Src/Utilities/Utilities/Tracing/EventId.cs
+++ b/Public/Src/Utilities/Utilities/Tracing/EventId.cs
@@ -174,8 +174,7 @@ namespace BuildXL.Utilities.Tracing
         BusyOrUnavailableOutputDirectoriesRetry = 214,
         InvalidInputSinceInputIsRewritten = 215,
         InvalidInputDueToMultipleConflictingRewriteCounts = 216,
-
-        // Reserved = 217,
+        InvalidInputSinceInputIsOutputWithNoProducer = 217,
 
         // Pips
         InvalidProcessPipDueToNoOutputArtifacts = 218,


### PR DESCRIPTION
The introduction of binary graph makes it possible to have this when deserializing binary graphs from files.

[AB#1638154](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1638154)