### PR TITLE
Make PipProcessCommandLineTooLong a User Error

### DIFF
--- a/Public/Src/Engine/Processes/Tracing/Log.cs
+++ b/Public/Src/Engine/Processes/Tracing/Log.cs
@@ -501,7 +501,7 @@ namespace BuildXL.Processes.Tracing
             (int)LogEventId.PipProcessCommandLineTooLong,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Error,
-            Keywords = (int)Keywords.UserMessage,
+            Keywords = (int)(Keywords.UserMessage | Keywords.UserError),
             EventTask = (int)Tasks.PipExecutor,
             Message = EventConstants.PipPrefix + "Process command line is longer than {3} characters: {2}")]
         public abstract void PipProcessCommandLineTooLong(


### PR DESCRIPTION
The action to perform when this error is hit is to switch over to using a response file. It should be a user error rather than an internal error.