### PR TITLE
Disable System.GC.* features for Unix builds

### DIFF
--- a/Public/Sdk/Public/Managed/runtimeConfigFiles.dsc
+++ b/Public/Sdk/Public/Managed/runtimeConfigFiles.dsc
@@ -211,7 +211,8 @@ namespace RuntimeConfigFiles {
             }
         } : {};
 
-        // when not using Server GC, in large builds the front end is likely to get completely bogged, on Unix we are currently disabling this
+        // when not using Server GC, in large builds the front end is likely to get completely bogged, on Unix we want GC passes
+        // happening more often to reduce the overall process memory footprint
         const gcRuntimeOptions = {
             configProperties: {
                 "System.GC.Server": Context.getCurrentHost().os === "win",

--- a/Public/Sdk/Public/Managed/runtimeConfigFiles.dsc
+++ b/Public/Sdk/Public/Managed/runtimeConfigFiles.dsc
@@ -211,11 +211,11 @@ namespace RuntimeConfigFiles {
             }
         } : {};
 
-        // when not using Server GC, in large builds the front end is likely to get completely bogged
+        // when not using Server GC, in large builds the front end is likely to get completely bogged, on Unix we are currently disabling this
         const gcRuntimeOptions = {
             configProperties: {
-                "System.GC.Server": true,
-                "System.GC.RetainVM": true
+                "System.GC.Server": Context.getCurrentHost().os === "win",
+                "System.GC.RetainVM": Context.getCurrentHost().os === "win"
             },
         };
 


### PR DESCRIPTION
Disable System.GC.Server and System.GC.RetainVM in Unix builds to avoid big BuildXL process footprints for involved builds (~12.5% overall footprint reduction).