### PR TITLE
Implement additional retry telemetry and custom pip property telemetry

### DIFF
--- a/Public/Src/Engine/Processes/OutputFilter.cs
+++ b/Public/Src/Engine/Processes/OutputFilter.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Diagnostics.ContractsLight;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace BuildXL.Processes
+{
+    internal readonly struct OutputFilter
+    {
+        /// <summary>
+        /// Group name from the ErrorRegex to use to extract error message.
+        /// When no such group exists, the entire match is used.
+        /// </summary>
+        private const string ErrorMessageGroupName = "ErrorMessage";
+
+        internal readonly Predicate<string> LinePredicate;
+        internal readonly Regex Regex;
+
+        /// <summary>
+        /// The GroupName to be used by the Regex
+        /// </summary>
+        /// <remarks>
+        /// Defaults to ErrorMessageGroupName if nothing is provided when constructing the OutputFiler with a Regex
+        /// </remarks>
+        internal readonly string GroupName;
+
+        internal OutputFilter(Predicate<string> linePredicate)
+            : this(linePredicate, null, null)
+        {
+            Contract.Requires(linePredicate != null);
+        }
+
+        internal OutputFilter(Regex regex, string groupName = null)
+            : this(null, regex, groupName)
+        {
+            Contract.Requires(regex != null);
+        }
+
+        private OutputFilter(Predicate<string> linePredicate, Regex regex, string groupName)
+        {
+            Contract.Requires(linePredicate != null || regex != null);
+            LinePredicate = linePredicate;
+            Regex = regex;
+            GroupName = groupName ?? ErrorMessageGroupName;
+        }
+
+        /// <summary>
+        /// When <see cref="LinePredicate" /> is specified: it is invoked against <paramref name="source" /> and if
+        /// it returns true <paramref name="source" /> is returned.
+        ///
+        /// When <see cref="Regex" /> is specified: it is invoked against <paramref name="source" /> to find all
+        /// matches; the matches are joined by <paramref name="outputSeparator"/> (or <see cref="Environment.NewLine" />
+        /// if null) and returned.
+        /// </summary>
+        internal string ExtractMatches(string source, string outputSeparator = null)
+        {
+            if (LinePredicate != null)
+            {
+                return LinePredicate(source) ? source : string.Empty;
+            }
+            else
+            {
+                return string.Join(
+                    outputSeparator ?? Environment.NewLine,
+                    Regex
+                        .Matches(source)
+                        .Cast<Match>()
+                        .Select(ExtractTextFromMatch));
+            }
+        }
+
+        private string ExtractTextFromMatch(Match match)
+        {
+            Group regexGroupName = match.Groups[GroupName];
+            return regexGroupName.Success
+                ? regexGroupName.Value
+                : match.Value;
+        }
+
+        /// <summary>
+        /// If errRegex is set and its options include <see cref="RegexOptions.Singleline"/> (which means that
+        /// the whole input string---which in turn may contain multiple lines---should be treated as a single line), returns the
+        /// regex itself (to be used later to find all the matches in the input string); otherwise, returns a line filter
+        /// (to be used later to match individual lines from the input string).
+        /// </summary>
+        /// <remarks>
+        /// The errRegex must be inialized prior to calling this, which means after TryInitializeErrorRegexAsync in <see cref="SandboxedProcessPipExecutor"/>
+        /// </remarks>
+        internal static OutputFilter GetErrorFilter(Regex errRegex, bool enableMultiLineScanning)
+        {
+            if (errRegex != null && enableMultiLineScanning)
+            {
+                return new OutputFilter(errRegex);
+            }
+            else
+            {
+                return new OutputFilter(line =>
+                {
+                    Contract.Requires(line != null, "line must not be null.");
+
+                    // in absence of regex, treating everything as error.
+                    if (errRegex == null)
+                    {
+                        return true;
+                    }
+
+                    return errRegex.IsMatch(line);
+                });
+            }
+        }
+
+        /// <summary>
+        /// Create an OutputFilter to match on all PipProperties by extracting all text between PipPropertyPrefix and PipPropertySuffix
+        /// </summary>
+        internal static OutputFilter GetPipPropertiesFilter(bool enableMultLineScanning)
+        {
+            const string PipPropertyPrefix = "PipProperty_";
+            const string PipPropertySuffix = "_EndProperty";
+
+            // Match everything between PipProperty_ and _EndProperty, assigned to a PipProperty_ group
+            Regex pipPropertyRegex = new Regex(PipPropertyPrefix + @"(?<" + PipPropertyPrefix + @">.+?)" + PipPropertySuffix, RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Multiline);
+            return new OutputFilter(pipPropertyRegex, PipPropertyPrefix);
+        }
+    }
+}

--- a/Public/Src/Engine/Scheduler/PipExecutorCounter.cs
+++ b/Public/Src/Engine/Scheduler/PipExecutorCounter.cs
@@ -622,9 +622,36 @@ namespace BuildXL.Scheduler
         AzureWatsonExitCodeRetriesCount,
 
         /// <summary>
+        /// The total pip execution time that was later retried for internal reasons.
+        /// </summary>
+        [CounterType(CounterType.Stopwatch)]
+        RetriedInternalExecutionDuration,
+
+        /// <summary>
         /// Counts the number of retries for pips because users allow them to be retried, e.g., based on their exit codes.
         /// </summary>
         ProcessUserRetries,
+
+        /// <summary>
+        /// The total count of unique pips impacted by user allowed retries.
+        /// </summary>
+        ProcessUserRetriesImpactedPipsCount,
+
+        /// <summary>
+        /// The count of pips that eventually succeeded for user allowed retries
+        /// </summary>
+        ProcessUserRetriesSucceededPipsCount,
+
+        /// <summary>
+        /// The count of pips that still failed after exhausting all user allowed tretries
+        /// </summary>
+        ProcessUserRetriesFailedPipsCount,
+
+        /// <summary>
+        /// The total pip execution time that was later retried for because users allowed them to be retried.
+        /// </summary>
+        [CounterType(CounterType.Stopwatch)]
+        RetriedUserExecutionDuration,
 
         /// <summary>
         /// Counts the number of process pips executed on remote workers

--- a/Public/Src/Engine/Scheduler/PipPropertyInfo.cs
+++ b/Public/Src/Engine/Scheduler/PipPropertyInfo.cs
@@ -1,0 +1,62 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Logger = BuildXL.Scheduler.Tracing.Logger;
+using BuildXL.Utilities.Instrumentation.Common;
+
+namespace BuildXL.Scheduler
+{
+    internal class PipPropertyInfo
+    {
+        /// <summary>
+        /// The max count of PipIds for telemetry fields recording a list if impact pips
+        /// </summary>
+        private const int MaxListOfPipIdsForTelemetry = 50; 
+
+        private ConcurrentDictionary<string, long> m_aggregatedPipPropertiesCount;
+        private ConcurrentDictionary<string, HashSet<string>> m_addgregatepipsPerPipProperty;
+
+        internal PipPropertyInfo()
+        {
+            m_aggregatedPipPropertiesCount = new ConcurrentDictionary<string, long>();
+            m_addgregatepipsPerPipProperty = new ConcurrentDictionary<string, HashSet<string>>();
+        }
+
+        internal void LogPipPropertyInfo(LoggingContext loggingContext)
+        {
+            if (m_aggregatedPipPropertiesCount.Count > 0)
+            {
+                // Log out one message with containing a string of pip properties with their impacted pips
+                string pipPropertiesPips = string.Empty;
+                foreach (var item in m_aggregatedPipPropertiesCount)
+                {
+                    var impactedPips = m_addgregatepipsPerPipProperty[item.Key];
+                    if (impactedPips.Count > 0)
+                    {
+                        pipPropertiesPips = pipPropertiesPips + item.Key + "Pips: " + string.Join(",", m_addgregatepipsPerPipProperty[item.Key]) + "; ";
+                    }
+                }
+                Logger.Log.ProcessPattern(loggingContext, pipPropertiesPips, m_aggregatedPipPropertiesCount);
+            }
+        }
+
+        internal void UpdatePipPropertyInfo(ProcessRunnablePip processRunnable, ExecutionResult executionResult)
+        {
+            if (executionResult.PipProperties != null && executionResult.PipProperties.Count > 0)
+            {
+                foreach (var kvp in executionResult.PipProperties)
+                {
+                    m_aggregatedPipPropertiesCount.AddOrUpdate(kvp.Key, kvp.Value, (key, oldValue) => oldValue + kvp.Value);
+
+                    var impactedPips = m_addgregatepipsPerPipProperty.GetOrAdd(kvp.Key, new HashSet<string>());
+                    lock (m_addgregatepipsPerPipProperty)
+                    {
+                        if (impactedPips.Count < MaxListOfPipIdsForTelemetry)
+                        {
+                            impactedPips.Add(processRunnable.Process.FormattedSemiStableHash);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Public/Src/Engine/Scheduler/PipRetryInfo.cs
+++ b/Public/Src/Engine/Scheduler/PipRetryInfo.cs
@@ -1,5 +1,3 @@
-using System.Collections.Concurrent;
-using System.Collections.Generic;
 using BuildXL.Pips;
 using Logger = BuildXL.Scheduler.Tracing.Logger;
 using BuildXL.Utilities.Collections;
@@ -15,15 +13,11 @@ namespace BuildXL.Scheduler
         /// </summary>
         private const int MaxListOfPipIdsForTelemetry = 50; 
 
-        private ConcurrentDictionary<string, long> m_aggregatedPipPropertiesCount;
-        private ConcurrentDictionary<string, HashSet<string>> m_addgregatepipsPerPipProperty;
         private ConcurrentBigSet<string> m_pipsSucceedingAfterUserRetry;
         private ConcurrentBigSet<string> m_pipsFailingAfterLastUserRetry;
 
         internal PipRetryInfo()
         {
-            m_aggregatedPipPropertiesCount = new ConcurrentDictionary<string, long>();
-            m_addgregatepipsPerPipProperty = new ConcurrentDictionary<string, HashSet<string>>();
             m_pipsSucceedingAfterUserRetry = new ConcurrentBigSet<string>();
             m_pipsFailingAfterLastUserRetry = new ConcurrentBigSet<string>();
         }
@@ -36,42 +30,10 @@ namespace BuildXL.Scheduler
                 string pipsFailingAfterLastUserRetry = string.Join(",", m_pipsFailingAfterLastUserRetry.UnsafeGetList());
                 Logger.Log.ProcessRetries(loggingContext, pipsSucceedingAfterUserRetry, pipsFailingAfterLastUserRetry);
             }
-
-            if (m_aggregatedPipPropertiesCount.Count > 0)
-            {
-                // Log out one message with containing a string of pip properties with their impacted pips
-                string pipPropertiesPips = string.Empty;
-                foreach (var item in m_aggregatedPipPropertiesCount)
-                {
-                    var impactedPips = m_addgregatepipsPerPipProperty[item.Key];
-                    if (impactedPips.Count > 0)
-                    {
-                        pipPropertiesPips = pipPropertiesPips + item.Key + "Pips: " + string.Join(",", m_addgregatepipsPerPipProperty[item.Key]) + "; ";
-                    }
-                }
-                Logger.Log.ProcessPattern(loggingContext, pipPropertiesPips, m_aggregatedPipPropertiesCount);
-            }
         }
 
-        internal void UpdatePipRetrInfo(ProcessRunnablePip processRunnable, ExecutionResult executionResult, CounterCollection<PipExecutorCounter> pipExecutionCounters)
+        internal void UpdatePipRetryInfo(ProcessRunnablePip processRunnable, ExecutionResult executionResult, CounterCollection<PipExecutorCounter> pipExecutionCounters)
         {
-            if (executionResult.PipProperties != null && executionResult.PipProperties.Count > 0)
-            {
-                foreach (var kvp in executionResult.PipProperties)
-                {
-                    m_aggregatedPipPropertiesCount.AddOrUpdate(kvp.Key, kvp.Value, (key, oldValue) => oldValue + kvp.Value);
-
-                    var impactedPips = m_addgregatepipsPerPipProperty.GetOrAdd(kvp.Key, new HashSet<string>());
-                    lock (m_addgregatepipsPerPipProperty)
-                    {
-                        if (impactedPips.Count < MaxListOfPipIdsForTelemetry)
-                        {
-                            impactedPips.Add(processRunnable.Process.FormattedSemiStableHash);
-                        }
-                    }
-                }
-            }
-
             if (executionResult.HasUserRetries)
             {
                 if (executionResult.Result == PipResultStatus.Succeeded)

--- a/Public/Src/Engine/Scheduler/PipRetryInfo.cs
+++ b/Public/Src/Engine/Scheduler/PipRetryInfo.cs
@@ -1,0 +1,96 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using BuildXL.Pips;
+using Logger = BuildXL.Scheduler.Tracing.Logger;
+using BuildXL.Utilities.Collections;
+using BuildXL.Utilities.Instrumentation.Common;
+using BuildXL.Utilities.Tracing;
+
+namespace BuildXL.Scheduler
+{
+    internal class PipRetryInfo
+    {
+        /// <summary>
+        /// The max count of PipIds for telemetry fields recording a list if impact pips
+        /// </summary>
+        private const int MaxListOfPipIdsForTelemetry = 50; 
+
+        private ConcurrentDictionary<string, long> m_aggregatedPipPropertiesCount;
+        private ConcurrentDictionary<string, HashSet<string>> m_addgregatepipsPerPipProperty;
+        private ConcurrentBigSet<string> m_pipsSucceedingAfterUserRetry;
+        private ConcurrentBigSet<string> m_pipsFailingAfterLastUserRetry;
+
+        internal PipRetryInfo()
+        {
+            m_aggregatedPipPropertiesCount = new ConcurrentDictionary<string, long>();
+            m_addgregatepipsPerPipProperty = new ConcurrentDictionary<string, HashSet<string>>();
+            m_pipsSucceedingAfterUserRetry = new ConcurrentBigSet<string>();
+            m_pipsFailingAfterLastUserRetry = new ConcurrentBigSet<string>();
+        }
+
+        internal void LogPipRetryInfo(LoggingContext loggingContext, CounterCollection<PipExecutorCounter> pipExecutionCounters)
+        {
+            if (pipExecutionCounters.GetCounterValue(PipExecutorCounter.ProcessUserRetries) > 0)
+            {
+                string pipsSucceedingAfterUserRetry = string.Join(",", m_pipsSucceedingAfterUserRetry.UnsafeGetList());
+                string pipsFailingAfterLastUserRetry = string.Join(",", m_pipsFailingAfterLastUserRetry.UnsafeGetList());
+                Logger.Log.ProcessRetries(loggingContext, pipsSucceedingAfterUserRetry, pipsFailingAfterLastUserRetry);
+            }
+
+            if (m_aggregatedPipPropertiesCount.Count > 0)
+            {
+                // Log out one message with containing a string of pip properties with their impacted pips
+                string pipPropertiesPips = string.Empty;
+                foreach (var item in m_aggregatedPipPropertiesCount)
+                {
+                    var impactedPips = m_addgregatepipsPerPipProperty[item.Key];
+                    if (impactedPips.Count > 0)
+                    {
+                        pipPropertiesPips = pipPropertiesPips + item.Key + "Pips: " + string.Join(",", m_addgregatepipsPerPipProperty[item.Key]) + "; ";
+                    }
+                }
+                Logger.Log.ProcessPattern(loggingContext, pipPropertiesPips, m_aggregatedPipPropertiesCount);
+            }
+        }
+
+        internal void UpdatePipRetrInfo(ProcessRunnablePip processRunnable, ExecutionResult executionResult, CounterCollection<PipExecutorCounter> pipExecutionCounters)
+        {
+            if (executionResult.PipProperties != null && executionResult.PipProperties.Count > 0)
+            {
+                foreach (var kvp in executionResult.PipProperties)
+                {
+                    m_aggregatedPipPropertiesCount.AddOrUpdate(kvp.Key, kvp.Value, (key, oldValue) => oldValue + kvp.Value);
+
+                    var impactedPips = m_addgregatepipsPerPipProperty.GetOrAdd(kvp.Key, new HashSet<string>());
+                    lock (m_addgregatepipsPerPipProperty)
+                    {
+                        if (impactedPips.Count < MaxListOfPipIdsForTelemetry)
+                        {
+                            impactedPips.Add(processRunnable.Process.FormattedSemiStableHash);
+                        }
+                    }
+                }
+            }
+
+            if (executionResult.HasUserRetries)
+            {
+                if (executionResult.Result == PipResultStatus.Succeeded)
+                {
+                    pipExecutionCounters.IncrementCounter(PipExecutorCounter.ProcessUserRetriesSucceededPipsCount);
+                    if (m_pipsSucceedingAfterUserRetry.Count < MaxListOfPipIdsForTelemetry)
+                    {
+                        m_pipsSucceedingAfterUserRetry.Add(processRunnable.Process.FormattedSemiStableHash);
+                    }
+                }
+                else if (executionResult.Result == PipResultStatus.Failed)
+                {
+                    pipExecutionCounters.IncrementCounter(PipExecutorCounter.ProcessUserRetriesFailedPipsCount);
+                    if (m_pipsFailingAfterLastUserRetry.Count < MaxListOfPipIdsForTelemetry)
+                    {
+                        m_pipsFailingAfterLastUserRetry.Add(processRunnable.Process.FormattedSemiStableHash);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -297,6 +297,8 @@ namespace BuildXL.Scheduler
         private int m_maxUnresponsivenessFactor = 0;
         private DateTime m_statusLastCollected = DateTime.MaxValue;
 
+        private PipRetryInfo m_pipRetryInfo = new PipRetryInfo();
+
         /// <summary>
         /// Enables distribution for the master node
         /// </summary>
@@ -1651,6 +1653,8 @@ namespace BuildXL.Scheduler
             m_pipExecutionStepCounters.LogAsStatistics("PipExecutionStep", loggingContext);
             m_executionLogFileTarget?.Counters.LogAsStatistics("ExecutionLogFileTarget", loggingContext);
             SandboxedProcessFactory.Counters.LogAsStatistics("SandboxedProcess", loggingContext);
+
+            m_pipRetryInfo.LogPipRetryInfo(loggingContext, PipExecutionCounters);
 
             m_apiServer?.LogStats(loggingContext);
             m_dropPipTracker?.LogStats(loggingContext);
@@ -3643,6 +3647,8 @@ namespace BuildXL.Scheduler
 
                             return PipExecutionStep.ChooseWorkerCpu;
                         }
+
+                        m_pipRetryInfo.UpdatePipRetrInfo(processRunnable, executionResult, PipExecutionCounters);
 
                         if (runnablePip.Worker?.IsRemote == true)
                         {

--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -298,6 +298,7 @@ namespace BuildXL.Scheduler
         private DateTime m_statusLastCollected = DateTime.MaxValue;
 
         private PipRetryInfo m_pipRetryInfo = new PipRetryInfo();
+        private PipPropertyInfo m_pipPropertyInfo = new PipPropertyInfo();
 
         /// <summary>
         /// Enables distribution for the master node
@@ -1654,6 +1655,7 @@ namespace BuildXL.Scheduler
             m_executionLogFileTarget?.Counters.LogAsStatistics("ExecutionLogFileTarget", loggingContext);
             SandboxedProcessFactory.Counters.LogAsStatistics("SandboxedProcess", loggingContext);
 
+            m_pipPropertyInfo.LogPipPropertyInfo(loggingContext);
             m_pipRetryInfo.LogPipRetryInfo(loggingContext, PipExecutionCounters);
 
             m_apiServer?.LogStats(loggingContext);
@@ -3648,7 +3650,8 @@ namespace BuildXL.Scheduler
                             return PipExecutionStep.ChooseWorkerCpu;
                         }
 
-                        m_pipRetryInfo.UpdatePipRetrInfo(processRunnable, executionResult, PipExecutionCounters);
+                        m_pipPropertyInfo.UpdatePipPropertyInfo(processRunnable, executionResult);
+                        m_pipRetryInfo.UpdatePipRetryInfo(processRunnable, executionResult, PipExecutionCounters);
 
                         if (runnablePip.Worker?.IsRemote == true)
                         {

--- a/Public/Src/Engine/Scheduler/Tracing/Log.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/Log.cs
@@ -3566,6 +3566,24 @@ namespace BuildXL.Scheduler.Tracing
         public abstract void JournalProcessingStatisticsForSchedulerTelemetry(LoggingContext context, string scanningJournalStatus, IDictionary<string, long> stats);
 
         [GeneratedEvent(
+            (int)EventId.ProcessRetries,
+            EventGenerators = EventGenerators.TelemetryOnly,
+            EventLevel = Level.Verbose,
+            EventTask = (ushort)Tasks.Scheduler,
+            Keywords = (int)Keywords.UserMessage,
+            Message = "ProcessRetries PipsSucceedingAfterUserRetry: {pipsSucceedingAfterUserRetry} and PipsFailingAfterUserRetry: {pipsFailingAfterLastUserRetry}")]
+        public abstract void ProcessRetries(LoggingContext context, string pipsSucceedingAfterUserRetry, string pipsFailingAfterLastUserRetry);
+
+        [GeneratedEvent(
+            (int)EventId.ProcessPattern,
+            EventGenerators = EventGenerators.TelemetryOnly | Generators.Statistics,
+            EventLevel = Level.Verbose,
+            EventTask = (ushort)Tasks.Scheduler,
+            Keywords = (int)Keywords.UserMessage,
+            Message = "ProcessPattern {pipPropertyImpactedPips}")]
+        public abstract void ProcessPattern(LoggingContext context, string pipPropertyImpactedPips, IDictionary<string, long> stats);
+
+        [GeneratedEvent(
             (int)EventId.IncrementalSchedulingNewlyPresentFile,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,

--- a/Public/Src/Engine/UnitTests/Processes.Detours/OutputFilterTest.cs
+++ b/Public/Src/Engine/UnitTests/Processes.Detours/OutputFilterTest.cs
@@ -1,0 +1,44 @@
+using System.Text.RegularExpressions;
+using BuildXL.Processes;
+using Test.BuildXL.TestUtilities.Xunit;
+using Xunit;
+
+namespace Test.BuildXL.Processes.Detours
+{
+    public sealed partial class OutputFilterTest
+    {
+        [Fact]
+        public void GetErrorFilterTest()
+        {
+            bool enableMultiLine = true;
+            Regex errRegex = new Regex(@"(?s)<error>[\\s*]*(?<ErrorMessage>.*?)[\\s*]*</error>");
+            OutputFilter errorFilter = OutputFilter.GetErrorFilter(errRegex, enableMultiLine);
+            const string ErrText = @"
+* BEFORE *
+* <error> *
+* err1 *
+* </error> *
+* AFTER *
+* <error>err2</error> * <error>err3</error> *
+";
+            const string ExpectedErrOutput = @" *
+* err1 *
+* 
+err2
+err3";
+
+            XAssert.AreEqual(ExpectedErrOutput, errorFilter.ExtractMatches(ErrText));
+        }
+
+        [Fact]
+        public void GetPipPropertyFilterTest()
+        {
+            bool enableMultiLine = true;
+            OutputFilter propertyFilter = OutputFilter.GetPipPropertiesFilter(enableMultiLine);
+            const string OutputText = @"RandomTextPipProperty_SomeProp_123456_EndPropertyOtherRandomText";
+            const string ExpectedPipPropertyMatches = @"SomeProp_123456";
+
+            XAssert.AreEqual(ExpectedPipPropertyMatches, propertyFilter.ExtractMatches(OutputText));
+        }
+    }
+}

--- a/Public/Src/Engine/UnitTests/Processes.Detours/SandboxedProcessPipExecutorTest.cs
+++ b/Public/Src/Engine/UnitTests/Processes.Detours/SandboxedProcessPipExecutorTest.cs
@@ -1995,6 +1995,71 @@ namespace Test.BuildXL.Processes.Detours
             }
         }
 
+        [Fact]
+        public async Task UpdatePipProperties()
+        {
+            var context = BuildXLContext.CreateInstanceForTesting();
+
+            using (var tempFiles = new TempFileStorage(canGetFileNames: true, rootPath: TemporaryDirectory))
+            {
+                string executable = CmdHelper.CmdX64;
+                FileArtifact executableFileArtifact = FileArtifact.CreateSourceFile(AbsolutePath.Create(context.PathTable, executable));
+
+                string workingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+                AbsolutePath workingDirectoryAbsolutePath = AbsolutePath.Create(context.PathTable, workingDirectory);
+
+                var arguments = new PipDataBuilder(context.PathTable.StringTable);
+                arguments.Add("/d");
+                arguments.Add("/c");
+                arguments.Add("echo PipProperty_Foo_EndProperty");
+                using (arguments.StartFragment(PipDataFragmentEscaping.CRuntimeArgumentRules, " "))
+                {
+                    arguments.Add("exit");
+                    arguments.Add("1");
+                }
+
+                var pip = new Process(
+                    executableFileArtifact,
+                    workingDirectoryAbsolutePath,
+                    arguments.ToPipData(" ", PipDataFragmentEscaping.NoEscaping),
+                    FileArtifact.Invalid,
+                    PipData.Invalid,
+                    ReadOnlyArray<EnvironmentVariable>.Empty,
+                    FileArtifact.Invalid,
+                    FileArtifact.Invalid,
+                    FileArtifact.Invalid,
+                    tempFiles.GetUniqueDirectory(context.PathTable),
+                    null,
+                    null,
+                    ReadOnlyArray<FileArtifact>.FromWithoutCopy(executableFileArtifact),
+                    ReadOnlyArray<FileArtifactWithAttributes>.Empty,
+                    ReadOnlyArray<DirectoryArtifact>.Empty,
+                    ReadOnlyArray<DirectoryArtifact>.Empty,
+                    ReadOnlyArray<PipId>.Empty,
+                    ReadOnlyArray<AbsolutePath>.From(CmdHelper.GetCmdDependencies(context.PathTable)),
+                    ReadOnlyArray<AbsolutePath>.From(CmdHelper.GetCmdDependencyScopes(context.PathTable)),
+                    ReadOnlyArray<StringId>.Empty,
+                    ReadOnlyArray<int>.FromWithoutCopy(1),
+                    semaphores: ReadOnlyArray<ProcessSemaphoreInfo>.Empty,
+                    provenance: PipProvenance.CreateDummy(context),
+                    toolDescription: StringId.Invalid,
+                    additionalTempDirectories: ReadOnlyArray<AbsolutePath>.Empty);
+
+                SandboxedProcessPipExecutionResult result = await RunProcess(
+                    context,
+                    new SandboxConfiguration { FileAccessIgnoreCodeCoverage = true }, 
+                    pip, 
+                    null, 
+                    new Dictionary<string, string>(), 
+                    SemanticPathExpander.Default, 
+                    null);
+
+                XAssert.AreEqual(1, result.PipProperties["Foo"]);
+                VerifyExecutionStatus(context, result, SandboxedProcessPipExecutionStatus.ExecutionFailed);
+                SetExpectedFailures(1, 0, "DX0064");
+            }
+        }
+
         private class TestSemanticPathExpander : SemanticPathExpander
         {
             private readonly IEnumerable<AbsolutePath> m_writableRoots;

--- a/Public/Src/Engine/UnitTests/Processes.Detours/Test.BuildXL.Processes.Detours.dsc
+++ b/Public/Src/Engine/UnitTests/Processes.Detours/Test.BuildXL.Processes.Detours.dsc
@@ -28,6 +28,7 @@ namespace Processes.Detours {
                 f`FileAccessManifestTreeTest.cs`,
                 f`SandboxedProcessInfoTest.cs`,
                 f`SubstituteProcessExecutionTests.cs`,
+                f`OutputFilterTest.cs`,
             ],
             references: [
                 EngineTestUtilities.dll,

--- a/Public/Src/Engine/UnitTests/Scheduler/ProcessExecutionResultSerializerTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/ProcessExecutionResultSerializerTests.cs
@@ -17,6 +17,7 @@ using Test.BuildXL.TestUtilities.Xunit;
 using Xunit;
 using Xunit.Abstractions;
 using BuildXL.Native.IO;
+using System.Collections.Generic;
 
 namespace Test.BuildXL.Scheduler
 {
@@ -86,7 +87,9 @@ namespace Test.BuildXL.Scheduler
                 pipCacheDescriptorV2Metadata: null,
                 converged: true,
                 pathSet: null,
-                cacheLookupStepDurations: null);
+                cacheLookupStepDurations: null,
+                pipProperties: new Dictionary<string, int> { { "Foo", 1 }, { "Bar", 9 } },
+                hasUserRetries: true);
 
             ExecutionResultSerializer serializer = new ExecutionResultSerializer(0, Context);
 
@@ -140,7 +143,10 @@ namespace Test.BuildXL.Scheduler
                 r => r.TwoPhaseCachingInfo.PathSetHash,
                 r => r.TwoPhaseCachingInfo.CacheEntry.MetadataHash,
                 r => r.TwoPhaseCachingInfo.CacheEntry.OriginatingCache,
-                r => r.TwoPhaseCachingInfo.CacheEntry.ReferencedContent.Length
+                r => r.TwoPhaseCachingInfo.CacheEntry.ReferencedContent.Length,
+
+                r => r.PipProperties.Count,
+                r => r.HasUserRetries
                 );
 
             for (int i = 0; i < processExecutionResult.OutputContent.Length; i++)
@@ -198,6 +204,8 @@ namespace Test.BuildXL.Scheduler
                     processExecutionResult.TwoPhaseCachingInfo.CacheEntry.ReferencedContent[i],
                     deserializedProcessExecutionResult.TwoPhaseCachingInfo.CacheEntry.ReferencedContent[i]);
             }
+
+            XAssert.AreEqual(9, deserializedProcessExecutionResult.PipProperties["Bar"]);
         }
 
         private (FileArtifact, FileMaterializationInfo, PipOutputOrigin) CreateRandomOutputContent()

--- a/Public/Src/Utilities/Utilities/Tracing/EventId.cs
+++ b/Public/Src/Utilities/Utilities/Tracing/EventId.cs
@@ -1152,5 +1152,8 @@ namespace BuildXL.Utilities.Tracing
 
         FailedToLoadPipGraphFragment = 14502,
         PipCacheLookupStats = 14503,
+
+        ProcessRetries = 14504,
+        ProcessPattern = 14505,
     }
 }


### PR DESCRIPTION
Track additional pip retry information, including pips that succeed after failure and those failing after all retries.  

Also allow logging a custom pip property that gets aggregated for the build and reported vi a processpattern event (count of pip properties hit, and csv if impacted pips).  

Fixes [AB#1612096](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1612096)