### PR TITLE
Better handling of augmented FPs

### DIFF
--- a/Public/Src/Engine/Scheduler/PipCacheMissType.cs
+++ b/Public/Src/Engine/Scheduler/PipCacheMissType.cs
@@ -26,6 +26,11 @@ namespace BuildXL.Scheduler
         MissForDescriptorsDueToWeakFingerprints = PipExecutorCounter.CacheMissesForDescriptorsDueToWeakFingerprints,
 
         /// <summary>
+        /// Number of times a process pip cache entry was not found (no prior execution information).
+        /// </summary>
+        CacheMissesForDescriptorsDueToAugmentedWeakFingerprints = PipExecutorCounter.CacheMissesForDescriptorsDueToAugmentedWeakFingerprints,
+
+        /// <summary>
         /// Number of times a process pip was forced to be a cache miss (despite finding a descriptor) due to artifial cache miss injection.
         /// </summary>
         MissForDescriptorsDueToArtificialMissOptions = PipExecutorCounter.CacheMissesForDescriptorsDueToArtificialMissOptions,

--- a/Public/Src/Engine/Scheduler/PipExecutor.cs
+++ b/Public/Src/Engine/Scheduler/PipExecutor.cs
@@ -4953,6 +4953,7 @@ namespace BuildXL.Scheduler
             return new PipExecutorCounter[]
             {
                 PipExecutorCounter.CacheMissesForDescriptorsDueToWeakFingerprints,
+                PipExecutorCounter.CacheMissesForDescriptorsDueToAugmentedWeakFingerprints,
                 PipExecutorCounter.CacheMissesForDescriptorsDueToStrongFingerprints,
                 PipExecutorCounter.CacheMissesForDescriptorsDueToArtificialMissOptions,
                 PipExecutorCounter.CacheMissesForCacheEntry,

--- a/Public/Src/Engine/Scheduler/PipExecutorCounter.cs
+++ b/Public/Src/Engine/Scheduler/PipExecutorCounter.cs
@@ -353,6 +353,11 @@ namespace BuildXL.Scheduler
         CacheMissesForDescriptorsDueToWeakFingerprints,
 
         /// <summary>
+        /// Number of times a process pip cache entry was not found using augmented weak fingerprint (no prior execution information).
+        /// </summary>
+        CacheMissesForDescriptorsDueToAugmentedWeakFingerprints,
+
+        /// <summary>
         /// Number of times a process pip was forced to be a cache miss (despite finding a descriptor) due to artifial cache miss injection.
         /// </summary>
         CacheMissesForDescriptorsDueToArtificialMissOptions,

--- a/Public/Src/Engine/Scheduler/Tracing/Log.cs
+++ b/Public/Src/Engine/Scheduler/Tracing/Log.cs
@@ -520,6 +520,15 @@ namespace BuildXL.Scheduler.Tracing
         internal abstract void TwoPhaseCacheDescriptorMissDueToWeakFingerprint(LoggingContext loggingContext, string pipDescription, string contentFingerprint);
 
         [GeneratedEvent(
+           (ushort)EventId.CacheDescriptorMissForAugmentedContentFingerprint,
+           EventGenerators = EventGenerators.LocalOnly,
+           EventLevel = Level.Verbose,
+           Keywords = (int)Keywords.Diagnostics,
+           EventTask = (ushort)Tasks.PipExecutor,
+           Message = "[{pipDescription}] Augmented weak fingerprint miss: A pip cache descriptor was not found for content fingerprint '{contentFingerprint}'.")]
+        internal abstract void TwoPhaseCacheDescriptorMissDueToAugmentedWeakFingerprint(LoggingContext loggingContext, string pipDescription, string contentFingerprint);
+
+        [GeneratedEvent(
             (ushort)EventId.InvalidCacheDescriptorForContentFingerprint,
             EventGenerators = EventGenerators.LocalOnly,
             EventLevel = Level.Verbose,

--- a/Public/Src/Tools/Xldb.Proto/Enums/PipCacheMissType.proto
+++ b/Public/Src/Tools/Xldb.Proto/Enums/PipCacheMissType.proto
@@ -13,11 +13,12 @@ enum PipCacheMissType{
     Hit = 51;
     MissForDescriptorsDueToStrongFingerprints = 53;
     MissForDescriptorsDueToWeakFingerprints = 54;
-    MissForDescriptorsDueToArtificialMissOptions = 55;
-    MissForCacheEntry = 56;
-    MissDueToInvalidDescriptors = 57;
-    MissForProcessMetadata = 58;
-    MissForProcessMetadataFromHistoricMetadata = 59;
-    MissForProcessOutputContent = 60;
-    MissForProcessConfiguredUncacheable = 61;
+    MissForDescriptorsDueToAugmentedWeakFingerprints = 55; 
+    MissForDescriptorsDueToArtificialMissOptions = 56;
+    MissForCacheEntry = 57;
+    MissDueToInvalidDescriptors = 58;
+    MissForProcessMetadata = 59;
+    MissForProcessMetadataFromHistoricMetadata = 60;
+    MissForProcessOutputContent = 61;
+    MissForProcessConfiguredUncacheable = 62;
 }

--- a/Public/Src/Utilities/Utilities/Tracing/EventId.cs
+++ b/Public/Src/Utilities/Utilities/Tracing/EventId.cs
@@ -1162,5 +1162,7 @@ namespace BuildXL.Utilities.Tracing
 
         ProcessRetries = 14504,
         ProcessPattern = 14505,
+
+        CacheDescriptorMissForAugmentedContentFingerprint = 14506,
     }
 }


### PR DESCRIPTION
Under rare conditions, we might have multiple augmented pathsets, as a result we might have ArgumentExceptions in FP Store. This PR provides a better handling of such scenarios. In addition, it also changes how we classify/log cache misses in case of FP augmentation.