### PR TITLE
Remove the assertion that cause contract violation on master

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabase.cs
@@ -327,10 +327,6 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             OperationContext context,
             EnumerationFilter filter = null)
         {
-            // This is called only when computing reconciliation between a worker's LLS and local store. This means we
-            // don't need to flush, because workers don't perform any updates.
-            Contract.Assert(!IsDatabaseWriteable);
-
             return EnumerateEntriesWithSortedKeysFromStorage(context.Token, filter);
         }
 

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabase.cs
@@ -327,6 +327,12 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
             OperationContext context,
             EnumerationFilter filter = null)
         {
+            // Flush only when the database is writable (and the cache is enabled).
+            if (IsDatabaseWriteable && IsInMemoryCacheEnabled)
+            {
+                ForceCacheFlush(context, ContentLocationDatabaseCounters.NumberOfCacheFlushesTriggeredByContentEnumeration, blocking: true);
+            }
+
             return EnumerateEntriesWithSortedKeysFromStorage(context.Token, filter);
         }
 

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabaseCounters.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/ContentLocationDatabaseCounters.cs
@@ -92,6 +92,9 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
         NumberOfCacheFlushesTriggeredByCheckpoint,
 
         /// <nodoc />
+        NumberOfCacheFlushesTriggeredByContentEnumeration,
+
+        /// <nodoc />
         NumberOfPersistedEntries,
 
         /// <nodoc />


### PR DESCRIPTION
This is the error that is happening both in CBTest and in prod:

```
02598691-463c-488b-9797-9a6877449478 Critical error occurred: LocalLocationStore.ReconcileAsync stop 3816.1517ms. result=[Error=[ContractException: Assertion failed.
	at \.\Public\Src\Cache\ContentStore\Distributed\NuCache\ContentLocationDatabase.cs:332] Diagnostics=[System.Diagnostics.ContractsLight.ContractException: Assertion failed.
	at \.\Public\Src\Cache\ContentStore\Distributed\NuCache\ContentLocationDatabase.cs:332
   at System.Diagnostics.ContractsLight.ContractRuntimeHelper.TriggerFailure(ContractFailureKind kind, String msg, String userMessage, String conditionTxt)
   at System.Diagnostics.ContractsLight.ContractRuntimeHelper.ReportFailure(ContractFailureKind kind, String msg, String conditionTxt, Provenance provenence)
   at BuildXL.Cache.ContentStore.Distributed.NuCache.ContentLocationDatabase.EnumerateEntriesWithSortedKeys(OperationContext context, EnumerationFilter filter) in \.\Public\Src\Cache\ContentStore\Distributed\NuCache\ContentLocationDatabase.cs:line 332
   at BuildXL.Cache.ContentStore.Distributed.NuCache.ContentLocationDatabaseExtensions.<EnumerateSortedDatabaseEntriesForMachineId>d__0.MoveNext() in \.\Public\Src\Cache\ContentStore\Distributed\NuCache\ContentLocationDatabaseExtensions.cs:line 24
   at BuildXL.Cache.ContentStore.Distributed.NuCache.ContentLocationDatabaseExtensions.<EnumerateSortedHashesWithContentSizeForMachineId>d__1.MoveNext() in \.\Public\Src\Cache\ContentStore\Distributed\NuCache\ContentLocationDatabaseExtensions.cs:line 45
   at BuildXL.Cache.ContentStore.Distributed.NuCache.NuCacheCollectionUtilities.<SortedUnique>d__5`2.MoveNext() in \.\Public\Src\Cache\ContentStore\Distributed\NuCache\NuCacheCollectionUtilities.cs:line 164
   at BuildXL.Cache.ContentStore.Distributed.NuCache.NuCacheCollectionUtilities.MoveNext[T](IEnumerator`1 enumerator1, T& current) in \.\Public\Src\Cache\ContentStore\Distributed\NuCache\NuCacheCollectionUtilities.cs:line 195
   at BuildXL.Cache.ContentStore.Distributed.NuCache.NuCacheCollectionUtilities.<DistinctMergeSorted>d__4`3.MoveNext() in \.\Public\Src\Cache\ContentStore\Distributed\NuCache\NuCacheCollectionUtilities.cs:line 0
   at BuildXL.Cache.ContentStore.Distributed.NuCache.NuCacheCollectionUtilities.<DistinctDiffSorted>d__2`2.MoveNext() in \.\Public\Src\Cache\ContentStore\Distributed\NuCache\NuCacheCollectionUtilities.cs:line 75
   at System.Linq.Enumerable.<TakeIterator>d__25`1.MoveNext()
   at BuildXL.Cache.ContentStore.Distributed.NuCache.LocalLocationStore.<>c__DisplayClass96_1.<<ReconcileAsync>g__performReconciliationCycleAsync|1>d.MoveNext() in \.\Public\Src\Cache\ContentStore\Distributed\NuCache\LocalLocationStore.cs:line 1260
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at BuildXL.Cache.ContentStore.Tracing.Internal.PerformOperationBuilderBase`2.<RunOperationAndConvertExceptionToErrorAsync>d__15`1.MoveNext() in \.\Public\Src\Cache\ContentStore\Library\Tracing\OperationContextExtensions.cs:line 0]].. Diagnostics: System.Diagnostics.ContractsLight.ContractException: Assertion failed.
	at \.\Public\Src\Cache\ContentStore\Distributed\NuCache\ContentLocationDatabase.cs:332
   at System.Diagnostics.ContractsLight.ContractRuntimeHelper.TriggerFailure(ContractFailureKind kind, String msg, String userMessage, String conditionTxt)
   at System.Diagnostics.ContractsLight.ContractRuntimeHelper.ReportFailure(ContractFailureKind kind, String msg, String conditionTxt, Provenance provenence)
   at BuildXL.Cache.ContentStore.Distributed.NuCache.ContentLocationDatabase.EnumerateEntriesWithSortedKeys(OperationContext context, EnumerationFilter filter) in \.\Public\Src\Cache\ContentStore\Distributed\NuCache\ContentLocationDatabase.cs:line 332
   at BuildXL.Cache.ContentStore.Distributed.NuCache.ContentLocationDatabaseExtensions.<EnumerateSortedDatabaseEntriesForMachineId>d__0.MoveNext() in \.\Public\Src\Cache\ContentStore\Distributed\NuCache\ContentLocationDatabaseExtensions.cs:line 24
   at BuildXL.Cache.ContentStore.Distributed.NuCache.ContentLocationDatabaseExtensions.<EnumerateSortedHashesWithContentSizeForMachineId>d__1.MoveNext() in \.\Public\Src\Cache\ContentStore\Distributed\NuCache\ContentLocationDatabaseExtensions.cs:line 45
   at BuildXL.Cache.ContentStore.Distributed.NuCache.NuCacheCollectionUtilities.<SortedUnique>d__5`2.MoveNext() in \.\Public\Src\Cache\ContentStore\Distributed\NuCache\NuCacheCollectionUtilities.cs:line 164
   at BuildXL.Cache.ContentStore.Distributed.NuCache.NuCacheCollectionUtilities.MoveNext[T](IEnumerator`1 enumerator1, T& current) in \.\Public\Src\Cache\ContentStore\Distributed\NuCache\NuCacheCollectionUtilities.cs:line 195
   at BuildXL.Cache.ContentStore.Distributed.NuCache.NuCacheCollectionUtilities.<DistinctMergeSorted>d__4`3.MoveNext() in \.\Public\Src\Cache\ContentStore\Distributed\NuCache\NuCacheCollectionUtilities.cs:line 0
   at BuildXL.Cache.ContentStore.Distributed.NuCache.NuCacheCollectionUtilities.<DistinctDiffSorted>d__2`2.MoveNext() in \.\Public\Src\Cache\ContentStore\Distributed\NuCache\NuCacheCollectionUtilities.cs:line 75
   at System.Linq.Enumerable.<TakeIterator>d__25`1.MoveNext()
   at BuildXL.Cache.ContentStore.Distributed.NuCache.LocalLocationStore.<>c__DisplayClass96_1.<<ReconcileAsync>g__performReconciliationCycleAsync|1>d.MoveNext() in \.\Public\Src\Cache\ContentStore\Distributed\NuCache\LocalLocationStore.cs:line 1260
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at BuildXL.Cache.ContentStore.Tracing.Internal.PerformOperationBuilderBase`2.<RunOperationAndConvertExceptionToErrorAsync>d__15`1.MoveNext() in \.\Public\Src\Cache\ContentStore\Library\Tracing\OperationContextExtensions.cs:line 0
```