### PR TITLE
Propagate caller name in CreateNestedContext

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/EventStreaming/EventHubContentLocationEventStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/EventStreaming/EventHubContentLocationEventStore.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.ContractsLight;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
@@ -372,14 +373,14 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache.EventStreaming
             }
         }
 
-        private static OperationContext CreateNestedContext(OperationContext context, string? operationId)
+        private static OperationContext CreateNestedContext(OperationContext context, string? operationId, [CallerMemberName]string? caller = null)
         {
             if (!Guid.TryParse(operationId, out var guid))
             {
                 guid = Guid.NewGuid();
             }
 
-            return context.CreateNested(guid);
+            return context.CreateNested(guid, caller);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Currently, we're seeing the following tracing message:

```
CreateNestedContext: 3184ffb2-8760-416e-9694-a8e75b96aabb parent to 3b0ff926-349c-4e09-bd15-fe4bb6a3721a
```

But should have:

```
ProcessEventsCoreAsync: 3184ffb2-8760-416e-9694-a8e75b96aabb parent to 3b0ff926-349c-4e09-bd15-fe4bb6a3721a
```