### PR TITLE
Complete symbolic link effects on Detoured file system functions

### DIFF
--- a/Public/Src/Engine/UnitTests/Processes.Detours/PipExecutorDetoursTest.cs
+++ b/Public/Src/Engine/UnitTests/Processes.Detours/PipExecutorDetoursTest.cs
@@ -20,7 +20,6 @@ using BuildXL.Utilities.Collections;
 using BuildXL.Utilities.Tracing;
 using BuildXL.Utilities.Configuration;
 using BuildXL.Utilities.Configuration.Mutable;
-using Microsoft.Win32.SafeHandles;
 using Test.BuildXL.TestUtilities;
 using Test.BuildXL.TestUtilities.Xunit;
 using Xunit;
@@ -5380,6 +5379,103 @@ namespace Test.BuildXL.Processes.Detours
                 {
                     (intermediateSymlink, RequestedAccess.Read, FileAccessStatus.Allowed),
                     (targetFile, RequestedAccess.Read, FileAccessStatus.Allowed)
+                };
+
+                if (followChainOfSymlinks)
+                {
+                    toVerify.AddRange(toVerifyOrFalsify);
+                }
+
+                var toFalsify = new List<(AbsolutePath absolutePath, RequestedAccess requestedAccess, FileAccessStatus fileAccessStatus)>();
+                if (!followChainOfSymlinks)
+                {
+                    toFalsify.AddRange(toVerifyOrFalsify);
+                }
+
+                VerifyFileAccesses(
+                    context,
+                    result.AllReportedFileAccesses,
+                    toVerify.ToArray(),
+                    toFalsify.Select(a => a.absolutePath).ToArray());
+            }
+        }
+
+        [TheoryIfSupported(requiresSymlinkPermission: true)]
+        [MemberData(nameof(TruthTable.GetTable), 1, MemberType = typeof(TruthTable))]
+        public async Task CallDetouredCopyFileThatCopiesToExistingSymlink(bool followChainOfSymlinks)
+        {
+            var context = BuildXLContext.CreateInstanceForTesting();
+            var pathTable = context.PathTable;
+
+            using (var tempFiles = new TempFileStorage(canGetFileNames: true, rootPath: TemporaryDirectory))
+            {
+                var linkToSource = tempFiles.GetFileName(pathTable, "LinkToSource.link");
+                var targetFile = tempFiles.GetFileName(pathTable, "Target.txt");
+                WriteFile(pathTable, targetFile, "target content");
+
+                var linkToDestination = tempFiles.GetFileName(pathTable, "LinkToDestination.link");
+                var destination = tempFiles.GetFileName(pathTable, "Destination.txt");
+
+                XAssert.PossiblySucceeded(FileUtilities.TryCreateSymbolicLink(linkToSource.ToString(pathTable), targetFile.ToString(pathTable), true));
+
+                var outputs = new List<FileArtifactWithAttributes>() { FileArtifactWithAttributes.Create(FileArtifact.CreateOutputFile(linkToDestination), FileExistence.Required) };
+                if (followChainOfSymlinks)
+                {
+                    outputs.Add(FileArtifactWithAttributes.Create(FileArtifact.CreateOutputFile(destination), FileExistence.Required));
+                }
+
+                var process = CreateDetourProcess(
+                    context,
+                    pathTable,
+                    tempFiles,
+                    argumentStr: followChainOfSymlinks
+                    ? "CallDetouredCopyFileToExistingSymlinkFollowChainOfSymlinks"
+                    : "CallDetouredCopyFileToExistingSymlinkNotFollowChainOfSymlinks",
+                    inputFiles:
+                        ReadOnlyArray<FileArtifact>.FromWithoutCopy(
+                            FileArtifact.CreateSourceFile(linkToSource),
+                            FileArtifact.CreateSourceFile(targetFile)),
+                    inputDirectories: ReadOnlyArray<DirectoryArtifact>.Empty,
+                    outputFiles: ReadOnlyArray<FileArtifactWithAttributes>.FromWithoutCopy(outputs.ToArray()),
+                    outputDirectories: ReadOnlyArray<DirectoryArtifact>.Empty,
+                    untrackedScopes: ReadOnlyArray<AbsolutePath>.Empty);
+
+                string errorString = null;
+                SandboxedProcessPipExecutionResult result = await RunProcessAsync(
+                    pathTable: pathTable,
+                    ignoreSetFileInformationByHandle: false,
+                    ignoreZwRenameFileInformation: false,
+                    monitorNtCreate: true,
+                    ignoreRepPoints: false,
+                    ignoreNonCreateFileReparsePoints: false,
+                    monitorZwCreateOpenQueryFile: false,
+                    context: context,
+                    pip: process,
+                    errorString: out errorString);
+
+                if (!followChainOfSymlinks && IsNotEnoughPrivilegesError(result))
+                {
+                    // When followChainOfSymlinks is false, this test calls CopyFileExW with COPY_FILE_COPY_SYMLINK.
+                    // With this flag, CopyFileExW essentially creates a symlink that points to the same target
+                    // as the source of copy file. However, the symlink creation is not via CreateSymbolicLink, and
+                    // thus SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE cannot be specified.
+                    return;
+                }
+
+                VerifyNormalSuccess(context, result);
+
+                XAssert.IsTrue(File.Exists(linkToDestination.ToString(pathTable)));
+
+                var toVerify = new List<(AbsolutePath, RequestedAccess, FileAccessStatus)>
+                {
+                    (linkToSource, RequestedAccess.Read, FileAccessStatus.Allowed),
+                    (linkToDestination, RequestedAccess.Write, FileAccessStatus.Allowed)
+                };
+
+                var toVerifyOrFalsify = new List<(AbsolutePath, RequestedAccess, FileAccessStatus)>
+                {
+                    (targetFile, RequestedAccess.Read, FileAccessStatus.Allowed),
+                    (destination, RequestedAccess.Write, FileAccessStatus.Allowed)
                 };
 
                 if (followChainOfSymlinks)

--- a/Public/Src/Sandbox/Windows/DetoursTests/Main.cpp
+++ b/Public/Src/Sandbox/Windows/DetoursTests/Main.cpp
@@ -1183,6 +1183,8 @@ static void SymlinkTests(const string& verb)
     IF_COMMAND(CallDetouredAccessesCreateSymlinkForQBuild);
     IF_COMMAND(CallDetouredCreateFileWForSymlinkProbeOnlyWithReparsePointFlag);
     IF_COMMAND(CallDetouredCreateFileWForSymlinkProbeOnlyWithoutReparsePointFlag);
+    IF_COMMAND(CallDetouredCopyFileToExistingSymlinkFollowChainOfSymlinks);
+    IF_COMMAND(CallDetouredCopyFileToExistingSymlinkNotFollowChainOfSymlinks);
     
 #undef IF_COMMAND1
 #undef IF_COMMAND2

--- a/Public/Src/Sandbox/Windows/DetoursTests/SymLinkTests.cpp
+++ b/Public/Src/Sandbox/Windows/DetoursTests/SymLinkTests.cpp
@@ -293,6 +293,33 @@ int CallDetouredCopyFileNotFollowingChainOfSymlinks()
     return (int)GetLastError();
 }
 
+int CallDetouredCopyFileToExistingSymlink(bool copySymlink)
+{
+    if (!TestCreateSymbolicLinkW(L"LinkToDestination.link", L"Destination.txt", 0))
+    {
+        return (int)GetLastError();
+    }
+
+    CopyFileExW(
+        L"LinkToSource.link",
+        L"LinkToDestination.link",
+        (LPPROGRESS_ROUTINE)NULL,
+        (LPVOID)NULL,
+        (LPBOOL)NULL,
+        copySymlink ? COPY_FILE_COPY_SYMLINK : (DWORD)0x0);
+
+    return (int)GetLastError();
+}
+int CallDetouredCopyFileToExistingSymlinkFollowChainOfSymlinks()
+{
+    return CallDetouredCopyFileToExistingSymlink(false);
+}
+
+int CallDetouredCopyFileToExistingSymlinkNotFollowChainOfSymlinks()
+{
+    return CallDetouredCopyFileToExistingSymlink(true);
+}
+
 int CallAccessNestedSiblingSymLinkOnFiles()
 {
     HANDLE hFile = CreateFileW(

--- a/Public/Src/Sandbox/Windows/DetoursTests/SymLinkTests.h
+++ b/Public/Src/Sandbox/Windows/DetoursTests/SymLinkTests.h
@@ -22,3 +22,5 @@ int CallAccessOnChainOfJunctions();
 int CallDetouredAccessesCreateSymlinkForQBuild();
 int CallDetouredCreateFileWForSymlinkProbeOnlyWithReparsePointFlag();
 int CallDetouredCreateFileWForSymlinkProbeOnlyWithoutReparsePointFlag();
+int CallDetouredCopyFileToExistingSymlinkFollowChainOfSymlinks();
+int CallDetouredCopyFileToExistingSymlinkNotFollowChainOfSymlinks();


### PR DESCRIPTION
Based on [Symbolic link doc](https://docs.microsoft.com/en-us/windows/win32/fileio/symbolic-link-effects-on-file-systems-functions)

One hole found during the review is the detoured copy file.

[AB#1575956](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1575956)