### PR TITLE
Change the solution name when it's created via -vsnew argument

### DIFF
--- a/Public/Src/Engine/UnitTests/Engine/MiniBuild.cs
+++ b/Public/Src/Engine/UnitTests/Engine/MiniBuild.cs
@@ -78,7 +78,11 @@ namespace Test.BuildXL.EngineTests
             RunEngine();
 
             var outputDirectoryPath = Configuration.Layout.OutputDirectory.ToString(Context.PathTable);
-            XAssert.IsTrue(File.Exists(Path.Combine(outputDirectoryPath, "vs", "src", "src.sln")));
+            XAssert.IsTrue(File.Exists(Path.Combine(
+                outputDirectoryPath, 
+                "vs",
+                Configuration.Ide.IsNewEnabled ? "srcNew" : "src",
+                Configuration.Ide.IsNewEnabled ? "srcNew.sln" : "src.sln")));
         }
 
         [Fact]

--- a/Public/Src/IDE/Generator/IdeGenerator.cs
+++ b/Public/Src/IDE/Generator/IdeGenerator.cs
@@ -85,6 +85,12 @@ namespace BuildXL.Ide.Generator
                     solutionNameCandidate = "ideGenerated";
                 }
 
+                // If a new solution generator is used, change the solution name so users can distinguish between the old and new one.
+                if (ideConfiguration.IsNewEnabled)
+                {
+                    solutionNameCandidate += "New";
+                }
+
                 ideConfiguration.SolutionName = PathAtom.Create(pathTable.StringTable, solutionNameCandidate);
             }
 

--- a/Shared/Scripts/bxl.ps1
+++ b/Shared/Scripts/bxl.ps1
@@ -256,7 +256,7 @@ if ($Vs) {
 }
 
 if ($VsNew) {
-    $AdditionalBuildXLArguments += "/p:[Sdk.BuildXL]GenerateVSSolution=true /q:DebugNet472 /vs /vsnew /solutionName:BuildXLNew";
+    $AdditionalBuildXLArguments += "/p:[Sdk.BuildXL]GenerateVSSolution=true /q:DebugNet472 /vs /vsnew";
 }
 
 # WARNING: CloudBuild selfhost builds do NOT use this script file. When adding a new argument below, we should add the argument to selfhost queues in CloudBuild. Please contact bxl team. 


### PR DESCRIPTION
Currently, if one uses '-vsnew' to create a solution, a generated solution will be named 'BuildXLNew'. If someone only has a single solution, it's fine. However, it becomes very confusing if you have multiple enlistments on your machine.

This PR changes how the name is constructed (essentially it's the old logic but we add 'new' at the end)