### PR TITLE
Use instance methods instead of local functions for kext callbacks

### DIFF
--- a/Public/Src/Engine/Processes/SandboxConnectionKext.cs
+++ b/Public/Src/Engine/Processes/SandboxConnectionKext.cs
@@ -166,16 +166,16 @@ Use the the following command to load/reload the sandbox kernel extension and fi
             m_workerThread.IsBackground = true;
             m_workerThread.Priority = ThreadPriority.Highest;
             m_workerThread.Start();
+        }
 
-            unsafe bool SetFailureNotificationHandler()
-            {
-                return Sandbox.SetFailureNotificationHandler(KextFailureCallback, m_kextConnectionInfo);
+        private unsafe bool SetFailureNotificationHandler()
+        {
+            return Sandbox.SetFailureNotificationHandler(KextFailureCallback, m_kextConnectionInfo);
+        }
 
-                void KextFailureCallback(void* refCon, int status)
-                {
-                    m_failureCallback?.Invoke(status, $"Unrecoverable kernel extension failure happened - try reloading the kernel extension or restart your system. {KextInstallHelper}");
-                }
-            }
+        private unsafe void KextFailureCallback(void* refCon, int status)
+        {
+            m_failureCallback?.Invoke(status, $"Unrecoverable kernel extension failure happened - try reloading the kernel extension or restart your system. {KextInstallHelper}");
         }
 
         /// <summary>


### PR DESCRIPTION
This should address a rare crash I saw recently:
```
Process terminated. A callback was made on a garbage collected delegate of type
'BuildXL.Interop!BuildXL.Interop.MacOS.Sandbox+NativeFailureCallback::Invoke'
```