### PR TITLE
Fix FileStream based copying

### DIFF
--- a/Public/Src/Engine/Scheduler/PipExecutor.cs
+++ b/Public/Src/Engine/Scheduler/PipExecutor.cs
@@ -143,8 +143,6 @@ namespace BuildXL.Scheduler
             var pipInfo = new PipInfo(pip, context);
             var pipDescription = pipInfo.Description;
 
-
-
             string destination = pip.Destination.Path.ToString(pathTable);
             string source = pip.Source.Path.ToString(pathTable);
 
@@ -1825,7 +1823,7 @@ namespace BuildXL.Scheduler
         {
             var fp = env.ContentFingerprinter.StaticFingerprintLookup(pip.PipId);
             return new SidebandMetadata(
-                pip.PipId.Value, 
+                pip.PipId.Value,
                 // in some tests the static fingerprint can have 0 length in which case ToByteArray() throws
                 fp.Length > 0 ? fp.ToByteArray() : new byte[0]);
         }

--- a/Public/Src/Utilities/Native/IO/Unix/FileUtilities.Unix.cs
+++ b/Public/Src/Utilities/Native/IO/Unix/FileUtilities.Unix.cs
@@ -421,6 +421,15 @@ namespace BuildXL.Native.IO.Unix
                         using (FileStream destinationStream = CreateReplacementFile(destination, FileShare.Delete, openAsync: true))
                         {
                             await sourceStream.CopyToAsync(destinationStream);
+
+                            var mode = GetFilePermissionsForFilePath(source, followSymlink: false);
+                            var result = SetFilePermissionsForFilePath(destination, checked((FilePermissions)mode), followSymlink: false);
+
+                            if (result < 0)
+                            {
+                                throw new BuildXLException($"Failed to set permissions for file copy at '{destination}' - error: {Marshal.GetLastWin32Error()}");
+                            }
+
                             onCompletion?.Invoke(sourceStream.SafeFileHandle, destinationStream.SafeFileHandle);
                         }
                     }


### PR DESCRIPTION
FileStream based copying does bitwise copying and does not take care of replicating source ACLs on the destination file. This fix rectifies this for Unix `CopyFilyAsync()` implementations.