### PR TITLE
Trim the contents of IpcClientForwardedMessage events

### DIFF
--- a/Public/Src/Engine/Scheduler/ApiServer.cs
+++ b/Public/Src/Engine/Scheduler/ApiServer.cs
@@ -93,7 +93,7 @@ namespace BuildXL.Scheduler
             });
         }
 
-        async Task<IIpcResult> IIpcOperationExecutor.ExecuteAsync(IIpcOperation op)
+        async Task<IIpcResult> IIpcOperationExecutor.ExecuteAsync(int id, IIpcOperation op)
         {
             Contract.Requires(op != null);
 

--- a/Public/Src/Tools/ServicePipDaemon/Command.cs
+++ b/Public/Src/Tools/ServicePipDaemon/Command.cs
@@ -30,7 +30,7 @@ namespace Tool.ServicePipDaemon
     /// the command line, it is to be marshaled and sent over to a running daemon server via an RPC.
     /// In such a case, the client action simply invokes <see cref="IClient.Send"/>. 
     /// 
-    /// When an RPC is received by a daemon server (<see cref="ServicePipDaemon.ParseAndExecuteCommand"/>),
+    /// When an RPC is received by a daemon server (<see cref="ServicePipDaemon.ParseAndExecuteCommandAsync"/>),
     /// a <see cref="Command"/> is unmarshaled from the payload of the RPC operation and 
     /// is interpreted on the server by executing its <see cref="ServerAction"/>.
     /// </summary>

--- a/Public/Src/Tools/ServicePipDaemon/ServicePipDaemon.cs
+++ b/Public/Src/Tools/ServicePipDaemon/ServicePipDaemon.cs
@@ -361,7 +361,7 @@ namespace Tool.ServicePipDaemon
         /// <summary>
         /// Starts to listen for client connections.  As soon as a connection is received,
         /// it is placed in an action block from which it is picked up and handled asynchronously
-        /// (in the <see cref="ParseAndExecuteCommand"/> method).
+        /// (in the <see cref="ParseAndExecuteCommandAsync"/> method).
         /// </summary>
         public void Start()
         {
@@ -394,10 +394,10 @@ namespace Tool.ServicePipDaemon
             m_logger.Dispose();
         }
 
-        private async Task<IIpcResult> ParseAndExecuteCommand(IIpcOperation operation)
+        private async Task<IIpcResult> ParseAndExecuteCommandAsync(int id, IIpcOperation operation)
         {
             string cmdLine = operation.Payload;
-            m_logger.Verbose("Command received: {0}", cmdLine);
+            m_logger.Verbose($"Command received. Request #{id}, CommandLine: {cmdLine}");
             ConfiguredCommand conf;
             using (m_counters.StartStopwatch(DaemonCounter.ParseArgsDuration))
             {
@@ -417,11 +417,11 @@ namespace Tool.ServicePipDaemon
             return result;
         }
 
-        Task<IIpcResult> IIpcOperationExecutor.ExecuteAsync(IIpcOperation operation)
+        Task<IIpcResult> IIpcOperationExecutor.ExecuteAsync(int id, IIpcOperation operation)
         {
             Contract.Requires(operation != null);
 
-            return ParseAndExecuteCommand(operation);
+            return ParseAndExecuteCommandAsync(id, operation);
         }
 
         /// <summary>

--- a/Public/Src/Utilities/Ipc/Common.Multiplexing/MultiplexingClient.cs
+++ b/Public/Src/Utilities/Ipc/Common.Multiplexing/MultiplexingClient.cs
@@ -177,9 +177,9 @@ namespace BuildXL.Ipc.Common.Multiplexing
         private async Task SendRequestAsync(Request request)
         {
             request.Operation.Timestamp.Request_BeforeSendTime = DateTime.UtcNow;
-            Logger.Verbose("Sending request...");
+            Logger.Verbose($"Sending request #{request.Id}");
             await request.SerializeAsync(m_stream);
-            Logger.Verbose("Request sent: " + request);
+            Logger.Verbose($"Sent request #{request.Id}");
             request.Operation.Timestamp.Request_AfterSendTime = DateTime.UtcNow;
 
             if (!request.Operation.ShouldWaitForServerAck)
@@ -193,9 +193,9 @@ namespace BuildXL.Ipc.Common.Multiplexing
         private async Task<Response> ReceiveResponseAsync(CancellationToken token)
         {
             DateTime beforeDeserialize = DateTime.UtcNow;
-            Logger.Verbose("Deserializing response...");
             var response = await Response.DeserializeAsync(m_stream, token);
-            Logger.Verbose("Response received: " + response);
+            Logger.Verbose($"Received response #{response.RequestId}");
+
             response.Result.Timestamp.Response_BeforeDeserializeTime = beforeDeserialize;
             response.Result.Timestamp.Response_AfterDeserializeTime = DateTime.UtcNow;
 

--- a/Public/Src/Utilities/Ipc/Common.Multiplexing/MultiplexingServer.cs
+++ b/Public/Src/Utilities/Ipc/Common.Multiplexing/MultiplexingServer.cs
@@ -224,7 +224,7 @@ namespace BuildXL.Ipc.Common.Multiplexing
             {
                 Logger.Verbose("({0}) Waiting to receive request...", Name);
                 var request = await Request.DeserializeAsync(m_stream, token);
-                Logger.Verbose("({0}) Request received: {1}", Name, request);
+                Logger.Verbose($"({Name}) Received request #{request.Id}");
 
                 request.Operation.Timestamp.Daemon_AfterReceivedTime = DateTime.UtcNow;
 
@@ -241,7 +241,7 @@ namespace BuildXL.Ipc.Common.Multiplexing
             {
                 request.Operation.Timestamp.Daemon_BeforeExecuteTime = DateTime.UtcNow;
 
-                Logger.Verbose("({0}) Executing request {1}", Name, request);
+                Logger.Verbose($"({Name}) Executing request #{request.Id}");
                 var ipcResult = await Utils.HandleExceptionsAsync(
                     IpcResultStatus.ExecutionError,
                     () => m_parent.m_executor.ExecuteAsync(request.Operation));
@@ -249,20 +249,20 @@ namespace BuildXL.Ipc.Common.Multiplexing
                 if (request.Operation.ShouldWaitForServerAck)
                 {
                     var response = new Response(request.Id, ipcResult);
-                    Logger.Verbose("({0}) Posting response {1}", Name, response);
+                    Logger.Verbose($"({Name}) Posting response #{request.Id}");
                     m_sendResponseBlock.Post(response);
                 }
                 else
                 {
-                    Logger.Verbose("({0}) Response not requested for request {1}", Name, request);
+                    Logger.Verbose($"({Name}) Response not requested for request #{request.Id}");
                 }
             }
 
             private async Task SendResponseAsync(Response response)
             {
-                Logger.Verbose("({0}) Sending response {1} ...", Name, response);
+                Logger.Verbose($"({Name}) Sending response #{response.RequestId}");
                 await response.SerializeAsync(m_stream);
-                Logger.Verbose("({0}) Response sent: {1}", Name, response);
+                Logger.Verbose($"({Name}) Sent response #{response.RequestId}");
             }
 
             private bool TryDisconnectClient(TClient client)

--- a/Public/Src/Utilities/Ipc/Common.Multiplexing/MultiplexingServer.cs
+++ b/Public/Src/Utilities/Ipc/Common.Multiplexing/MultiplexingServer.cs
@@ -244,7 +244,7 @@ namespace BuildXL.Ipc.Common.Multiplexing
                 Logger.Verbose($"({Name}) Executing request #{request.Id}");
                 var ipcResult = await Utils.HandleExceptionsAsync(
                     IpcResultStatus.ExecutionError,
-                    () => m_parent.m_executor.ExecuteAsync(request.Operation));
+                    () => m_parent.m_executor.ExecuteAsync(request.Id, request.Operation));
 
                 if (request.Operation.ShouldWaitForServerAck)
                 {

--- a/Public/Src/Utilities/Ipc/Common.Multiplexing/NonMultiplexingServer.cs
+++ b/Public/Src/Utilities/Ipc/Common.Multiplexing/NonMultiplexingServer.cs
@@ -22,6 +22,7 @@ namespace BuildXL.Ipc.Common.Multiplexing
     {
         private readonly IConnectivityProvider<TClient> m_connectivityProvider;
         private readonly GenericServer<TClient> m_clientListener;
+        private static int s_requestIdCounter = 0;
 
         /// <summary>Arbitrary name only for descriptive purposes.</summary>
         public string Name { get; }
@@ -51,7 +52,8 @@ namespace BuildXL.Ipc.Common.Multiplexing
                 using (client)
                 using (var bundle = m_connectivityProvider.GetStreamForClient(client))
                 {
-                    await Utils.ReceiveOperationAndExecuteLocallyAsync(bundle, executor, CancellationToken.None);
+                    int id = Interlocked.Increment(ref s_requestIdCounter);
+                    await Utils.ReceiveOperationAndExecuteLocallyAsync(id, bundle, executor, CancellationToken.None);
                 }
             });
         }

--- a/Public/Src/Utilities/Ipc/Common/LambdaIpcOperationExecutor.cs
+++ b/Public/Src/Utilities/Ipc/Common/LambdaIpcOperationExecutor.cs
@@ -9,7 +9,7 @@ using BuildXL.Ipc.Interfaces;
 namespace BuildXL.Ipc.Common
 {
     /// <summary>
-    /// Executor that receives a lambda function to which it delegates all <see cref="ExecuteAsync(IIpcOperation)"/> calls.
+    /// Executor that receives a lambda function to which it delegates all <see cref="ExecuteAsync"/> calls.
     /// </summary>
     public sealed class LambdaIpcOperationExecutor : IIpcOperationExecutor
     {
@@ -24,7 +24,7 @@ namespace BuildXL.Ipc.Common
         }
 
         /// <inheritdoc />
-        public Task<IIpcResult> ExecuteAsync(IIpcOperation op)
+        public Task<IIpcResult> ExecuteAsync(int id, IIpcOperation op)
         {
             Contract.Requires(op != null);
 

--- a/Public/Src/Utilities/Ipc/Common/Utils.cs
+++ b/Public/Src/Utilities/Ipc/Common/Utils.cs
@@ -37,10 +37,10 @@ namespace BuildXL.Ipc.Common
         /// If executing the operation (via <paramref name="executor"/>) fails, the <see cref="IIpcResult.ExitCode"/>
         /// of the result is <see cref="IpcResultStatus.ExecutionError"/>
         /// </summary>
-        internal static async Task<IIpcResult> ReceiveOperationAndExecuteLocallyAsync(Stream stream, IIpcOperationExecutor executor, CancellationToken token)
+        internal static async Task<IIpcResult> ReceiveOperationAndExecuteLocallyAsync(int id, Stream stream, IIpcOperationExecutor executor, CancellationToken token)
         {
             IIpcOperation operation = await IpcOperation.DeserializeAsync(stream, token);
-            IIpcResult result = await HandleExceptionsAsync(IpcResultStatus.ExecutionError, () => executor.ExecuteAsync(operation));
+            IIpcResult result = await HandleExceptionsAsync(IpcResultStatus.ExecutionError, () => executor.ExecuteAsync(id, operation));
             if (operation.ShouldWaitForServerAck)
             {
                 await IpcResult.SerializeAsync(stream, result, token);

--- a/Public/Src/Utilities/Ipc/Impl.MultiplexingSocketBasedIpc/Client.cs
+++ b/Public/Src/Utilities/Ipc/Impl.MultiplexingSocketBasedIpc/Client.cs
@@ -88,7 +88,6 @@ namespace BuildXL.Ipc.MultiplexingSocketBasedIpc
         [SuppressMessage("Microsoft.Reliability", "CA2000:DisposeTcpClient", Justification = "TcpClient.Dispose is inaccessible due to its protection level")]
         private async Task<Possible<MultiplexingClient>> CreateMultiplexingClientAsync()
         {
-            Config.Logger.Verbose("CreateMultiplexingClient called");
             var maybeConnected = await Utils.ConnectAsync(
                 Config.MaxConnectRetries,
                 Config.ConnectRetryDelay,

--- a/Public/Src/Utilities/Ipc/Interfaces/IIpcOperationExecutor.cs
+++ b/Public/Src/Utilities/Ipc/Interfaces/IIpcOperationExecutor.cs
@@ -20,6 +20,6 @@ namespace BuildXL.Ipc.Interfaces
         /// because <see cref="IServer"/> is responsible for handling exceptions any thrown
         /// from here.
         /// </summary>
-        Task<IIpcResult> ExecuteAsync([NotNull]IIpcOperation op);
+        Task<IIpcResult> ExecuteAsync(int id, [NotNull]IIpcOperation op);
     }
 }


### PR DESCRIPTION
DX12005_IpcClientForwardedMessage_DurationMs is pretty high in many selfhost builds. The average duration is around 3min. With these changes, I dramatically reduce the content of the messages. 

For Office builds, that duration is pretty low; less than 30sec. 