### PR TITLE
Stop creating unnecessary nested tracing context when sending events

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/EventStreaming/EventHubContentLocationEventStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/EventStreaming/EventHubContentLocationEventStore.cs
@@ -165,8 +165,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache.EventStreaming
                 eventDatas = SerializeEventData(context, events);
             }
 
-            var operationId = Guid.NewGuid();
-            context = context.CreateNested(operationId);
+            var operationId = context.TracingContext.Id;
 
             for (var eventNumber = 0; eventNumber < eventDatas.Count; eventNumber++)
             {


### PR DESCRIPTION
`SendEventsAsync` method already creates a new tracing context, so creating yet another one inside `SendEventsCoreAsync` just makes the tracing analysis more complicated without adding any extra value.