### PR TITLE
Keep track of commit memory as a resource

### DIFF
--- a/Public/Src/App/Bxl/Tracing/Log.cs
+++ b/Public/Src/App/Bxl/Tracing/Log.cs
@@ -288,7 +288,7 @@ namespace BuildXL.App.Tracing
 
                 if (perfInfo.EnginePerformanceInfo.SchedulerPerformanceInfo.HitLowMemorySmell)
                 {
-                    LogPerfSmell(context, () => Scheduler.Tracing.Logger.Log.LowMemory(context, perfInfo.EnginePerformanceInfo.SchedulerPerformanceInfo.MachineMinimumAvailablePhysicalMB));
+                    LogPerfSmell(context, () => Scheduler.Tracing.Logger.Log.HitLowMemorySmell(context));
                 }
 
                 if (config.Sandbox.LogProcesses)

--- a/Public/Src/Cache/ContentStore/Library/Utils/MachinePerformanceCollector.cs
+++ b/Public/Src/Cache/ContentStore/Library/Utils/MachinePerformanceCollector.cs
@@ -25,7 +25,7 @@ namespace BuildXL.Cache.ContentStore.Utils
 
             set.AddMetric("MachineAvailableRamMb", perfInfo.AvailableRamMb ?? -1);
             set.AddMetric("CommitLimitMb", perfInfo.CommitLimitMb ?? -1);
-            set.AddMetric("CommitTotalMb", perfInfo.CommitTotalMb ?? -1);
+            set.AddMetric("CommitTotalMb", perfInfo.CommitUsedMb ?? -1);
             set.AddMetric("CommitUsagePercentage", perfInfo.CommitUsagePercentage ?? -1);
             set.AddMetric("CpuUsagePercentage", perfInfo.CpuUsagePercentage);
             set.AddMetric("MachineBandwidth", perfInfo.MachineBandwidth);

--- a/Public/Src/Engine/Cache/Fingerprints/OpenBondDistribution.bond
+++ b/Public/Src/Engine/Cache/Fingerprints/OpenBondDistribution.bond
@@ -171,8 +171,11 @@ struct SinglePipBuildRequest
 	/// The expected RAM usage of the pip
 	6: nullable<int32> ExpectedRamUsageMb;
 
+    /// The expected commit usage of the pip
+	7: nullable<int32> ExpectedCommitUsageMb;
+
 	/// Sequence number for deduplicating worker calls
-	7: int32 SequenceNumber;
+	8: int32 SequenceNumber;
 }
 
 /// A request to build pips on a worker
@@ -197,6 +200,9 @@ struct AttachCompletionInfo
 	/// The content hash of the workers unique content
     3: BuildXL.Engine.Cache.Fingerprints.BondContentHash WorkerCacheValidationContentHash;
 
-	/// The availale RAM on the worker
+	/// The available RAM on the worker
 	4: nullable<int32> AvailableRamMb;
+
+    /// The available commit on the worker
+	5: nullable<int32> AvailableCommitMb;
 }

--- a/Public/Src/Engine/Distribution.Grpc/Interfaces.proto
+++ b/Public/Src/Engine/Distribution.Grpc/Interfaces.proto
@@ -41,6 +41,9 @@ message AttachCompletionInfo
 
     // The available RAM on the worker
     int32 AvailableRamMb = 4;
+
+    // The available commit on the worker
+    int32 AvailableCommitMb = 5;
 }
 
 // Defines information about a completed pip and its outputs
@@ -164,11 +167,14 @@ message SinglePipBuildRequest
     // The execution step requested
     int32 Step = 5;
 
-    /// The expected RAM usage of the pip
+    // The expected RAM usage of the pip
     int32 ExpectedRamUsageMb = 6;
+    
+    // The expected commit usage of the pip
+    int32 ExpectedCommitUsageMb = 7;
 
     // Sequence number for deduplicating worker calls
-    int32 SequenceNumber = 7;
+    int32 SequenceNumber = 8;
 }
 
 message FileArtifactKeyedHash

--- a/Public/Src/Engine/Dll/Distribution/Grpc/OpenBondConversionUtils.cs
+++ b/Public/Src/Engine/Dll/Distribution/Grpc/OpenBondConversionUtils.cs
@@ -19,7 +19,8 @@ namespace BuildXL.Engine.Distribution.Grpc
             {
                 WorkerId = message.WorkerId,
 
-                AvailableRamMb = message.AvailableRamMb ?? 100000,
+                AvailableRamMb = message.AvailableRamMb ?? 0,
+                AvailableCommitMb = message.AvailableCommitMb ?? 0,
                 MaxConcurrency = message.MaxConcurrency,
                 WorkerCacheValidationContentHash = message.WorkerCacheValidationContentHash.Data.ToByteString(),
             };
@@ -32,6 +33,7 @@ namespace BuildXL.Engine.Distribution.Grpc
                 WorkerId = message.WorkerId,
                 
                 AvailableRamMb = message.AvailableRamMb,
+                AvailableCommitMb = message.AvailableCommitMb,
                 MaxConcurrency = message.MaxConcurrency,
                 WorkerCacheValidationContentHash = message.WorkerCacheValidationContentHash.ToBondContentHash(),
             };
@@ -241,6 +243,7 @@ namespace BuildXL.Engine.Distribution.Grpc
                 {
                     ActivityId = i.ActivityId,
                     ExpectedRamUsageMb = i.ExpectedRamUsageMb ?? 0,
+                    ExpectedCommitUsageMb = i.ExpectedCommitUsageMb ?? 0,
                     Fingerprint = i.Fingerprint.Data.ToByteString(),
                     PipIdValue = i.PipIdValue,
                     Priority = i.Priority,
@@ -291,6 +294,7 @@ namespace BuildXL.Engine.Distribution.Grpc
                 {
                     ActivityId = i.ActivityId,
                     ExpectedRamUsageMb = i.ExpectedRamUsageMb,
+                    ExpectedCommitUsageMb = i.ExpectedCommitUsageMb,
                     Fingerprint = new BondFingerprint() { Data = i.Fingerprint.ToArraySegmentByte() },
                     PipIdValue = i.PipIdValue,
                     Priority = i.Priority,

--- a/Public/Src/Engine/Dll/Distribution/RemoteWorker.cs
+++ b/Public/Src/Engine/Dll/Distribution/RemoteWorker.cs
@@ -117,11 +117,11 @@ namespace BuildXL.Engine.Distribution
             m_sendThread = new Thread(SendBuildRequests);
         }
 
-        public override void Initialize(PipGraph pipGraph, IExecutionLogTarget executionLogTarget)
+        public override void Initialize(PipGraph pipGraph, IExecutionLogTarget executionLogTarget, PipExecutionContext context)
         {
             m_pipGraph = pipGraph;
             m_workerExecutionLogTarget = executionLogTarget;
-            base.Initialize(pipGraph, executionLogTarget);
+            base.Initialize(pipGraph, executionLogTarget, context);
         }
 
         public override int WaitingBuildRequestsCount => m_buildRequests.Count;
@@ -635,7 +635,8 @@ namespace BuildXL.Engine.Distribution
                 Fingerprint = fingerprint.Hash.ToBondFingerprint(),
                 Priority = runnable.Priority,
                 Step = (int)runnable.Step,
-                ExpectedRamUsageMb = processRunnable?.ExpectedRamUsageMb,
+                ExpectedRamUsageMb = processRunnable?.ExpectedMemoryCounters?.PeakWorkingSetMb,
+                ExpectedCommitUsageMb = processRunnable?.ExpectedMemoryCounters?.PeakCommitUsageMb,
                 SequenceNumber = Interlocked.Increment(ref m_nextSequenceNumber),
             };
 
@@ -946,7 +947,20 @@ namespace BuildXL.Engine.Distribution
 
             m_cacheValidationContentHash = attachCompletionInfo.WorkerCacheValidationContentHash;
             TotalProcessSlots = attachCompletionInfo.MaxConcurrency;
-            TotalMemoryMb = attachCompletionInfo.AvailableRamMb;
+            TotalRamMb = attachCompletionInfo.AvailableRamMb;
+            TotalCommitMb = attachCompletionInfo.AvailableCommitMb;
+
+            if (TotalRamMb == 0)
+            {
+                // If BuildXL did not properly retrieve the available ram, then we use the default: 100gb
+                TotalRamMb = 100000;
+                Logger.Log.WorkerTotalRamMb(m_appLoggingContext, Name, TotalRamMb.Value, TotalCommitMb.Value);
+            }
+
+            if (TotalCommitMb == 0)
+            {
+                TotalCommitMb = (int)(TotalRamMb * 1.5);
+            }
 
             var validateCacheSuccess = await ValidateCacheConnection();
 

--- a/Public/Src/Engine/Dll/Distribution/RemoteWorker.cs
+++ b/Public/Src/Engine/Dll/Distribution/RemoteWorker.cs
@@ -117,11 +117,11 @@ namespace BuildXL.Engine.Distribution
             m_sendThread = new Thread(SendBuildRequests);
         }
 
-        public override void Initialize(PipGraph pipGraph, IExecutionLogTarget executionLogTarget, PipExecutionContext context)
+        public override void Initialize(PipGraph pipGraph, IExecutionLogTarget executionLogTarget)
         {
             m_pipGraph = pipGraph;
             m_workerExecutionLogTarget = executionLogTarget;
-            base.Initialize(pipGraph, executionLogTarget, context);
+            base.Initialize(pipGraph, executionLogTarget);
         }
 
         public override int WaitingBuildRequestsCount => m_buildRequests.Count;

--- a/Public/Src/Engine/Dll/Distribution/WorkerService.cs
+++ b/Public/Src/Engine/Dll/Distribution/WorkerService.cs
@@ -419,7 +419,8 @@ namespace BuildXL.Engine.Distribution
             {
                 WorkerId = WorkerId,
                 MaxConcurrency = m_maxProcesses,
-                AvailableRamMb = m_scheduler.LocalWorker.TotalMemoryMb,
+                AvailableRamMb = m_scheduler.LocalWorker.TotalRamMb,
+                AvailableCommitMb = m_scheduler.LocalWorker.TotalCommitMb,
                 WorkerCacheValidationContentHash = cacheValidationContentHash.ToBondContentHash(),
             };
 
@@ -583,7 +584,10 @@ namespace BuildXL.Engine.Distribution
                         var fingerprint = pipBuildRequest.Fingerprint.ToFingerprint();
                         processRunnable.SetCacheResult(RunnableFromCacheResult.CreateForMiss(new WeakContentFingerprint(fingerprint)));
 
-                        processRunnable.ExpectedRamUsageMb = pipBuildRequest.ExpectedRamUsageMb;
+                        processRunnable.ExpectedMemoryCounters = ProcessMemoryCounters.CreateFromMb(
+                            peakVirtualMemoryUsageMb: pipBuildRequest.ExpectedRamUsageMb ?? 0,
+                            peakWorkingSetMb: pipBuildRequest.ExpectedRamUsageMb ?? 0,
+                            peakCommitUsageMb: pipBuildRequest.ExpectedCommitUsageMb ?? 0);
                     }
 
                     break;

--- a/Public/Src/Engine/Dll/Tracing/Log.cs
+++ b/Public/Src/Engine/Dll/Tracing/Log.cs
@@ -427,6 +427,15 @@ namespace BuildXL.Engine.Tracing
         #region Distribution
 
         [GeneratedEvent(
+            (ushort)LogEventId.WorkerTotalRamMb,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Verbose,
+            Keywords = (int)Keywords.UserMessage,
+            EventTask = (ushort)Tasks.Scheduler,
+            Message = "{worker} could not send available ram to master. Master used the default limit in MB: {defaultRamMb}. Available Commit in MB: {commitMb}")]
+        public abstract void WorkerTotalRamMb(LoggingContext context, string worker, int defaultRamMb, int commitMb);
+
+        [GeneratedEvent(
             (ushort)LogEventId.DistributionHostLog,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,

--- a/Public/Src/Engine/Dll/Tracing/LogEventId.cs
+++ b/Public/Src/Engine/Dll/Tracing/LogEventId.cs
@@ -180,6 +180,7 @@ namespace BuildXL.Engine.Tracing
         DistributionBondCall = 7041,
         DistributionDebugMessage = 7042,
         DistributionServiceInitializationError = 7043,
+        WorkerTotalRamMb = 7044,
 
         // Scheduling
         ForceSkipDependenciesOrDistributedBuildOverrideIncrementalScheduling = 7051,

--- a/Public/Src/Engine/Processes/JobObject.cs
+++ b/Public/Src/Engine/Processes/JobObject.cs
@@ -388,8 +388,8 @@ namespace BuildXL.Processes
                        KernelTime = new TimeSpan(checked((long)info.BasicAccountingInformation.TotalKernelTime)),
                        UserTime = new TimeSpan(checked((long)info.BasicAccountingInformation.TotalUserTime)),
                        NumberOfProcesses = info.BasicAccountingInformation.TotalProcesses,
-                       MemoryCounters = new ProcessMemoryCounters(GetPeakVirtualMemoryUsage(), peakWorkingSetUsage, peakPagefileUsage)
-            };
+                       MemoryCounters = ProcessMemoryCounters.CreateFromBytes(GetPeakVirtualMemoryUsage(), peakWorkingSetUsage, peakPagefileUsage)
+                    };
         }
 
         /// <summary>

--- a/Public/Src/Engine/Processes/SandboxedProcessMac.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessMac.cs
@@ -426,7 +426,7 @@ namespace BuildXL.Processes
                         WriteTransferCount = Convert.ToUInt64(m_perfAggregator.DiskBytesWritten.Total)
                     });
 
-                    memoryCounters = new ProcessMemoryCounters(0, Convert.ToUInt64(m_perfAggregator.PeakMemoryBytes.Maximum), 0);
+                    memoryCounters = ProcessMemoryCounters.CreateFromBytes(0, Convert.ToUInt64(m_perfAggregator.PeakMemoryBytes.Maximum), 0);
                 }
                 catch(OverflowException ex)
                 {
@@ -440,7 +440,7 @@ namespace BuildXL.Processes
                         WriteTransferCount = 0
                     });
 
-                    memoryCounters = new ProcessMemoryCounters(0, 0, 0);
+                    memoryCounters = ProcessMemoryCounters.CreateFromBytes(0, 0, 0);
                 }
 
                 return new JobObject.AccountingInformation

--- a/Public/Src/Engine/Scheduler/Distribution/LocalWorker.cs
+++ b/Public/Src/Engine/Scheduler/Distribution/LocalWorker.cs
@@ -81,7 +81,7 @@ namespace BuildXL.Scheduler.Distribution
                     environment.State.GetScope(process),
                     process,
                     fingerprint,
-                    expectedRamUsageMb: GetExpectedRamUsageMb(processRunnable));
+                    expectedMemoryCounters: GetExpectedMemoryCounters(processRunnable));
                 processRunnable.SetExecutionResult(executionResult);
 
                 Unit ignore;

--- a/Public/Src/Engine/Scheduler/Distribution/WorkerResource.cs
+++ b/Public/Src/Engine/Scheduler/Distribution/WorkerResource.cs
@@ -32,9 +32,14 @@ namespace BuildXL.Scheduler.Distribution
         public static readonly WorkerResource AvailableCacheLookupSlots = new WorkerResource(nameof(AvailableCacheLookupSlots), Precedence.AvailableCacheLookupSlots);
 
         /// <summary>
-        /// See <see cref="Worker.TotalMemoryMb"/>
+        /// See <see cref="Worker.TotalRamMb"/>
         /// </summary>
         public static readonly WorkerResource AvailableMemoryMb = new WorkerResource(nameof(AvailableMemoryMb), Precedence.AvailableMemoryMb);
+
+        /// <summary>
+        /// See <see cref="Worker.TotalCommitMb"/>
+        /// </summary>
+        public static readonly WorkerResource AvailableCommitMb = new WorkerResource(nameof(AvailableCommitMb), Precedence.AvailableCommitMb);
 
         /// <summary>
         /// See <see cref="Worker.ResourcesAvailable"/>
@@ -113,6 +118,7 @@ namespace BuildXL.Scheduler.Distribution
             AvailableCacheLookupSlots,
             AvailableProcessSlots,
             AvailableMemoryMb,
+            AvailableCommitMb,
             ResourcesAvailable,
             SemaphorePrecedence,
         }

--- a/Public/Src/Engine/Scheduler/Performance/PipRuntimeTimeTable.cs
+++ b/Public/Src/Engine/Scheduler/Performance/PipRuntimeTimeTable.cs
@@ -27,7 +27,7 @@ namespace BuildXL.Scheduler
         /// <summary>
         /// The version for format of <see cref="PipRuntimeTimeTable"/>
         /// </summary>
-        public const int FormatVersion = 0;
+        public const int FormatVersion = 1;
 
         private static readonly FileEnvelope FileEnvelope = new FileEnvelope(name: "Runtime", version: FormatVersion);
 

--- a/Public/Src/Engine/Scheduler/PipExecutor.cs
+++ b/Public/Src/Engine/Scheduler/PipExecutor.cs
@@ -1136,7 +1136,7 @@ namespace BuildXL.Scheduler
         /// <param name="pip">The pip to execute</param>
         /// <param name="fingerprint">The pip fingerprint</param>
         /// <param name="processIdListener">Callback to call when the process is actually started</param>
-        /// <param name="expectedRamUsageMb">the expected ram usage for the process in megabytes</param>
+        /// <param name="expectedMemoryCounters">the expected memory counters for the process in megabytes</param>
         /// <returns>A task that returns the execution result when done</returns>
         public static async Task<ExecutionResult> ExecuteProcessAsync(
             OperationContext operationContext,
@@ -1147,7 +1147,7 @@ namespace BuildXL.Scheduler
             // TODO: This should be removed, or should become a WeakContentFingerprint
             ContentFingerprint? fingerprint,
             Action<int> processIdListener = null,
-            int expectedRamUsageMb = 0)
+            ProcessMemoryCounters expectedMemoryCounters = default(ProcessMemoryCounters))
         {
             var context = environment.Context;
             var counters = environment.Counters;
@@ -1309,7 +1309,7 @@ namespace BuildXL.Scheduler
                 .ExecuteWithResources(
                     operationContext,
                     pip.PipId,
-                    expectedRamUsageMb,
+                    expectedMemoryCounters,
                     allowResourceBasedCancellation,
                     async (resourceLimitCancellationToken, registerQueryRamUsageMb) =>
                     {
@@ -1328,7 +1328,7 @@ namespace BuildXL.Scheduler
                                         processDescription,
                                         (long)(operationContext.Duration?.TotalMilliseconds ?? -1),
                                         peakMemoryMb: lastObservedPeakRamUsage,
-                                        expectedMemoryMb: expectedRamUsageMb);
+                                        expectedMemoryMb: expectedMemoryCounters.PeakWorkingSetMb);
 
                                     using (operationContext.StartAsyncOperation(PipExecutorCounter.ResourceLimitCancelProcessDuration))
                                     {
@@ -1386,7 +1386,7 @@ namespace BuildXL.Scheduler
                                         using (counters[PipExecutorCounter.QueryRamUsageDuration].Start())
                                         {
                                             lastObservedPeakRamUsage =
-                                                (int)ByteSizeFormatter.ToMegabytes((long)(executor.GetActivePeakWorkingSet() ?? 0));
+                                                (int)ByteSizeFormatter.ToMegabytes(executor.GetActivePeakWorkingSet() ?? 0);
                                         }
 
                                         return lastObservedPeakRamUsage;
@@ -1544,9 +1544,8 @@ namespace BuildXL.Scheduler
                                         operationContext,
                                         processDescription,
                                         (long)(operationContext.Duration?.TotalMilliseconds ?? -1),
-                                        peakMemoryMb:
-                                            (int)ByteSizeFormatter.ToMegabytes((long)(result.JobAccountingInformation?.MemoryCounters.PeakWorkingSet ?? 0)),
-                                        expectedMemoryMb: expectedRamUsageMb,
+                                        peakMemoryMb: result.JobAccountingInformation?.MemoryCounters.PeakWorkingSetMb ?? 0,
+                                        expectedMemoryMb: expectedMemoryCounters.PeakWorkingSetMb,
                                         cancelMilliseconds: (int)(cancelTime?.TotalMilliseconds ?? 0));
                                 }
                             }

--- a/Public/Src/Engine/Scheduler/PipExecutor.cs
+++ b/Public/Src/Engine/Scheduler/PipExecutor.cs
@@ -1546,6 +1546,8 @@ namespace BuildXL.Scheduler
                                         (long)(operationContext.Duration?.TotalMilliseconds ?? -1),
                                         peakMemoryMb: result.JobAccountingInformation?.MemoryCounters.PeakWorkingSetMb ?? 0,
                                         expectedMemoryMb: expectedMemoryCounters.PeakWorkingSetMb,
+                                        peakCommitMb: result.JobAccountingInformation?.MemoryCounters.PeakCommitUsageMb ?? 0,
+                                        expectedCommitMb: expectedMemoryCounters.PeakCommitUsageMb,
                                         cancelMilliseconds: (int)(cancelTime?.TotalMilliseconds ?? 0));
                                 }
                             }

--- a/Public/Src/Engine/Scheduler/ProcessRunnablePip.cs
+++ b/Public/Src/Engine/Scheduler/ProcessRunnablePip.cs
@@ -43,9 +43,9 @@ namespace BuildXL.Scheduler
         public bool Executed { get; set; }
 
         /// <summary>
-        /// The expected RAM utilization of the pip
+        /// The expected memory usage for the pip
         /// </summary>
-        public int? ExpectedRamUsageMb;
+        public ProcessMemoryCounters? ExpectedMemoryCounters;
 
         /// <summary>
         /// The expected historical duration of the pip

--- a/Public/Src/Engine/Scheduler/RunnablePip.cs
+++ b/Public/Src/Engine/Scheduler/RunnablePip.cs
@@ -489,7 +489,7 @@ namespace BuildXL.Scheduler
                             ioCounters: default(IOCounters),
                             userTime: TimeSpan.Zero,
                             kernelTime: TimeSpan.Zero,
-                            memoryCounters: new ProcessMemoryCounters(0, 0, 0),
+                            memoryCounters: ProcessMemoryCounters.CreateFromMb(0, 0, 0),
                             numberOfProcesses: 0,
                             workerId: 0);
                 }

--- a/Public/Src/Engine/Scheduler/Scheduler.cs
+++ b/Public/Src/Engine/Scheduler/Scheduler.cs
@@ -332,7 +332,7 @@ namespace BuildXL.Scheduler
                     ExecutionLog?.CreateWorkerTarget((uint)worker.WorkerId);
 
                 worker.TrackStatusOperation(m_workersStatusOperation);
-                worker.Initialize(PipGraph, workerExecutionLogTarget, Context);
+                worker.Initialize(PipGraph, workerExecutionLogTarget);
                 worker.AdjustTotalCacheLookupSlots(m_scheduleConfiguration.MaxCacheLookup * (worker.IsLocal ? 1 : 5)); // Oversubscribe the cachelookup step for remote workers
                 worker.StatusChanged += OnWorkerStatusChanged;
                 worker.Start();

--- a/Public/Src/Engine/Scheduler/Tracing/ExecutionLog.Events.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/ExecutionLog.Events.cs
@@ -1143,12 +1143,12 @@ namespace BuildXL.Scheduler.Tracing
         /// <summary>
         /// Ram utilization in MB
         /// </summary>
-        public int MachineRamUtilizationMB;
+        public int RamUsedMb;
 
         /// <summary>
         /// Available Ram in MB
         /// </summary>
-        public int MachineAvailableRamMB;
+        public int RamFreeMb;
 
         /// <summary>
         /// Percentage of available commit used. Note if the machine has an expandable page file, this is based on the
@@ -1160,7 +1160,12 @@ namespace BuildXL.Scheduler.Tracing
         /// <summary>
         /// The machine's total commit in MB
         /// </summary>
-        public int CommitTotalMB;
+        public int CommitUsedMb;
+
+        /// <summary>
+        /// Available Commit in MB
+        /// </summary>
+        public int CommitFreeMb;
 
         /// <summary>
         /// CPU utilization of the current process
@@ -1282,10 +1287,11 @@ namespace BuildXL.Scheduler.Tracing
                 writer.Write(pipsSucceeded);
             }
 
-            writer.Write(MachineRamUtilizationMB);
-            writer.Write(MachineAvailableRamMB);
+            writer.Write(RamUsedMb);
+            writer.Write(RamFreeMb);
             writer.Write(CommitPercent);
-            writer.Write(CommitTotalMB);
+            writer.Write(CommitUsedMb);
+            writer.Write(CommitFreeMb);
         }
 
         /// <inheritdoc />
@@ -1332,10 +1338,11 @@ namespace BuildXL.Scheduler.Tracing
                 PipsSucceededAllTypes[i] = reader.ReadInt64();
             }
 
-            MachineRamUtilizationMB = reader.ReadInt32();
-            MachineAvailableRamMB = reader.ReadInt32();
+            RamUsedMb = reader.ReadInt32();
+            RamFreeMb = reader.ReadInt32();
             CommitPercent = reader.ReadInt32();
-            CommitTotalMB = reader.ReadInt32();
+            CommitUsedMb = reader.ReadInt32();
+            CommitFreeMb = reader.ReadInt32();
         }
     }
 

--- a/Public/Src/Engine/Scheduler/Tracing/Log.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/Log.cs
@@ -1249,8 +1249,8 @@ namespace BuildXL.Scheduler.Tracing
             EventLevel = Level.Warning,
             Keywords = (int)Keywords.UserMessage,
             EventTask = (ushort)Tasks.PipExecutor,
-            Message = "[{pipDescription}] Cancelled process execution due to exceeding resource threshold. Elapsed execution time: {elapsedMs} ms. Peak memory: {peakMemoryMb} MB. Expected memory: {expectedMemoryMb} MB. Cancel time (ms): {cancelMilliseconds}")]
-        internal abstract void CancellingProcessPipExecutionDueToResourceExhaustion(LoggingContext loggingContext, string pipDescription, long elapsedMs, int peakMemoryMb, int expectedMemoryMb, int cancelMilliseconds);
+            Message = "[{pipDescription}] Cancelled process execution due to exceeding resource threshold. Elapsed execution time: {elapsedMs} ms. Peak memory: {peakMemoryMb} MB. Expected memory: {expectedMemoryMb} MB. Peak commit memory: {peakCommitMb} MB. Expected commit memory: {expectedCommitMb} MB. Cancel time (ms): {cancelMilliseconds}")]
+        internal abstract void CancellingProcessPipExecutionDueToResourceExhaustion(LoggingContext loggingContext, string pipDescription, long elapsedMs, int peakMemoryMb, int expectedMemoryMb, int peakCommitMb, int expectedCommitMb, int cancelMilliseconds);
 
         [GeneratedEvent(
             (ushort)LogEventId.StartCancellingProcessPipExecutionDueToResourceExhaustion,

--- a/Public/Src/Engine/Scheduler/Tracing/Log.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/Log.cs
@@ -4336,13 +4336,31 @@ namespace BuildXL.Scheduler.Tracing
         public abstract void KextFailureNotificationReceived(LoggingContext context, int errorCode, string description);
 
         [GeneratedEvent(
-            (ushort)EventId.LowMemory,
+            (ushort)EventId.LowRamMemory,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Verbose,
+            EventTask = (ushort)Tasks.HostApplication,
+            Message = "Machine ran out of physical ram and had to fall back to the page file: {machineAvailablePhysicalMb} MB - {machineRamUsagePercentage}%.",
+            Keywords = (int)Keywords.UserMessage)]
+        public abstract void LowRamMemory(LoggingContext context, int machineAvailablePhysicalMb, int machineRamUsagePercentage);
+
+        [GeneratedEvent(
+            (ushort)EventId.LowCommitMemory,
+            EventGenerators = EventGenerators.LocalOnly,
+            EventLevel = Level.Verbose,
+            EventTask = (ushort)Tasks.HostApplication,
+            Message = "Machine ran out of commit memory: {machineAvailableCommitMb} MB - {machineCommitUsagePercentage}%.",
+            Keywords = (int)Keywords.UserMessage)]
+        public abstract void LowCommitMemory(LoggingContext context, int machineAvailableCommitMb, int machineCommitUsagePercentage);
+
+        [GeneratedEvent(
+            (ushort)EventId.HitLowMemorySmell,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,
             EventTask = (ushort)Tasks.HostApplication,
             Message = "Machine ran out of physical ram and had to fall back to the page file. This can dramatically impact build performance. Either too much concurrency was used during the build or the memory throttling options were not effective. Try adjusting the following options: /maxproc, /maxRamUtilizationPercentage, /minAvailableRamMb. See verbose help text for details: {MainExecutableName} /help:verbose",
             Keywords = (int)Keywords.UserMessage)]
-        public abstract void LowMemory(LoggingContext context, long machineMinimumAvailablePhysicalMB);
+        public abstract void HitLowMemorySmell(LoggingContext context);
 
         [GeneratedEvent(
             (int)EventId.InvalidSharedOpaqueDirectoryDueToOverlap,
@@ -4546,8 +4564,8 @@ namespace BuildXL.Scheduler.Tracing
             EventLevel = Level.Verbose,
             Keywords = (int)Keywords.UserMessage,
             EventTask = (ushort)Tasks.PipExecutor,
-            Message = "[{pipDescription}] NumProcesses: {numProcesses}, ExpectedDurationSec: {expectedDurationSec}, ActualDurationSec: {actualDurationSec}, ProcessorUseInPercents: {processorUseInPercents}, DefaultMemoryUsageMb: {defaultMemoryUsageMb}, ExpectedMemoryUsageMb: {expectedMemoryUsageMb}, PeakVirtualMemoryMb: {peakVirtualMemoryMb}, PeakWorkingSetMb: {peakWorkingSetMb}, PeakPagefileUsageMb: {peakPagefileUsageMb}")]
-        internal abstract void ProcessPipExecutionInfo(LoggingContext loggingContext, string pipDescription, uint numProcesses, ulong expectedDurationSec, double actualDurationSec, int processorUseInPercents, int defaultMemoryUsageMb, int expectedMemoryUsageMb, int peakVirtualMemoryMb, int peakWorkingSetMb, int peakPagefileUsageMb);
+            Message = "[{pipDescription}] NumProcesses: {numProcesses}, ExpectedDurationSec: {expectedDurationSec}, ActualDurationSec: {actualDurationSec}, ProcessorUseInPercents: {processorUseInPercents}, DefaultMemoryUsageMb: {defaultMemoryUsageMb}, ExpectedMemoryUsageMb: {expectedMemoryUsageMb}, PeakVirtualMemoryMb: {peakVirtualMemoryMb}, PeakWorkingSetMb: {peakWorkingSetMb}, ExpectedCommitUsageMb: {expectedCommitUsageMb}, PeakCommitUsageMb: {peakCommitUsageMb}")]
+        internal abstract void ProcessPipExecutionInfo(LoggingContext loggingContext, string pipDescription, uint numProcesses, ulong expectedDurationSec, double actualDurationSec, int processorUseInPercents, int defaultMemoryUsageMb, int expectedMemoryUsageMb, int peakVirtualMemoryMb, int peakWorkingSetMb, int expectedCommitUsageMb, int peakCommitUsageMb);
 
         [GeneratedEvent(
             (ushort)LogEventId.ProcessPipExecutionInfoOverflowFailure,

--- a/Public/Src/Engine/Scheduler/Tracing/MasterSpecificExecutionLogTarget.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/MasterSpecificExecutionLogTarget.cs
@@ -66,9 +66,8 @@ namespace BuildXL.Scheduler.Tracing
         {
             var worker = m_scheduler.Workers[m_workerId];
 
-            worker.ActualAvailableMemoryMb = data.MachineAvailableRamMB;
-            worker.ActualCommitPercent = data.CommitPercent;
-            worker.ActualCommitTotalMB = data.CommitTotalMB;
+            worker.ActualFreeMemoryMb = data.RamFreeMb;
+            worker.ActualFreeCommitMb = data.CommitFreeMb;
         }
     }
 }

--- a/Public/Src/Engine/UnitTests/Processes/SandboxedProcessTest.cs
+++ b/Public/Src/Engine/UnitTests/Processes/SandboxedProcessTest.cs
@@ -266,9 +266,9 @@ namespace Test.BuildXL.Processes
                         "Expected a non-zero user+kernel time.");
                 }
 
-                XAssert.AreNotEqual<ulong>(0, accounting.MemoryCounters.PeakVirtualMemoryUsage, "Expecting non-zero memory usage");
-                XAssert.AreNotEqual<ulong>(0, accounting.MemoryCounters.PeakWorkingSet, "Expecting non-zero memory usage");
-                XAssert.AreNotEqual<ulong>(0, accounting.MemoryCounters.PeakPagefileUsage, "Expecting non-zero pagefile usage");
+                XAssert.AreNotEqual(0, accounting.MemoryCounters.PeakVirtualMemoryUsageMb, "Expecting non-zero memory usage");
+                XAssert.AreNotEqual(0, accounting.MemoryCounters.PeakWorkingSetMb, "Expecting non-zero memory usage");
+                XAssert.AreNotEqual(0, accounting.MemoryCounters.PeakCommitUsageMb, "Expecting non-zero pagefile usage");
 
                 // Prior to Win10, cmd.exe launched within a job but its associated conhost.exe was exempt from the job.
                 // That changed with Bug #633552

--- a/Public/Src/Engine/UnitTests/Scheduler/PipRunningTimeTableTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/PipRunningTimeTableTests.cs
@@ -27,7 +27,9 @@ namespace Test.BuildXL.Scheduler
                         };
             var spans = new[] { TimeSpan.Zero, TimeSpan.FromSeconds(1), TimeSpan.MaxValue };
             var ints = new[] {0, int.MaxValue};
-            var ulongs = new ulong[] {0, 1, ulong.MaxValue};
+
+            // Let's say that the highest possible memory usage is currently 1TB.
+            var ulongs = new ulong[] {0, 1, (ulong)1024 * 1024 * 1024 * 1024}; 
             var uints = new uint[] {0, 1, uint.MaxValue};
 
             foreach (var executionStart in times)
@@ -77,7 +79,7 @@ namespace Test.BuildXL.Scheduler
                                                         ioCounters,
                                                         userTime,
                                                         kernelTime,
-                                                        new ProcessMemoryCounters(peakMemoryUsage, peakMemoryUsage, peakMemoryUsage),
+                                                        ProcessMemoryCounters.CreateFromBytes(peakMemoryUsage, peakMemoryUsage, peakMemoryUsage),
                                                         numberOfProcesses,
                                                         workerId);
                                                     var data = new PipHistoricPerfData(performance);
@@ -126,7 +128,7 @@ namespace Test.BuildXL.Scheduler
                         default(IOCounters),
                         TimeSpan.FromMilliseconds(execTime),
                         TimeSpan.FromMilliseconds(execTime / 2),
-                        new ProcessMemoryCounters(1024 * 1024, 1024 * 1024, 1024 * 1024),
+                        ProcessMemoryCounters.CreateFromMb(1024, 1024, 1024),
                         1,
                         workerId: 0);
 
@@ -166,7 +168,7 @@ namespace Test.BuildXL.Scheduler
                 default(IOCounters),
                 TimeSpan.FromMilliseconds(execTime),
                 TimeSpan.FromMilliseconds(execTime / 2),
-                new ProcessMemoryCounters(1024 * 1024, 1024 * 1024, 1024 * 1024),
+                ProcessMemoryCounters.CreateFromMb(1024, 1024, 1024),
                 1,
                 workerId: 0);
 

--- a/Public/Src/Engine/UnitTests/Scheduler/ProcessExecutionResultSerializerTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/ProcessExecutionResultSerializerTests.cs
@@ -49,7 +49,7 @@ namespace Test.BuildXL.Scheduler
                     default(IOCounters),
                     TimeSpan.FromMinutes(3),
                     TimeSpan.FromMinutes(3),
-                    new ProcessMemoryCounters(12324, 12325, 12326),
+                    ProcessMemoryCounters.CreateFromBytes(12324, 12325, 12326),
                     33,
                     7),
                 fingerprint: new WeakContentFingerprint(fingerprint), 
@@ -123,9 +123,9 @@ namespace Test.BuildXL.Scheduler
                 r => r.PerformanceInformation.FileMonitoringViolations.NumFileAccessesWhitelistedButNotCacheable,
                 r => r.PerformanceInformation.UserTime,
                 r => r.PerformanceInformation.KernelTime,
-                r => r.PerformanceInformation.MemoryCounters.PeakVirtualMemoryUsage,
-                r => r.PerformanceInformation.MemoryCounters.PeakWorkingSet,
-                r => r.PerformanceInformation.MemoryCounters.PeakPagefileUsage,
+                r => r.PerformanceInformation.MemoryCounters.PeakVirtualMemoryUsageMb,
+                r => r.PerformanceInformation.MemoryCounters.PeakWorkingSetMb,
+                r => r.PerformanceInformation.MemoryCounters.PeakCommitUsageMb,
 
                 r => r.PerformanceInformation.NumberOfProcesses,
 

--- a/Public/Src/Engine/UnitTests/Scheduler/ProcessResourceManagerTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/ProcessResourceManagerTests.cs
@@ -117,7 +117,7 @@ namespace Test.BuildXL.Scheduler
                 m_execute = () => ExecutionTask = resourceManager.ExecuteWithResources(
                     OperationContext.CreateUntracked(Events.StaticContext),
                     new PipId(id),
-                    estimatedRamUsage,
+                    ProcessMemoryCounters.CreateFromMb(estimatedRamUsage, estimatedRamUsage, estimatedRamUsage),
                     allowCancellation,
                     async (cancellationToken, registerQueryRamUsage) =>
                 {

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/Xldb/XldbProtobufExtensions.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Core/Xldb/XldbProtobufExtensions.cs
@@ -109,7 +109,7 @@ namespace BuildXL.Execution.Analyzer
 
                 processPipExecPerformance.UserTime = Google.Protobuf.WellKnownTypes.Duration.FromTimeSpan(performance.UserTime);
                 processPipExecPerformance.KernelTime = Google.Protobuf.WellKnownTypes.Duration.FromTimeSpan(performance.KernelTime);
-                processPipExecPerformance.PeakMemoryUsage = performance.MemoryCounters.PeakWorkingSet;
+                processPipExecPerformance.PeakMemoryUsageMb = performance.MemoryCounters.PeakWorkingSetMb;
                 processPipExecPerformance.NumberOfProcesses = performance.NumberOfProcesses;
 
                 processPipExecPerformance.FileMonitoringViolationCounters = new Xldb.Proto.FileMonitoringViolationCounters()
@@ -334,9 +334,9 @@ namespace BuildXL.Execution.Analyzer
                 Time = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(data.Time),
                 CpuPercent = data.CpuPercent,
                 RamPercent = data.RamPercent,
-                MachineRamUtilizationMB = data.MachineRamUtilizationMB,
+                MachineRamUtilizationMB = data.RamUsedMb,
                 CommitPercent = data.CommitPercent,
-                CommitTotalMB = data.CommitTotalMB,
+                CommitTotalMB = data.CommitUsedMb,
                 ProcessCpuPercent = data.ProcessCpuPercent,
                 ProcessWorkingSetMB = data.ProcessWorkingSetMB,
                 CpuWaiting = data.CpuWaiting,

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/CosineJsonExport.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/CosineJsonExport.cs
@@ -794,10 +794,10 @@ namespace BuildXL.Execution.Analyzer
                         m_writer.WriteValue(processPerformance.KernelTime.Ticks);
                     }
 
-                    if (processPerformance.MemoryCounters.PeakWorkingSet != 0)
+                    if (processPerformance.MemoryCounters.PeakWorkingSetMb != 0)
                     {
-                        m_writer.WritePropertyName("peakMemory");
-                        m_writer.WriteValue(processPerformance.MemoryCounters.PeakWorkingSet);
+                        m_writer.WritePropertyName("peakMemoryMb");
+                        m_writer.WriteValue(processPerformance.MemoryCounters.PeakWorkingSetMb);
                     }
 
                     if (processPerformance.IO.GetAggregateIO().TransferCount > 0)

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/PipExecutionPerformanceAnalyzer.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/PipExecutionPerformanceAnalyzer.cs
@@ -119,7 +119,7 @@ namespace BuildXL.Execution.Analyzer
                 WriteColumn(Math.Round(performance.IO.WriteCounters.TransferCount / 1024 / 1024 / 1024.0, 1).ToString());
                 WriteColumn(Math.Round(performance.IO.OtherCounters.TransferCount / 1024 / 1024 / 1024.0, 1).ToString());
                 WriteColumn(performance.NumberOfProcesses.ToString());
-                m_writer.Write(performance.MemoryCounters.PeakWorkingSet.ToString());
+                m_writer.Write(performance.MemoryCounters.PeakWorkingSetMb.ToString());
 
                 m_writer.WriteLine();
             }
@@ -158,7 +158,7 @@ namespace BuildXL.Execution.Analyzer
                 WriteLineIndented(I($"\"executionTimeInMs\" : {performance.ProcessExecutionTime.TotalMilliseconds},"));
                 WriteLineIndented(I($"\"userExecutionTimeInMs\" : {performance.UserTime.TotalMilliseconds},"));
                 WriteLineIndented(I($"\"kernelExecutionTimeInMs\" : {performance.KernelTime.TotalMilliseconds},"));
-                WriteLineIndented(I($"\"peakMemoryUsageInByte\" : {performance.MemoryCounters.PeakVirtualMemoryUsage},"));
+                WriteLineIndented(I($"\"peakMemoryUsageInMb\" : {performance.MemoryCounters.PeakWorkingSetMb},"));
 
                 WriteLineIndented("\"io\" : {");
                 IncrementIndent();

--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/PipGraphExporter.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/PipGraphExporter.cs
@@ -731,10 +731,10 @@ namespace BuildXL.Execution.Analyzer
                         m_writer.WriteValue(processPerformance.KernelTime.Ticks);
                     }
 
-                    if (processPerformance.MemoryCounters.PeakWorkingSet != 0)
+                    if (processPerformance.MemoryCounters.PeakWorkingSetMb != 0)
                     {
-                        m_writer.WritePropertyName("peakMemory");
-                        m_writer.WriteValue(processPerformance.MemoryCounters.PeakWorkingSet);
+                        m_writer.WritePropertyName("peakMemoryMb");
+                        m_writer.WriteValue(processPerformance.MemoryCounters.PeakWorkingSetMb);
                     }
 
                     if (processPerformance.IO.GetAggregateIO().TransferCount > 0)

--- a/Public/Src/Tools/Xldb.Proto/HelperStructs.proto
+++ b/Public/Src/Tools/Xldb.Proto/HelperStructs.proto
@@ -108,8 +108,8 @@ message ProcessPipExecutionPerformance{
     // Kernel-mode execution time. Note that this counter increases as threads in the process tree execute (it is not equivalent to wall clock time)
     google.protobuf.Duration KernelTime = 6;
 
-    // Peak memory usage (in bytes) considering all processes (highest point-in-time sum of the memory usage of the process tree)
-    uint64 PeakMemoryUsage = 7;
+    // Peak memory usage (in MB) considering all processes (highest point-in-time sum of the memory usage of the process tree)
+    int32 PeakMemoryUsageMb = 7;
     
     // Number of processes that executed as part of the pip (the entry-point process may start children)
     uint32 NumberOfProcesses = 8;

--- a/Public/Src/Utilities/Interop/Windows/Processor.cs
+++ b/Public/Src/Utilities/Interop/Windows/Processor.cs
@@ -27,7 +27,7 @@ namespace BuildXL.Interop.Windows
             public uint cb;
 
             /// <nodoc />
-            public IntPtr CommitTotal;
+            public IntPtr CommitUsed;
 
             /// <nodoc />
             public IntPtr CommitLimit;

--- a/Public/Src/Utilities/Utilities/ByteSizeFormatter.cs
+++ b/Public/Src/Utilities/Utilities/ByteSizeFormatter.cs
@@ -16,9 +16,9 @@ namespace BuildXL.Utilities
         private const long TB = 1024 * GB;
 
         /// <nodoc />
-        public static long ToMegabytes(long bytes)
+        public static long ToMegabytes(ulong bytes)
         {
-            return bytes / MB;
+            return (long)(bytes / (ulong)MB);
         }
 
         /// <nodoc />

--- a/Public/Src/Utilities/Utilities/PerformanceCollector.cs
+++ b/Public/Src/Utilities/Utilities/PerformanceCollector.cs
@@ -530,7 +530,7 @@ namespace BuildXL.Utilities
             /// <summary>
             /// Total committed memory in MB. This is not an indication of physical memory usage.
             /// </summary>
-            public int? CommitTotalMb;
+            public int? CommitUsedMb;
 
             /// <summary>
             /// Maximum memory that can be committed in MB. If the page file can be extended, this is a soft limit.
@@ -769,7 +769,7 @@ namespace BuildXL.Utilities
                         var commitUsagePercentage = SafeConvert.ToInt32(((100.0 * commitTotal) / commitLimit));
 
                         perfInfo.CommitUsagePercentage = commitUsagePercentage;
-                        perfInfo.CommitTotalMb = commitTotal;
+                        perfInfo.CommitUsedMb = commitTotal;
                         perfInfo.CommitLimitMb = commitLimit;
                     }
 

--- a/Public/Src/Utilities/Utilities/PerformanceCollector.cs
+++ b/Public/Src/Utilities/Utilities/PerformanceCollector.cs
@@ -154,7 +154,7 @@ namespace BuildXL.Utilities
 
                 double? machineAvailablePhysicalBytes = null;
                 double? machineTotalPhysicalBytes = null;
-                double? commitTotalBytes = null;
+                double? commitUsedBytes = null;
                 double? commitLimitBytes = null;
                 DISK_PERFORMANCE[] diskStats = null;
 
@@ -172,7 +172,7 @@ namespace BuildXL.Utilities
                     PERFORMANCE_INFORMATION performanceInfo = PERFORMANCE_INFORMATION.CreatePerfInfo();
                     if (GetPerformanceInfo(out performanceInfo, performanceInfo.cb))
                     {
-                        commitTotalBytes = performanceInfo.CommitTotal.ToInt64() * performanceInfo.PageSize.ToInt64();
+                        commitUsedBytes = performanceInfo.CommitUsed.ToInt64() * performanceInfo.PageSize.ToInt64();
                         commitLimitBytes = performanceInfo.CommitLimit.ToInt64() * performanceInfo.PageSize.ToInt64();
                     }
 
@@ -215,7 +215,7 @@ namespace BuildXL.Utilities
                             machineCpu: machineCpu,
                             machineTotalPhysicalBytes: machineTotalPhysicalBytes,
                             machineAvailablePhysicalBytes: machineAvailablePhysicalBytes,
-                            commitTotalBytes: commitTotalBytes,
+                            commitUsedBytes: commitUsedBytes,
                             commitLimitBytes: commitLimitBytes,
                             machineBandwidth: m_networkMonitor?.Bandwidth,
                             machineKbitsPerSecSent: machineKbitsPerSecSent,
@@ -611,7 +611,7 @@ namespace BuildXL.Utilities
             /// <summary>
             /// The total megabytes of memory current committed by the system
             /// </summary>
-            public readonly Aggregation CommitTotalMB;
+            public readonly Aggregation CommitUsedMB;
 
             /// <summary>
             /// The total megabytes of memory current that can be committed by the system without extending the page
@@ -707,7 +707,7 @@ namespace BuildXL.Utilities
                 MachineAvailablePhysicalMB = new Aggregation();
                 MachineTotalPhysicalMB = new Aggregation();
                 CommitLimitMB = new Aggregation();
-                CommitTotalMB = new Aggregation();
+                CommitUsedMB = new Aggregation();
 
                 MachineBandwidth = new Aggregation();
                 MachineKbitsPerSecSent = new Aggregation();
@@ -764,12 +764,12 @@ namespace BuildXL.Utilities
 
                     if (CommitLimitMB.Latest > 0)
                     {
-                        var commitTotal = SafeConvert.ToInt32(CommitTotalMB.Latest);
+                        var commitUsed = SafeConvert.ToInt32(CommitUsedMB.Latest);
                         var commitLimit = SafeConvert.ToInt32(CommitLimitMB.Latest);
-                        var commitUsagePercentage = SafeConvert.ToInt32(((100.0 * commitTotal) / commitLimit));
+                        var commitUsagePercentage = SafeConvert.ToInt32(((100.0 * commitUsed) / commitLimit));
 
                         perfInfo.CommitUsagePercentage = commitUsagePercentage;
-                        perfInfo.CommitUsedMb = commitTotal;
+                        perfInfo.CommitUsedMb = commitUsed;
                         perfInfo.CommitLimitMb = commitLimit;
                     }
 
@@ -853,7 +853,7 @@ namespace BuildXL.Utilities
                 double? machineCpu,
                 double? machineAvailablePhysicalBytes,
                 double? machineTotalPhysicalBytes,
-                double? commitTotalBytes,
+                double? commitUsedBytes,
                 double? commitLimitBytes,
                 long? machineBandwidth,
                 double? machineKbitsPerSecSent,
@@ -870,7 +870,7 @@ namespace BuildXL.Utilities
                 MachineCpu.RegisterSample(machineCpu);
                 MachineAvailablePhysicalMB.RegisterSample(BytesToMB(machineAvailablePhysicalBytes));
                 MachineTotalPhysicalMB.RegisterSample(BytesToMB(machineTotalPhysicalBytes));
-                CommitTotalMB.RegisterSample(BytesToMB(commitTotalBytes));
+                CommitUsedMB.RegisterSample(BytesToMB(commitUsedBytes));
                 CommitLimitMB.RegisterSample(BytesToMB(commitLimitBytes));
                 ProcessHeldMB.RegisterSample(BytesToMB(gcHeldBytes));
                 MachineBandwidth.RegisterSample(machineBandwidth);

--- a/Public/Src/Utilities/Utilities/Tracing/EventId.cs
+++ b/Public/Src/Utilities/Utilities/Tracing/EventId.cs
@@ -1105,13 +1105,15 @@ namespace BuildXL.Utilities.Tracing
         ServerModeDisabled = 14004,
         GraphCacheCheckJournalDisabled = 14005,
         SlowCacheInitialization = 14006,
-        LowMemory = 14007,
+        LowRamMemory = 14007,
         // Elsewhere  = 14008,
         // Elsewhere  = 14009,
         BuildHasPerfSmells = 14010,
         LogProcessesEnabled = 14011,
         FrontendIOSlow = 14012,
         ProblematicWorkerExitError = 14013,
+        LowCommitMemory = 14014,
+        HitLowMemorySmell = 14015,
 
         // Graph validation.
         InvalidGraphSinceOutputDirectoryContainsSourceFile = 14100,


### PR DESCRIPTION
As the linkers pip occasionally fail due to unavailable commit memory in CloudBuild, we started keeping track of commit memory as another resource. For MacOS, as we do not keep track of swapfile usage, I set CommitTotal to a very high number; so that there is no throttling based on commit memory in MacOS. 