### PR TITLE
Reduce scrubber logs

### DIFF
--- a/Public/Src/Engine/Dll/EngineSchedule.cs
+++ b/Public/Src/Engine/Dll/EngineSchedule.cs
@@ -798,7 +798,7 @@ namespace BuildXL.Engine
             if (sharedOpaqueSidebandFiles.Any())
             {
                 Logger.Log.DeletingSharedOpaqueSidebandFilesStarted(loggingContext);
-                scrubber.DeleteFiles(sharedOpaqueSidebandFiles);
+                scrubber.DeleteFiles(sharedOpaqueSidebandFiles, logDeletedFiles: false);
             }
 
             if (pathsToScrub.Count > 0)


### PR DESCRIPTION
In some WDG logs, we found ~74,000 lines of 
```
[3:44.874] verbose DX0858: Scrubber deletes file...
```
Most of them coming from deleting sideband files.

[AB#1647405](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1647405)