### PR TITLE
[macOS] Forward all signal handling masks to spawned child processes

### DIFF
--- a/Public/Src/Sandbox/MacOs/Interop/Posix/process.c
+++ b/Public/Src/Sandbox/MacOs/Interop/Posix/process.c
@@ -242,24 +242,15 @@ void RegisterSignalHandlers()
         SIGSEGV
     };
 
-    void *handler_defaults[] = {
-        SIG_IGN,  // SIGBUS
-        SIG_HOLD, // SIGILL: Can't be ignored, hence we add it to the calling process signal mask
-        SIG_IGN,  // SIGHUP
-        SIG_IGN,  // SIGABRT
-        SIG_IGN   // SIGSEGV
-    };
-
     int signalsLength = sizeof(signals) / sizeof(signals[0]);
-    int defaultsLength = sizeof(handler_defaults) / sizeof(handler_defaults[0]);
-
-    // Make sure we provide default handler behavior for every signal we hijack
-    assert(signalsLength == defaultsLength);
 
     for (int i = 0; i < signalsLength; i++)
     {
         struct sigaction action = { 0 };
-        action.sa_handler = handler_defaults[i];
+
+        // Also forward all intercepted signal masks to potential children,
+        // so they can do their own signal handling if required
+        action.sa_handler = SIG_HOLD;
 
         int sig = signals[i];
         sigaction(sig, &action, NULL);

--- a/cg/nuget/cgmanifest.json
+++ b/cg/nuget/cgmanifest.json
@@ -4191,7 +4191,7 @@
         "Type": "NuGet",
         "NuGet": {
           "Name": "runtime.osx-x64.BuildXL",
-          "Version": "2.4.99"
+          "Version": "2.5.1"
         }
       }
     },

--- a/config.microsoftInternal.dsc
+++ b/config.microsoftInternal.dsc
@@ -11,7 +11,7 @@ export const pkgs = isMicrosoftInternal ? [
     { id: "BuildXL.DeviceMap", version: "0.0.1" },
 
     // Runtime dependencies used for macOS deployments
-    { id: "runtime.osx-x64.BuildXL", version: "2.4.99" },
+    { id: "runtime.osx-x64.BuildXL", version: "2.5.1" },
     { id: "Aria.Cpp.SDK", version: "8.5.6" },
 
     { id: "CB.QTest", version: "19.10.17.210051" },


### PR DESCRIPTION
Fix child process mask forwarding and bump interop lib, this allows spawned processes (pips) to do their own signal / dump handling instead of BuildXL taking care of it all.