### PR TITLE
Add /vsTargetFramework for constraining flavors of generated VS projects

### DIFF
--- a/Public/Src/App/Bxl/Args.cs
+++ b/Public/Src/App/Bxl/Args.cs
@@ -17,7 +17,6 @@ using BuildXL.Utilities;
 using BuildXL.Utilities.CLI;
 using BuildXL.Utilities.Configuration;
 using BuildXL.Utilities.Tracing;
-using static BuildXL.Interop.MacOS.Memory;
 using static BuildXL.Utilities.FormattableStringEx;
 using HelpLevel = BuildXL.Utilities.Configuration.HelpLevel;
 using Strings = bxl.Strings;
@@ -1163,6 +1162,10 @@ namespace BuildXL
                         OptionHandlerFactory.CreateBoolOption(
                             "vsOutputSrc",
                             sign => ideConfiguration.CanWriteToSrc = sign),
+                        OptionHandlerFactory.CreateOption2(
+                            "vsTF",
+                            "vsTargetFramework",
+                            opt => ParseStringOption(opt, ideConfiguration.TargetFrameworks)),
                         OptionHandlerFactory.CreateBoolOptionWithValue(
                             "warnAsError",
                             (opt, sign) =>

--- a/Public/Src/App/Bxl/Args.cs
+++ b/Public/Src/App/Bxl/Args.cs
@@ -17,6 +17,7 @@ using BuildXL.Utilities;
 using BuildXL.Utilities.CLI;
 using BuildXL.Utilities.Configuration;
 using BuildXL.Utilities.Tracing;
+using static BuildXL.Interop.MacOS.Memory;
 using static BuildXL.Utilities.FormattableStringEx;
 using HelpLevel = BuildXL.Utilities.Configuration.HelpLevel;
 using Strings = bxl.Strings;

--- a/Public/Src/IDE/Generator/Context.cs
+++ b/Public/Src/IDE/Generator/Context.cs
@@ -74,6 +74,7 @@ namespace BuildXL.Ide.Generator
         internal readonly StringTable StringTable;
         internal readonly SymbolTable SymbolTable;
         internal readonly QualifierTable QualifierTable;
+        internal readonly IIdeConfiguration IdeConfig;
 
         internal readonly AbsolutePath ProjectsRoot;
         internal readonly AbsolutePath EnlistmentRoot;
@@ -112,6 +113,7 @@ namespace BuildXL.Ide.Generator
             PathTable = pipContext.PathTable;
             SymbolTable = pipContext.SymbolTable;
             QualifierTable = pipContext.QualifierTable;
+            IdeConfig = ideConfig;
 
             DotSettingsPathStr = ideConfig.DotSettingsFile.IsValid ? ideConfig.DotSettingsFile.ToString(PathTable) : null;
             ConfigFilePathStr = configFilePath.ToString(PathTable);

--- a/Public/Src/IDE/Generator/CsprojFile.cs
+++ b/Public/Src/IDE/Generator/CsprojFile.cs
@@ -54,7 +54,7 @@ namespace BuildXL.Ide.Generator
                 return;
             }
 
-            // if requested, only generate project flavors that match the currently specified qualifiers
+            // if requested, only generate project flavors that match the currently specified qualifiers.
             if (Context.IdeConfig.TargetFrameworks?.Any() == true
                 && !Context.IdeConfig.TargetFrameworks.Any(tf => QualifierPropertyEquals(qualifier, QualifierTargetFrameworkPropertyName, tf)))
             {

--- a/Public/Src/IDE/Generator/CsprojFile.cs
+++ b/Public/Src/IDE/Generator/CsprojFile.cs
@@ -54,6 +54,13 @@ namespace BuildXL.Ide.Generator
                 return;
             }
 
+            // if requested, only generate project flavors that match the currently specified qualifiers
+            if (Context.IdeConfig.TargetFrameworks?.Any() == true
+                && !Context.IdeConfig.TargetFrameworks.Any(tf => QualifierPropertyEquals(qualifier, QualifierTargetFrameworkPropertyName, tf)))
+            {
+                return;
+            }
+
             var friendlyQualifier = process.Provenance.QualifierId;
 
             switch (pipCategory)

--- a/Public/Src/Utilities/Configuration/IIdeConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/IIdeConfiguration.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+
 namespace BuildXL.Utilities.Configuration
 {
     /// <summary>
@@ -37,5 +39,10 @@ namespace BuildXL.Utilities.Configuration
         /// Optional resharper dotsettings file to be placed next to the generated solution.
         /// </summary>
         AbsolutePath DotSettingsFile { get; }
+
+        /// <summary>
+        /// Optional list of target frameworks to which to restrict generated projects.
+        /// </summary>
+        IReadOnlyList<string> TargetFrameworks { get; }
     }
 }

--- a/Public/Src/Utilities/Configuration/Mutable/IdeConfiguration.cs
+++ b/Public/Src/Utilities/Configuration/Mutable/IdeConfiguration.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.ContractsLight;
 
 namespace BuildXL.Utilities.Configuration.Mutable
@@ -25,6 +27,7 @@ namespace BuildXL.Utilities.Configuration.Mutable
             SolutionName = pathRemapper.Remap(template.SolutionName);
             SolutionRoot = pathRemapper.Remap(template.SolutionRoot);
             DotSettingsFile = pathRemapper.Remap(template.DotSettingsFile);
+            TargetFrameworks = new List<string>(template.TargetFrameworks);
         }
 
         /// <inheritdoc />
@@ -45,12 +48,19 @@ namespace BuildXL.Utilities.Configuration.Mutable
         /// <nodoc />
         // Temporary redirect for back compat
         [Obsolete]
-        public AbsolutePath VsDominoRoot { 
-            get { return SolutionRoot;} 
+        public AbsolutePath VsDominoRoot {
+            get { return SolutionRoot; }
             set { SolutionRoot = value; }
         }
 
         /// <inheritdoc />
         public AbsolutePath DotSettingsFile { get; set; }
+
+        /// <nodoc />
+        [SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
+        public List<string> TargetFrameworks { get; set; } = new List<string>();
+
+        /// <inheritdoc />
+        IReadOnlyList<string> IIdeConfiguration.TargetFrameworks => TargetFrameworks;
     }
 }

--- a/Shared/Scripts/bxl.ps1
+++ b/Shared/Scripts/bxl.ps1
@@ -128,6 +128,15 @@ param(
     [Parameter(Mandatory=$false)]
     [switch]$VsNew = $false,
 
+    [Parameter(Mandatory=$false)]
+    [switch]$VsNewNetCore = $false,
+
+    [Parameter(Mandatory=$false)]
+    [switch]$VsNewNet472 = $false,
+
+    [Parameter(Mandatory=$false)]
+    [switch]$VsNewAll = $false,
+
     [Parameter(ValueFromRemainingArguments=$true)]
     [string[]]$DominoArguments
 )
@@ -255,12 +264,21 @@ if ($Vs) {
     $AdditionalBuildXLArguments += "/p:[Sdk.BuildXL]GenerateVSSolution=true /q:DebugNet472 /vs";
 }
 
-if ($VsNew) {
-    $AdditionalBuildXLArguments += "/p:[Sdk.BuildXL]GenerateVSSolution=true /q:DebugNet472 /vs /vsnew /solutionName:BuildXLNew";
+if ($VsNew -or $VsNewNetCore -or $VsNewNet472 -or $VsNewAll) {
+    $AdditionalBuildXLArguments += "/p:[Sdk.BuildXL]GenerateVSSolution=true /vs /vsnew /solutionName:BuildXLNew";
+    if ($VsNewNetCore) {
+        $AdditionalBuildXLArguments += "/q:DebugDotNetCore /vsTargetFramework:netcoreapp3.0 /vsTargetFramework:netstandard2.0";
+    } elseif ($VsNewNet472) {
+        $AdditionalBuildXLArguments += "/q:DebugNet472 /vsTargetFramework:net472";
+    } elseif ($VsNewAll) {
+        $AdditionalBuildXLArguments += "/q:DebugNet472 /q:DebugDotNetCore";
+    } else {
+        $AdditionalBuildXLArguments += "/q:DebugNet472"; # same as before, for compat reasons
+    }
 }
 
 # WARNING: CloudBuild selfhost builds do NOT use this script file. When adding a new argument below, we should add the argument to selfhost queues in CloudBuild. Please contact bxl team. 
-$AdditionalBuildXLArguments += @("/remotetelemetry", "/reuseOutputsOnDisk+", "/scrubDirectory:${enlistmentRoot}\out\objects", "/storeFingerprints", "/cacheMiss");
+$AdditionalBuildXLArguments += @("/remotetelemetry", "/reuseOutputsOnDisk+", "/scrubDirectory:${enlistmentRoot}\out\objects", "/storeFingerprints", "/cacheMiss", "/enableEvaluationThrottling");
 $AdditionalBuildXLArguments += @("/p:[Sdk.BuildXL]useQTest=true");
 
 if (($DominoArguments -match "logsDirectory:.*").Length -eq 0 -and ($DominoArguments -match "logPrefix:.*").Length -eq 0) {


### PR DESCRIPTION
Three additional switches are added to `bxl.ps1`:
  * `-vsNewNet472`
  * `-vsNewNetCore`
  * `-vsNewAll`

Those switches are implemented via the `/vsTargetFramework` BuildXL command-line argument.

The idea is to be able to explicitly limit generated CS projects to a set of target frameworks.

Right now, the VS generator looks at the pip graph, goes through all csc pips, groups them by their assembly name, then for each group generates a .csproj file where its `<TargetFrameworks>` property contains the union of `qualifier.targetFramework` values of all the pips in the group.

The problem is, even when a qualifier is explicitly specified (e.g., /q:DebugNet472), the pip graph will still contain some projects whose qualifier's target framework is something else (e.g., netcoreapp3.0), and therefore, the generated VS projects will contain multiple target frameworks for those projects.  That, among other things, causes "find references" in VS to return references for each target framework, which can be annoying. 

With this change, passing `-vsNewNet472` causes the VS generator to ignore pips whose target framework is different from Net472; `-vsNewNetCore` is the same, except only pips targeting netcoreapp/netstandard are accepted.  In either case, generated VS projects will all target a single framework.  On the other hand, `-vsNewAll` does not make any restrictions and so target frameworks of generated projects will reflect what was in the pip graph when `/vs` was invoked.