### PR TITLE
Add telemetry for more info on incremental scheduling underbuild

### DIFF
--- a/Public/Src/Engine/Scheduler/IncrementalScheduling/IncrementalSchedulingPathMapping.cs
+++ b/Public/Src/Engine/Scheduler/IncrementalScheduling/IncrementalSchedulingPathMapping.cs
@@ -33,6 +33,11 @@ namespace BuildXL.Scheduler.IncrementalScheduling
         private readonly ConcurrentBigMap<T, List<AbsolutePath>> m_valueToPathApproximation;
 
         /// <summary>
+        /// Number of mappings.
+        /// </summary>
+        public int Count => m_pathToValue.Where(kvp => kvp.Value != null && kvp.Value.Count > 0).Count();
+
+        /// <summary>
         /// Creates an instance of <see cref="IncrementalSchedulingPathMapping{T}"/>
         /// </summary>
         public IncrementalSchedulingPathMapping()

--- a/Public/Src/Engine/Scheduler/IncrementalScheduling/PipOrigins.cs
+++ b/Public/Src/Engine/Scheduler/IncrementalScheduling/PipOrigins.cs
@@ -19,6 +19,11 @@ namespace BuildXL.Scheduler.IncrementalScheduling
     internal sealed class PipOrigins
     {
         /// <summary>
+        /// Number of tracked pip origins.
+        /// </summary>
+        public int Count => m_pipOrigins.Count;
+
+        /// <summary>
         /// Mappings from pip fingerprints to their semi-stable hash, (index of) origin pip graph, and pip id.
         /// </summary>
         private readonly ConcurrentBigMap<ContentFingerprint, (long semiStableHash, int pipGraphIndex)> m_pipOrigins;

--- a/Public/Src/Engine/Scheduler/IncrementalScheduling/PipProducers.cs
+++ b/Public/Src/Engine/Scheduler/IncrementalScheduling/PipProducers.cs
@@ -20,6 +20,16 @@ namespace BuildXL.Scheduler.IncrementalScheduling
         private readonly ConcurrentBigMap<PipStableId, HashSet<AbsolutePath>> m_producedPaths;
 
         /// <summary>
+        /// Number of producers.
+        /// </summary>
+        public int ProducerCount => m_producedPaths.Count;
+
+        /// <summary>
+        /// Number of produced paths.
+        /// </summary>
+        public int ProducedPathCount => m_pipProducers.Count;
+
+        /// <summary>
         /// Creates a new instance of <see cref="PipProducers"/>.
         /// </summary>
         public static PipProducers CreateNew() => new PipProducers(new ConcurrentBigMap<AbsolutePath, PipStableId>(), new ConcurrentBigMap<PipStableId, HashSet<AbsolutePath>>());

--- a/Public/Src/Engine/Scheduler/Tracing/Log.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/Log.cs
@@ -3809,6 +3809,33 @@ namespace BuildXL.Scheduler.Tracing
         public abstract void IncrementalSchedulingPipsOfOtherPipGraphsGetDirtiedAfterScan(LoggingContext context, int pipCount, long elapsedMs);
 
         [GeneratedEvent(
+           (int)EventId.IncrementalSchedulingStateStatsAfterLoad,
+           EventGenerators = EventGenerators.TelemetryOnly | Generators.Statistics,
+           EventLevel = Level.Verbose,
+           EventTask = (ushort)Tasks.Scheduler,
+           Keywords = (int)Keywords.UserMessage,
+           Message = "N/A")]
+        public abstract void IncrementalSchedulingStateStatsAfterLoad(LoggingContext context, IDictionary<string, long> stats);
+
+        [GeneratedEvent(
+           (int)EventId.IncrementalSchedulingStateStatsAfterScan,
+           EventGenerators = EventGenerators.TelemetryOnly | Generators.Statistics,
+           EventLevel = Level.Verbose,
+           EventTask = (ushort)Tasks.Scheduler,
+           Keywords = (int)Keywords.UserMessage,
+           Message = "N/A")]
+        public abstract void IncrementalSchedulingStateStatsAfterScan(LoggingContext context, IDictionary<string, long> stats);
+
+        [GeneratedEvent(
+           (int)EventId.IncrementalSchedulingStateStatsEnd,
+           EventGenerators = EventGenerators.TelemetryOnly | Generators.Statistics,
+           EventLevel = Level.Verbose,
+           EventTask = (ushort)Tasks.Scheduler,
+           Keywords = (int)Keywords.UserMessage,
+           Message = "N/A")]
+        public abstract void IncrementalSchedulingStateStatsEnd(LoggingContext context, IDictionary<string, long> stats);
+
+        [GeneratedEvent(
             (ushort)EventId.ServicePipStarting,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,

--- a/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/IncrementalSchedulingTests/GraphChangesTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler.IntegrationTest/IncrementalSchedulingTests/GraphChangesTests.cs
@@ -1457,5 +1457,74 @@ namespace IntegrationTest.BuildXL.Scheduler.IncrementalSchedulingTests
             RunScheduler().AssertScheduled(pWithOutputs.Process.PipId, qWithOutputs.Process.PipId);
             XAssert.AreEqual("f2", ReadAllText(g));
         }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DynamicObservationChangeShouldNotCauseOverScheduleWhenGraphChanges(bool shareInput)
+        {
+            // Graph G1: A -> SSD(f, g, h)
+            // Graph G2: B -> SSD(f, g, h)
+
+            var directoryPath = CreateUniqueDirectory(SourceRoot);
+            var sealedDirectory = CreateAndScheduleSealDirectory(directoryPath, SealDirectoryKind.SourceTopDirectoryOnly);
+
+            var inputF = CreateSourceFile(directoryPath);
+            var inputG = CreateSourceFile(directoryPath);
+            var inputH = CreateSourceFile(directoryPath);
+
+            // file h points to path to f.
+            ModifyFile(inputH, ArtifactToString(inputF));
+
+            var outputX = CreateOutputFileArtifact();
+            var pipBuilderA = CreatePipBuilder(new[] {
+                Operation.ReadFileFromOtherFile(inputH, doNotInfer: true),
+                Operation.WriteFile(outputX) });
+            pipBuilderA.AddInputDirectory(sealedDirectory.Directory);
+            var processA = SchedulePipBuilder(pipBuilderA).Process;
+
+            RunScheduler().AssertCacheMiss(processA.PipId);
+
+            // file h points to path to g.
+            ModifyFile(inputH, ArtifactToString(inputG));
+
+            RunScheduler().AssertScheduled(processA.PipId).AssertCacheMiss(processA.PipId);
+
+            // Switch to G2.
+            ResetPipGraphBuilder();
+
+            sealedDirectory = CreateAndScheduleSealDirectory(directoryPath, SealDirectoryKind.SourceTopDirectoryOnly);
+            var outputY = CreateOutputFileArtifact();
+            var bInput = shareInput ? inputG : inputF;
+            var pipBuilderB = CreatePipBuilder(new[] { Operation.ReadFile(bInput, doNotInfer: true), Operation.WriteFile(outputY) });
+            pipBuilderB.AddInputDirectory(sealedDirectory.Directory);
+            var processB = SchedulePipBuilder(pipBuilderB).Process;
+
+            RunScheduler().AssertCacheMiss(processB.PipId);
+
+            // Modify B's input.
+            ModifyFile(bInput);
+
+            RunScheduler().AssertCacheMiss(processB.PipId);
+
+            // Switch back to G1.
+            ResetPipGraphBuilder();
+
+            sealedDirectory = CreateAndScheduleSealDirectory(directoryPath, SealDirectoryKind.SourceTopDirectoryOnly);
+            pipBuilderA = CreatePipBuilder(new[] {
+                Operation.ReadFileFromOtherFile(inputH, doNotInfer: true),
+                Operation.WriteFile(outputX) });
+            pipBuilderA.AddInputDirectory(sealedDirectory.Directory);
+            processA = SchedulePipBuilder(pipBuilderA).Process;
+
+            if (shareInput)
+            {
+                RunScheduler().AssertScheduled(processA.PipId).AssertCacheMiss();
+            }
+            else
+            {
+                RunScheduler().AssertNotScheduled(processA.PipId);
+            }
+        }
     }
 }

--- a/Public/Src/Engine/UnitTests/Scheduler/PipTestBase.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/PipTestBase.cs
@@ -1135,6 +1135,7 @@ namespace Test.BuildXL.Scheduler
                                 break;
 
                             case Operation.Type.ReadFile:
+                            case Operation.Type.ReadFileFromOtherFile:
                             case Operation.Type.WaitUntilFileExists:
                                 dao.Dependencies.Add(op.Path.FileArtifact);
                                 break;

--- a/Public/Src/Utilities/Utilities/Tracing/EventId.cs
+++ b/Public/Src/Utilities/Utilities/Tracing/EventId.cs
@@ -976,6 +976,10 @@ namespace BuildXL.Utilities.Tracing
         IncrementalSchedulingPipDirtyDueToChangesInDynamicObservationAfterScan = 8078,
         IncrementalSchedulingPipsOfOtherPipGraphsGetDirtiedAfterScan = 8079,
 
+        IncrementalSchedulingStateStatsAfterLoad = 8080,
+        IncrementalSchedulingStateStatsAfterScan = 8081,
+        IncrementalSchedulingStateStatsEnd = 8082,
+
         // Server mode
         UsingExistingServer = 8100,
         AppServerBuildStart = 8101,


### PR DESCRIPTION
A user reports an underbuild after changing a header. The underbuild is caused by incremental scheduling state losing all data about dynamic observations. However, this seemed to happen long before the user reported the underbuild, and thus some important logs have gone. 

This change adds more telemetry about the statistics of the state itself. Also, this change includes unit tests that exercise the code that can make incremental scheduling state lose its dynamic observation data.

[AB#1642365](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1642365)