### PR TITLE
Add a ceiling for the number of idle HashAlgorithm instances held by ContentHasher

### DIFF
--- a/Public/Src/App/Bxl/Args.cs
+++ b/Public/Src/App/Bxl/Args.cs
@@ -196,8 +196,9 @@ namespace BuildXL
                 bool unsafeUnexpectedFileAccessesAreErrorsSet = false;
                 bool failPipOnFileAccessErrorSet = false;
                 bool? enableProfileRedirect = null;
+                ContentHashingUtilities.SetContentHasherIdlePoolSize(10);
                 ContentHashingUtilities.SetDefaultHashType();
-
+                
                 // Notes
                 //
                 //  * Handlers must be in alphabetical order according to their long forms.

--- a/Public/Src/App/Bxl/Args.cs
+++ b/Public/Src/App/Bxl/Args.cs
@@ -196,7 +196,8 @@ namespace BuildXL
                 bool unsafeUnexpectedFileAccessesAreErrorsSet = false;
                 bool failPipOnFileAccessErrorSet = false;
                 bool? enableProfileRedirect = null;
-                
+                ContentHashingUtilities.SetDefaultHashType();
+
                 // Notes
                 //
                 //  * Handlers must be in alphabetical order according to their long forms.

--- a/Public/Src/App/Bxl/Args.cs
+++ b/Public/Src/App/Bxl/Args.cs
@@ -196,8 +196,6 @@ namespace BuildXL
                 bool unsafeUnexpectedFileAccessesAreErrorsSet = false;
                 bool failPipOnFileAccessErrorSet = false;
                 bool? enableProfileRedirect = null;
-                ContentHashingUtilities.SetContentHasherIdlePoolSize(10);
-                ContentHashingUtilities.SetDefaultHashType();
                 
                 // Notes
                 //

--- a/Public/Src/App/Bxl/Program.cs
+++ b/Public/Src/App/Bxl/Program.cs
@@ -12,6 +12,7 @@ using System.Net;
 using BuildXL.App.Tracing;
 using BuildXL.Native.IO.Windows;
 using BuildXL.Native.Processes;
+using BuildXL.Storage;
 using BuildXL.Utilities;
 using BuildXL.Utilities.Configuration;
 using BuildXL.Utilities.Instrumentation.Common;
@@ -138,6 +139,8 @@ namespace BuildXL
                 var pathTable = new PathTable();
 
                 ICommandLineConfiguration configuration;
+                ContentHashingUtilities.SetContentHasherIdlePoolSize(10);
+                ContentHashingUtilities.SetDefaultHashType();
                 if (!args.TryParse(rawArgs.ToArray(), pathTable, out configuration))
                 {
                     return ExitKind.InvalidCommandLine;

--- a/Public/Src/App/Bxl/Program.cs
+++ b/Public/Src/App/Bxl/Program.cs
@@ -140,7 +140,6 @@ namespace BuildXL
 
                 ICommandLineConfiguration configuration;
                 ContentHashingUtilities.SetContentHasherIdlePoolSize(10);
-                ContentHashingUtilities.SetDefaultHashType();
                 if (!args.TryParse(rawArgs.ToArray(), pathTable, out configuration))
                 {
                     return ExitKind.InvalidCommandLine;

--- a/Public/Src/Cache/ContentStore/Hashing/ContentHasher.cs
+++ b/Public/Src/Cache/ContentStore/Hashing/ContentHasher.cs
@@ -25,7 +25,7 @@ namespace BuildXL.Cache.ContentStore.Hashing
         ///     Object pool that holds all instantiated hash algorithms for each hash type.
         /// </summary>
         /// <remarks>
-        ///     Cap the number of idel reserve instances in the pool so as to not unnecessarily hold large amounts of memory
+        ///     Cap the number of idle reserve instances in the pool so as to not unnecessarily hold large amounts of memory
         /// </remarks>
         private readonly Pool<HashAlgorithm> _algorithmsPool = new Pool<HashAlgorithm>(() => new T(), maxReserveInstances: 10);
 

--- a/Public/Src/Cache/ContentStore/Hashing/ContentHasher.cs
+++ b/Public/Src/Cache/ContentStore/Hashing/ContentHasher.cs
@@ -24,7 +24,10 @@ namespace BuildXL.Cache.ContentStore.Hashing
         /// <summary>
         ///     Object pool that holds all instantiated hash algorithms for each hash type.
         /// </summary>
-        private readonly Pool<HashAlgorithm> _algorithmsPool = new Pool<HashAlgorithm>(() => new T());
+        /// <remarks>
+        ///     Cap the number of idel reserve instances in the pool so as to not unnecessarily hold large amounts of memory
+        /// </remarks>
+        private readonly Pool<HashAlgorithm> _algorithmsPool = new Pool<HashAlgorithm>(() => new T(), maxReserveInstances: 10);
 
         private readonly ByteArrayPool _bufferPool = new ByteArrayPool(FileSystemConstants.FileIOBufferSize);
 

--- a/Public/Src/Cache/ContentStore/Hashing/ContentHasher.cs
+++ b/Public/Src/Cache/ContentStore/Hashing/ContentHasher.cs
@@ -27,7 +27,7 @@ namespace BuildXL.Cache.ContentStore.Hashing
         /// <remarks>
         ///     Cap the number of idle reserve instances in the pool so as to not unnecessarily hold large amounts of memory
         /// </remarks>
-        private readonly Pool<HashAlgorithm> _algorithmsPool = new Pool<HashAlgorithm>(() => new T(), maxReserveInstances: 10);
+        private readonly Pool<HashAlgorithm> _algorithmsPool = new Pool<HashAlgorithm>(() => new T(), maxReserveInstances: HashInfoLookup.ContentHasherIdlePoolSize);
 
         private readonly ByteArrayPool _bufferPool = new ByteArrayPool(FileSystemConstants.FileIOBufferSize);
 

--- a/Public/Src/Cache/ContentStore/Hashing/HashInfoLookup.cs
+++ b/Public/Src/Cache/ContentStore/Hashing/HashInfoLookup.cs
@@ -48,5 +48,14 @@ namespace BuildXL.Cache.ContentStore.Hashing
         {
             return HashInfoByType.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.CreateContentHasher());
         }
+
+        /// <summary>
+        ///     The maximum number of unused idle ContentHashers to be kept in reserve for future use.
+        /// </summary>
+        /// <remarks>
+        ///     -1 (default) means the maximum number of idle hashers is unbounded.
+        ///     Note: This does not limit the maximum number of ContentHashers that can be pooled.
+        /// </remarks>
+        public static int ContentHasherIdlePoolSize = -1;
     }
 }

--- a/Public/Src/Cache/ContentStore/Hashing/Pool.cs
+++ b/Public/Src/Cache/ContentStore/Hashing/Pool.cs
@@ -67,7 +67,7 @@ namespace BuildXL.Cache.ContentStore.Hashing
         private readonly int _maxReserveInstances;
         private readonly ConcurrentQueue<T> _queue = new ConcurrentQueue<T>();
 
-        public Pool(Func<T> factory, Action<T> reset = null, int maxReserveInstances = 0)
+        public Pool(Func<T> factory, Action<T> reset = null, int maxReserveInstances = -1)
         {
             _factory = factory;
             _reset = reset;
@@ -88,10 +88,15 @@ namespace BuildXL.Cache.ContentStore.Hashing
 
         private void Return(T item)
         {
-            if (Size < _maxReserveInstances)
+            if ((_maxReserveInstances > 0) && (Size < _maxReserveInstances))
             {
                 _reset?.Invoke(item);
                 _queue.Enqueue(item);
+            }
+            else
+            {
+                // Still reset the item incase the reset logic has side effects other than cleanup for future reuse
+                _reset?.Invoke(item);
             }
         }
 

--- a/Public/Src/Cache/ContentStore/Hashing/Pool.cs
+++ b/Public/Src/Cache/ContentStore/Hashing/Pool.cs
@@ -64,9 +64,17 @@ namespace BuildXL.Cache.ContentStore.Hashing
     {
         private readonly Func<T> _factory;
         private readonly Action<T> _reset;
+
+        // Number of idle reserve instances to hold in the queue. -1 means unbounded
         private readonly int _maxReserveInstances;
         private readonly ConcurrentQueue<T> _queue = new ConcurrentQueue<T>();
 
+        /// <summary>
+        /// Initializes an object pool
+        /// </summary>
+        /// <param name="factory">Func to create a new object for the pool</param>
+        /// <param name="reset">Action to reset the state of the object for future reuse</param>
+        /// <param name="maxReserveInstances">Number of idle reserve instances to keep. No bound when unset</param>
         public Pool(Func<T> factory, Action<T> reset = null, int maxReserveInstances = -1)
         {
             _factory = factory;
@@ -88,7 +96,7 @@ namespace BuildXL.Cache.ContentStore.Hashing
 
         private void Return(T item)
         {
-            if ((_maxReserveInstances > 0) && (Size < _maxReserveInstances))
+            if ((_maxReserveInstances < 0) || (Size < _maxReserveInstances))
             {
                 _reset?.Invoke(item);
                 _queue.Enqueue(item);

--- a/Public/Src/Utilities/Storage/ContentHashingUtilities.cs
+++ b/Public/Src/Utilities/Storage/ContentHashingUtilities.cs
@@ -129,6 +129,15 @@ namespace BuildXL.Storage
         }
 
         /// <summary>
+        /// Sets the ContentHasher idle pool size
+        /// </summary>
+        public static void SetContentHasherIdlePoolSize(int idlePoolSize)
+        {
+            Contract.Requires(!s_isInitialized, "ContentHasher idle pool size must be specified before setting the default hash type");
+            HashInfoLookup.ContentHasherIdlePoolSize = idlePoolSize;
+        }
+
+        /// <summary>
         /// Create a ContentHash with all zeros except the given value in the first byte and the algorithm ID in the last byte.
         /// </summary>
         public static ContentHash CreateSpecialValue(byte first)


### PR DESCRIPTION
Right now we accumulate a lot of HashAlgorithm instances. Each instance of the VsoHashAlgorithm takes 2MB so this accumulation adds up. The maximum number of concurrently used instances ends up being the number that gets pooled.

This change sets a cap for the maximum number of reserve instances that can exist idle in the queue. The total number of instances participating in the pool can still be larger than that cap since instances are not in the queue while in use. So the number in the pool can still spike up quite a bit higher than the limit while there are many instances in use. This just limits the number it idle instances above what is current in use.