### PR TITLE
Add support for shared compilation for MSBuild scheduled pips

### DIFF
--- a/Public/Sdk/Public/Prelude/Prelude.Configuration.Resolvers.dsc
+++ b/Public/Sdk/Public/Prelude/Prelude.Configuration.Resolvers.dsc
@@ -246,6 +246,14 @@ interface MsBuildResolver extends ResolverBase, UntrackingSettings {
      * When true, default targets will be used as heuristics. Defaults to false.
      */
     allowProjectsToNotSpecifyTargetProtocol?: boolean;
+
+    /**
+     * Whether VBCSCompiler is allowed to be launched as a service to serve managed compilation requests.
+     * Defaults to on.
+     * This option will only be honored when process breakaway is supported by the underlying sandbox. Otherwise,
+     * it defaults to false.
+     */
+    useManagedSharedCompilation?: boolean;
 }
 
 

--- a/Public/Src/FrontEnd/MsBuild/BuildXL.FrontEnd.MsBuild.dsc
+++ b/Public/Src/FrontEnd/MsBuild/BuildXL.FrontEnd.MsBuild.dsc
@@ -38,5 +38,17 @@ namespace MsBuild {
         internalsVisibleTo: [
             "Test.BuildXL.FrontEnd.MsBuild",
         ],
+        runtimeContent: [
+            {
+                subfolder: r`net472`,
+                contents: [importFrom("BuildXL.Tools").VBCSCompilerLogger
+                    .withQualifier(Object.merge<BuildXLSdk.DefaultQualifier>(qualifier, {targetFramework: "net472"})).exe]
+            },
+            {
+                subfolder: r`dotnetcore`,
+                contents: [importFrom("BuildXL.Tools").VBCSCompilerLogger
+                    .withQualifier(Object.merge<BuildXLSdk.DefaultQualifier>(qualifier, {targetFramework: "netcoreapp3.0"})).exe]
+            }
+        ]
     });
 }

--- a/Public/Src/FrontEnd/UnitTests/Libs/Prelude.Configuration.Resolvers.ts
+++ b/Public/Src/FrontEnd/UnitTests/Libs/Prelude.Configuration.Resolvers.ts
@@ -186,6 +186,13 @@ interface MsBuildResolver {
      * Defaults to false.
      */
     enableEngineTracing?: boolean;
+	
+	/**
+     * Whether VBCSCompiler is allowed to be launched as a service to serve managed compilation requests.
+     * Defaults to on.
+     * This option will only be honored when process breakaway is supported by the underlying sandbox.
+     */
+    useManagedSharedCompilation?: boolean;
 }
 
 interface ToolConfiguration {

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/ExecutionTests/MsBuildIntegrationTests.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/ExecutionTests/MsBuildIntegrationTests.cs
@@ -246,10 +246,7 @@ namespace Test.BuildXL.FrontEnd.MsBuild
             var managedProject = GetCscProject(sourceFilename, targetType, outputAssembly);
             var program = GetHellowWorldProgram();
 
-            var config = (CommandLineConfiguration)Build(
-                            msBuildRuntime: "DotNetCore",
-                            dotnetSearchLocations: $"[d`{TestDeploymentDir}/{RelativePathToDotnetExe}`]",
-                            useSharedCompilation: true)
+            var config = (CommandLineConfiguration)Build(useSharedCompilation: true)
                 .AddSpec(R("ManagedProject.csproj"), managedProject)
                 .AddFile(R("Program.cs"), program)
                 .PersistSpecsAndGetConfiguration();
@@ -287,10 +284,7 @@ namespace Test.BuildXL.FrontEnd.MsBuild
             var managedProject = GetCscProject("Program.cs", "exe", "Out.exe", $"References='{Path.GetFileName(thisAssemblyLocation)}' AdditionalLibPaths='{Path.GetDirectoryName(thisAssemblyLocation)}'");
             var program = GetHellowWorldProgram();
 
-            var config = (CommandLineConfiguration)Build(
-                            msBuildRuntime: "DotNetCore",
-                            dotnetSearchLocations: $"[d`{TestDeploymentDir}/{RelativePathToDotnetExe}`]",
-                            useSharedCompilation: true)
+            var config = (CommandLineConfiguration)Build(useSharedCompilation: true)
                 .AddSpec(R("ManagedProject.csproj"), managedProject)
                 .AddFile(R("Program.cs"), program)
                 .PersistSpecsAndGetConfiguration();
@@ -312,7 +306,7 @@ namespace Test.BuildXL.FrontEnd.MsBuild
             // we use the real Csc task implementation, but through a custom (incomplete) Csc task that we define here
             return $@"<Project DefaultTargets='Build'>
     <UsingTask TaskName='Csc'
-        AssemblyFile = '{PathToCscTaskDll}'/>
+        AssemblyFile = '{PathToCscTaskDll(shouldRunDotNetCoreMSBuild: false)}'/>
 
   <Target Name='Build'>
     <Csc

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/ExecutionTests/MsBuildIntegrationTests.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/ExecutionTests/MsBuildIntegrationTests.cs
@@ -238,8 +238,8 @@ namespace Test.BuildXL.FrontEnd.MsBuild
         [InlineData("Program.cs", null, "Out.exe")]
         [InlineData("Program.cs", null, "Out.dll")]
         [InlineData("Program.cs", "library", null)]
-        //// This case should not finish successfully if csc was called directly, but the csc task implementation always 
-        //// makes sure the output file is specified (and picks the first source file on absence)
+        // This case should not finish successfully if csc was called directly, but the csc task implementation always 
+        // makes sure the output file is specified (and picks the first source file on absence)
         [InlineData("Program.cs", "exe", null)]
         public void ValidateSharedCompilation(string sourceFilename, [CanBeNull]string targetType, [CanBeNull] string outputAssembly)
         {

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/ExecutionTests/MsBuildIntegrationTests.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/ExecutionTests/MsBuildIntegrationTests.cs
@@ -12,8 +12,11 @@ using Test.BuildXL.EngineTestUtilities;
 using Xunit;
 using Xunit.Abstractions;
 using System;
-using BuildXL.Utilities;
 using BuildXL.Utilities.Configuration;
+using Test.BuildXL.TestUtilities.Xunit;
+using System.Reflection;
+using BuildXL.Utilities.Tracing;
+using JetBrains.Annotations;
 
 namespace Test.BuildXL.FrontEnd.MsBuild
 {
@@ -229,6 +232,87 @@ namespace Test.BuildXL.FrontEnd.MsBuild
             // Even though there will be an access to a file that is not there anymore, we should run to success
             var result = RunEngineWithConfig(config);
             Assert.True(result.IsSuccess);
+        }
+
+        [TheoryIfSupported(requiresWindowsBasedOperatingSystem: true)]
+        [InlineData("Program.cs", null, "Out.exe")]
+        [InlineData("Program.cs", null, "Out.dll")]
+        [InlineData("Program.cs", "library", null)]
+        // This case should not finish successfully if csc was called directly, but the csc task implementation always 
+        // makes sure the output file is specified (and picks the first source file on absence)
+        [InlineData("Program.cs", "exe", null)]
+        public void ValidateSharedCompilation(string sourceFilename, [CanBeNull]string targetType, [CanBeNull] string outputAssembly)
+        {
+            var managedProject = GetCscProject(sourceFilename, targetType, outputAssembly);
+            var program = GetHellowWorldProgram();
+
+            var config = (CommandLineConfiguration)Build(
+                            msBuildRuntime: "DotNetCore",
+                            dotnetSearchLocations: $"[d`{TestDeploymentDir}/{RelativePathToDotnetExe}`]",
+                            useSharedCompilation: true)
+                .AddSpec(R("ManagedProject.csproj"), managedProject)
+                .AddFile(R("Program.cs"), program)
+                .PersistSpecsAndGetConfiguration();
+
+            config.Sandbox.FileSystemMode = FileSystemMode.RealAndMinimalPipGraph;
+            config.Sandbox.LogObservedFileAccesses = true;
+
+            var result = RunEngineWithConfig(config);
+            Assert.True(result.IsSuccess);
+
+            // Let's verify now that accesses were properly compensated. We should see the (single) source
+            // file and the output + pdb as outputs
+            var allInputAssertions = EventListener.GetLogMessagesForEventId(EventId.PipInputAssertion);
+            Assert.True(allInputAssertions.Any(input => input.Contains(sourceFilename)));
+
+            var allProducedOutputs = EventListener.GetLogMessagesForEventId(EventId.PipOutputProduced);
+
+            // If the output assembly is not specified, there should be an output reported anyway, with a 
+            // filename (modulo extension) equal to the source
+            if (outputAssembly == null)
+            {
+                outputAssembly = Path.ChangeExtension(sourceFilename, null);
+            }
+
+            Assert.True(allProducedOutputs.Any(output => output.Contains(outputAssembly)));
+            Assert.True(allProducedOutputs.Any(output => output.Contains(Path.ChangeExtension(outputAssembly, ".pdb"))));
+        }
+
+        private string GetCscProject(string sourceFilename, string targetType, string outputAssembly)
+        {
+            // In order to avoid depending on MSBuild SDKs, which are hard to deploy in a self-contained way,
+            // we use the real Csc task implementation, but through a custom (incomplete) Csc task that we define here
+            return $@"<Project DefaultTargets='Build'>
+    <UsingTask TaskName='Csc'
+        AssemblyFile = '{PathToCscTaskDll}'/>
+
+  <Target Name='Build'>
+    <Csc
+        OutputAssembly='{outputAssembly ?? string.Empty}'
+        {(targetType != null ? $"TargetType='{targetType}'" : "")}
+        EmitDebugInformation='true'
+        Sources='{sourceFilename}'
+        UseSharedCompilation='true'
+    />
+  </Target>
+</Project>";
+        }
+
+        private static string GetHellowWorldProgram()
+        {
+            // A simple hello world program
+            return @"
+using System;
+namespace CscCompilation
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine(""Hello World!"");
+        }
+    }
+}";
         }
     }
 }

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/ExecutionTests/MsBuildIntegrationTests.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/ExecutionTests/MsBuildIntegrationTests.cs
@@ -253,7 +253,7 @@ namespace Test.BuildXL.FrontEnd.MsBuild
 
             config.Sandbox.FileSystemMode = FileSystemMode.RealAndMinimalPipGraph;
             config.Sandbox.LogObservedFileAccesses = true;
-
+            
             var result = RunEngineWithConfig(config);
             Assert.True(result.IsSuccess);
 
@@ -277,7 +277,7 @@ namespace Test.BuildXL.FrontEnd.MsBuild
 
         [Fact]
         public void ValidateSharedCompilationWithRelativePaths()
-        {
+        { 
             // We pass the executing assembly to the compiler call just as a way to pass an arbitrary valid assembly (and not because there are any required dependencies on it)
             var thisAssemblyLocation = Assembly.GetExecutingAssembly().Location;
             // We just use the assembly name, but add the assembly directory to the collection of additional paths

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/Infrastructure/MsBuildPipExecutionTestBase.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/Infrastructure/MsBuildPipExecutionTestBase.cs
@@ -345,20 +345,5 @@ config({{
                 string.Empty :
                 $"{memberName}: Map.empty<string, (PassthroughEnvironmentVariable | string)>(){ string.Join(string.Empty, dictionary.Select(property => $".add('{property.Key}', {(property.Value?.GetValue() is UnitValue ? "Unit.unit()" : $"'{property.Value?.GetValue()}'")})")) },");
         }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                // There are some tests that configure VBCSCompiler to break away from the sandbox.
-                // Make sure we don't leave any lingering instance after all MSBuild related tests are done
-                foreach (var process in Process.GetProcessesByName("VBCSCompiler"))
-                {
-                    process.Kill();
-                }
-            }
-
-            base.Dispose(disposing);
-        }
     }
 }

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/Infrastructure/MsBuildPipExecutionTestBase.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/Infrastructure/MsBuildPipExecutionTestBase.cs
@@ -15,6 +15,8 @@ using Test.DScript.Ast;
 using Test.BuildXL.FrontEnd.Core;
 using Xunit.Abstractions;
 using BuildXL.Utilities;
+using System;
+using System.Diagnostics;
 
 namespace Test.BuildXL.FrontEnd.MsBuild
 {
@@ -46,6 +48,14 @@ namespace Test.BuildXL.FrontEnd.MsBuild
         /// <nodoc/>
         protected string RelativePathToDotnetExe => "dotnet";
 
+        /// <summary>
+        /// Path to Microsoft.Build.Tasks.CodeAnalysis.dll, where csc task is located
+        /// </summary>
+        /// <remarks>
+        /// Keep in sync with the deployment
+        /// </remarks>
+        protected string PathToCscTaskDll => Path.Combine(TestDeploymentDir, "Compilers-win", "tools", "Microsoft.Build.Tasks.CodeAnalysis.dll").Replace("\\", "/");
+
         protected MsBuildPipExecutionTestBase(ITestOutputHelper output) : base(output, true)
         {
             RegisterEventSource(global::BuildXL.Engine.ETWLogger.Log);
@@ -75,14 +85,16 @@ namespace Test.BuildXL.FrontEnd.MsBuild
             Dictionary<string, string> globalProperties = null, 
             string filenameEntryPoint = null,
             string msBuildRuntime = null,
-            string dotnetSearchLocations = null)
+            string dotnetSearchLocations = null,
+            bool useSharedCompilation = false)
         {
             return Build(runInContainer, 
                 environment != null? environment.ToDictionary(kvp => kvp.Key, kvp => new DiscriminatingUnion<string, UnitValue>(kvp.Value)) : null, 
                 globalProperties,
                 filenameEntryPoint,
                 msBuildRuntime,
-                dotnetSearchLocations);
+                dotnetSearchLocations,
+                useSharedCompilation);
         }
 
         /// <inheritdoc/>
@@ -92,7 +104,8 @@ namespace Test.BuildXL.FrontEnd.MsBuild
             Dictionary<string, string> globalProperties, 
             string filenameEntryPoint, 
             string msBuildRuntime,
-            string dotnetSearchLocations)
+            string dotnetSearchLocations,
+            bool useSharedCompilation = false)
         {
             // Let's explicitly pass an empty environment, so the process environment won't affect tests by default
             return base.Build().Configuration(
@@ -102,7 +115,8 @@ namespace Test.BuildXL.FrontEnd.MsBuild
                     globalProperties, 
                     filenameEntryPoint: filenameEntryPoint, 
                     msBuildRuntime: msBuildRuntime,
-                    dotnetSearchLocations: dotnetSearchLocations));
+                    dotnetSearchLocations: dotnetSearchLocations,
+                    useSharedCompilation: useSharedCompilation));
         }
 
         /// <inheritdoc/>
@@ -274,7 +288,8 @@ $@"<?xml version='1.0' encoding='utf-8'?>
             bool allowProjectsToNotSpecifyTargetProtocol = true,
             string filenameEntryPoint = null,
             string msBuildRuntime = null,
-            string dotnetSearchLocations = null) => $@"
+            string dotnetSearchLocations = null,
+            bool useSharedCompilation = false) => $@"
 config({{
     disableDefaultSourceResolver: true,
     resolvers: [
@@ -293,6 +308,7 @@ config({{
             {(filenameEntryPoint != null ? $"fileNameEntryPoints: [r`{filenameEntryPoint}`]," : string.Empty)}
             {(msBuildRuntime != null ? $"msBuildRuntime: \"{msBuildRuntime}\"," : string.Empty)}
             {(dotnetSearchLocations != null ? $"dotNetSearchLocations: {dotnetSearchLocations}," : string.Empty)}
+            useManagedSharedCompilation: {(useSharedCompilation ? "true" : "false")},
         }},
     ],
 }});";
@@ -309,6 +325,7 @@ config({{
             msBuildSearchLocations: [d`{TestDeploymentDir}/{RelativePathToFullframeworkMSBuild}`],
             root: d`.`,
             allowProjectsToNotSpecifyTargetProtocol: true,
+            useManagedSharedCompilation: false,
             {(environment != null? $"environment: {environment}," : DictionaryToExpression("environment", new Dictionary<string, string>()))}
             {extraArguments ?? string.Empty}
         }},
@@ -327,6 +344,21 @@ config({{
             return (dictionary == null ?
                 string.Empty :
                 $"{memberName}: Map.empty<string, (PassthroughEnvironmentVariable | string)>(){ string.Join(string.Empty, dictionary.Select(property => $".add('{property.Key}', {(property.Value?.GetValue() is UnitValue ? "Unit.unit()" : $"'{property.Value?.GetValue()}'")})")) },");
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                // There are some tests that configure VBCSCompiler to break away from the sandbox.
+                // Make sure we don't leave any lingering instance after all MSBuild related tests are done
+                foreach (var process in Process.GetProcessesByName("VBCSCompiler"))
+                {
+                    process.Kill();
+                }
+            }
+
+            base.Dispose(disposing);
         }
     }
 }

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/Infrastructure/MsBuildPipExecutionTestBase.cs
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/Infrastructure/MsBuildPipExecutionTestBase.cs
@@ -54,7 +54,7 @@ namespace Test.BuildXL.FrontEnd.MsBuild
         /// <remarks>
         /// Keep in sync with the deployment
         /// </remarks>
-        protected string PathToCscTaskDll => Path.Combine(TestDeploymentDir, "Compilers-win", "tools", "Microsoft.Build.Tasks.CodeAnalysis.dll").Replace("\\", "/");
+        protected string PathToCscTaskDll(bool shouldRunDotNetCoreMSBuild) => Path.Combine(TestDeploymentDir, "Compilers", shouldRunDotNetCoreMSBuild ? "dotnetcore" : "net472", "tools", "Microsoft.Build.Tasks.CodeAnalysis.dll").Replace("\\", "/");
 
         protected MsBuildPipExecutionTestBase(ITestOutputHelper output) : base(output, true)
         {

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/Test.BuildXL.FrontEnd.MsBuild.dsc
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/Test.BuildXL.FrontEnd.MsBuild.dsc
@@ -54,8 +54,17 @@ namespace Test.MsBuild {
             },
             // We need csc.exe for integration tests
             {
-                subfolder: a`Compilers-win`,
-                contents: [importFrom("Microsoft.Net.Compilers").Contents.all]
+                subfolder: a`Compilers`,
+                contents: [
+                    {
+                        subfolder: a`net472`,
+                        contents: [importFrom("Microsoft.Net.Compilers").Contents.all]
+                    },
+                    {
+                        subfolder: a`dotnetcore`,
+                        contents: [importFrom("Microsoft.NETCore.Compilers").Contents.all]
+                    },
+                ]
             }
         ],
     });

--- a/Public/Src/FrontEnd/UnitTests/MsBuild/Test.BuildXL.FrontEnd.MsBuild.dsc
+++ b/Public/Src/FrontEnd/UnitTests/MsBuild/Test.BuildXL.FrontEnd.MsBuild.dsc
@@ -40,8 +40,8 @@ namespace Test.MsBuild {
             ...BuildXLSdk.tplPackages,
         ],
         
-        // We need both the full framework and dotnet core versions of MSBuild, plus dotnet.exe for the dotnet core case
         runtimeContent: [
+            // We need both the full framework and dotnet core versions of MSBuild, plus dotnet.exe for the dotnet core case
             ...importFrom("Sdk.Selfhost.MSBuild").withQualifier(Object.merge<BuildXLSdk.DefaultQualifier>(qualifier, {targetFramework: "net472"})).deployment,
             ...importFrom("Sdk.Selfhost.MSBuild").withQualifier(Object.merge<BuildXLSdk.DefaultQualifier>(qualifier, {targetFramework: "netcoreapp3.0"})).deployment,
             {
@@ -51,6 +51,11 @@ namespace Test.MsBuild {
             {
                 subfolder: a`tools`,
                 contents: [importFrom("BuildXL.Tools").MsBuildGraphBuilder.deployment]
+            },
+            // We need csc.exe for integration tests
+            {
+                subfolder: a`Compilers-win`,
+                contents: [importFrom("Microsoft.Net.Compilers").Contents.all]
             }
         ],
     });

--- a/Public/Src/Tools/VBCSCompilerLogger/CompilerUtilities.cs
+++ b/Public/Src/Tools/VBCSCompilerLogger/CompilerUtilities.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics.ContractsLight;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.VisualBasic;
+
+namespace VBCSCompilerLogger
+{
+    /// <summary>
+    /// Parses csc/vbc compiler command line arguments
+    /// </summary>
+    public static class CompilerUtilities
+    {
+        /// <summary>
+        /// Uses the Roslyn command line parser to understand the arguments passed to the compiler
+        /// </summary>
+        public static CommandLineArguments GetParsedCommandLineArguments(string language, string arguments, string projectFile)
+        {
+            Contract.RequiresNotNullOrEmpty(language);
+            Contract.RequiresNotNullOrEmpty(arguments);
+            Contract.RequiresNotNullOrEmpty(projectFile);
+
+            var sdkDirectory = RuntimeEnvironment.GetRuntimeDirectory();
+            var args = CommandLineParser.SplitCommandLineIntoArguments(arguments, removeHashComments: false).ToArray();
+
+            var projectDirectory = Path.GetDirectoryName(projectFile);
+
+            CommandLineArguments result;
+            switch (language)
+            {
+                case LanguageNames.CSharp:
+                    result = CSharpCommandLineParser.Default.Parse(args, projectDirectory, sdkDirectory);
+                    break;
+                case LanguageNames.VisualBasic:
+                    result = VisualBasicCommandLineParser.Default.Parse(args, projectDirectory, sdkDirectory);
+                    break;
+                default:
+                    throw new InvalidOperationException($"Unexpected language '{language}'");
+            }
+
+            return result;
+        }
+    }
+}

--- a/Public/Src/Tools/VBCSCompilerLogger/VBCSCompilerLogger.cs
+++ b/Public/Src/Tools/VBCSCompilerLogger/VBCSCompilerLogger.cs
@@ -22,7 +22,7 @@ namespace VBCSCompilerLogger
     /// This MSBuild logger is used by the MSBuild frontend of BuildXL when scheduling pips: when process breakaway is supported, VBSCompiler.exe is allowed to escape the sandbox
     /// and outlive the originating pip. This logger is used as a way to compensate for the missing accesses and the MSBuild frontend attaches it to every MSBuild invocation.
     /// </remarks>
-    public class CompilerFileAccessLogger : Logger
+    public class VBCSCompilerLogger : Logger
     {
         private const string CscTaskName = "Csc";
         private const string VbcTaskName = "Vbc";

--- a/Public/Src/Tools/VBCSCompilerLogger/VBCSCompilerLogger.cs
+++ b/Public/Src/Tools/VBCSCompilerLogger/VBCSCompilerLogger.cs
@@ -106,7 +106,16 @@ namespace VBCSCompilerLogger
             RegisterOutput(args.DocumentationPath);
             RegisterOutput(args.ErrorLogPath);
             RegisterOutput(args.OutputRefFilePath);
+            var outputFileName = ComputeOutputFileName(args);
+            RegisterOutput(Path.Combine(args.OutputDirectory, outputFileName));
+            if (args.EmitPdb)
+            {
+                RegisterOutput(Path.Combine(args.OutputDirectory, args.PdbPath ?? Path.ChangeExtension(outputFileName, ".pdb")));
+            }
+        }
 
+        private static string ComputeOutputFileName(CommandLineArguments args)
+        {
             string outputFileName = args.OutputFileName;
 
             // If the output filename is not specified, we follow the logic documented for csc.exe
@@ -143,12 +152,7 @@ namespace VBCSCompilerLogger
             }
 
             Contract.Assert(!string.IsNullOrEmpty(outputFileName));
-
-            RegisterOutput(Path.Combine(args.OutputDirectory, outputFileName));
-            if (args.EmitPdb)
-            {
-                RegisterOutput(Path.Combine(args.OutputDirectory, args.PdbPath ?? Path.ChangeExtension(outputFileName, ".pdb")));
-            }
+            return outputFileName;
         }
 
         private void RegisterOutput(string filePath)

--- a/Public/Src/Tools/VBCSCompilerLogger/VBCSCompilerLogger.cs
+++ b/Public/Src/Tools/VBCSCompilerLogger/VBCSCompilerLogger.cs
@@ -97,7 +97,7 @@ namespace VBCSCompilerLogger
         {
             // All inputs
             RegisterInputs(args.SourceFiles.Select(source => source.Path));
-            RegisterInputs(args.AnalyzerReferences.Select(reference => reference.FilePath));
+            RegisterInputs(args.ReferencePaths);
             RegisterInputs(args.EmbeddedFiles.Select(embedded => embedded.Path));
             RegisterInput(args.Win32ResourceFile);
             RegisterInput(args.Win32Icon);

--- a/Public/Src/Tools/VBCSCompilerLogger/VBCSCompilerLogger.cs
+++ b/Public/Src/Tools/VBCSCompilerLogger/VBCSCompilerLogger.cs
@@ -108,8 +108,6 @@ namespace VBCSCompilerLogger
             RegisterInput(args.RuleSetPath);
             RegisterInput(args.SourceLink);
             
-            RegisterInputs(args.MetadataReferences.Select(metadata => metadata.Reference).Where(pathOrAssemblyName => FileUtilities.FileSystem.IsPathRooted(pathOrAssemblyName)));
-            
             // All outputs
             RegisterOutput(args.TouchedFilesPath?.Insert(args.TouchedFilesPath.Length - 1, ".read"));
             RegisterOutput(args.TouchedFilesPath?.Insert(args.TouchedFilesPath.Length - 1, ".write"));

--- a/Public/Src/Tools/VBCSCompilerLogger/VBCSCompilerLogger.cs
+++ b/Public/Src/Tools/VBCSCompilerLogger/VBCSCompilerLogger.cs
@@ -1,0 +1,187 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.ContractsLight;
+using System.IO;
+using System.Linq;
+using BuildXL.Native.IO;
+using BuildXL.Processes;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.CodeAnalysis;
+
+namespace VBCSCompilerLogger
+{
+    /// <summary>
+    /// This logger catches csc and vbc MSBuild tasks and uses the command line argument passed to the compiler to mimic the file accesses that the compiler 
+    /// would have produced.
+    /// </summary>
+    /// <remarks>
+    /// This MSBuild logger is used by the MSBuild frontend of BuildXL when scheduling pips: when process breakaway is supported, VBSCompiler.exe is allowed to escape the sandbox
+    /// and outlive the originating pip. This logger is used as a way to compensate for the missing accesses and the MSBuild frontend attaches it to every MSBuild invocation.
+    /// </remarks>
+    public class CompilerFileAccessLogger : Logger
+    {
+        private const string CscTaskName = "Csc";
+        private const string VbcTaskName = "Vbc";
+        private const string CscToolName = "csc.exe";
+        private const string VbcToolName = "vbc.exe";
+        private AugmentedManifestReporter m_augmentedReported;
+
+        /// <inheritdoc/>
+        public override void Initialize(IEventSource eventSource)
+        {
+            eventSource.MessageRaised += EventSourceOnMessageRaised;
+            m_augmentedReported = AugmentedManifestReporter.Instance;
+        }
+
+        private void EventSourceOnMessageRaised(object sender, BuildMessageEventArgs e)
+        {
+            if (e is TaskCommandLineEventArgs commandLine)
+            {
+                // We are only interested in CSharp and VisualBasic tasks
+                string language;
+                string arguments;
+                switch (commandLine.TaskName)
+                {
+                    case CscTaskName:
+                        language = LanguageNames.CSharp;
+                        arguments = GetArgumentsFromCommandLine(CscToolName, commandLine.CommandLine);
+                        break;
+                    case VbcTaskName:
+                        language = LanguageNames.VisualBasic;
+                        arguments = GetArgumentsFromCommandLine(VbcToolName, commandLine.CommandLine);
+                        break;
+                    default:
+                        return;
+                }
+
+                // We were able to split the compiler invocation from its arguments. This is the indicator
+                // that something didn't go as expected. Since failing to parse the command line means we
+                // are not catching all inputs/outputs properly, we have no option but to fail the corresponding pip
+                if (arguments == null)
+                {
+                    throw new ArgumentException($"Unexpected tool name in command line. Expected '{CscToolName}' or '{VbcToolName}', but got: {commandLine.CommandLine}");
+                }
+
+                var parsedCommandLine = CompilerUtilities.GetParsedCommandLineArguments(language, arguments, commandLine.ProjectFile);
+                RegisterAccesses(parsedCommandLine);
+            }
+        }
+
+        private string GetArgumentsFromCommandLine(string toolToTrim, string commandLine)
+        {
+            toolToTrim += " ";
+            int index = commandLine.IndexOf(toolToTrim, StringComparison.OrdinalIgnoreCase);
+            
+            if (index == -1)
+            {
+                return null;
+            }
+
+            return commandLine.Substring(index + toolToTrim.Length);
+        }
+
+        private void RegisterAccesses(CommandLineArguments args)
+        {
+            // All inputs
+            RegisterInputs(args.SourceFiles.Select(source => source.Path));
+            RegisterInputs(args.AnalyzerReferences.Select(reference => reference.FilePath));
+            RegisterInputs(args.EmbeddedFiles.Select(embedded => embedded.Path));
+            RegisterInput(args.Win32ResourceFile);
+            RegisterInput(args.Win32Icon);
+            RegisterInput(args.Win32Manifest);
+            RegisterInputs(args.AdditionalFiles.Select(additional => additional.Path));
+            RegisterInputs(args.MetadataReferences.Select(metadata => metadata.Reference).Where(pathOrAssemblyName => FileUtilities.FileSystem.IsPathRooted(pathOrAssemblyName)));
+            RegisterInput(args.AppConfigPath);
+            RegisterInput(args.RuleSetPath);
+            RegisterInput(args.SourceLink);
+            RegisterInputs(args.AnalyzerReferences.Select(analyzerRef => analyzerRef.FilePath));
+
+            // All outputs
+            RegisterOutput(args.TouchedFilesPath?.Insert(args.TouchedFilesPath.Length - 1, ".read"));
+            RegisterOutput(args.TouchedFilesPath?.Insert(args.TouchedFilesPath.Length - 1, ".write"));
+            RegisterOutput(args.DocumentationPath);
+            RegisterOutput(args.ErrorLogPath);
+            RegisterOutput(args.OutputRefFilePath);
+
+            string outputFileName = args.OutputFileName;
+
+            // If the output filename is not specified, we follow the logic documented for csc.exe
+            // https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/out-compiler-option
+            // If you do not specify the name of the output file:
+            // - An.exe will take its name from the source code file that contains the Main method.
+            // - A.dll or .netmodule will take its name from the first source code file.
+            // Note: observe however that when invoked through the standard MSBuild csc task, the output file name is always specified
+            // and it is based on the first source file (when the original task didn't specify it). So this is just about being conservative.
+            if (string.IsNullOrEmpty(outputFileName))
+            {
+                switch (args.CompilationOptions.OutputKind)
+                {
+                    // For these cases, the first source file is used
+                    case OutputKind.DynamicallyLinkedLibrary:
+                        outputFileName = Path.ChangeExtension(args.SourceFiles[0].Path, ".dll");
+                        break;
+                    case OutputKind.NetModule:
+                        outputFileName = Path.ChangeExtension(args.SourceFiles[0].Path, ".netmodule");
+                        break;
+                    case OutputKind.WindowsRuntimeMetadata:
+                        outputFileName = Path.ChangeExtension(args.SourceFiles[0].Path, ".winmdobj");
+                        break;
+                    // For these cases an .exe will be generated based on the source file that contains a Main method.
+                    // We cannot easily predict this statically, so we bail out for this case.
+                    case OutputKind.ConsoleApplication:
+                    case OutputKind.WindowsApplication:
+                    case OutputKind.WindowsRuntimeApplication:
+                        throw new InvalidOperationException("The output filename was not specified and it could not be statically predicted. Static predictions are required for managed compilers when shared compilation is enabled. " +
+                            "Please specify the output filename or disable shared compilation by setting 'useManagedSharedCompilation' in Bxl main configuration file.");
+                    default:
+                        throw new InvalidOperationException($"Unrecognized OutputKind: ${args.CompilationOptions.OutputKind}");
+                }
+            }
+
+            Contract.Assert(!string.IsNullOrEmpty(outputFileName));
+
+            RegisterOutput(Path.Combine(args.OutputDirectory, outputFileName));
+            if (args.EmitPdb)
+            {
+                RegisterOutput(Path.Combine(args.OutputDirectory, args.PdbPath ?? Path.ChangeExtension(outputFileName, ".pdb")));
+            }
+        }
+
+        private void RegisterOutput(string filePath)
+        {
+            RegisterAccess(filePath, m_augmentedReported.TryReportFileCreations);
+        }
+
+        private void RegisterInput(string filePath)
+        {
+            RegisterAccess(filePath, m_augmentedReported.TryReportFileReads);
+        }
+
+        private void RegisterInputs(IEnumerable<string> filePaths)
+        {
+            Contract.Requires(filePaths != null);
+
+            if (!m_augmentedReported.TryReportFileReads(filePaths))
+            {
+                throw new InvalidOperationException($"Failed at reporting augmented file accesses [${string.Join(", ", filePaths)}]");
+            }
+        }
+
+        private void RegisterAccess(string filePath, Func<IEnumerable<string>, bool> tryReport)
+        {
+            if (string.IsNullOrEmpty(filePath))
+            {
+                return;
+            }
+
+            if (!tryReport(new[] { filePath }))
+            {
+                throw new InvalidOperationException($"Failed at reporting an augmented file access for ${filePath}");
+            }
+        }
+    }
+}

--- a/Public/Src/Tools/VBCSCompilerLogger/VBCSCompilerLogger.dsc
+++ b/Public/Src/Tools/VBCSCompilerLogger/VBCSCompilerLogger.dsc
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import * as BuildXLSdk from "Sdk.BuildXL";
+import * as MSBuild from "Sdk.Selfhost.MSBuild";
+
+namespace VBCSCompilerLogger {
+    export declare const qualifier: BuildXLSdk.DefaultQualifier;
+
+    @@public
+    export const exe = BuildXLSdk.library({
+        assemblyName: "VBCSCompilerLogger",
+        skipDocumentationGeneration: true,
+        skipDefaultReferences: true,
+        sources: globR(d`.`, "*.cs"),
+        references:[
+            ...MSBuild.msbuildReferences,
+            importFrom("Microsoft.CodeAnalysis.VisualBasic").pkg,
+            importFrom("Microsoft.CodeAnalysis.CSharp").pkg,
+            importFrom("Microsoft.CodeAnalysis.Common").pkg,
+            importFrom("System.Collections.Immutable").pkg,
+            importFrom("BuildXL.Utilities").dll,
+            importFrom("BuildXL.Utilities").Native.dll,
+            importFrom("BuildXL.Engine").Processes.dll,
+        ],
+        runtimeContent:[
+            importFrom("System.Reflection.Metadata").pkg
+        ]
+    });
+}

--- a/Public/Src/Utilities/Configuration/Resolvers/IMsBuildResolverSettings.cs
+++ b/Public/Src/Utilities/Configuration/Resolvers/IMsBuildResolverSettings.cs
@@ -167,6 +167,15 @@ namespace BuildXL.Utilities.Configuration
         /// When true, default targets will be used as a heuristic. Defaults to false.
         /// </remarks>
         bool? AllowProjectsToNotSpecifyTargetProtocol { get; }
+
+        /// <summary>
+        /// Whether VBCSCompiler is allowed to be launched as a service to serve managed compilation requests
+        /// </summary>
+        /// <remarks>
+        /// Defaults to on.
+        /// This option will only be honored when process breakaway is supported by the underlying sandbox.
+        /// </remarks>
+        bool? UseManagedSharedCompilation { get; }
     }
 
     /// <nodoc/>

--- a/Public/Src/Utilities/Configuration/Resolvers/Mutable/MsBuildResolverSettings.cs
+++ b/Public/Src/Utilities/Configuration/Resolvers/Mutable/MsBuildResolverSettings.cs
@@ -47,6 +47,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             AllowProjectsToNotSpecifyTargetProtocol = resolverSettings.AllowProjectsToNotSpecifyTargetProtocol;
             MsBuildRuntime = resolverSettings.MsBuildRuntime;
             DotNetSearchLocations = resolverSettings.DotNetSearchLocations;
+            UseManagedSharedCompilation = resolverSettings.UseManagedSharedCompilation;
         }
 
         /// <inheritdoc/>
@@ -117,5 +118,8 @@ namespace BuildXL.Utilities.Configuration.Mutable
 
         /// <inheritdoc/>
         public IReadOnlyList<DirectoryArtifact> DotNetSearchLocations { get; set; }
+
+        /// <inheritdoc/>
+        public bool? UseManagedSharedCompilation { get; set; }
     }
 }


### PR DESCRIPTION
This PR adds shared compilation support for csc/vbc compilations for the MSBuild frontend.
This is achieved by:
- Configuring VBCSCompiler.exe so it can breakaway from the sandbox (if that feature is supported by the underlying sandbox)
- Attaching an MSBuild logger in that case that can compensate for missing accesses and report them as augmented accesses. This is done by intercepting the csc/vbc MSBuild task command line arguments and using the Roslyn code analysis functionality to statically predict inputs/outputs.