### PR TITLE
[kext] More robust report sending

### DIFF
--- a/Public/Src/Engine/Processes/SandboxConnectionKext.cs
+++ b/Public/Src/Engine/Processes/SandboxConnectionKext.cs
@@ -67,7 +67,7 @@ Use the the following command to load/reload the sandbox kernel extension and fi
         /// Until some automation for kernel extension building and deployment is in place, this number has to be kept in sync with the 'CFBundleVersion'
         /// inside the Info.plist file of the kernel extension code base. BuildXL will not work if a version mismatch is detected!
         /// </summary>
-        public const string RequiredKextVersionNumber = "2.9.99";
+        public const string RequiredKextVersionNumber = "2.10.1";
 
         /// <summary>
         /// See TN2420 (https://developer.apple.com/library/archive/technotes/tn2420/_index.html) on how versioning numbers are formatted in the Apple ecosystem

--- a/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
+++ b/Public/Src/Sandbox/MacOs/Sandbox/Src/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>2.9.99</string>
+	<string>2.10.1</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>BuildXLSandbox</key>

--- a/cg/nuget/cgmanifest.json
+++ b/cg/nuget/cgmanifest.json
@@ -4191,7 +4191,7 @@
         "Type": "NuGet",
         "NuGet": {
           "Name": "runtime.osx-x64.BuildXL",
-          "Version": "2.9.99"
+          "Version": "2.10.1"
         }
       }
     },

--- a/config.microsoftInternal.dsc
+++ b/config.microsoftInternal.dsc
@@ -11,7 +11,7 @@ export const pkgs = isMicrosoftInternal ? [
     { id: "BuildXL.DeviceMap", version: "0.0.1" },
 
     // Runtime dependencies used for macOS deployments
-    { id: "runtime.osx-x64.BuildXL", version: "2.9.99" },
+    { id: "runtime.osx-x64.BuildXL", version: "2.10.1" },
     { id: "Aria.Cpp.SDK", version: "8.5.6" },
 
     { id: "CB.QTest", version: "19.11.5.170405" },


### PR DESCRIPTION
When enqueuing into `IOSharedDateQueue` fails (because the queue is full), instead of failing we can just re-queue into our own batching queue which, unlike the `IOSharedDataQueue`, can grow dynamically to accommodate high volumes of reports.