### PR TITLE
QTest: Add support for Dotnet core 3.0

### DIFF
--- a/Public/Sdk/Public/Tools/QTest/Tool.QTestRunner.dsc
+++ b/Public/Sdk/Public/Tools/QTest/Tool.QTestRunner.dsc
@@ -85,6 +85,18 @@ function qTestDotNetFrameworkToString(qTestDotNetFramework: QTestDotNetFramework
             return "Framework40";
         case QTestDotNetFramework.framework45:
             return "Framework45";
+        case QTestDotNetFramework.framework46:
+            return "Framework46";
+        case QTestDotNetFramework.frameworkCore10:
+            return "FrameworkCore10";
+        case QTestDotNetFramework.frameworkCore20:
+            return "FrameworkCore20";
+        case QTestDotNetFramework.frameworkCore21:
+            return "FrameworkCore21";
+        case QTestDotNetFramework.frameworkCore22:
+            return "FrameworkCore22";
+        case QTestDotNetFramework.frameworkCore30:
+            return "FrameworkCore30";
         case QTestDotNetFramework.unspecified:
         default:
             return "Unspecified";
@@ -326,6 +338,18 @@ export const enum QTestDotNetFramework {
     framework40,
     @@Tool.option("--qtestDotNetFramework framework45")
     framework45,
+    @@Tool.option("--qtestDotNetFramework framework46")
+    framework46,
+    @@Tool.option("--qtestDotNetFramework frameworkCore10")
+    frameworkCore10,
+    @@Tool.option("--qtestDotNetFramework frameworkCore20")
+    frameworkCore20,
+    @@Tool.option("--qtestDotNetFramework frameworkCore21")
+    frameworkCore21,
+    @@Tool.option("--qtestDotNetFramework frameworkCore22")
+    frameworkCore22,
+    @@Tool.option("--qtestDotNetFramework frameworkCore30")
+    frameworkCore30,
 }
 /**
  * Arguments of DBS.QTest.exe

--- a/cg/nuget/cgmanifest.json
+++ b/cg/nuget/cgmanifest.json
@@ -123,7 +123,7 @@
         "Type": "NuGet",
         "NuGet": {
           "Name": "CB.QTest",
-          "Version": "19.10.17.210051"
+          "Version": "19.11.5.170405"
         }
       }
     },

--- a/config.microsoftInternal.dsc
+++ b/config.microsoftInternal.dsc
@@ -14,7 +14,7 @@ export const pkgs = isMicrosoftInternal ? [
     { id: "runtime.osx-x64.BuildXL", version: "2.8.99" },
     { id: "Aria.Cpp.SDK", version: "8.5.6" },
 
-    { id: "CB.QTest", version: "19.10.17.210051" },
+    { id: "CB.QTest", version: "19.11.5.170405" },
 
     { id: "BuildXL.Tracing.AriaTenantToken", version: "1.0.0" },
 


### PR DESCRIPTION
Add support for Dotnet core for QTest

https://dev.azure.com/mseng/1ES/_workitems/edit/1641008