### PR TITLE
Address recent OverflowException occurrences 

### DIFF
--- a/Public/Src/Engine/Processes/SandboxedProcessMac.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessMac.cs
@@ -84,8 +84,8 @@ namespace BuildXL.Processes
         /// <summary>
         /// Timeout period for inactivity from the sandbox kernel extension.
         /// </summary>
-        internal TimeSpan ReportQueueProcessTimeout => SandboxConnection.IsInTestMode 
-            ? ProcessInfo.ReportQueueProcessTimeoutForTests ?? TimeSpan.FromSeconds(100) 
+        internal TimeSpan ReportQueueProcessTimeout => SandboxConnection.IsInTestMode
+            ? ProcessInfo.ReportQueueProcessTimeoutForTests ?? TimeSpan.FromSeconds(100)
             : TimeSpan.FromMinutes(45);
 
         private Task m_processTreeTimeoutTask;
@@ -399,21 +399,50 @@ namespace BuildXL.Processes
         // <inheritdoc />
         internal override JobObject.AccountingInformation GetJobAccountingInfo()
         {
-            return !MeasureCpuTime
-                ? base.GetJobAccountingInfo()
-                : new JobObject.AccountingInformation
+            if (!MeasureCpuTime)
+            {
+                return base.GetJobAccountingInfo();
+            }
+            else
+            {
+                IOCounters ioCounters;
+                ProcessMemoryCounters memoryCounters;
+
+                try
                 {
-                    IO = new IOCounters(new IO_COUNTERS()
+                    ioCounters = new IOCounters(new IO_COUNTERS()
                     {
                         ReadOperationCount = 1,
                         WriteOperationCount = 1,
                         ReadTransferCount = Convert.ToUInt64(m_perfAggregator.DiskBytesRead.Total),
                         WriteTransferCount = Convert.ToUInt64(m_perfAggregator.DiskBytesWritten.Total)
-                    }),
-                    MemoryCounters = new ProcessMemoryCounters(0, Convert.ToUInt64(m_perfAggregator.PeakMemoryBytes.Maximum), 0),
+                    });
+
+                    memoryCounters = new ProcessMemoryCounters(0, Convert.ToUInt64(m_perfAggregator.PeakMemoryBytes.Maximum), 0);
+                }
+                catch(OverflowException ex)
+                {
+                    LogProcessState($"Overflow exception caught while calculating AccountingInformation:{Environment.NewLine}{ex.ToString()}");
+
+                    ioCounters = new IOCounters(new IO_COUNTERS()
+                    {
+                        ReadOperationCount = 0,
+                        WriteOperationCount = 0,
+                        ReadTransferCount = 0,
+                        WriteTransferCount = 0
+                    });
+
+                    memoryCounters = new ProcessMemoryCounters(0, 0, 0);
+                }
+
+                return new JobObject.AccountingInformation
+                {
+                    IO = ioCounters,
+                    MemoryCounters = memoryCounters,
                     KernelTime = TimeSpan.FromMilliseconds(m_perfAggregator.JobKernelTimeMs.Latest),
                     UserTime = TimeSpan.FromMilliseconds(m_perfAggregator.JobUserTimeMs.Latest),
                 };
+            }
         }
 
         private void ReportProcessCreated()

--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -3612,7 +3612,9 @@ namespace BuildXL.Scheduler
                             }
                             catch (OverflowException ex)
                             {
-                                 m_groupedPipCounters.AddToCounters(processRunnable.Process,
+                                Logger.Log.ExecutePipStepOverflowFailure(operationContext, ex.Message);
+
+                                m_groupedPipCounters.AddToCounters(processRunnable.Process,
                                     new[] { (PipCountersByGroup.IOReadBytes, 0L), (PipCountersByGroup.IOWriteBytes, 0L) },
                                     new[] { (PipCountersByGroup.ExecuteProcessDuration, perfInfo.ProcessExecutionTime) }
                                 );
@@ -3712,7 +3714,7 @@ namespace BuildXL.Scheduler
                             }
                             catch (OverflowException ex)
                             {
-                                Logger.Log.ProcessPipExecutionInfoOverflowFailure(operationContext, ex.Message);
+                                Logger.Log.ExecutePipStepOverflowFailure(operationContext, ex.Message);
                             }
 
                             // File violation analysis needs to happen on the master as it relies on

--- a/Public/Src/Engine/Scheduler/Tracing/Log.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/Log.cs
@@ -4528,7 +4528,16 @@ namespace BuildXL.Scheduler.Tracing
             Keywords = (int)Keywords.UserMessage,
             EventTask = (ushort)Tasks.PipExecutor,
             Message = "[{pipDescription}] NumProcesses: {numProcesses}, ExpectedDurationSec: {expectedDurationSec}, ActualDurationSec: {actualDurationSec}, ProcessorUseInPercents: {processorUseInPercents}, DefaultMemoryUsageMb: {defaultMemoryUsageMb}, ExpectedMemoryUsageMb: {expectedMemoryUsageMb}, PeakVirtualMemoryMb: {peakVirtualMemoryMb}, PeakWorkingSetMb: {peakWorkingSetMb}, PeakPagefileUsageMb: {peakPagefileUsageMb}")]
-        internal abstract void ProcessPipExecutionInfo(LoggingContext loggingContext, string pipDescription, int numProcesses, int expectedDurationSec, int actualDurationSec, int processorUseInPercents, int defaultMemoryUsageMb, int expectedMemoryUsageMb, int peakVirtualMemoryMb, int peakWorkingSetMb, int peakPagefileUsageMb);
+        internal abstract void ProcessPipExecutionInfo(LoggingContext loggingContext, string pipDescription, uint numProcesses, ulong expectedDurationSec, double actualDurationSec, int processorUseInPercents, int defaultMemoryUsageMb, int expectedMemoryUsageMb, int peakVirtualMemoryMb, int peakWorkingSetMb, int peakPagefileUsageMb);
+
+        [GeneratedEvent(
+            (ushort)LogEventId.ProcessPipExecutionInfoOverflowFailure,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Verbose,
+            Keywords = (int)Keywords.UserMessage,
+            EventTask = (ushort)Tasks.PipExecutor,
+            Message = "Unable to log process pip execution info due to an overflow exception: {exception}")]
+        internal abstract void ProcessPipExecutionInfoOverflowFailure(LoggingContext loggingContext, string exception);
     }
 }
 #pragma warning restore CA1823 // Unused field

--- a/Public/Src/Engine/Scheduler/Tracing/Log.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/Log.cs
@@ -4536,8 +4536,8 @@ namespace BuildXL.Scheduler.Tracing
             EventLevel = Level.Verbose,
             Keywords = (int)Keywords.UserMessage,
             EventTask = (ushort)Tasks.PipExecutor,
-            Message = "Unable to log process pip execution info due to an overflow exception: {exception}")]
-        internal abstract void ProcessPipExecutionInfoOverflowFailure(LoggingContext loggingContext, string exception);
+            Message = "Caught OverflowException in ExecutePipStep: {exception}")]
+        internal abstract void ExecutePipStepOverflowFailure(LoggingContext loggingContext, string exception);
     }
 }
 #pragma warning restore CA1823 // Unused field

--- a/Public/Src/Engine/Scheduler/Tracing/LogEventId.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/LogEventId.cs
@@ -152,6 +152,7 @@ namespace BuildXL.Scheduler.Tracing
 
         ProblematicWorkerExit = 5070,
         ProcessPipExecutionInfo = 5071,
+        ProcessPipExecutionInfoOverflowFailure = 5072,
 
         // was DependencyViolationGenericWithRelatedPip_AsError = 25000,
         // was DependencyViolationGeneric_AsError = 25001,


### PR DESCRIPTION
Handle potential places we saw OverflowExceptions happen in recent crash reports, log occurrences so we get a more thorough picture. Note: our csc invocations pass the `/checked+` flag, so the places addressed could be possible culprits.