### PR TITLE
Report pip kext stats to BuildXL

### DIFF
--- a/Public/Src/Engine/Processes/BuildXL.Processes.dsc
+++ b/Public/Src/Engine/Processes/BuildXL.Processes.dsc
@@ -34,6 +34,7 @@ namespace Processes {
             importFrom("BuildXL.Utilities").Storage.dll,
             importFrom("BuildXL.Utilities").Collections.dll,
             importFrom("BuildXL.Utilities").Configuration.dll,
+            importFrom("Newtonsoft.Json").pkg
         ],
         internalsVisibleTo: [
             "Test.BuildXL.Engine",

--- a/Public/Src/Engine/Processes/SandboxConnectionKext.cs
+++ b/Public/Src/Engine/Processes/SandboxConnectionKext.cs
@@ -67,7 +67,7 @@ Use the the following command to load/reload the sandbox kernel extension and fi
         /// Until some automation for kernel extension building and deployment is in place, this number has to be kept in sync with the 'CFBundleVersion'
         /// inside the Info.plist file of the kernel extension code base. BuildXL will not work if a version mismatch is detected!
         /// </summary>
-        public const string RequiredKextVersionNumber = "2.7.99";
+        public const string RequiredKextVersionNumber = "2.8.1";
 
         /// <summary>
         /// See TN2420 (https://developer.apple.com/library/archive/technotes/tn2420/_index.html) on how versioning numbers are formatted in the Apple ecosystem

--- a/Public/Src/Engine/Processes/SandboxConnectionKext.cs
+++ b/Public/Src/Engine/Processes/SandboxConnectionKext.cs
@@ -67,7 +67,7 @@ Use the the following command to load/reload the sandbox kernel extension and fi
         /// Until some automation for kernel extension building and deployment is in place, this number has to be kept in sync with the 'CFBundleVersion'
         /// inside the Info.plist file of the kernel extension code base. BuildXL will not work if a version mismatch is detected!
         /// </summary>
-        public const string RequiredKextVersionNumber = "2.8.1";
+        public const string RequiredKextVersionNumber = "2.8.99";
 
         /// <summary>
         /// See TN2420 (https://developer.apple.com/library/archive/technotes/tn2420/_index.html) on how versioning numbers are formatted in the Apple ecosystem

--- a/Public/Src/Engine/UnitTests/Processes/SandboxedProcessMacTest.cs
+++ b/Public/Src/Engine/UnitTests/Processes/SandboxedProcessMacTest.cs
@@ -257,11 +257,11 @@ namespace Test.BuildXL.Processes
         {
             var report = new Sandbox.AccessReport
             {
-                Operation = operation,
-                Statistics = stats,
-                Pid        = pid,
-                Path       = path,
-                Status     = allowed ? (uint)FileAccessStatus.Allowed : (uint)FileAccessStatus.Denied
+                Operation      = operation,
+                Statistics     = stats,
+                Pid            = pid,
+                PathOrPipStats = Sandbox.AccessReport.EncodePath(path),
+                Status         = allowed ? (uint)FileAccessStatus.Allowed : (uint)FileAccessStatus.Denied
             };
 
             proc.PostAccessReport(report);

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/BuildXLSandboxShared.hpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/BuildXLSandboxShared.hpp
@@ -163,6 +163,13 @@ typedef struct {
 } CountAndSize;
 
 typedef struct {
+    int64_t totalAllocatedBytes;
+    CountAndSize fastNodes;
+    CountAndSize lightNodes;
+    CountAndSize cacheRecords;
+} MemoryCountsAndSizes;
+
+typedef struct {
     DurationCounter findTrackedProcess;
     DurationCounter setLastLookedUpPath;
     DurationCounter checkPolicy;
@@ -176,10 +183,6 @@ typedef struct {
     Counter numForks;
     Counter numCacheHits;
     Counter numCacheMisses;
-    uint64_t totalAllocatedBytes;
-    CountAndSize fastNodes;
-    CountAndSize lightNodes;
-    CountAndSize cacheRecords;
 } AllCounters;
 
 typedef struct {
@@ -226,6 +229,7 @@ typedef struct {
 typedef struct {
     uint numAttachedClients;
     AllCounters counters;
+    MemoryCountsAndSizes memory;
     KextConfig kextConfig;
     uint numReportedPips;
     PipInfo pips[kMaxReportedPips];
@@ -242,6 +246,20 @@ typedef struct {
 } AccessReportStatistics;
 
 typedef struct {
+    uint32_t lastPathLookupElemCount;
+    uint32_t lastPathLookupNodeCount;
+    uint32_t lastPathLookupNodeSize;
+    uint32_t numCacheHits;
+    uint32_t numCacheMisses;
+    uint32_t cacheRecordCount;
+    uint32_t cacheRecordSize;
+    uint32_t cacheNodeCount;
+    uint32_t cacheNodeSize;
+    uint32_t numForks;
+    uint32_t numHardLinkRetries;
+} PipCompletionStats; // sizeof(PipCompletionStats) must be less than MAXPATHLEN, i.e., 1024
+
+typedef struct {
     FileOperation operation;
     pid_t pid;
     pid_t rootPid;
@@ -250,7 +268,11 @@ typedef struct {
     uint reportExplicitly;
     DWORD error;
     pipid_t pipId;
-    char path[MAXPATHLEN];
+    union
+    {
+        char path[MAXPATHLEN];
+        PipCompletionStats pipStats;
+    };
     AccessReportStatistics stats;
 } AccessReport;
 
@@ -268,11 +290,11 @@ inline bool HasAllFlags(const T source, const T bitMask)
 #pragma mark Macros and defines
 
 #ifndef BUILDXL_BUNDLE_IDENTIFIER
-static_assert(false, "BUILDXL_BUNDLE_IDENTIFIER not defined (shold be something like: com.microsoft.buildxl.sandbox)");
+static_assert(false, "BUILDXL_BUNDLE_IDENTIFIER not defined (should be something like: com.microsoft.buildxl.sandbox)");
 #endif
 
 #ifndef BUILDXL_CLASS_PREFIX
-static_assert(false, "BUILDXL_CLASS_PREFIX not defined (shold be something like: com_microsoft_buildxl_)");
+static_assert(false, "BUILDXL_CLASS_PREFIX not defined (should be something like: com_microsoft_buildxl_)");
 #endif
 
 #define CONCAT(prefix, name) prefix ## name

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/CLI/SandboxMonitor/main.cpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/CLI/SandboxMonitor/main.cpp
@@ -363,12 +363,12 @@ int main(int argc, const char * argv[])
                    << " (" << renderDouble(PERCENT(response.counters.reportCounters.numCoalescedReports.count(), response.counters.reportCounters.totalNumSent.count())) << "%)"
                    << endl;
             output << "Memory     :: "
-                   << "FastTrieNodes: " << renderCountAndSize(response.counters.fastNodes)
-                   << ", LightTrieNodes: " << renderCountAndSize(response.counters.lightNodes)
-                   << ", CacheRecords: " << renderCountAndSize(response.counters.cacheRecords)
+                   << "FastTrieNodes: " << renderCountAndSize(response.memory.fastNodes)
+                   << ", LightTrieNodes: " << renderCountAndSize(response.memory.lightNodes)
+                   << ", CacheRecords: " << renderCountAndSize(response.memory.cacheRecords)
                    << ", FreeListNodes: " << to_string(response.counters.reportCounters.freeListNodeCount)
                    << " (" << renderDouble(response.counters.reportCounters.freeListSizeMB) << " MB)"
-                   << ", IONew allocations: " << renderBytesAsMebabytes(response.counters.totalAllocatedBytes)
+                   << ", IONew allocations: " << renderBytesAsMebabytes(response.memory.totalAllocatedBytes)
                    << endl;
             output << "Processes  :: #Client: " << response.numAttachedClients
                    << ", #Pips: " << response.numReportedPips

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Kauth/AccessHandler.cpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Kauth/AccessHandler.cpp
@@ -82,6 +82,20 @@ bool AccessHandler::ReportProcessTreeCompleted()
         .pid       = proc_selfpid(),
         .rootPid   = GetProcessId(),
         .pipId     = GetPipId(),
+        .pipStats  =
+        {
+            .lastPathLookupElemCount = GetPip()->getLastPathLookupElemCount(),
+            .lastPathLookupNodeCount = GetPip()->getLastPathLookupNodeCount(),
+            .lastPathLookupNodeSize  = GetPip()->getLastPathLookupNodeSize(),
+            .numCacheHits            = GetPip()->Counters()->numCacheHits.count(),
+            .numCacheMisses          = GetPip()->Counters()->numCacheMisses.count(),
+            .cacheRecordCount        = GetPip()->getPathCacheElemCount(),
+            .cacheRecordSize         = sizeof(CacheRecord),
+            .cacheNodeCount          = GetPip()->getPathCacheNodeCount(),
+            .cacheNodeSize           = GetPip()->getPathCacheNodeSize(),
+            .numForks                = GetPip()->Counters()->numForks.count(),
+            .numHardLinkRetries      = GetPip()->Counters()->numHardLinkRetries.count(),
+        },
         .stats     = { .creationTime = creationTimestamp_ }
     };
 

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>2.7.99</string>
+	<string>2.8.1</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>BuildXLSandbox</key>

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>2.8.1</string>
+	<string>2.8.99</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>BuildXLSandbox</key>

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/SandboxedPip.hpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/SandboxedPip.hpp
@@ -97,6 +97,24 @@ public:
     /*! Various counters. */
     AllCounters* Counters() { return &counters_; }
 
+    /*! Number of elements in the 'lastPathLookup' dictionary. */
+    uint getLastPathLookupElemCount() { return lastPathLookup_->getCount(); }
+
+    /*! Number of nodes in the 'lastPathLookup' dictionary. */
+    uint getLastPathLookupNodeCount() { return lastPathLookup_->getNodeCount(); }
+
+    /*! Size in bytes of each node in the 'lastPathLookup' dictionary. */
+    uint getLastPathLookupNodeSize() { return lastPathLookup_->getNodeSize(); }
+
+    /*! Number of elements in the 'pathCache' dictionary. */
+    uint getPathCacheElemCount() { return pathCache_->getCount(); }
+
+    /*! Number of nodes in the 'pathCache' dictionary. */
+    uint getPathCacheNodeCount() { return pathCache_->getNodeCount(); }
+
+    /*! Size in bytes of each node in the 'pathCache' dictionary. */
+    uint getPathCacheNodeSize() { return pathCache_->getNodeSize(); }
+
     /*!
      * Uses a thread-local storage to save a given path as the last path that was looked up on the current thread.
      */

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/SysCtl.cpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/SysCtl.cpp
@@ -4,14 +4,13 @@
 #include "SysCtl.hpp"
 
 #if DEBUG
-int g_bxl_enable_counters = 1;
 int g_bxl_verbose_logging = 1;
 #else
-int g_bxl_enable_counters = 0;
 int g_bxl_verbose_logging = 0;
 #endif
 
 int g_bxl_enable_cache = 1;
+int g_bxl_enable_counters = 1;	
 int g_bxl_enable_light_trie = 1;
 
 SYSCTL_INT(_kern,                               // parent

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/ThreadLocal.cpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/ThreadLocal.cpp
@@ -53,11 +53,6 @@ void ThreadLocal::free()
 
 #pragma mark count/insert/remove/get methods
 
-uint ThreadLocal::getCount()
-{
-    return dict_->getCount();
-}
-
 bool ThreadLocal::insert(const OSObject *value)
 {
     auto result = dict_->replace(self_tid(), value);

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/ThreadLocal.hpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/ThreadLocal.hpp
@@ -16,7 +16,7 @@
 class ThreadLocal : public OSObject
 {
     OSDeclareDefaultStructors(ThreadLocal);
-    
+
 private:
 
     /* backing dictionary */
@@ -26,7 +26,7 @@ private:
     {
         return thread_tid(current_thread());
     }
-    
+
 protected:
 
     /*!
@@ -35,7 +35,7 @@ protected:
      * @result True if successful, False otherwise.
      */
     bool init() override;
-    
+
     /*!
      * Releases held resources, following the OSObject pattern.
      */
@@ -43,12 +43,21 @@ protected:
 
 public:
 
-    
     /*!
      * @return Number of entries in this collection
      */
-    uint getCount();
-    
+    uint getCount() { return dict_->getCount(); }
+
+    /*!
+     * @return Number of nodes in the underlying dictionary.
+     */
+    uint getNodeCount() { return dict_->getNodeCount(); }
+
+    /*!
+     * @return Size in bytes of each node in the underlying dictionary.
+     */
+    uint getNodeSize() { return dict_->getNodeSize(); }
+
     /*!
      * Associates 'value' with current thread.
      *
@@ -57,7 +66,7 @@ public:
      *         and False when an existing value is updated to point to the new value.
      */
     bool insert(const OSObject *value);
-    
+
     /*!
      * Removes the value currently associated with the current thread (if any).
      *
@@ -72,7 +81,7 @@ public:
     OSObject* get() const;
     
 #pragma mark Static Methods
-    
+
     /*!
      * Factory method, following the OSObject pattern.
      *

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/Trie.cpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/Trie.cpp
@@ -30,6 +30,7 @@ bool Trie::init(TrieKind kind)
     }
 
     size_ = 0;
+    nodeCount_ = 0;
     kind_ = mergeKindAndImpl(kind, g_bxl_enable_light_trie ? kLightTrie : kFastTrie);
     onChangeData_ = nullptr;
     onChangeCallback_ = nullptr;
@@ -60,6 +61,7 @@ void Trie::free()
     lock_ = nullptr;
     root_ = nullptr;
     size_ = 0;
+    nodeCount_ = 0;
 
     super::free();
 }
@@ -472,6 +474,7 @@ Node* Trie::findPathNode(const char *path, bool createIfMissing)
 
     Node *currNode = root_;
     unsigned char ch;
+    bool outNewNodeCreated = false;
     while ((ch = *path++) != '\0')
     {
         int idx = s_char2idx[ch];
@@ -479,10 +482,14 @@ Node* Trie::findPathNode(const char *path, bool createIfMissing)
         {
             return nullptr;
         }
-        currNode = currNode->findChild(idx, createIfMissing, lock_);
+        currNode = currNode->findChild(idx, createIfMissing, lock_, &outNewNodeCreated);
         if (currNode == nullptr)
         {
             return nullptr;
+        }
+        if (outNewNodeCreated)
+        {
+            OSIncrementAtomic(&nodeCount_);
         }
     }
 
@@ -497,14 +504,19 @@ Node* Trie::findUintNode(uint64_t key, bool createIfMissing)
         return nullptr;
     }
 
+    bool outNewNodeCreated = false;
     Node *currNode = root_;
     while (true)
     {
         int lsd = key % 10;
-        currNode = currNode->findChild(lsd, createIfMissing, lock_);
+        currNode = currNode->findChild(lsd, createIfMissing, lock_, &outNewNodeCreated);
         if (!currNode)
         {
             return nullptr;
+        }
+        if (outNewNodeCreated)
+        {
+            OSIncrementAtomic(&nodeCount_);
         }
 
         if (key < 10)

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/Trie.hpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/Trie.hpp
@@ -72,6 +72,9 @@ private:
     /*! The size of the tree (i.e., number of records stored) and not the number of nodes in the tree. */
     uint size_;
 
+    /*! The number of nodes in this tree */
+    uint nodeCount_;
+
     /*! Callback function to call whenever the size of the tree changes. */
     on_change_fn onChangeCallback_;
 
@@ -197,10 +200,15 @@ private:
     /*! Creates either a Uint or a Path node, based on the kind of this trie. */
     Node* createNode(uint key)
     {
-        return isLightTrie() ? (Node*)NodeLight::create(key) :
-               isUintTrie()  ? (Node*)NodeFast::createUintNode() :
-               isPathTrie()  ? (Node*)NodeFast::createPathNode() :
-               nullptr;
+        Node* node = isLightTrie() ? (Node*)NodeLight::create(key) :
+                     isUintTrie()  ? (Node*)NodeFast::createUintNode() :
+                     isPathTrie()  ? (Node*)NodeFast::createPathNode() :
+                     nullptr;
+        if (node != nullptr)
+        {
+            OSIncrementAtomic(&nodeCount_);
+        }
+        return node;
     }
 
     /*!
@@ -216,8 +224,17 @@ public:
     /*!
      * Returns the size of the tree (i.e., the number of values stored).
      */
-    inline uint getCount() { return size_; }
+    uint getCount() { return size_; }
 
+    /*!
+     * Returns the number of trie nodes in this tree.
+     */
+    uint getNodeCount() { return nodeCount_; }
+
+    /*!
+     * Returns the size in bytes of each node in this tree.
+     */
+    uint getNodeSize() { return isLightTrie() ? sizeof(NodeLight) : sizeof(NodeFast); }
     /*!
      * Callback to be invoked every time the size of this tree changes.
      */

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/TrieNode.hpp
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Utilities/TrieNode.hpp
@@ -56,7 +56,7 @@ protected:
      * @param lock A lock unique to the parent tree to use when needed.
      * @result True IFF this node contains a child node with key 'key' after this method returns.
      */
-    virtual Node* findChild(uint key, bool createIfMissing, IORecursiveLock *lock) = 0;
+    virtual Node* findChild(uint key, bool createIfMissing, IORecursiveLock *lock, bool *outNewNodeCreated) = 0;
 
     /*! Calls 'callback' for every node in the tree rooted in this node (the traversal is pre-order) */
     virtual void traverse(bool computeKey, void *callbackArgs, traverse_fn callback) = 0;
@@ -90,7 +90,11 @@ private:
     /*! Pointer to the first child node */
     NodeLight *children_;
 
-    NodeLight* findChild(uint key, bool createIfMissing, IORecursiveLock *maybeNulllock, IORecursiveLock *nonNullLock);
+    NodeLight* findChild(uint key,
+                         bool createIfMissing,
+                         IORecursiveLock *maybeNulllock,
+                         IORecursiveLock *nonNullLock,
+                         bool *outNewNodeCreated);
 
     bool init(uint key);
 
@@ -100,9 +104,9 @@ public:
 
 protected:
 
-    Node* findChild(uint key, bool createIfMissing, IORecursiveLock *lock) override
+    Node* findChild(uint key, bool createIfMissing, IORecursiveLock *lock, bool *outNewNodeCreated) override
     {
-        return findChild(key, createIfMissing, nullptr, lock);
+        return findChild(key, createIfMissing, nullptr, lock, outNewNodeCreated);
     }
 
     void traverse(bool computeKey, void *callbackArgs, traverse_fn callback) override;
@@ -137,7 +141,7 @@ public:
 
 protected:
 
-    Node* findChild(uint key, bool createIfMissing, IORecursiveLock *lock) override;
+    Node* findChild(uint key, bool createIfMissing, IORecursiveLock *lock, bool *outNewNodeCreated) override;
     void traverse(bool computeKey, void *callbackArgs, traverse_fn callback) override;
     void free() override;
 };

--- a/Public/Src/Sandbox/MacOs/scripts/sandbox-load.sh
+++ b/Public/Src/Sandbox/MacOs/scripts/sandbox-load.sh
@@ -112,20 +112,20 @@ function parseArgs {
                 arg_noReload=1
                 shift
                 ;;
-            --enable-counters)
-                arg_enableCounters="1"
+            --enable-counters|--disable-counters)
+                arg_enableCounters=$([[ $cmd == --enable-* ]] && echo "1" || echo "0")
                 shift
                 ;;
-            --verbose-logging)
-                arg_verboseLogging="1"
+            --verbose-logging|--no-verbose-logging)
+                arg_verboseLogging=$([[ $cmd == --no-* ]] && echo "0" || echo "1")
                 shift
                 ;;
-            --disable-cache)
-                arg_enableCache="0"
+            --enable-cache|--disable-cache)
+                arg_enableCache=$([[ $cmd == --enable-* ]] && echo "1" || echo "0")
                 shift
                 ;;
-            --disable-light-trie|--enable-fast-trie)
-                arg_enableLightTrie="0"
+            --enable-light-trie|--disable-light-trie)
+                arg_enableLightTrie=$([[ $cmd == --enable-* ]] && echo "1" || echo "0")
                 shift
                 ;;
             *)

--- a/Public/Src/Utilities/Interop/MacOS/Sandbox.cs
+++ b/Public/Src/Utilities/Interop/MacOS/Sandbox.cs
@@ -5,6 +5,8 @@ using System;
 using System.Runtime.InteropServices;
 using System.Text;
 
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member 
+
 namespace BuildXL.Interop.MacOS
 {
     /// <summary>
@@ -12,56 +14,37 @@ namespace BuildXL.Interop.MacOS
     /// </summary>
     public static class Sandbox
     {
-        /// <nodoc />
         public static readonly int ReportQueueSuccessCode = 0x1000;
-
-        /// <nodoc />
         public static readonly int SandboxSuccess = 0x0;
 
-        /// <nodoc />
         [DllImport(Libraries.BuildXLInteropLibMacOS)]
         public static extern unsafe int NormalizePathAndReturnHash(byte[] pPath, byte* buffer, int bufferLength);
 
-        /// <nodoc />
         [StructLayout(LayoutKind.Sequential)]
         public struct ESConnectionInfo
         {
-            /// <nodoc />
             public int Error;
-
-            /// <nodoc />
             public ulong Client;
-
-            /// <nodoc />
             public ulong Source;
-
-            /// <nodoc />
             public ulong RunLoop;
         }
 
-        /// <nodoc />
         [DllImport(Libraries.BuildXLInteropLibMacOS, SetLastError = true)]
         public static extern void InitializeEndpointSecuritySandbox(ref ESConnectionInfo info, int host);
 
-        /// <nodoc />
         [DllImport(Libraries.BuildXLInteropLibMacOS, SetLastError = true)]
         public static extern void DeinitializeEndpointSecuritySandbox(ESConnectionInfo info);
 
-        /// <nodoc />
         [DllImport(Libraries.BuildXLInteropLibMacOS, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
         public static extern void ObserverFileAccessReports(
             ref ESConnectionInfo info,
             [MarshalAs(UnmanagedType.FunctionPtr)] AccessReportCallback callbackPointer,
             long accessReportSize);
-            
-        /// <nodoc />
+
         [StructLayout(LayoutKind.Sequential)]
         public struct KextConnectionInfo
         {
-            /// <nodoc />
             public int Error;
-
-            /// <nodoc />
             public uint Connection;
 
             /// <summary>
@@ -74,71 +57,52 @@ namespace BuildXL.Interop.MacOS
         [DllImport(Libraries.BuildXLInteropLibMacOS, CallingConvention = CallingConvention.Cdecl)]
         private static extern void InitializeKextConnection(ref KextConnectionInfo info, long infoSize);
 
-        /// <nodoc />
         public static void InitializeKextConnection(ref KextConnectionInfo info)
             => InitializeKextConnection(ref info, Marshal.SizeOf(info));
 
-        /// <nodoc />
         [StructLayout(LayoutKind.Sequential)]
         public struct KextSharedMemoryInfo
         {
-            /// <nodoc />
             public int Error;
-
-            /// <nodoc />
             public ulong Address;
-
-            /// <nodoc />
             public uint Port;
         }
 
         [DllImport(Libraries.BuildXLInteropLibMacOS, CallingConvention = CallingConvention.Cdecl)]
         private static extern void InitializeKextSharedMemory(ref KextSharedMemoryInfo memoryInfo, long memoryInfoSize, KextConnectionInfo info);
 
-        /// <nodoc />
         public static void InitializeKextSharedMemory(KextConnectionInfo connectionInfo, ref KextSharedMemoryInfo memoryInfo)
             => InitializeKextSharedMemory(ref memoryInfo, Marshal.SizeOf(memoryInfo), connectionInfo);
 
-        /// <nodoc />
         [DllImport(Libraries.BuildXLInteropLibMacOS, CallingConvention = CallingConvention.Cdecl)]
         public static extern void DeinitializeKextConnection(KextConnectionInfo info);
 
-        /// <nodoc />
         [DllImport(Libraries.BuildXLInteropLibMacOS, CallingConvention = CallingConvention.Cdecl)]
         public static extern void DeinitializeKextSharedMemory(KextSharedMemoryInfo memoryInfo, KextConnectionInfo info);
 
-        /// <nodoc />
         [DllImport(Libraries.BuildXLInteropLibMacOS, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
         [return: MarshalAs(UnmanagedType.LPStr)]
         public static extern void KextVersionString(StringBuilder s, int size);
 
-        /// <nodoc />
         [Flags]
         public enum ConnectionType
         {
-            /// <nodoc />
             Kext,
-            
-            /// <nodoc />
             EndpointSecurity
         }
 
-        /// <nodoc />
         [DllImport(Libraries.BuildXLInteropLibMacOS, EntryPoint = "SendPipStarted")]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool SendPipStarted(int processId, long pipId, byte[] famBytes, int famBytesLength, ConnectionType type, ref KextConnectionInfo info);
 
-        /// <nodoc />
         [DllImport(Libraries.BuildXLInteropLibMacOS, EntryPoint = "SendPipProcessTerminated")]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool SendPipProcessTerminated(long pipId, int processId, ConnectionType type, ref KextConnectionInfo info);
 
-        /// <nodoc />
         [DllImport(Libraries.BuildXLInteropLibMacOS, EntryPoint = "CheckForDebugMode")]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool CheckForDebugMode(ref bool isDebug, KextConnectionInfo info);
 
-        /// <nodoc />
         [StructLayout(LayoutKind.Sequential)]
         public struct ResourceThresholds
         {
@@ -171,48 +135,80 @@ namespace BuildXL.Interop.MacOS
             }
         }
 
-        /// <nodoc />
         [StructLayout(LayoutKind.Sequential)]
         public struct KextConfig
         {
-            /// <nodoc />
             public uint ReportQueueSizeMB;
-
-            /// <nodoc />
             public bool EnableReportBatching;
-
-            /// <nodoc />
             public ResourceThresholds ResourceThresholds;
-            
-            /// <nodoc />
             public bool EnableCatalinaDataPartitionFiltering;
         }
 
-        /// <nodoc />
         [DllImport(Libraries.BuildXLInteropLibMacOS, EntryPoint = "Configure")]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool Configure(KextConfig config, KextConnectionInfo info);
 
-        /// <nodoc />
         [DllImport(Libraries.BuildXLInteropLibMacOS, EntryPoint = "UpdateCurrentResourceUsage")]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool UpdateCurrentResourceUsage(uint cpuUsageBasisPoints, uint availableRamMB, KextConnectionInfo info);
 
-        /// <nodoc />
+        private static readonly Encoding s_accessReportStringEncoding = Encoding.UTF8;
+
         [StructLayout(LayoutKind.Sequential)]
         public struct AccessReportStatistics
         {
-            /// <nodoc />
             public ulong CreationTime;
-
-            /// <nodoc />
             public ulong EnqueueTime;
-
-            /// <nodoc />
             public ulong DequeueTime;
         }
 
-        /// <nodoc />
+        /// <summary>
+        /// Struct sent in place of <see cref="AccessReport.PathOrPipStats"/> in case of a 
+        /// <see cref="FileOperation.OpProcessTreeCompleted"/> operation.
+        /// </summary>
+        /// <remarks>
+        /// CODESYNC: Public/Src/Sandbox/MacOs/Sandbox/Src/BuildXLSandboxShared.hpp
+        /// </remarks>
+        [StructLayout(LayoutKind.Explicit, Size = 1024)]
+        public struct PipKextStats 
+        {
+            [MarshalAs(UnmanagedType.U4)][FieldOffset(0)]
+            public uint LastPathLookupElemCount;
+
+            [MarshalAs(UnmanagedType.U4)][FieldOffset(4)]
+            public uint LastPathLookupNodeCount;
+
+            [MarshalAs(UnmanagedType.U4)][FieldOffset(8)]
+            public uint LastPathLookupNodeSize;
+
+            [MarshalAs(UnmanagedType.U4)][FieldOffset(12)]
+            public uint NumCacheHits;
+
+            [MarshalAs(UnmanagedType.U4)][FieldOffset(16)]
+            public uint NumCacheMisses;
+
+            [MarshalAs(UnmanagedType.U4)][FieldOffset(20)]
+            public uint CacheRecordCount;
+
+            [MarshalAs(UnmanagedType.U4)][FieldOffset(24)]
+            public uint CacheRecordSize;
+
+            [MarshalAs(UnmanagedType.U4)][FieldOffset(28)]
+            public uint CacheNodeCount;
+
+            [MarshalAs(UnmanagedType.U4)][FieldOffset(32)]
+            public uint CacheNodeSize;
+
+            [MarshalAs(UnmanagedType.U4)][FieldOffset(36)]
+            public uint NumForks;
+
+            [MarshalAs(UnmanagedType.U4)][FieldOffset(40)]
+            public uint NumHardLinkRetries;
+        } 
+
+        /// <remarks>
+        /// CODESYNC: Public/Src/Sandbox/MacOs/Sandbox/Src/BuildXLSandboxShared.hpp
+        /// </remarks>
         [StructLayout(LayoutKind.Sequential)]
         public struct AccessReport
         {
@@ -225,37 +221,62 @@ namespace BuildXL.Interop.MacOS
             /// <summary>Process ID of the root pip process</summary>
             public int RootPid;
 
-            /// <nodoc />
             public uint RequestedAccess;
-
-            /// <nodoc />
             public uint Status;
-
-            /// <nodoc />
             public uint ExplicitLogging;
-
-            /// <nodoc />
             public uint Error;
-
-            /// <nodoc />
             public long PipId;
 
-            /// <nodoc />
-            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = Constants.MaxPathLength)]
-            public string Path;
+            /// <summary>
+            /// Corresponds to a <c>union { char path[MAXPATHLEN]; PipCompletionStats pipStats; }</c> C type.
+            /// Use <see cref="DecodePath"/> and <see cref="DecodePipKextStats"/> method to decode this value
+            /// into either a path string or a <see cref="PipKextStats"/> structure.
+            /// </summary>
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst=Constants.MaxPathLength)]
+            public byte[] PathOrPipStats;
 
-            /// <nodoc />
             public AccessReportStatistics Statistics;
 
-            /// <nodoc />
             public string DecodeOperation() => Operation.GetName();
+
+            /// <summary>
+            /// Interprets <see cref="PathOrPipStats"/> as a 0-terminated UTF8-encoded string.
+            /// </summary>
+            public string DecodePath()
+            {
+                return s_accessReportStringEncoding.GetString(PathOrPipStats).TrimEnd('\0');
+            }
+
+            /// <summary>
+            /// Encodes a given string into a byte array of a given size.
+            /// </summary>
+            public static byte[] EncodePath(string path, int bufferLength = Constants.MaxPathLength)
+            {
+                byte[] result = new byte[bufferLength];
+                s_accessReportStringEncoding.GetBytes(path, charIndex: 0, charCount: path.Length, bytes: result, byteIndex: 0);
+                return result;
+            }
+
+            /// <summary>
+            /// Interprets <see cref="PathOrPipStats"/> as an instance of the <see cref="PipKextStats"/> struct.
+            /// </summary>
+            public PipKextStats DecodePipKextStats()
+            {
+                var handle = GCHandle.Alloc(PathOrPipStats, GCHandleType.Pinned);
+                try
+                {
+                    return (PipKextStats)Marshal.PtrToStructure(handle.AddrOfPinnedObject(), typeof(PipKextStats));
+                }
+                finally
+                {
+                    handle.Free();
+                }
+            }
         }
 
-        /// <nodoc />
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void AccessReportCallback(AccessReport report, int error);
 
-        /// <nodoc />
         [DllImport(Libraries.BuildXLInteropLibMacOS, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
         public static extern void ListenForFileAccessReports(
             [MarshalAs(UnmanagedType.FunctionPtr)] AccessReportCallback callbackPointer,
@@ -266,7 +287,7 @@ namespace BuildXL.Interop.MacOS
         /// <summary>
         /// Callback the kernel extension can use to report any unrecoverable failures.
         ///
-        /// This callback adhears to the IOAsyncCallback0 signature (see https://developer.apple.com/documentation/iokit/ioasynccallback0?language=objc)
+        /// This callback adheres to the IOAsyncCallback0 signature (see https://developer.apple.com/documentation/iokit/ioasynccallback0?language=objc)
         /// We don't transfer any data from the sandbox kernel extension to the managed code when an unrecoverable error happens for now, this can potentially be extended later.
         /// </summary>
         /// <param name="refCon">The pointer to the callback itself</param>
@@ -282,12 +303,12 @@ namespace BuildXL.Interop.MacOS
         /// <param name="description">Arbitrary description</param>
         public delegate void ManagedFailureCallback(int status, string description);
 
-        /// <nodoc />
         [DllImport(Libraries.BuildXLInteropLibMacOS, CallingConvention = CallingConvention.Cdecl)]
         public static extern bool SetFailureNotificationHandler([MarshalAs(UnmanagedType.FunctionPtr)] NativeFailureCallback callback, KextConnectionInfo info);
 
-        /// <nodoc />
         [DllImport(Libraries.BuildXLInteropLibMacOS)]
         public static extern ulong GetMachAbsoluteTime();
     }
 }
+
+#pragma warning restore CS1591

--- a/cg/nuget/cgmanifest.json
+++ b/cg/nuget/cgmanifest.json
@@ -4191,7 +4191,7 @@
         "Type": "NuGet",
         "NuGet": {
           "Name": "runtime.osx-x64.BuildXL",
-          "Version": "2.7.99"
+          "Version": "2.8.1"
         }
       }
     },

--- a/cg/nuget/cgmanifest.json
+++ b/cg/nuget/cgmanifest.json
@@ -4191,7 +4191,7 @@
         "Type": "NuGet",
         "NuGet": {
           "Name": "runtime.osx-x64.BuildXL",
-          "Version": "2.8.1"
+          "Version": "2.8.99"
         }
       }
     },

--- a/config.microsoftInternal.dsc
+++ b/config.microsoftInternal.dsc
@@ -11,7 +11,7 @@ export const pkgs = isMicrosoftInternal ? [
     { id: "BuildXL.DeviceMap", version: "0.0.1" },
 
     // Runtime dependencies used for macOS deployments
-    { id: "runtime.osx-x64.BuildXL", version: "2.7.99" },
+    { id: "runtime.osx-x64.BuildXL", version: "2.8.1" },
     { id: "Aria.Cpp.SDK", version: "8.5.6" },
 
     { id: "CB.QTest", version: "19.10.17.210051" },

--- a/config.microsoftInternal.dsc
+++ b/config.microsoftInternal.dsc
@@ -11,7 +11,7 @@ export const pkgs = isMicrosoftInternal ? [
     { id: "BuildXL.DeviceMap", version: "0.0.1" },
 
     // Runtime dependencies used for macOS deployments
-    { id: "runtime.osx-x64.BuildXL", version: "2.8.1" },
+    { id: "runtime.osx-x64.BuildXL", version: "2.8.99" },
     { id: "Aria.Cpp.SDK", version: "8.5.6" },
 
     { id: "CB.QTest", version: "19.10.17.210051" },


### PR DESCRIPTION
Pip stats are reported from the sandbox kext to BuildXL as part of the ProcessTreeCompleted message; the unused `char[1024] Path` field is used to store those stats.

The stats are:
```c
    uint32_t lastPathLookupElemCount;
    uint32_t lastPathLookupNodeCount;
    uint32_t lastPathLookupNodeSize;
    uint32_t numCacheHits;
    uint32_t numCacheMisses;
    uint32_t cacheRecordCount;
    uint32_t cacheRecordSize;
    uint32_t cacheNodeCount;
    uint32_t cacheNodeSize;
    uint32_t numForks;
    uint32_t numHardLinkRetries;
```

The stats are logged by BuildXL.  In the future, they could be used to have a more accurate estimate of memory requirements for each pip.