### PR TITLE
Update qtest version

### DIFF
--- a/cg/nuget/cgmanifest.json
+++ b/cg/nuget/cgmanifest.json
@@ -123,7 +123,7 @@
         "Type": "NuGet",
         "NuGet": {
           "Name": "CB.QTest",
-          "Version": "19.10.17.210051"
+          "Version": "19.11.3.131505"
         }
       }
     },

--- a/config.microsoftInternal.dsc
+++ b/config.microsoftInternal.dsc
@@ -14,7 +14,7 @@ export const pkgs = isMicrosoftInternal ? [
     { id: "runtime.osx-x64.BuildXL", version: "2.7.99" },
     { id: "Aria.Cpp.SDK", version: "8.5.6" },
 
-    { id: "CB.QTest", version: "19.10.17.210051" },
+    { id: "CB.QTest", version: "19.11.3.131505" },
 
     { id: "BuildXL.Tracing.AriaTenantToken", version: "1.0.0" },
 


### PR DESCRIPTION
The newer version of QTest collects telemetry about coverage file upload.