### PR TITLE
RocksDB tuning for macOS

### DIFF
--- a/cg/nuget/cgmanifest.json
+++ b/cg/nuget/cgmanifest.json
@@ -2499,7 +2499,7 @@
         "Type": "NuGet",
         "NuGet": {
           "Name": "RocksDbNative",
-          "Version": "6.0.1-b20191114.5"
+          "Version": "6.0.1-b20191115.2"
         }
       }
     },
@@ -2508,7 +2508,7 @@
         "Type": "NuGet",
         "NuGet": {
           "Name": "RocksDbSharp",
-          "Version": "5.8.0-b20191114.5"
+          "Version": "5.8.0-b20191115.2"
         }
       }
     },

--- a/cg/nuget/cgmanifest.json
+++ b/cg/nuget/cgmanifest.json
@@ -2499,7 +2499,7 @@
         "Type": "NuGet",
         "NuGet": {
           "Name": "RocksDbNative",
-          "Version": "6.0.1-b20191113.6"
+          "Version": "6.0.1-b20191114.5"
         }
       }
     },
@@ -2508,7 +2508,7 @@
         "Type": "NuGet",
         "NuGet": {
           "Name": "RocksDbSharp",
-          "Version": "5.8.0-b20191113.6"
+          "Version": "5.8.0-b20191114.5"
         }
       }
     },

--- a/config.dsc
+++ b/config.dsc
@@ -140,8 +140,8 @@ config({
                 { id: "Microsoft.Windows.ProjFS", version: "1.0.19079.1" },
 
                 // RocksDb
-                { id: "RocksDbSharp", version: "5.8.0-b20191113.6", alias: "RocksDbSharpSigned" },
-                { id: "RocksDbNative", version: "6.0.1-b20191113.6" },
+                { id: "RocksDbSharp", version: "5.8.0-b20191114.5", alias: "RocksDbSharpSigned" },
+                { id: "RocksDbNative", version: "6.0.1-b20191114.5" },
 
                 { id: "JsonDiffPatch.Net", version: "2.1.0" },
 

--- a/config.dsc
+++ b/config.dsc
@@ -140,8 +140,8 @@ config({
                 { id: "Microsoft.Windows.ProjFS", version: "1.0.19079.1" },
 
                 // RocksDb
-                { id: "RocksDbSharp", version: "5.8.0-b20191114.5", alias: "RocksDbSharpSigned" },
-                { id: "RocksDbNative", version: "6.0.1-b20191114.5" },
+                { id: "RocksDbSharp", version: "5.8.0-b20191115.2", alias: "RocksDbSharpSigned" },
+                { id: "RocksDbNative", version: "6.0.1-b20191115.2" },
 
                 { id: "JsonDiffPatch.Net", version: "2.1.0" },
 


### PR DESCRIPTION
This PR updates the RocksDB packages and introduces some performance tuning adjustments for the macOS version. Flushing out + compacting memtables more frequently reduces the BuildXL memory footprint and using LZ4 does so at a minimal cost. The RocksDB repo has been updated to build RocksDB for macOS with dynamically linked Snappy and LZ4 libraries, the build steps patch the RocksDB dylib to look for its dependencies in the @loader_path when loading.

(NEW)

<img width="1288" alt="ServerOffRAM-J" src="https://user-images.githubusercontent.com/1250428/68950943-79173980-07bd-11ea-8d1c-400cdc9eb720.png">

vs. (OLD)

<img width="1270" alt="ServerOffRAM-H" src="https://user-images.githubusercontent.com/1250428/68951027-9ea44300-07bd-11ea-92b0-a42daccbf765.png">
