### PR TITLE
Failure in making outputs private should not fail builds

### DIFF
--- a/Public/Src/Engine/Cache/Artifacts/LocalDiskContentStore.cs
+++ b/Public/Src/Engine/Cache/Artifacts/LocalDiskContentStore.cs
@@ -313,11 +313,7 @@ namespace BuildXL.Engine.Cache.Artifacts
                 var updatedDestination = destination.Substring(0, destination.Length - requiredFileName.Length) + requiredFileName;
 
                 // Move file to temporary location
-                var changeCasing = await FileUtilities.MoveFileAsync(destination, updatedDestination, replaceExisting: false);
-                if (!changeCasing)
-                {
-                    return new Failure<string>(I($"Could not move file '{destination}' to change file name casing to '{requiredFileName}'."));
-                }
+                await FileUtilities.MoveFileAsync(destination, updatedDestination, replaceExisting: false);
 
                 return Unit.Void;
             }

--- a/Public/Src/Engine/Dll/Recovery/CorruptedMemosDbRecovery.cs
+++ b/Public/Src/Engine/Dll/Recovery/CorruptedMemosDbRecovery.cs
@@ -112,12 +112,7 @@ namespace BuildXL.Engine.Recovery
             //         RenameMemoDb();
             //     }
             var corruptedMemosDbFile = PrepareCorruptedMemosDbBackupFile(cacheDirectory);
-            var result = FileUtilities.MoveFileAsync(memosDbFile, corruptedMemosDbFile, replaceExisting: true).Result;
-
-            if (!result)
-            {
-                return new Failure<string>(I($"Failed to rename '{memosDbFile}' to '{corruptedMemosDbFile}'"));
-            }
+            FileUtilities.MoveFileAsync(memosDbFile, corruptedMemosDbFile, replaceExisting: true).Wait();
 
             // Delete marker file in case of successful recovery.
             FileUtilities.DeleteFile(MarkerFile(cacheDirectory));

--- a/Public/Src/Engine/Dll/Recovery/CorruptedMemosDbRecovery.cs
+++ b/Public/Src/Engine/Dll/Recovery/CorruptedMemosDbRecovery.cs
@@ -111,11 +111,18 @@ namespace BuildXL.Engine.Recovery
             //         Assert(cacheIntegrityResult == NoIssueFound);
             //         RenameMemoDb();
             //     }
-            var corruptedMemosDbFile = PrepareCorruptedMemosDbBackupFile(cacheDirectory);
-            FileUtilities.MoveFileAsync(memosDbFile, corruptedMemosDbFile, replaceExisting: true).Wait();
+            try
+            {
+                var corruptedMemosDbFile = PrepareCorruptedMemosDbBackupFile(cacheDirectory);
+                FileUtilities.MoveFileAsync(memosDbFile, corruptedMemosDbFile, replaceExisting: true).Wait();
 
-            // Delete marker file in case of successful recovery.
-            FileUtilities.DeleteFile(MarkerFile(cacheDirectory));
+                // Delete marker file in case of successful recovery.
+                FileUtilities.DeleteFile(MarkerFile(cacheDirectory));
+            }
+            catch (BuildXLException ex)
+            {
+                return new RecoverableExceptionFailure(ex);
+            }
 
             return Unit.Void;
         }

--- a/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
@@ -2622,19 +2622,25 @@ namespace BuildXL.Processes
                                         }
                                     });
 
-                                bool allOutputsPrivate = true;
+                                string filePathNotPrivate = null;
 
                                 foreach (var path in filePaths)
                                 {
                                     if (!await m_makeOutputPrivate(path))
                                     {
-                                        allOutputsPrivate = false;
+                                        filePathNotPrivate = path;
                                         break;
                                     }
                                 }
 
-                                if (!allOutputsPrivate)
+                                if (filePathNotPrivate != null)
                                 {
+                                    Tracing.Logger.Log.PipProcessPreserveOutputDirectoryFailedToMakeFilePrivate(
+                                        m_loggingContext, 
+                                        m_pip.SemiStableHash, 
+                                        m_pip.GetDescription(m_context), 
+                                        directoryOutput.Path.ToString(m_pathTable), filePathNotPrivate);
+
                                     PreparePathForDirectory(directoryPathStr, createIfNonExistent: true);
                                 }
                             }

--- a/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessPipExecutor.cs
@@ -28,6 +28,7 @@ using BuildXL.Utilities.Tracing;
 using BuildXL.Utilities.VmCommandProxy;
 using static BuildXL.Processes.SandboxedProcessFactory;
 using static BuildXL.Utilities.BuildParameters;
+using static BuildXL.Utilities.FormattableStringEx;
 
 namespace BuildXL.Processes
 {
@@ -2621,12 +2622,20 @@ namespace BuildXL.Processes
                                         }
                                     });
 
+                                bool allOutputsPrivate = true;
+
                                 foreach (var path in filePaths)
                                 {
                                     if (!await m_makeOutputPrivate(path))
                                     {
-                                        throw new BuildXLException("Failed to create a private, writeable copy of an output file from a previous invocation.");
+                                        allOutputsPrivate = false;
+                                        break;
                                     }
+                                }
+
+                                if (!allOutputsPrivate)
+                                {
+                                    PreparePathForDirectory(directoryPathStr, createIfNonExistent: true);
                                 }
                             }
                         }

--- a/Public/Src/Engine/Processes/Tracing/Log.cs
+++ b/Public/Src/Engine/Processes/Tracing/Log.cs
@@ -830,6 +830,20 @@ namespace BuildXL.Processes.Tracing
             string message);
 
         [GeneratedEvent(
+            (int)LogEventId.PipProcessPreserveOutputDirectoryFailedToMakeFilePrivate,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Verbose,
+            Keywords = (int)Keywords.UserMessage,
+            EventTask = (int)Tasks.PipExecutor,
+            Message = EventConstants.PipSpecPrefix + "Failed to preserve output directory '{directory}' because '{file}' cannot be made private, contents of the directory will be deleted")]
+        public abstract void PipProcessPreserveOutputDirectoryFailedToMakeFilePrivate(
+            LoggingContext context,
+            long pipSemiStableHash,
+            string pipDescription,
+            string directory,
+            string file);
+
+        [GeneratedEvent(
             (int)LogEventId.PipProcessChangeAffectedInputsWrittenFileCreationFailed,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Error,

--- a/Public/Src/Engine/Processes/Tracing/LogEventId.cs
+++ b/Public/Src/Engine/Processes/Tracing/LogEventId.cs
@@ -40,6 +40,7 @@ namespace BuildXL.Processes.Tracing
         PipProcessChildrenSurvivedTooMany = 43,
         PipProcessMissingExpectedOutputOnCleanExit = 44,
         PipProcessOutputPreparationFailed = 46,
+        PipProcessPreserveOutputDirectoryFailedToMakeFilePrivate = 53,
 
 
         PipProcessError = 64,
@@ -47,7 +48,6 @@ namespace BuildXL.Processes.Tracing
         PipProcessOutput = 66,
 
         PipProcessResponseFileCreationFailed = 74,
-        PipProcessPreserveOutputDirectoryFailedToMakeFilePrivate = 75,
 
         PipProcessStartExternalTool = 78,
         PipProcessFinishedExternalTool = 79,

--- a/Public/Src/Engine/Processes/Tracing/LogEventId.cs
+++ b/Public/Src/Engine/Processes/Tracing/LogEventId.cs
@@ -47,6 +47,7 @@ namespace BuildXL.Processes.Tracing
         PipProcessOutput = 66,
 
         PipProcessResponseFileCreationFailed = 74,
+        PipProcessPreserveOutputDirectoryFailedToMakeFilePrivate = 75,
 
         PipProcessStartExternalTool = 78,
         PipProcessFinishedExternalTool = 79,

--- a/Public/Src/Utilities/Native/IO/FileUtilities.cs
+++ b/Public/Src/Utilities/Native/IO/FileUtilities.cs
@@ -218,7 +218,7 @@ namespace BuildXL.Native.IO
             Action<SafeFileHandle, SafeFileHandle> onCompletion = null) => s_fileUtilities.CopyFileAsync(source, destination, predicate, onCompletion);
 
         /// <see cref="IFileUtilities.MoveFileAsync(string, string, bool)"/>
-        public static Task<bool> MoveFileAsync(
+        public static Task MoveFileAsync(
             string source,
             string destination,
             bool replaceExisting = false) => s_fileUtilities.MoveFileAsync(source, destination, replaceExisting);
@@ -1189,10 +1189,7 @@ namespace BuildXL.Native.IO
                 SetFileTimestamps(temporaryPath, timestamps);
             }
 
-            if (!await MoveFileAsync(temporaryPath, originalPath, replaceExisting: true))
-            {
-                return new Failure<string>(I($"Failed to make exclusive link for '{originalPath}' because renaming '{temporaryPath}' failed"));
-            }
+            await MoveFileAsync(temporaryPath, originalPath, replaceExisting: true);
 
             return Unit.Void;
         }

--- a/Public/Src/Utilities/Native/IO/IFileUtilities.cs
+++ b/Public/Src/Utilities/Native/IO/IFileUtilities.cs
@@ -129,7 +129,6 @@ namespace BuildXL.Native.IO
         /// <remarks>
         /// Does not support paths longer than MAX_PATH
         /// </remarks>
-        /// <returns>If true is returned, the move proceeded and completed. </returns>
         /// <exception cref="BuildXLException">
         /// Thrown if the file move fails in a recoverable manner, including if the destination
         /// already exists and <paramref name="replaceExisting" /> is set to false or if the source doesn't exist
@@ -137,7 +136,7 @@ namespace BuildXL.Native.IO
         /// <param name="source">Full path of the source</param>
         /// <param name="destination">Full path of the destination</param>
         /// <param name="replaceExisting">whether to replace an existing file at the destination</param>
-        Task<bool> MoveFileAsync(string source, string destination, bool replaceExisting);
+        Task MoveFileAsync(string source, string destination, bool replaceExisting);
 
         /// <summary>
         /// Creates a copy on write clone of files if supported by the underlying OS.

--- a/Public/Src/Utilities/Native/IO/Unix/FileUtilities.Unix.cs
+++ b/Public/Src/Utilities/Native/IO/Unix/FileUtilities.Unix.cs
@@ -427,11 +427,11 @@ namespace BuildXL.Native.IO.Unix
 
                     return true;
                 },
-                ex => { throw new BuildXLException("File copy failed", ex); });
+                ex => { throw new BuildXLException(I($"File copy from '{source}' to '{destination}' failed"), ex); });
         }
 
         /// <inheritdoc />
-        public Task<bool> MoveFileAsync(
+        public Task MoveFileAsync(
             string source,
             string destination,
             bool replaceExisting = false)
@@ -439,7 +439,7 @@ namespace BuildXL.Native.IO.Unix
             Contract.Requires(!string.IsNullOrEmpty(source));
             Contract.Requires(!string.IsNullOrEmpty(destination));
 
-            return Task.Run<bool>(
+            return Task.Run(
                 () => ExceptionUtilities.HandleRecoverableIOException(
                     () =>
                     {
@@ -449,9 +449,8 @@ namespace BuildXL.Native.IO.Unix
                         }
 
                         File.Move(source, destination);
-                        return true;
                     },
-                    ex => { throw new BuildXLException("File move failed", ex); }));
+                    ex => { throw new BuildXLException(I($"File move from '{source}' to '{destination}' failed"), ex); }));
         }
 
         /// <inheritdoc />

--- a/Public/Src/Utilities/Native/IO/Windows/FileSystem.Win.cs
+++ b/Public/Src/Utilities/Native/IO/Windows/FileSystem.Win.cs
@@ -3598,13 +3598,17 @@ namespace BuildXL.Native.IO.Windows
         /// <summary>
         /// Moves file to a new location.
         /// </summary>
-        public bool MoveFile(string existingFileName, string newFileName, bool replaceExisting)
+        public void MoveFile(string existingFileName, string newFileName, bool replaceExisting)
         {
             existingFileName = ToLongPathIfExceedMaxPath(existingFileName);
             newFileName = ToLongPathIfExceedMaxPath(newFileName);
             MoveFileFlags moveFlags = replaceExisting ? MoveFileFlags.MOVEFILE_REPLACE_EXISTING : MoveFileFlags.MOVEFILE_COPY_ALLOWED;
 
-            return MoveFileEx(existingFileName, newFileName, moveFlags);
+            if  (!MoveFileEx(existingFileName, newFileName, moveFlags))
+            {
+                int hr = Marshal.GetLastWin32Error();
+                ThrowForNativeFailure(hr, nameof(MoveFileEx), nameof(MoveFile));
+            }
         }
 
         /// <summary>

--- a/Public/Src/Utilities/Native/IO/Windows/FileUtilities.Win.cs
+++ b/Public/Src/Utilities/Native/IO/Windows/FileUtilities.Win.cs
@@ -1142,11 +1142,11 @@ namespace BuildXL.Native.IO.Windows
 
                     return true;
                 },
-                ex => { throw new BuildXLException("File copy failed", ex); });
+                ex => { throw new BuildXLException(I($"File copy from '{source}' to '{destination}' failed"), ex); });
         }
 
         /// <inheritdoc />
-        public Task<bool> MoveFileAsync(
+        public Task MoveFileAsync(
             string source,
             string destination,
             bool replaceExisting = false)
@@ -1154,13 +1154,16 @@ namespace BuildXL.Native.IO.Windows
             Contract.Requires(!string.IsNullOrEmpty(source));
             Contract.Requires(!string.IsNullOrEmpty(destination));
 
-            return Task.Run<bool>(
-                () => ExceptionUtilities.HandleRecoverableIOException(
-                    () =>
-                    {
-                        return s_fileSystem.MoveFile(source, destination, replaceExisting);
-                    },
-                    ex => { throw new BuildXLException("File move failed", ex); }));
+            return Task.Run(() => {
+                try
+                {
+                    s_fileSystem.MoveFile(source, destination, replaceExisting);
+                }
+                catch (NativeWin32Exception ex)
+                {
+                    throw new BuildXLException(I($"File move from '{source}' to '{destination}' failed"), ex);
+                }
+            });
         }
 
         /// <inheritdoc />

--- a/Public/Src/Utilities/Utilities/Tracing/EventId.cs
+++ b/Public/Src/Utilities/Utilities/Tracing/EventId.cs
@@ -69,7 +69,7 @@ namespace BuildXL.Utilities.Tracing
         CacheClientStats = 50,
         CatastrophicFailureCausedByCorruptedCache = 51,
         ProcessingPipOutputFileFailed = 52,
-        // Reserved = 53,
+        PipProcessPreserveOutputDirectoryFailedToMakeFilePrivate = 53,
         // Reserved = 54,
         // Reserved = 55,
         // Reserved = 56,


### PR DESCRIPTION
When making output directory private, instead of failing the build, we default to the normal behavior where we wipe out the directory. This is consistent with the treatment of preserved output file.

We also include the error code in the exception and log message when move-file failed.

[AB#1640665](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1640665)