### PR TITLE
Grpc push copy supporting touch-less puts

### DIFF
--- a/Public/Src/Cache/ContentStore/App/Application.cs
+++ b/Public/Src/Cache/ContentStore/App/Application.cs
@@ -602,7 +602,7 @@ namespace BuildXL.Cache.ContentStore.App
         internal DistributedCacheServiceArguments CreateDistributedCacheServiceArguments(
             IAbsolutePathFileCopier copier,
             IAbsolutePathTransformer pathTransformer,
-            ICopyRequester copyRequester,
+            ICopySender copyRequester,
             DistributedContentSettings dcs,
             HostInfo host,
             string cacheName,

--- a/Public/Src/Cache/ContentStore/App/Application.cs
+++ b/Public/Src/Cache/ContentStore/App/Application.cs
@@ -602,7 +602,7 @@ namespace BuildXL.Cache.ContentStore.App
         internal DistributedCacheServiceArguments CreateDistributedCacheServiceArguments(
             IAbsolutePathFileCopier copier,
             IAbsolutePathTransformer pathTransformer,
-            ICopySender copyRequester,
+            IProactiveCopier copyRequester,
             DistributedContentSettings dcs,
             HostInfo host,
             string cacheName,

--- a/Public/Src/Cache/ContentStore/App/CopyFileTo.cs
+++ b/Public/Src/Cache/ContentStore/App/CopyFileTo.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Threading;
+using BuildXL.Cache.ContentStore.Exceptions;
+using BuildXL.Cache.ContentStore.Hashing;
+using BuildXL.Cache.ContentStore.Interfaces.FileSystem;
+using BuildXL.Cache.ContentStore.Interfaces.Tracing;
+using BuildXL.Cache.ContentStore.Service;
+using BuildXL.Cache.ContentStore.Service.Grpc;
+using BuildXL.Cache.ContentStore.Tracing.Internal;
+using BuildXL.Cache.ContentStore.Utils;
+using CLAP;
+using Microsoft.Practices.TransientFaultHandling;
+
+namespace BuildXL.Cache.ContentStore.App
+{
+    internal sealed partial class Application
+    {
+        /// <summary>
+        /// Run the CopyFileTo verb.
+        /// </summary>
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [Verb(Description = "Copy file to another CASaaS")]
+        internal void CopyFileTo(
+            [Required, Description("Machine to copy to")] string host,
+            [Required, Description("Path to source file")] string sourcePath,
+            [Description("File name where the GRPC port can be found when using cache service. 'CASaaS GRPC port' if not specified")] string grpcPortFileName,
+            [Description("The GRPC port"), DefaultValue(0)] int grpcPort)
+        {
+            Initialize();
+
+            var context = new Context(_logger);
+            var operationContext = new OperationContext(context, CancellationToken.None);
+            var retryPolicy = new RetryPolicy(
+                new TransientErrorDetectionStrategy(),
+                new FixedInterval("RetryInterval", (int)_retryCount, TimeSpan.FromSeconds(_retryIntervalSeconds), false));
+
+            if (grpcPort == 0)
+            {
+                grpcPort = Helpers.GetGrpcPortFromFile(_logger, grpcPortFileName);
+            }
+
+            var hasher = ContentHashers.Get(HashType.MD5);
+            var bytes = File.ReadAllBytes(sourcePath);
+            var hash = hasher.GetContentHash(bytes);
+
+            try
+            {
+                using var clientCache = new GrpcCopyClientCache(context);
+                using var rpcClientWrapper = clientCache.CreateAsync(host, grpcPort, useCompression: false).GetAwaiter().GetResult();
+                var rpcClient = rpcClientWrapper.Value;
+                var path = new AbsolutePath(sourcePath);
+
+                using var stream = File.OpenRead(path.Path);
+
+                // This action is synchronous to make sure the calling application doesn't exit before the method returns.
+                var copyFileResult = retryPolicy.ExecuteAsync(() => rpcClient.PushFileAsync(operationContext, hash, stream)).Result;
+                if (!copyFileResult.Succeeded)
+                {
+                    _logger.Error($"{copyFileResult}");
+                    throw new CacheException(copyFileResult.ErrorMessage);
+                }
+                else
+                {
+                    _logger.Info($"Copy of {sourcePath} was successful");
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new CacheException(ex.ToString());
+            }
+        }
+    }
+}

--- a/Public/Src/Cache/ContentStore/App/CopyFileTo.cs
+++ b/Public/Src/Cache/ContentStore/App/CopyFileTo.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using BuildXL.Cache.ContentStore.Exceptions;
 using BuildXL.Cache.ContentStore.Hashing;
 using BuildXL.Cache.ContentStore.Interfaces.FileSystem;
@@ -54,10 +54,10 @@ namespace BuildXL.Cache.ContentStore.App
                 var rpcClient = rpcClientWrapper.Value;
                 var path = new AbsolutePath(sourcePath);
 
-                using var stream = File.OpenRead(path.Path);
+                using Stream stream = File.OpenRead(path.Path);
 
                 // This action is synchronous to make sure the calling application doesn't exit before the method returns.
-                var copyFileResult = retryPolicy.ExecuteAsync(() => rpcClient.PushFileAsync(operationContext, hash, stream)).Result;
+                var copyFileResult = retryPolicy.ExecuteAsync(() => rpcClient.PushFileAsync(operationContext, hash, () => Task.FromResult(stream))).Result;
                 if (!copyFileResult.Succeeded)
                 {
                     _logger.Error($"{copyFileResult}");

--- a/Public/Src/Cache/ContentStore/App/CopyFileTo.cs
+++ b/Public/Src/Cache/ContentStore/App/CopyFileTo.cs
@@ -23,7 +23,6 @@ namespace BuildXL.Cache.ContentStore.App
         /// <summary>
         /// Run the CopyFileTo verb.
         /// </summary>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         [Verb(Description = "Copy file to another CASaaS")]
         internal void CopyFileTo(
             [Required, Description("Machine to copy to")] string host,

--- a/Public/Src/Cache/ContentStore/Distributed/ContentLocations/IContentLocationStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/ContentLocations/IContentLocationStore.cs
@@ -91,7 +91,7 @@ namespace BuildXL.Cache.ContentStore.Distributed
         /// <summary>
         /// Registers the current machine has the content for the given hash
         /// </summary>
-        Task<BoolResult> RegisterLocalLocationAsync(Context context, IReadOnlyList<ContentHashWithSize> contentHashes, CancellationToken cts, UrgencyHint urgencyHint);
+        Task<BoolResult> RegisterLocalLocationAsync(Context context, IReadOnlyList<ContentHashWithSize> contentHashes, CancellationToken cts, UrgencyHint urgencyHint, bool touch = true);
 
         /// <summary>
         /// Puts a blob into the content location store.

--- a/Public/Src/Cache/ContentStore/Distributed/FileSystem/IFileCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/FileSystem/IFileCopier.cs
@@ -71,6 +71,11 @@ namespace BuildXL.Cache.ContentStore.Distributed
         /// <param name="hash">The hash of the file to be copied.</param>
         /// <param name="targetMachine">The machine that should copy the file</param>
         Task<BoolResult> RequestCopyFileAsync(OperationContext context, ContentHash hash, MachineLocation targetMachine);
+
+        /// <summary>
+        /// Pushes content to a target machine.
+        /// </summary>
+        Task<BoolResult> PushFileAsync(OperationContext context, ContentHash hash, Stream source, MachineLocation targetMachine);
     }
 
     /// <summary>

--- a/Public/Src/Cache/ContentStore/Distributed/FileSystem/IFileCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/FileSystem/IFileCopier.cs
@@ -60,16 +60,13 @@ namespace BuildXL.Cache.ContentStore.Distributed
     }
 
     /// <summary>
-    /// Requests another machine to copy from the current machine.
+    /// Copies files to another machine.
     /// </summary>
-    public interface ICopyRequester
+    public interface ICopySender
     {
         /// <summary>
         /// Requests another machine to copy a file.
         /// </summary>
-        /// <param name="context">The context of the operation</param>
-        /// <param name="hash">The hash of the file to be copied.</param>
-        /// <param name="targetMachine">The machine that should copy the file</param>
         Task<BoolResult> RequestCopyFileAsync(OperationContext context, ContentHash hash, MachineLocation targetMachine);
 
         /// <summary>

--- a/Public/Src/Cache/ContentStore/Distributed/FileSystem/IFileCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/FileSystem/IFileCopier.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using BuildXL.Cache.ContentStore.Hashing;
 using BuildXL.Cache.ContentStore.Interfaces.FileSystem;
 using BuildXL.Cache.ContentStore.Interfaces.Results;
-using BuildXL.Cache.ContentStore.Interfaces.Tracing;
 using BuildXL.Cache.ContentStore.Tracing.Internal;
 
 // ReSharper disable All
@@ -72,7 +72,7 @@ namespace BuildXL.Cache.ContentStore.Distributed
         /// <summary>
         /// Pushes content to a target machine.
         /// </summary>
-        Task<BoolResult> PushFileAsync(OperationContext context, ContentHash hash, Stream source, MachineLocation targetMachine);
+        Task<BoolResult> PushFileAsync(OperationContext context, ContentHash hash, Func<Task<Stream>> source, MachineLocation targetMachine);
     }
 
     /// <summary>

--- a/Public/Src/Cache/ContentStore/Distributed/FileSystem/IFileCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/FileSystem/IFileCopier.cs
@@ -62,7 +62,7 @@ namespace BuildXL.Cache.ContentStore.Distributed
     /// <summary>
     /// Copies files to another machine.
     /// </summary>
-    public interface ICopySender
+    public interface IProactiveCopier
     {
         /// <summary>
         /// Requests another machine to copy a file.

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabase.cs
@@ -861,11 +861,11 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         }
 
         /// <nodoc />
-        public void LocationAdded(OperationContext context, ShortHash hash, MachineId machine, long size, bool reconciling = false)
+        public void LocationAdded(OperationContext context, ShortHash hash, MachineId machine, long size, bool reconciling = false, bool updateLastAccessTime = true)
         {
             using (Counters[ContentLocationDatabaseCounters.LocationAdded].Start())
             {
-                SetMachineExistenceAndUpdateDatabase(context, hash, machine, existsOnMachine: true, size: size, lastAccessTime: Clock.UtcNow, reconciling: reconciling);
+                SetMachineExistenceAndUpdateDatabase(context, hash, machine, existsOnMachine: true, size: size, lastAccessTime: updateLastAccessTime ? Clock.UtcNow : (DateTime?)null, reconciling: reconciling);
             }
         }
 

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/EventStreaming/ContentLocationEventData.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/EventStreaming/ContentLocationEventData.cs
@@ -251,13 +251,13 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache.EventStreaming
         public override bool Equals(ContentLocationEventData other)
         {
             var rhs = (AddContentLocationEventData)other;
-            return base.Equals(other) && ContentSizes.SequenceEqual(rhs.ContentSizes);
+            return base.Equals(other) && (Touch == rhs.Touch) && ContentSizes.SequenceEqual(rhs.ContentSizes);
         }
 
         /// <inheritdoc />
         public override int GetHashCode()
         {
-            return (base.GetHashCode(), ContentSizes.GetHashCode()).GetHashCode();
+            return (base.GetHashCode(), ContentSizes.GetHashCode(), Touch).GetHashCode();
         }
     }
 

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/EventStreaming/ContentLocationEventData.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/EventStreaming/ContentLocationEventData.cs
@@ -50,6 +50,9 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache.EventStreaming
         /// <nodoc />
         public EventKind Kind { get; }
 
+        /// <nodoc />
+        protected virtual EventKind SerializationKind => Kind;
+
         /// <summary>
         /// A current machine id.
         /// </summary>
@@ -86,15 +89,14 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache.EventStreaming
             switch (kind)
             {
                 case EventKind.AddLocation:
-                    return new AddContentLocationEventData(sender, hashes, reader.ReadReadOnlyList(r => r.ReadInt64Compact()));
+                case EventKind.AddLocationWithoutTouching:
+                    return new AddContentLocationEventData(sender, hashes, reader.ReadReadOnlyList(r => r.ReadInt64Compact()), touch: kind == EventKind.AddLocation);
                 case EventKind.RemoveLocation:
                     return new RemoveContentLocationEventData(sender, hashes);
                 case EventKind.Touch:
                     return new TouchContentLocationEventData(sender, hashes, eventTimeUtc);
                 case EventKind.Reconcile:
                     return new ReconcileContentLocationEventData(sender, reader.ReadString());
-                case EventKind.AddLocationWithoutTouching:
-                    return new AddContentLocationWithoutTouchingEventData(sender, hashes, reader.ReadReadOnlyList(r => r.ReadInt64Compact()));
                 default:
                     throw new ArgumentOutOfRangeException($"Unknown event kind '{kind}'.");
             }
@@ -103,16 +105,13 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache.EventStreaming
         /// <nodoc />
         public void Serialize(BuildXLWriter writer)
         {
-            writer.Write((byte)Kind);
+            writer.Write((byte)SerializationKind);
             Sender.Serialize(writer);
             writer.WriteReadOnlyList(ContentHashes, (w, hash) => w.Write(hash));
 
             switch (this) {
                 case AddContentLocationEventData addContentLocationEventData:
                     writer.WriteReadOnlyList(addContentLocationEventData.ContentSizes, (w, size) => w.WriteCompact(size));
-                    break;
-                case AddContentLocationWithoutTouchingEventData addContentLocationWithoutTouchingEventData:
-                    writer.WriteReadOnlyList(addContentLocationWithoutTouchingEventData.ContentSizes, (w, size) => w.WriteCompact(size));
                     break;
                 case RemoveContentLocationEventData removeContentLocationEventData:
                 case TouchContentLocationEventData touchContentLocationEventData:
@@ -158,7 +157,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache.EventStreaming
                     var contentSizes = addContentLocationEventData.ContentSizes.Split(maxHashCount).ToList();
                     Contract.Assert(hashes.Count == contentSizes.Count);
 
-                    result.AddRange(hashes.Select((t, index) => new AddContentLocationEventData(Sender, t, contentSizes[index])));
+                    result.AddRange(hashes.Select((t, index) => new AddContentLocationEventData(Sender, t, contentSizes[index], addContentLocationEventData.Touch)));
                     break;
                 case RemoveContentLocationEventData _:
                     result.AddRange(hashes.Select(t => new RemoveContentLocationEventData(Sender, t)));
@@ -211,20 +210,29 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache.EventStreaming
         /// </summary>
         public IReadOnlyList<long> ContentSizes { get; }
 
+        /// <summary>
+        /// Whether or not to extend the lifetime of the content.
+        /// </summary>
+        public bool Touch { get; }
+
+        /// <inheritdoc />
+        protected override EventKind SerializationKind => Touch ? EventKind.AddLocation : EventKind.AddLocationWithoutTouching;
+
         /// <nodoc />
-        public AddContentLocationEventData(MachineId sender, IReadOnlyList<ShortHashWithSize> addedContent)
-            : this(sender, addedContent.SelectList(c => c.Hash), addedContent.SelectList(c => c.Size))
+        public AddContentLocationEventData(MachineId sender, IReadOnlyList<ShortHashWithSize> addedContent, bool touch = true)
+            : this(sender, addedContent.SelectList(c => c.Hash), addedContent.SelectList(c => c.Size), touch)
         {
         }
 
         /// <nodoc />
-        public AddContentLocationEventData(MachineId sender, IReadOnlyList<ShortHash> contentHashes, IReadOnlyList<long> contentSizes)
+        public AddContentLocationEventData(MachineId sender, IReadOnlyList<ShortHash> contentHashes, IReadOnlyList<long> contentSizes, bool touch = true)
             : base(EventKind.AddLocation, sender, contentHashes)
         {
             Contract.Requires(contentSizes != null);
             Contract.Requires(contentSizes.Count == contentHashes.Count);
 
             ContentSizes = contentSizes;
+            Touch = touch;
         }
 
         /// <inheritdoc />
@@ -236,7 +244,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache.EventStreaming
                 sb.Append($"Hash={ContentHashes[i]}, Size={ContentSizes[i]}");
             }
 
-            return $"Event: {Kind}, Sender: {Sender}, {sb}";
+            return $"Event: {Kind}, Sender: {Sender}, Touch: {Touch}, {sb}";
         }
 
         /// <inheritdoc />
@@ -317,56 +325,6 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache.EventStreaming
         public override int GetHashCode()
         {
             return (base.GetHashCode(), AccessTime.GetHashCode()).GetHashCode();
-        }
-    }
-
-    /// <nodoc />
-    public sealed class AddContentLocationWithoutTouchingEventData : ContentLocationEventData
-    {
-        /// <summary>
-        /// A list of content sizes associated with <see cref="ContentLocationEventData.ContentHashes"/>.
-        /// </summary>
-        public IReadOnlyList<long> ContentSizes { get; }
-
-        /// <nodoc />
-        public AddContentLocationWithoutTouchingEventData(MachineId sender, IReadOnlyList<ShortHashWithSize> addedContent)
-            : this(sender, addedContent.SelectList(c => c.Hash), addedContent.SelectList(c => c.Size))
-        {
-        }
-
-        /// <nodoc />
-        public AddContentLocationWithoutTouchingEventData(MachineId sender, IReadOnlyList<ShortHash> contentHashes, IReadOnlyList<long> contentSizes)
-            : base(EventKind.AddLocationWithoutTouching, sender, contentHashes)
-        {
-            Contract.Requires(contentSizes != null);
-            Contract.Requires(contentSizes.Count == contentHashes.Count);
-
-            ContentSizes = contentSizes;
-        }
-
-        /// <inheritdoc />
-        public override string ToString()
-        {
-            var sb = new StringBuilder();
-            for (int i = 0; i < ContentHashes.Count; i++)
-            {
-                sb.Append($"Hash={ContentHashes[i]}, Size={ContentSizes[i]}");
-            }
-
-            return $"Event: {Kind}, Sender: {Sender}, {sb}";
-        }
-
-        /// <inheritdoc />
-        public override bool Equals(ContentLocationEventData other)
-        {
-            var rhs = (AddContentLocationEventData)other;
-            return base.Equals(other) && ContentSizes.SequenceEqual(rhs.ContentSizes);
-        }
-
-        /// <inheritdoc />
-        public override int GetHashCode()
-        {
-            return (base.GetHashCode(), ContentSizes.GetHashCode()).GetHashCode();
         }
     }
 }

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/EventStreaming/ContentLocationEventStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/EventStreaming/ContentLocationEventStore.cs
@@ -125,7 +125,8 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache.EventStreaming
                             context,
                             addContent.Sender,
                             addContent.ContentHashes.SelectList((hash, index) => new ShortHashWithSize(hash, addContent.ContentSizes[index])),
-                            eventData.Reconciling);
+                            eventData.Reconciling,
+                            addContent.ShouldTouch);
                     }
 
                     break;
@@ -378,7 +379,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache.EventStreaming
         /// <summary>
         /// Notify that the content specified by the <paramref name="hashesWithSize"/> was added to the machine <paramref name="machine"/>.
         /// </summary>
-        public BoolResult AddLocations(OperationContext context, MachineId machine, IReadOnlyList<ShortHashWithSize> hashesWithSize, bool reconciling = false)
+        public BoolResult AddLocations(OperationContext context, MachineId machine, IReadOnlyList<ShortHashWithSize> hashesWithSize, bool reconciling = false, bool touch = true)
         {
             if (hashesWithSize.Count == 0)
             {
@@ -392,7 +393,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache.EventStreaming
                     var hashes = hashesWithSize.SelectList(h => h.Hash);
                     var sizes = hashesWithSize.SelectList(h => h.Size);
 
-                    Publish(context, new AddContentLocationEventData(machine, hashes, sizes) { Reconciling = reconciling });
+                    Publish(context, new AddContentLocationEventData(machine, hashes, sizes, touch) { Reconciling = reconciling });
 
                     return BoolResult.Success;
                 },
@@ -403,14 +404,14 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache.EventStreaming
         /// <summary>
         /// Notify that the content specified by the <paramref name="hashesWithSize"/> was added to the machine <paramref name="machine"/>.
         /// </summary>
-        public BoolResult AddLocations(OperationContext context, MachineId machine, IReadOnlyList<ContentHashWithSize> hashesWithSize)
+        public BoolResult AddLocations(OperationContext context, MachineId machine, IReadOnlyList<ContentHashWithSize> hashesWithSize, bool touch = true)
         {
             if (hashesWithSize.Count == 0)
             {
                 return BoolResult.Success;
             }
 
-            return AddLocations(context, machine, hashesWithSize.SelectList(h => new ShortHashWithSize(h.Hash, h.Size)));
+            return AddLocations(context, machine, hashesWithSize.SelectList(h => new ShortHashWithSize(h.Hash, h.Size)), touch: touch);
         }
 
         /// <summary>

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/EventStreaming/ContentLocationEventStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/EventStreaming/ContentLocationEventStore.cs
@@ -126,7 +126,20 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache.EventStreaming
                             addContent.Sender,
                             addContent.ContentHashes.SelectList((hash, index) => new ShortHashWithSize(hash, addContent.ContentSizes[index])),
                             eventData.Reconciling,
-                            addContent.ShouldTouch);
+                            updateLastAccessTime: true);
+                    }
+
+                    break;
+                case AddContentLocationWithoutTouchingEventData addContentWithoutTouching:
+                using (counters[DispatchAddLocations].Start())
+                    {
+                        counters[DispatchAddLocationsHashes].Add(eventData.ContentHashes.Count);
+                        EventHandler.LocationAdded(
+                            context,
+                            addContentWithoutTouching.Sender,
+                            addContentWithoutTouching.ContentHashes.SelectList((hash, index) => new ShortHashWithSize(hash, addContentWithoutTouching.ContentSizes[index])),
+                            eventData.Reconciling,
+                            updateLastAccessTime: false);
                     }
 
                     break;
@@ -393,7 +406,11 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache.EventStreaming
                     var hashes = hashesWithSize.SelectList(h => h.Hash);
                     var sizes = hashesWithSize.SelectList(h => h.Size);
 
-                    Publish(context, new AddContentLocationEventData(machine, hashes, sizes, touch) { Reconciling = reconciling });
+                    var eventData = touch
+                        ? (ContentLocationEventData) new AddContentLocationEventData(machine, hashes, sizes) { Reconciling = reconciling }
+                        : new AddContentLocationWithoutTouchingEventData(machine, hashes, sizes) { Reconciling = reconciling };
+
+                    Publish(context, eventData);
 
                     return BoolResult.Success;
                 },

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/EventStreaming/ContentLocationEventStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/EventStreaming/ContentLocationEventStore.cs
@@ -293,6 +293,10 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache.EventStreaming
                         case EventKind.Reconcile:
                             localCounters[SentReconcileEvents].Add(eventCount);
                             break;
+                        case EventKind.AddLocationWithoutTouching:
+                            localCounters[SentAddLocationsWithoutTouchingEvents].Add(eventCount);
+                            localCounters[SentAddLocationsWithoutTouchingHashes].Add(eventCount);
+                            break;
                         default:
                             throw new ArgumentOutOfRangeException($"Unknown {nameof(EventKind)} '{group.Key}'.");
                     }

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/EventStreaming/ContentLocationEventStoreCounters.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/EventStreaming/ContentLocationEventStoreCounters.cs
@@ -117,8 +117,15 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache.EventStreaming
 
         /// <nodoc />
         SentAddLocationsEvents,
+
         /// <nodoc />
         SentAddLocationsHashes,
+
+        /// <nodoc />
+        SentAddLocationsWithoutTouchingEvents,
+
+        /// <nodoc />
+        SentAddLocationsWithoutTouchingHashes,
 
         /// <nodoc />
         SentRemoveLocationsEvents,

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/EventStreaming/ContentLocationEventStoreCounters.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/EventStreaming/ContentLocationEventStoreCounters.cs
@@ -122,12 +122,6 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache.EventStreaming
         SentAddLocationsHashes,
 
         /// <nodoc />
-        SentAddLocationsWithoutTouchingEvents,
-
-        /// <nodoc />
-        SentAddLocationsWithoutTouchingHashes,
-
-        /// <nodoc />
         SentRemoveLocationsEvents,
 
         /// <nodoc />

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/EventStreaming/IContentLocationEventHandler.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/EventStreaming/IContentLocationEventHandler.cs
@@ -16,7 +16,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache.EventStreaming
         /// <summary>
         /// The specified <paramref name="hashes"/> were added to the <paramref name="sender"/>.
         /// </summary>
-        void LocationAdded(OperationContext context, MachineId sender, IReadOnlyList<ShortHashWithSize> hashes, bool reconciling);
+        void LocationAdded(OperationContext context, MachineId sender, IReadOnlyList<ShortHashWithSize> hashes, bool reconciling, bool updateLastAccessTime);
 
         /// <summary>
         /// The specified <paramref name="hashes"/> were removed from the <paramref name="sender"/>.

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
@@ -933,7 +933,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         /// <summary>
         /// Notifies a central store that content represented by <paramref name="contentHashes"/> is available on a current machine.
         /// </summary>
-        public async Task<BoolResult> RegisterLocalLocationAsync(OperationContext context, IReadOnlyList<ContentHashWithSize> contentHashes)
+        public async Task<BoolResult> RegisterLocalLocationAsync(OperationContext context, IReadOnlyList<ContentHashWithSize> contentHashes, bool touch = true)
         {
             Contract.Requires(contentHashes != null);
 
@@ -992,7 +992,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                     if (eventContentHashes.Count != 0)
                     {
                         // Send add events
-                        EventStore.AddLocations(context, LocalMachineId, eventContentHashes).ThrowIfFailure();
+                        EventStore.AddLocations(context, LocalMachineId, eventContentHashes, touch).ThrowIfFailure();
                     }
 
                     // Register all recently added hashes so subsequent operations do not attempt to re-add
@@ -1404,13 +1404,13 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             }
 
             /// <inheritdoc />
-            public void LocationAdded(OperationContext context, MachineId sender, IReadOnlyList<ShortHashWithSize> hashes, bool reconciling)
+            public void LocationAdded(OperationContext context, MachineId sender, IReadOnlyList<ShortHashWithSize> hashes, bool reconciling, bool updateLastAccessTime)
             {
                 _clusterState.MarkMachineActive(sender);
 
                 foreach (var hashWithSize in hashes.AsStructEnumerable())
                 {
-                    _database.LocationAdded(context, hashWithSize.Hash, sender, hashWithSize.Size, reconciling);
+                    _database.LocationAdded(context, hashWithSize.Hash, sender, hashWithSize.Size, reconciling, updateLastAccessTime);
                 }
             }
 

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/LocalLocationStore.cs
@@ -933,7 +933,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         /// <summary>
         /// Notifies a central store that content represented by <paramref name="contentHashes"/> is available on a current machine.
         /// </summary>
-        public async Task<BoolResult> RegisterLocalLocationAsync(OperationContext context, IReadOnlyList<ContentHashWithSize> contentHashes, bool touch = true)
+        public async Task<BoolResult> RegisterLocalLocationAsync(OperationContext context, IReadOnlyList<ContentHashWithSize> contentHashes, bool touch)
         {
             Contract.Requires(contentHashes != null);
 

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/TransitioningContentLocationStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/TransitioningContentLocationStore.cs
@@ -136,12 +136,12 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         }
 
         /// <inheritdoc />
-        public Task<BoolResult> RegisterLocalLocationAsync(Context context, IReadOnlyList<ContentHashWithSize> contentHashes, CancellationToken cts, UrgencyHint urgencyHint)
+        public Task<BoolResult> RegisterLocalLocationAsync(Context context, IReadOnlyList<ContentHashWithSize> contentHashes, CancellationToken cts, UrgencyHint urgencyHint, bool touch = true)
         {
             var operationContext = new OperationContext(context, cts);
             return MultiExecuteAsync(
-                executeLegacyStore: () => _redisContentLocationStore.RegisterLocalLocationAsync(context, contentHashes, cts, urgencyHint),
-                executeLocalLocationStore: () => _localLocationStore.RegisterLocalLocationAsync(operationContext, contentHashes));
+                executeLegacyStore: () => _redisContentLocationStore.RegisterLocalLocationAsync(context, contentHashes, cts, urgencyHint, touch),
+                executeLocalLocationStore: () => _localLocationStore.RegisterLocalLocationAsync(operationContext, contentHashes, touch));
         }
 
         /// <inheritdoc />

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/TransitioningContentLocationStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/TransitioningContentLocationStore.cs
@@ -136,7 +136,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         }
 
         /// <inheritdoc />
-        public Task<BoolResult> RegisterLocalLocationAsync(Context context, IReadOnlyList<ContentHashWithSize> contentHashes, CancellationToken cts, UrgencyHint urgencyHint, bool touch = true)
+        public Task<BoolResult> RegisterLocalLocationAsync(Context context, IReadOnlyList<ContentHashWithSize> contentHashes, CancellationToken cts, UrgencyHint urgencyHint, bool touch)
         {
             var operationContext = new OperationContext(context, cts);
             return MultiExecuteAsync(

--- a/Public/Src/Cache/ContentStore/Distributed/Redis/RedisContentLocationStoreBase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Redis/RedisContentLocationStoreBase.cs
@@ -86,7 +86,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Redis
         }
 
         /// <nodoc />
-        public Task<BoolResult> RegisterLocalLocationAsync(Context context, IReadOnlyList<ContentHashWithSize> contentHashes, CancellationToken cts, UrgencyHint urgencyHint)
+        public Task<BoolResult> RegisterLocalLocationAsync(Context context, IReadOnlyList<ContentHashWithSize> contentHashes, CancellationToken cts, UrgencyHint urgencyHint, bool touch = true)
         {
             var operationContext = new OperationContext(context, cts);
             return operationContext.PerformOperationAsync(

--- a/Public/Src/Cache/ContentStore/Distributed/Sessions/DistributedContentSession.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Sessions/DistributedContentSession.cs
@@ -426,13 +426,21 @@ namespace BuildXL.Cache.ContentStore.Distributed.Sessions
         {
             if (Settings.PushProactiveCopies)
             {
-                var streamResult = await Inner.OpenStreamAsync(context, hash, context.Token);
-                if (!streamResult.Succeeded)
-                {
-                    return new BoolResult(streamResult);
-                }
+                return await DistributedCopier.PushFileAsync(
+                    context,
+                    hash,
+                    target,
+                    async () =>
+                    {
+                        var streamResult = await Inner.OpenStreamAsync(context, hash, context.Token);
+                        if (streamResult.Succeeded)
+                        {
+                            return streamResult.Stream;
+                        }
 
-                return await DistributedCopier.PushFileAsync(context, hash, target, streamResult.Stream, isInsideRing);
+                        return null;
+                    }
+                    , isInsideRing);
             }
             else
             {

--- a/Public/Src/Cache/ContentStore/Distributed/Sessions/DistributedContentSession.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Sessions/DistributedContentSession.cs
@@ -273,6 +273,12 @@ namespace BuildXL.Cache.ContentStore.Distributed.Sessions
                 if (Settings.InlineProactiveCopies)
                 {
                     var proactiveCopyResult = await proactiveCopyTask;
+
+                    // Only fail if all copies failed.
+                    if (!proactiveCopyResult.Succeeded && proactiveCopyResult.RingCopyResult?.Succeeded == false && proactiveCopyResult.OutsideRingCopyResult?.Succeeded == false)
+                    {
+                        return new PutResult(proactiveCopyResult);
+                    }
                 }
                 else
                 {

--- a/Public/Src/Cache/ContentStore/Distributed/Sessions/ProactiveCopyResult.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Sessions/ProactiveCopyResult.cs
@@ -11,6 +11,10 @@ namespace BuildXL.Cache.ContentStore.Distributed.Sessions
         /// <nodoc />
         public bool WasProactiveCopyNeeded { get; }
 
+        public BoolResult RingCopyResult { get; }
+
+        public BoolResult OutsideRingCopyResult { get; }
+
         /// <nodoc />
         public static ProactiveCopyResult CopyNotRequiredResult { get; } = new ProactiveCopyResult();
 
@@ -23,6 +27,8 @@ namespace BuildXL.Cache.ContentStore.Distributed.Sessions
         public ProactiveCopyResult(BoolResult ringCopyResult, BoolResult outsideRingCopyResult)
             : base(GetErrorMessage(ringCopyResult, outsideRingCopyResult), GetDiagnostics(ringCopyResult, outsideRingCopyResult))
         {
+            RingCopyResult = ringCopyResult;
+            OutsideRingCopyResult = outsideRingCopyResult;
         }
 
         /// <nodoc />

--- a/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
@@ -43,7 +43,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
         private readonly int _maxRetryCount;
         private readonly DisposableDirectory _tempFolderForCopies;
         private readonly IFileCopier<T> _remoteFileCopier;
-        private readonly ICopyRequester _copyRequester;
+        private readonly ICopySender _copyRequester;
         private readonly IFileExistenceChecker<T> _remoteFileExistenceChecker;
         private readonly IPathTransformer<T> _pathTransformer;
         private readonly IContentLocationStore _contentLocationStore;
@@ -68,7 +68,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
             IAbsFileSystem fileSystem,
             IFileCopier<T> fileCopier,
             IFileExistenceChecker<T> fileExistenceChecker,
-            ICopyRequester copyRequester,
+            ICopySender copyRequester,
             IPathTransformer<T> pathTransformer,
             IContentLocationStore contentLocationStore)
         {

--- a/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
@@ -39,7 +39,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
         private readonly SemaphoreSlim _proactiveCopyIoGate;
 
         private readonly IReadOnlyList<TimeSpan> _retryIntervals;
-        private readonly TimeSpan _timeoutForPoractiveCopies;
+        private readonly TimeSpan _timeoutForProactiveCopies;
         private readonly int _maxRetryCount;
         private readonly DisposableDirectory _tempFolderForCopies;
         private readonly IFileCopier<T> _remoteFileCopier;
@@ -90,7 +90,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
             _proactiveCopyIoGate = new SemaphoreSlim(_settings.MaxConcurrentProactiveCopyOperations);
             _retryIntervals = settings.RetryIntervalForCopies;
             _maxRetryCount = settings.MaxRetryCount;
-            _timeoutForPoractiveCopies = settings.TimeoutForProactiveCopies;
+            _timeoutForProactiveCopies = settings.TimeoutForProactiveCopies;
         }
 
         /// <inheritdoc />
@@ -245,7 +245,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
             return _proactiveCopyIoGate.GatedOperationAsync(ts =>
                 {
                     var cts = new CancellationTokenSource();
-                    cts.CancelAfter(_timeoutForPoractiveCopies);
+                    cts.CancelAfter(_timeoutForProactiveCopies);
                     // Creating new operation context with a new token, but the newly created context 
                     // still would have the same tracing context to simplify proactive copy trace analysis.
                     var innerContext = context.WithCancellationToken(cts.Token);
@@ -259,7 +259,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
                             $"InsideRing={isInsideRing} " +
                             $"IOGate.OccupiedCount={_settings.MaxConcurrentProactiveCopyOperations - _proactiveCopyIoGate.CurrentCount} " +
                             $"IOGate.Wait={ts.TotalMilliseconds}ms." +
-                            $"Timeout={_timeoutForPoractiveCopies}" +
+                            $"Timeout={_timeoutForProactiveCopies}" +
                             $"TimedOut={cts.Token.IsCancellationRequested}"
                         );
                 },
@@ -274,7 +274,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
             return _proactiveCopyIoGate.GatedOperationAsync(ts =>
             {
                 var cts = new CancellationTokenSource();
-                cts.CancelAfter(_timeoutForPoractiveCopies);
+                cts.CancelAfter(_timeoutForProactiveCopies);
                 // Creating new operation context with a new token, but the newly created context 
                 // still would have the same tracing context to simplify proactive copy trace analysis.
                 var innerContext = context.WithCancellationToken(cts.Token);
@@ -288,7 +288,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
                         $"InsideRing={isInsideRing} " +
                         $"IOGate.OccupiedCount={_settings.MaxConcurrentProactiveCopyOperations - _proactiveCopyIoGate.CurrentCount} " +
                         $"IOGate.Wait={ts.TotalMilliseconds}ms." +
-                        $"Timeout={_timeoutForPoractiveCopies}" +
+                        $"Timeout={_timeoutForProactiveCopies}" +
                         $"TimedOut={cts.Token.IsCancellationRequested}"
                     );
             },

--- a/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
@@ -267,7 +267,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
         /// <summary>
         /// Pushes content to another machine.
         /// </summary>
-        public Task<BoolResult> PushFileAsync(OperationContext context, ContentHash hash, MachineLocation targetLocation, Stream source, bool isInsideRing)
+        public Task<BoolResult> PushFileAsync(OperationContext context, ContentHash hash, MachineLocation targetLocation, Func<Task<Stream>> streamFactory, bool isInsideRing)
         {
             return _proactiveCopyIoGate.GatedOperationAsync(ts =>
             {
@@ -278,7 +278,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
                 var innerContext = context.WithCancellationToken(cts.Token);
                 return context.PerformOperationAsync(
                     Tracer,
-                    operation: () => _copyRequester.PushFileAsync(innerContext, hash, source, targetLocation),
+                    operation: () => _copyRequester.PushFileAsync(innerContext, hash, streamFactory, targetLocation),
                     traceOperationStarted: false,
                     extraEndMessage: result =>
                         $"ContentHash={hash.ToShortString()} " +

--- a/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
@@ -240,14 +240,14 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
         /// </summary>
         public Task<BoolResult> RequestCopyFileAsync(OperationContext context, ContentHash hash, MachineLocation targetLocation, bool isInsideRing)
         {
-            return _proactiveCopyIoGate.GatedOperationAsync(ts =>
+            return _proactiveCopyIoGate.GatedOperationAsync(async ts =>
                 {
                     using var cts = new CancellationTokenSource();
                     cts.CancelAfter(_timeoutForProactiveCopies);
                     // Creating new operation context with a new token, but the newly created context 
                     // still would have the same tracing context to simplify proactive copy trace analysis.
                     var innerContext = context.WithCancellationToken(cts.Token);
-                    return context.PerformOperationAsync(
+                    return await context.PerformOperationAsync(
                         Tracer,
                         operation: () => _copyRequester.RequestCopyFileAsync(innerContext, hash, targetLocation),
                         traceOperationStarted: false,

--- a/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
@@ -256,8 +256,8 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
                             $"TargetLocation=[{targetLocation}] " +
                             $"InsideRing={isInsideRing} " +
                             $"IOGate.OccupiedCount={_settings.MaxConcurrentProactiveCopyOperations - _proactiveCopyIoGate.CurrentCount} " +
-                            $"IOGate.Wait={ts.TotalMilliseconds}ms." +
-                            $"Timeout={_timeoutForProactiveCopies}" +
+                            $"IOGate.Wait={ts.TotalMilliseconds}ms. " +
+                            $"Timeout={_timeoutForProactiveCopies} " +
                             $"TimedOut={cts.Token.IsCancellationRequested}"
                         );
                 },
@@ -285,8 +285,8 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
                         $"TargetLocation=[{targetLocation}] " +
                         $"InsideRing={isInsideRing} " +
                         $"IOGate.OccupiedCount={_settings.MaxConcurrentProactiveCopyOperations - _proactiveCopyIoGate.CurrentCount} " +
-                        $"IOGate.Wait={ts.TotalMilliseconds}ms." +
-                        $"Timeout={_timeoutForProactiveCopies}" +
+                        $"IOGate.Wait={ts.TotalMilliseconds}ms. " +
+                        $"Timeout={_timeoutForProactiveCopies} " +
                         $"TimedOut={cts.Token.IsCancellationRequested}"
                     );
             },

--- a/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentCopier.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.ContractsLight;
 using System.IO;
 using System.Linq;
-using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using BuildXL.Cache.ContentStore.Distributed.Sessions;
@@ -43,7 +41,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
         private readonly int _maxRetryCount;
         private readonly DisposableDirectory _tempFolderForCopies;
         private readonly IFileCopier<T> _remoteFileCopier;
-        private readonly ICopySender _copyRequester;
+        private readonly IProactiveCopier _copyRequester;
         private readonly IFileExistenceChecker<T> _remoteFileExistenceChecker;
         private readonly IPathTransformer<T> _pathTransformer;
         private readonly IContentLocationStore _contentLocationStore;
@@ -68,7 +66,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
             IAbsFileSystem fileSystem,
             IFileCopier<T> fileCopier,
             IFileExistenceChecker<T> fileExistenceChecker,
-            ICopySender copyRequester,
+            IProactiveCopier copyRequester,
             IPathTransformer<T> pathTransformer,
             IContentLocationStore contentLocationStore)
         {
@@ -244,7 +242,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
         {
             return _proactiveCopyIoGate.GatedOperationAsync(ts =>
                 {
-                    var cts = new CancellationTokenSource();
+                    using var cts = new CancellationTokenSource();
                     cts.CancelAfter(_timeoutForProactiveCopies);
                     // Creating new operation context with a new token, but the newly created context 
                     // still would have the same tracing context to simplify proactive copy trace analysis.

--- a/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentStore.cs
@@ -89,7 +89,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
             IFileExistenceChecker<T> fileExistenceChecker,
             IFileCopier<T> fileCopier,
             IPathTransformer<T> pathTransform,
-            ICopyRequester copyRequester,
+            ICopySender copyRequester,
             ReadOnlyDistributedContentSession<T>.ContentAvailabilityGuarantee contentAvailabilityGuarantee,
             AbsolutePath tempFolderForCopies,
             IAbsFileSystem fileSystem,

--- a/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentStore.cs
@@ -608,11 +608,11 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
         }
 
         /// <inheritdoc />
-        public async Task<PutResult> HandlePushFileAsync(Context context, ContentHash hash, Stream source, CancellationToken token)
+        public async Task<PutResult> HandlePushFileAsync(Context context, ContentHash hash, AbsolutePath sourcePath, CancellationToken token)
         {
             if (InnerContentStore is IPushFileHandler inner)
             {
-                var result = await inner.HandlePushFileAsync(context, hash, source, token);
+                var result = await inner.HandlePushFileAsync(context, hash, sourcePath, token);
                 if (!result)
                 {
                     return result;

--- a/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentStore.cs
@@ -629,5 +629,16 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
 
             return new PutResult(new InvalidOperationException($"{nameof(InnerContentStore)} does not implement {nameof(IPushFileHandler)}"), hash);
         }
+
+        /// <inheritdoc />
+        public bool HasContentLocally(Context context, ContentHash hash)
+        {
+            if (InnerContentStore is IPushFileHandler inner)
+            {
+                return inner.HasContentLocally(context, hash);
+            }
+
+            return false;
+        }
     }
 }

--- a/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentStore.cs
@@ -89,7 +89,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
             IFileExistenceChecker<T> fileExistenceChecker,
             IFileCopier<T> fileCopier,
             IPathTransformer<T> pathTransform,
-            ICopySender copyRequester,
+            IProactiveCopier copyRequester,
             ReadOnlyDistributedContentSession<T>.ContentAvailabilityGuarantee contentAvailabilityGuarantee,
             AbsolutePath tempFolderForCopies,
             IAbsFileSystem fileSystem,

--- a/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentStoreSettings.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Stores/DistributedContentStoreSettings.cs
@@ -153,6 +153,16 @@ namespace BuildXL.Cache.ContentStore.Distributed.Stores
         public ProactiveCopyMode ProactiveCopyMode { get; set; } = ProactiveCopyMode.Disabled;
 
         /// <summary>
+        /// Whether to push the content. If disabled, the copy will be requested and the target machine then will pull.
+        /// </summary>
+        public bool PushProactiveCopies { get; set; } = false;
+
+        /// <summary>
+        /// Should only be used for testing.
+        /// </summary>
+        public bool InlineProactiveCopies { get; set; } = false;
+
+        /// <summary>
         /// Maximum number of locations which should trigger a proactive copy.
         /// </summary>
         public int ProactiveCopyLocationsThreshold { get; set; } = 1;

--- a/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcFileCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcFileCopier.cs
@@ -92,16 +92,14 @@ namespace BuildXL.Cache.ContentStore.Distributed.Utilities
             return await clientWrapper.Value.CopyToAsync(context, contentHash, destinationStream, context.Token);
         }
 
-        // TODO: Add interfaces
         /// <inheritdoc />
-        public async Task<BoolResult> PushFileAsync(OperationContext context, ContentHash hash, AbsolutePath sourcePath, MachineLocation targetMachine)
+        public async Task<BoolResult> PushFileAsync(OperationContext context, ContentHash hash, Stream source, MachineLocation targetMachine)
         {
             var targetPath = new AbsolutePath(targetMachine.Path);
             var targetMachineName = targetPath.IsLocal ? "localhost" : targetPath.GetSegments()[0];
 
             using var clientWrapper = await _clientCache.CreateAsync(targetMachineName, _grpcPort, _useCompression);
-            using var stream = File.OpenRead(sourcePath.Path);
-            return await clientWrapper.Value.PushFileAsync(context, hash, stream);
+            return await clientWrapper.Value.PushFileAsync(context, hash, source);
         }
 
         /// <inheritdoc />

--- a/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcFileCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcFileCopier.cs
@@ -20,7 +20,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Utilities
     /// <summary>
     /// File copier which operates over Grpc. <seealso cref="GrpcCopyClient"/>
     /// </summary>
-    public class GrpcFileCopier : ITraceableAbsolutePathFileCopier, ICopyRequester
+    public class GrpcFileCopier : ITraceableAbsolutePathFileCopier, ICopySender
     {
         private readonly Context _context;
         private readonly int _grpcPort;

--- a/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcFileCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcFileCopier.cs
@@ -92,6 +92,18 @@ namespace BuildXL.Cache.ContentStore.Distributed.Utilities
             return await clientWrapper.Value.CopyToAsync(context, contentHash, destinationStream, context.Token);
         }
 
+        // TODO: Add interfaces
+        /// <inheritdoc />
+        public async Task<BoolResult> PushFileAsync(OperationContext context, ContentHash hash, AbsolutePath sourcePath, MachineLocation targetMachine)
+        {
+            var targetPath = new AbsolutePath(targetMachine.Path);
+            var targetMachineName = targetPath.IsLocal ? "localhost" : targetPath.GetSegments()[0];
+
+            using var clientWrapper = await _clientCache.CreateAsync(targetMachineName, _grpcPort, _useCompression);
+            using var stream = File.OpenRead(sourcePath.Path);
+            return await clientWrapper.Value.PushFileAsync(context, hash, stream);
+        }
+
         /// <inheritdoc />
         public async Task<BoolResult> RequestCopyFileAsync(OperationContext context, ContentHash hash, MachineLocation targetMachine)
         {

--- a/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcFileCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcFileCopier.cs
@@ -20,7 +20,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Utilities
     /// <summary>
     /// File copier which operates over Grpc. <seealso cref="GrpcCopyClient"/>
     /// </summary>
-    public class GrpcFileCopier : ITraceableAbsolutePathFileCopier, ICopySender
+    public class GrpcFileCopier : ITraceableAbsolutePathFileCopier, IProactiveCopier
     {
         private readonly Context _context;
         private readonly int _grpcPort;

--- a/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcFileCopier.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Utilities/GrpcFileCopier.cs
@@ -93,7 +93,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.Utilities
         }
 
         /// <inheritdoc />
-        public async Task<BoolResult> PushFileAsync(OperationContext context, ContentHash hash, Stream source, MachineLocation targetMachine)
+        public async Task<BoolResult> PushFileAsync(OperationContext context, ContentHash hash, Func<Task<Stream>> source, MachineLocation targetMachine)
         {
             var targetPath = new AbsolutePath(targetMachine.Path);
             var targetMachineName = targetPath.IsLocal ? "localhost" : targetPath.GetSegments()[0];

--- a/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/LocalLocationStoreDistributedContentTests.cs
+++ b/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/LocalLocationStoreDistributedContentTests.cs
@@ -170,7 +170,7 @@ namespace ContentStoreTest.Distributed.Sessions
                 {
                     RetryIntervalForCopies = DistributedContentSessionTests.DefaultRetryIntervalsForTest,
                     PinConfiguration = PinConfiguration,
-                    ShouldInlinePutBlob = true
+                    ShouldInlinePutBlob = true,
                     ProactiveCopyMode = EnableProactiveCopy ? ProactiveCopyMode.Both : ProactiveCopyMode.Disabled,
                     InlineProactiveCopies = true,
                     PushProactiveCopies = PushProactiveCopies

--- a/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/TestFileCopier.cs
+++ b/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/TestFileCopier.cs
@@ -17,7 +17,7 @@ using ContentStoreTest.Test;
 
 namespace ContentStoreTest.Distributed.ContentLocation
 {
-    public class TestFileCopier : IFileCopier<AbsolutePath>, IFileExistenceChecker<AbsolutePath>, ICopyRequester
+    public class TestFileCopier : IFileCopier<AbsolutePath>, IFileExistenceChecker<AbsolutePath>, ICopySender
     {
         public AbsolutePath WorkingDirectory { get; set; }
 

--- a/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/TestFileCopier.cs
+++ b/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/TestFileCopier.cs
@@ -29,6 +29,8 @@ namespace ContentStoreTest.Distributed.ContentLocation
 
         public Dictionary<MachineLocation, ICopyRequestHandler> CopyHandlersByLocation { get; } = new Dictionary<MachineLocation, ICopyRequestHandler>();
 
+        public Dictionary<MachineLocation, IPushFileHandler> PushHandlersByLocation { get; } = new Dictionary<MachineLocation, IPushFileHandler>();
+
         public int FilesCopyAttemptCount => FilesCopied.Count;
 
         public async Task<CopyFileResult> CopyToAsync(AbsolutePath sourcePath, Stream destinationStream, long expectedContentSize, CancellationToken cancellationToken)
@@ -112,6 +114,12 @@ namespace ContentStoreTest.Distributed.ContentLocation
         public Task<BoolResult> RequestCopyFileAsync(OperationContext context, ContentHash hash, MachineLocation targetMachine)
         {
             return CopyHandlersByLocation[targetMachine].HandleCopyFileRequestAsync(context, hash);
+        }
+
+        public async Task<BoolResult> PushFileAsync(OperationContext context, ContentHash hash, Stream source, MachineLocation targetMachine)
+        {
+            var result = await PushHandlersByLocation[targetMachine].HandlePushFileAsync(context, hash, source, CancellationToken.None);
+            return result ? BoolResult.Success : new BoolResult(result);
         }
     }
 }

--- a/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/TestFileCopier.cs
+++ b/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/TestFileCopier.cs
@@ -118,12 +118,13 @@ namespace ContentStoreTest.Distributed.ContentLocation
             return CopyHandlersByLocation[targetMachine].HandleCopyFileRequestAsync(context, hash);
         }
 
-        public async Task<BoolResult> PushFileAsync(OperationContext context, ContentHash hash, Stream source, MachineLocation targetMachine)
+        public async Task<BoolResult> PushFileAsync(OperationContext context, ContentHash hash, Func<Task<Stream>> source, MachineLocation targetMachine)
         {
             var tempFile = AbsolutePath.CreateRandomFileName(WorkingDirectory);
+            using var stream = await source();
             using (var file = File.OpenWrite(tempFile.Path))
             {
-                await source.CopyToAsync(file);
+                await stream.CopyToAsync(file);
             }
 
             var result = await PushHandlersByLocation[targetMachine].HandlePushFileAsync(context, hash, tempFile, CancellationToken.None);

--- a/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/TestFileCopier.cs
+++ b/Public/Src/Cache/ContentStore/DistributedTest/ContentLocation/TestFileCopier.cs
@@ -17,7 +17,7 @@ using ContentStoreTest.Test;
 
 namespace ContentStoreTest.Distributed.ContentLocation
 {
-    public class TestFileCopier : IFileCopier<AbsolutePath>, IFileExistenceChecker<AbsolutePath>, ICopySender
+    public class TestFileCopier : IFileCopier<AbsolutePath>, IFileExistenceChecker<AbsolutePath>, IProactiveCopier
     {
         public AbsolutePath WorkingDirectory { get; set; }
 

--- a/Public/Src/Cache/ContentStore/DistributedTest/Sessions/DistributedContentTests.cs
+++ b/Public/Src/Cache/ContentStore/DistributedTest/Sessions/DistributedContentTests.cs
@@ -955,7 +955,10 @@ namespace ContentStoreTest.Distributed.Sessions
             var indexedDirectories = Enumerable.Range(0, storeCount)
                 .Select(i => new { Index = i, Directory = new DisposableDirectory(FileSystem, TestRootDirectoryPath / i.ToString()) })
                 .ToList();
-            var testFileCopier = new TestFileCopier();
+            var testFileCopier = new TestFileCopier()
+            {
+                WorkingDirectory = indexedDirectories[0].Directory.Path
+            };
             for (int iteration = 0; iteration < iterations; iteration++)
             {
                 var stores = indexedDirectories.Select(

--- a/Public/Src/Cache/ContentStore/DistributedTest/Sessions/DistributedContentTests.cs
+++ b/Public/Src/Cache/ContentStore/DistributedTest/Sessions/DistributedContentTests.cs
@@ -79,6 +79,7 @@ namespace ContentStoreTest.Distributed.Sessions
                 {
                     var distributedStore = (DistributedContentStore<AbsolutePath>)GetDistributedStore(i);
                     fileCopier.CopyHandlersByLocation[distributedStore.LocalMachineLocation] = distributedStore;
+                    fileCopier.PushHandlersByLocation[distributedStore.LocalMachineLocation] = distributedStore;
                 }
             }
 

--- a/Public/Src/Cache/ContentStore/DistributedTest/Stores/DistributedContentCopierTests.cs
+++ b/Public/Src/Cache/ContentStore/DistributedTest/Stores/DistributedContentCopierTests.cs
@@ -144,7 +144,7 @@ namespace ContentStoreTest.Distributed.Stores
             IAbsFileSystem fileSystem,
             IFileCopier<AbsolutePath> fileCopier,
             IFileExistenceChecker<AbsolutePath> fileExistenceChecker,
-            ICopyRequester copyRequester,
+            ICopySender copyRequester,
             IPathTransformer<AbsolutePath> pathTransformer,
             IContentLocationStore contentLocationStore)
                 : base(workingDirectory, settings, fileSystem, fileCopier, fileExistenceChecker, copyRequester, pathTransformer, contentLocationStore)

--- a/Public/Src/Cache/ContentStore/DistributedTest/Stores/DistributedContentCopierTests.cs
+++ b/Public/Src/Cache/ContentStore/DistributedTest/Stores/DistributedContentCopierTests.cs
@@ -239,7 +239,7 @@ namespace ContentStoreTest.Distributed.Stores
             public CounterSet GetCounters(Context context) => null;
 
             /// <inheritdoc />
-            public Task<BoolResult> RegisterLocalLocationAsync(Context context, IReadOnlyList<ContentHashWithSize> contentHashes, CancellationToken cts, UrgencyHint urgencyHint) => null;
+            public Task<BoolResult> RegisterLocalLocationAsync(Context context, IReadOnlyList<ContentHashWithSize> contentHashes, CancellationToken cts, UrgencyHint urgencyHint, bool touch) => null;
 
             /// <inheritdoc />
             public Task<BoolResult> PutBlobAsync(OperationContext context, ContentHash contentHash, byte[] blob) => null;

--- a/Public/Src/Cache/ContentStore/DistributedTest/Stores/DistributedContentCopierTests.cs
+++ b/Public/Src/Cache/ContentStore/DistributedTest/Stores/DistributedContentCopierTests.cs
@@ -144,7 +144,7 @@ namespace ContentStoreTest.Distributed.Stores
             IAbsFileSystem fileSystem,
             IFileCopier<AbsolutePath> fileCopier,
             IFileExistenceChecker<AbsolutePath> fileExistenceChecker,
-            ICopySender copyRequester,
+            IProactiveCopier copyRequester,
             IPathTransformer<AbsolutePath> pathTransformer,
             IContentLocationStore contentLocationStore)
                 : base(workingDirectory, settings, fileSystem, fileCopier, fileExistenceChecker, copyRequester, pathTransformer, contentLocationStore)

--- a/Public/Src/Cache/ContentStore/Grpc/ContentStore.proto
+++ b/Public/Src/Cache/ContentStore/Grpc/ContentStore.proto
@@ -33,6 +33,8 @@ service ContentServer {
 
     rpc CopyFile(CopyFileRequest) returns (stream CopyFileResponse) {}
 
+    rpc PushFile(stream PushFileRequest) returns (stream PushFileResponse) {}
+
     rpc CheckFileExists(ExistenceRequest) returns (ExistenceResponse) {}
 
     rpc Delete(DeleteContentRequest) returns (DeleteContentResponse) {}
@@ -194,6 +196,19 @@ message CopyFileResponse {
 enum CopyCompression {
     none = 0;
     gzip = 1;
+}
+
+// PushFile
+message PushFileRequest {
+    string traceId = 1;
+    int32 hashType = 2;
+    bytes contentHash = 3;
+    bytes content = 4;
+}
+
+message PushFileResponse {
+    ResponseHeader Header = 1;
+    bool shouldCopy = 2;
 }
 
 // RequestCopyFile

--- a/Public/Src/Cache/ContentStore/Grpc/ContentStore.proto
+++ b/Public/Src/Cache/ContentStore/Grpc/ContentStore.proto
@@ -33,7 +33,7 @@ service ContentServer {
 
     rpc CopyFile(CopyFileRequest) returns (stream CopyFileResponse) {}
 
-    rpc PushFile(stream PushFileRequest) returns (PushFileResponse) {}
+    rpc PushFile(stream PushFileRequest) returns (stream PushFileResponse) {}
 
     rpc CheckFileExists(ExistenceRequest) returns (ExistenceResponse) {}
 

--- a/Public/Src/Cache/ContentStore/Grpc/ContentStore.proto
+++ b/Public/Src/Cache/ContentStore/Grpc/ContentStore.proto
@@ -33,7 +33,7 @@ service ContentServer {
 
     rpc CopyFile(CopyFileRequest) returns (stream CopyFileResponse) {}
 
-    rpc PushFile(stream PushFileRequest) returns (stream PushFileResponse) {}
+    rpc PushFile(stream PushFileRequest) returns (PushFileResponse) {}
 
     rpc CheckFileExists(ExistenceRequest) returns (ExistenceResponse) {}
 
@@ -200,15 +200,11 @@ enum CopyCompression {
 
 // PushFile
 message PushFileRequest {
-    string traceId = 1;
-    int32 hashType = 2;
-    bytes contentHash = 3;
-    bytes content = 4;
+    bytes content = 1;
 }
 
 message PushFileResponse {
     ResponseHeader Header = 1;
-    bool shouldCopy = 2;
 }
 
 // RequestCopyFile

--- a/Public/Src/Cache/ContentStore/Interfaces/FileSystem/ICopyRequestHandler.cs
+++ b/Public/Src/Cache/ContentStore/Interfaces/FileSystem/ICopyRequestHandler.cs
@@ -30,8 +30,10 @@ namespace BuildXL.Cache.ContentStore.Interfaces.FileSystem
     /// </summary>
     public interface IPushFileHandler
     {
-        //TODO docs
         /// <nodoc />
         Task<PutResult> HandlePushFileAsync(Context context, ContentHash hash, AbsolutePath sourcePath, CancellationToken token);
+
+        /// <nodoc />
+        bool HasContentLocally(Context context, ContentHash hash);
     }
 }

--- a/Public/Src/Cache/ContentStore/Interfaces/FileSystem/ICopyRequestHandler.cs
+++ b/Public/Src/Cache/ContentStore/Interfaces/FileSystem/ICopyRequestHandler.cs
@@ -32,6 +32,6 @@ namespace BuildXL.Cache.ContentStore.Interfaces.FileSystem
     {
         //TODO docs
         /// <nodoc />
-        Task<PutResult> HandlePushFileAsync(Context context, ContentHash hash, Stream source, CancellationToken token);
+        Task<PutResult> HandlePushFileAsync(Context context, ContentHash hash, AbsolutePath sourcePath, CancellationToken token);
     }
 }

--- a/Public/Src/Cache/ContentStore/Interfaces/FileSystem/ICopyRequestHandler.cs
+++ b/Public/Src/Cache/ContentStore/Interfaces/FileSystem/ICopyRequestHandler.cs
@@ -1,6 +1,7 @@
 // Copyright(c) Microsoft.All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using BuildXL.Cache.ContentStore.Hashing;
@@ -29,7 +30,8 @@ namespace BuildXL.Cache.ContentStore.Interfaces.FileSystem
     /// </summary>
     public interface IPushFileHandler
     {
+        //TODO docs
         /// <nodoc />
-        Task<PutResult> HandlePushFileAsync(Context context, ContentHash hash, AbsolutePath path, CancellationToken token);
+        Task<PutResult> HandlePushFileAsync(Context context, ContentHash hash, Stream source, CancellationToken token);
     }
 }

--- a/Public/Src/Cache/ContentStore/Interfaces/FileSystem/ICopyRequestHandler.cs
+++ b/Public/Src/Cache/ContentStore/Interfaces/FileSystem/ICopyRequestHandler.cs
@@ -1,6 +1,7 @@
 // Copyright(c) Microsoft.All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using BuildXL.Cache.ContentStore.Hashing;
 using BuildXL.Cache.ContentStore.Interfaces.Results;
@@ -21,5 +22,14 @@ namespace BuildXL.Cache.ContentStore.Interfaces.FileSystem
         /// <param name="context">The context of the operation</param>
         /// <param name="hash">The hash of the file to be copied.</param>
         Task<BoolResult> HandleCopyFileRequestAsync(Context context, ContentHash hash);
+    }
+
+    /// <summary>
+    /// Handles requests to push content to this machine.
+    /// </summary>
+    public interface IPushFileHandler
+    {
+        /// <nodoc />
+        Task<PutResult> HandlePushFileAsync(Context context, ContentHash hash, AbsolutePath path, CancellationToken token);
     }
 }

--- a/Public/Src/Cache/ContentStore/Library/BuildXL.Cache.ContentStore.Library.dsc
+++ b/Public/Src/Cache/ContentStore/Library/BuildXL.Cache.ContentStore.Library.dsc
@@ -22,6 +22,7 @@ namespace Library {
             // TODO: This needs to be renamed to just utilities... but it is in a package in public/src
             importFrom("BuildXL.Utilities").dll,
             importFrom("BuildXL.Utilities").Native.dll,
+            importFrom("BuildXL.Utilities").Collections.dll,
             importFrom("BuildXL.Cache.DistributedCache.Host").Configuration.dll,
             importFrom("Grpc.Core").pkg,
             importFrom("Google.Protobuf").pkg,

--- a/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcContentServer.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcContentServer.cs
@@ -393,7 +393,11 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
                 }
             }
 
-            var result = await store.HandlePushFileAsync(cacheContext, hash, tempFile, token);
+            PutResult result;
+            using (var source = File.OpenRead(tempFile.Path))
+            {
+                result = await store.HandlePushFileAsync(cacheContext, hash, source, token);
+            }
 
             var response = result
                 ? new PushFileResponse { Header = ResponseHeader.Success(startTime) }

--- a/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcCopyClient.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcCopyClient.cs
@@ -281,11 +281,11 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
                 var firstResponse = responseStream.Current;
                 if (!firstResponse.ShouldCopy)
                 {
+                    context.TraceDebug($"{nameof(PushFileAsync)}: copy of {hash.ToShortString()} was skipped.");
                     return BoolResult.Success;
                 }
 
-                var bufferSize = 64 * 1024; // TODO: Determine buffer size in config.
-                await StreamContentAsync(source, new byte[bufferSize], requestStream, context.Token);
+                await StreamContentAsync(source, new byte[_bufferSize], requestStream, context.Token);
                 await requestStream.CompleteAsync();
 
                 await responseStream.MoveNext(context.Token);

--- a/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcCopyClient.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcCopyClient.cs
@@ -267,9 +267,9 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
             {
                 var headers = new Metadata()
                 {
-                    { "hash", hash.ToHashByteArray() },
-                    { "hashType", hash.HashType.ToString() },
-                    { "traceId", context.TracingContext.Id.ToString() }
+                    { "hash-bin", hash.ToHashByteArray() }, // -bin suffix required to send bytes directly
+                    { "hash_type", hash.HashType.ToString() },
+                    { "trace_id", context.TracingContext.Id.ToString() }
                 };
 
                 var call = _client.PushFile(headers, cancellationToken: context.Token);
@@ -278,7 +278,7 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
                 var responseHeaders = await call.ResponseHeadersAsync;
                 foreach (var header in responseHeaders)
                 {
-                    if (header.Key == "shouldCopy")
+                    if (header.Key == "should_copy")
                     {
                         if (bool.TryParse(header.Value, out var shouldCopy) && !shouldCopy)
                         {

--- a/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcCopyClient.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/Grpc/GrpcCopyClient.cs
@@ -291,11 +291,13 @@ namespace BuildXL.Cache.ContentStore.Service.Grpc
                 await StreamContentAsync(source, new byte[_bufferSize], requestStream, context.Token);
                 await requestStream.CompleteAsync();
 
-                var finalResponse = await call.ResponseAsync;
+                var responseStream = call.ResponseStream;
+                await responseStream.MoveNext(context.Token);
+                var response = responseStream.Current;
 
-                return finalResponse.Header.Succeeded
+                return response.Header.Succeeded
                     ? BoolResult.Success
-                    : new BoolResult(finalResponse.Header.ErrorMessage);
+                    : new BoolResult(response.Header.ErrorMessage);
             }
             catch (RpcException r)
             {

--- a/Public/Src/Cache/ContentStore/Library/Service/Grpc/PushFileMetadata.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/Grpc/PushFileMetadata.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using BuildXL.Cache.ContentStore.Hashing;
+using Grpc.Core;
+
+namespace BuildXL.Cache.ContentStore.Service.Grpc
+{
+    /// <nodoc />
+    internal class PushRequest
+    {
+        /// <nodoc />
+        public ContentHash Hash { get; }
+
+        /// <nodoc />
+        public Guid TraceId { get; }
+
+        /// <nodoc />
+        public PushRequest(ContentHash hash, Guid traceId)
+        {
+            Hash = hash;
+            TraceId = traceId;
+        }
+
+        /// <nodoc />
+        public static PushRequest FromMetadata(Metadata metadata)
+        {
+            byte[] hashBytes = null;
+            var hashType = HashType.Unknown;
+            Guid traceId = default;
+
+            foreach (var header in metadata)
+            {
+                switch (header.Key)
+                {
+                    case "hash-bin": hashBytes = header.ValueBytes; break;
+                    case "hash_type": Enum.TryParse(header.Value, out hashType); break;
+                    case "trace_id": traceId = new Guid(header.Value); break;
+                }
+            }
+
+            var hash = new ContentHash(hashType, hashBytes);
+
+            return new PushRequest(hash, traceId);
+        }
+
+        /// <nodoc />
+        public Metadata GetMetadata()
+        {
+            return new Metadata()
+            {
+                { "hash-bin", Hash.ToHashByteArray() }, // -bin suffix required to send bytes directly
+                { "hash_type", Hash.HashType.ToString() },
+                { "trace_id", TraceId.ToString() }
+            };
+        }
+    }
+
+    /// <nodoc />
+    internal class PushResponse
+    {
+        /// <nodoc />
+        public bool ShouldCopy { get; }
+
+        private readonly Lazy<Metadata> _metadata = new Lazy<Metadata>(() => new Metadata { { "should_copy", "false" } });
+
+        /// <nodoc />
+        public Metadata Metadata => _metadata.Value;
+
+        private PushResponse(bool shouldCopy)
+        {
+            ShouldCopy = shouldCopy;
+        }
+
+        /// <nodoc />
+        public static PushResponse Copy { get; } = new PushResponse(shouldCopy: true);
+
+        /// <nodoc />
+        public static PushResponse DontCopy { get; } = new PushResponse(shouldCopy: false);
+
+        /// <nodoc />
+        public static PushResponse FromMetadata(Metadata metadata)
+        {
+            foreach (var header in metadata)
+            {
+                if (header.Key == "should_copy")
+                {
+                    if (bool.TryParse(header.Value, out var shouldCopy))
+                    {
+                        return shouldCopy ? Copy : DontCopy;
+                    }
+                }
+            }
+
+            return Copy;
+        }
+    }
+}

--- a/Public/Src/Cache/ContentStore/Library/Service/LocalServerConfiguration.cs
+++ b/Public/Src/Cache/ContentStore/Library/Service/LocalServerConfiguration.cs
@@ -14,13 +14,14 @@ namespace BuildXL.Cache.ContentStore.Service
     public sealed class LocalServerConfiguration
     {
         /// <nodoc />
-        public LocalServerConfiguration(AbsolutePath dataRootPath, IReadOnlyDictionary<string, AbsolutePath> namedCacheRoots, int grpcPort, int? bufferSizeForGrpcCopies = null, int? gzipBarrierSizeForGrpcCopies = null)
+        public LocalServerConfiguration(AbsolutePath dataRootPath, IReadOnlyDictionary<string, AbsolutePath> namedCacheRoots, int grpcPort, IAbsFileSystem fileSystem, int? bufferSizeForGrpcCopies = null, int? gzipBarrierSizeForGrpcCopies = null)
         {
             DataRootPath = dataRootPath;
             NamedCacheRoots = namedCacheRoots;
             GrpcPort = grpcPort;
             BufferSizeForGrpcCopies = bufferSizeForGrpcCopies;
             GzipBarrierSizeForGrpcCopies = gzipBarrierSizeForGrpcCopies;
+            FileSystem = fileSystem;
         }
 
         /// <nodoc />
@@ -109,6 +110,9 @@ namespace BuildXL.Cache.ContentStore.Service
 
         /// <nodoc />
         public int? GrpcThreadPoolSize { get; set; }
+
+        /// <nodoc />
+        public IAbsFileSystem FileSystem { get; set; }
 
         /// <inheritdoc />
         public override string ToString()

--- a/Public/Src/Cache/ContentStore/Library/Stores/FileSystemContentStore.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/FileSystemContentStore.cs
@@ -238,9 +238,9 @@ namespace BuildXL.Cache.ContentStore.Stores
         public void PostInitializationCompleted(Context context, BoolResult result) { }
 
         /// <inheritdoc />
-        public Task<PutResult> HandlePushFileAsync(Context context, ContentHash hash, Stream source, CancellationToken token)
+        public Task<PutResult> HandlePushFileAsync(Context context, ContentHash hash, AbsolutePath sourcePath, CancellationToken token)
         {
-            return Store.PutStreamAsync(context, source, hash, pinRequest: null);
+            return Store.PutFileAsync(context, sourcePath, FileRealizationMode.Copy, hash, pinRequest: null);
         }
     }
 }

--- a/Public/Src/Cache/ContentStore/Library/Stores/FileSystemContentStore.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/FileSystemContentStore.cs
@@ -24,7 +24,7 @@ namespace BuildXL.Cache.ContentStore.Stores
     /// <summary>
     ///     An <see cref="IContentStore"/> implemented over <see cref="FileSystemContentStoreInternal"/>
     /// </summary>
-    public class FileSystemContentStore : StartupShutdownBase, IContentStore, IAcquireDirectoryLock, IRepairStore, ILocalContentStore, IStreamStore
+    public class FileSystemContentStore : StartupShutdownBase, IContentStore, IAcquireDirectoryLock, IRepairStore, ILocalContentStore, IStreamStore, IPushFileHandler
     {
         private const string Component = nameof(FileSystemContentStore);
 
@@ -235,5 +235,11 @@ namespace BuildXL.Cache.ContentStore.Stores
 
         /// <inheritdoc />
         public void PostInitializationCompleted(Context context, BoolResult result) { }
+
+        /// <inheritdoc />
+        public Task<PutResult> HandlePushFileAsync(Context context, ContentHash hash, AbsolutePath path, CancellationToken token)
+        {
+            return Store.PutFileAsync(context, path, FileRealizationMode.Copy, hash, pinRequest: null);
+        }
     }
 }

--- a/Public/Src/Cache/ContentStore/Library/Stores/FileSystemContentStore.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/FileSystemContentStore.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.ContractsLight;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using BuildXL.Cache.ContentStore.Hashing;
@@ -237,9 +238,9 @@ namespace BuildXL.Cache.ContentStore.Stores
         public void PostInitializationCompleted(Context context, BoolResult result) { }
 
         /// <inheritdoc />
-        public Task<PutResult> HandlePushFileAsync(Context context, ContentHash hash, AbsolutePath path, CancellationToken token)
+        public Task<PutResult> HandlePushFileAsync(Context context, ContentHash hash, Stream source, CancellationToken token)
         {
-            return Store.PutFileAsync(context, path, FileRealizationMode.Copy, hash, pinRequest: null);
+            return Store.PutStreamAsync(context, source, hash, pinRequest: null);
         }
     }
 }

--- a/Public/Src/Cache/ContentStore/Library/Stores/FileSystemContentStore.cs
+++ b/Public/Src/Cache/ContentStore/Library/Stores/FileSystemContentStore.cs
@@ -242,5 +242,11 @@ namespace BuildXL.Cache.ContentStore.Stores
         {
             return Store.PutFileAsync(context, sourcePath, FileRealizationMode.Copy, hash, pinRequest: null);
         }
+
+        /// <inheritdoc />
+        public bool HasContentLocally(Context context, ContentHash hash)
+        {
+            return Store.Contains(hash);
+        }
     }
 }

--- a/Public/Src/Cache/ContentStore/Vfs/VfsCasRunner.cs
+++ b/Public/Src/Cache/ContentStore/Vfs/VfsCasRunner.cs
@@ -68,7 +68,8 @@ namespace BuildXL.Cache.ContentStore.Vfs
                         {
                             { configuration.CacheName, configuration.ServerRootPath }
                         },
-                        configuration.ServerGrpcPort)))
+                        configuration.ServerGrpcPort,
+                        fileSystem)))
                 {
                     await server.StartupAsync(context).ThrowIfFailure();
 

--- a/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
@@ -569,6 +569,9 @@ namespace BuildXL.Cache.Host.Configuration
         public string ProactiveCopyMode { get; set; } = "Disabled";
 
         [DataMember]
+        public bool PushProactiveCopies { get; set; } = false;
+
+        [DataMember]
         public int ProactiveCopyLocationsThreshold { get; set; } = 1;
 
         [DataMember]

--- a/Public/Src/Cache/DistributedCache.Host/Service/DistributedCacheServiceArguments.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Service/DistributedCacheServiceArguments.cs
@@ -21,7 +21,7 @@ namespace BuildXL.Cache.Host.Service
         /// <nodoc />
         public IAbsolutePathFileCopier Copier { get; }
 
-        public ICopyRequester CopyRequester { get; }
+        public ICopySender CopyRequester { get; }
 
         /// <nodoc />
         public IAbsolutePathTransformer PathTransformer { get; }
@@ -49,7 +49,7 @@ namespace BuildXL.Cache.Host.Service
             ILogger logger,
             IAbsolutePathFileCopier copier,
             IAbsolutePathTransformer pathTransformer,
-            ICopyRequester copyRequester,
+            ICopySender copyRequester,
             IDistributedCacheServiceHost host,
             HostInfo hostInfo,
             CancellationToken cancellation,

--- a/Public/Src/Cache/DistributedCache.Host/Service/DistributedCacheServiceArguments.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Service/DistributedCacheServiceArguments.cs
@@ -21,7 +21,7 @@ namespace BuildXL.Cache.Host.Service
         /// <nodoc />
         public IAbsolutePathFileCopier Copier { get; }
 
-        public ICopySender CopyRequester { get; }
+        public IProactiveCopier CopyRequester { get; }
 
         /// <nodoc />
         public IAbsolutePathTransformer PathTransformer { get; }
@@ -49,7 +49,7 @@ namespace BuildXL.Cache.Host.Service
             ILogger logger,
             IAbsolutePathFileCopier copier,
             IAbsolutePathTransformer pathTransformer,
-            ICopySender copyRequester,
+            IProactiveCopier copyRequester,
             IDistributedCacheServiceHost host,
             HostInfo hostInfo,
             CancellationToken cancellation,

--- a/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
@@ -224,6 +224,7 @@ namespace BuildXL.Cache.Host.Service.Internal
                         MaxRetryCount = _distributedSettings.MaxRetryCount,
                         TimeoutForProactiveCopies = TimeSpan.FromMinutes(_distributedSettings.TimeoutForProactiveCopiesMinutes),
                         ProactiveCopyMode = (ProactiveCopyMode)Enum.Parse(typeof(ProactiveCopyMode), _distributedSettings.ProactiveCopyMode),
+                        PushProactiveCopies = _distributedSettings.PushProactiveCopies,
                         MaxConcurrentProactiveCopyOperations = _distributedSettings.MaxConcurrentProactiveCopyOperations,
                         ProactiveCopyLocationsThreshold = _distributedSettings.ProactiveCopyLocationsThreshold,
                         MaximumConcurrentPutFileOperations = _distributedSettings.MaximumConcurrentPutFileOperations,

--- a/Public/Src/Cache/MemoizationStore/Test/Sessions/InProcessServiceLocalCacheTests.cs
+++ b/Public/Src/Cache/MemoizationStore/Test/Sessions/InProcessServiceLocalCacheTests.cs
@@ -42,7 +42,7 @@ namespace BuildXL.Cache.MemoizationStore.Test.Sessions
             var namedCacheRoots = new Dictionary<string, AbsolutePath> {[CacheName] = backendCacheDirectory / "Root"};
 
             var grpcPort = PortExtensions.GetNextAvailablePort();
-            var serverConfiguration = new LocalServerConfiguration(backendCacheDirectory, namedCacheRoots, grpcPort)
+            var serverConfiguration = new LocalServerConfiguration(backendCacheDirectory, namedCacheRoots, grpcPort, FileSystem)
             {
                 GrpcPortFileName = null, // Port is well known at configuration time, no need to expose it.
             };


### PR DESCRIPTION
Implementing a gRPC push file, to eventually replace the current way of copyiong to a machine of requesting them to request a copy from us.

Also, making sure that these copies do not bump the lastAccessTimes of the content.

Note about how the push copy is implemented. There is an initial "handshake" between Machine A trying to send the content to Machine B (This is done via request/response headers):
- A: I want to send you hash X
- B: "Start sending bytes" or "Do not copy (either because I already have the content or I'm currently copying the content)"
- A starts or aborts the copy
- B reports back the status of the operation (Only when the copy was initiated)