### PR TITLE
Stop logger from throwing when receiving template strings without arguments

### DIFF
--- a/Public/Src/Cache/ContentStore/Library/Logging/Logger.cs
+++ b/Public/Src/Cache/ContentStore/Library/Logging/Logger.cs
@@ -152,7 +152,12 @@ namespace BuildXL.Cache.ContentStore.Logging
         /// <inheritdoc />
         public void Fatal(Exception exception, string messageFormat, params object[] messageArgs)
         {
-            var messageIn = string.Format(CultureInfo.CurrentCulture, messageFormat, messageArgs);
+            var messageIn = messageFormat;
+            if (messageArgs != null && messageArgs.Length > 0)
+            {
+                messageIn = string.Format(CultureInfo.CurrentCulture, messageFormat, messageArgs);
+            }
+
             var message = string.Format(CultureInfo.CurrentCulture, "{0}, Exception=[{1}]", messageIn, exception);
             LogString(Severity.Fatal, message);
             Flush();
@@ -168,7 +173,12 @@ namespace BuildXL.Cache.ContentStore.Logging
         /// <inheritdoc />
         public void Error(Exception exception, string messageFormat, params object[] messageArgs)
         {
-            var messageIn = string.Format(CultureInfo.CurrentCulture, messageFormat, messageArgs);
+            var messageIn = messageFormat;
+            if (messageArgs != null && messageArgs.Length > 0)
+            {
+                messageIn = string.Format(CultureInfo.CurrentCulture, messageFormat, messageArgs);
+            }
+
             var message = string.Format(CultureInfo.CurrentCulture, "{0}, Exception=[{1}]", messageIn, ResultBase.GetExceptionString(exception));
             LogString(Severity.Error, message);
             Flush();
@@ -221,7 +231,12 @@ namespace BuildXL.Cache.ContentStore.Logging
         /// <inheritdoc />
         public void LogFormat(Severity severity, string messageFormat, params object[] messageArgs)
         {
-            LogString(severity, string.Format(CultureInfo.InvariantCulture, messageFormat, messageArgs));
+            if (messageArgs != null && messageArgs.Length > 0)
+            {
+                messageFormat = string.Format(CultureInfo.InvariantCulture, messageFormat, messageArgs);
+            }
+
+            LogString(severity, messageFormat);
         }
 
         private void LogString(Severity severity, string message)

--- a/Public/Src/Cache/ContentStore/Test/Logging/LoggerTests.cs
+++ b/Public/Src/Cache/ContentStore/Test/Logging/LoggerTests.cs
@@ -22,6 +22,9 @@ namespace ContentStoreTest.Logging
         private const string ExceptionalFormattedMessage =
             "argument 1, Exception=[System.InvalidOperationException: text]";
 
+        private const string ExceptionalFormattedMessageNoArgs =
+            "argument {0}, Exception=[System.InvalidOperationException: text]";
+
         private readonly Exception _exception = new InvalidOperationException("text");
 
         private class LogWriteArgs
@@ -144,6 +147,7 @@ namespace ContentStoreTest.Logging
         public void FatalMethodWritesCorrectMessage()
         {
             InvokeLoggerMethod(logger => logger.Fatal(MessageFormat, Arg)).MessageString.Should().Be(FormattedMessage);
+            InvokeLoggerMethod(logger => logger.Fatal(MessageFormat)).MessageString.Should().Be(MessageFormat);
         }
 
         [Fact]
@@ -157,6 +161,7 @@ namespace ContentStoreTest.Logging
         public void ErrorMethodWritesCorrectMessage()
         {
             InvokeLoggerMethod(logger => logger.Error(MessageFormat, Arg)).MessageString.Should().Be(FormattedMessage);
+            InvokeLoggerMethod(logger => logger.Error(MessageFormat)).MessageString.Should().Be(MessageFormat);
         }
 
         [Fact]
@@ -165,6 +170,14 @@ namespace ContentStoreTest.Logging
             InvokeLoggerMethod(logger => logger.Error(_exception, MessageFormat, Arg))
                 .MessageString.Should()
                 .Be(ExceptionalFormattedMessage);
+        }
+
+        [Fact]
+        public void ErrorMethodWritesCorrectExceptionalMessageNoArgs()
+        {
+            InvokeLoggerMethod(logger => logger.Error(_exception, MessageFormat))
+                .MessageString.Should()
+                .Be(ExceptionalFormattedMessageNoArgs);
         }
 
         [Fact]
@@ -203,6 +216,7 @@ namespace ContentStoreTest.Logging
         public void WarnMethodWritesCorrectMessage()
         {
             InvokeLoggerMethod(logger => logger.Warning(MessageFormat, Arg)).MessageString.Should().Be(FormattedMessage);
+            InvokeLoggerMethod(logger => logger.Warning(MessageFormat)).MessageString.Should().Be(MessageFormat);
         }
 
         [Fact]
@@ -215,6 +229,7 @@ namespace ContentStoreTest.Logging
         public void NormalMethodWritesCorrectMessage()
         {
             InvokeLoggerMethod(logger => logger.Always(MessageFormat, Arg)).MessageString.Should().Be(FormattedMessage);
+            InvokeLoggerMethod(logger => logger.Always(MessageFormat)).MessageString.Should().Be(MessageFormat);
         }
 
         [Fact]
@@ -227,6 +242,7 @@ namespace ContentStoreTest.Logging
         public void InfoMethodWritesCorrectMessage()
         {
             InvokeLoggerMethod(logger => logger.Info(MessageFormat, Arg)).MessageString.Should().Be(FormattedMessage);
+            InvokeLoggerMethod(logger => logger.Info(MessageFormat)).MessageString.Should().Be(MessageFormat);
         }
 
         [Fact]
@@ -239,6 +255,7 @@ namespace ContentStoreTest.Logging
         public void DebugMethodWritesCorrectMessage()
         {
             InvokeLoggerMethod(logger => logger.Debug(MessageFormat, Arg)).MessageString.Should().Be(FormattedMessage);
+            InvokeLoggerMethod(logger => logger.Debug(MessageFormat)).MessageString.Should().Be(MessageFormat);
         }
 
         [Fact]
@@ -260,6 +277,14 @@ namespace ContentStoreTest.Logging
             InvokeLoggerMethod(logger => logger.Diagnostic(MessageFormat, Arg))
                 .MessageString.Should()
                 .Be(FormattedMessage);
+        }
+
+        [Fact]
+        public void DiagnosticMethodWritesCorrectMessageNoArgs()
+        {
+            InvokeLoggerMethod(logger => logger.Diagnostic(MessageFormat))
+                .MessageString.Should()
+                .Be(MessageFormat);
         }
 
         [Fact]
@@ -290,6 +315,14 @@ namespace ContentStoreTest.Logging
             InvokeLoggerMethod(logger => logger.LogFormat(Severity.Diagnostic, MessageFormat, Arg))
                 .MessageString.Should()
                 .Be(FormattedMessage);
+        }
+
+        [Fact]
+        public void LogFormatMethodWritesCorrectMessageNoArgs()
+        {
+            InvokeLoggerMethod(logger => logger.LogFormat(Severity.Diagnostic, MessageFormat))
+                .MessageString.Should()
+                .Be(MessageFormat);
         }
 
         private static LogWriteArgs InvokeLoggerMethod(Action<ILogger> action)


### PR DESCRIPTION
Doing this:

``_logger.Error("{0}")``

Would throw because we'd attempt to `string.Format` the thing. When part of what you're printing is uncontrolled (i.e. an exception from a different subsystem), calls like this:

``_logger.Error($"{exception}")``

Will throw if the string representation of the exception contains any `{}` as substring. This PR stops that from happening, since the latter case is much more common than the former.