### PR TITLE
Cancellation for slower redis

### DIFF
--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/RaidedRedisDatabase.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/RaidedRedisDatabase.cs
@@ -122,15 +122,15 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
 
                 if (secondResult != slowerResultTask)
                 {
+                    // Avoiding task unobserved exception if the second task will fail.
+                    // TODO ST: pass the severity into this operation to trace the failure as a debug severity message (not available yet).
+                    slowerResultTask.FireAndForget(context);
+
                     // The second task is not done within a given timeout.
                     cancellationTokenSource.Cancel();
 
                     var failingRedisDb = GetDbName(fasterResultTask == primaryResultTask ? SecondaryRedisDb : PrimaryRedisDb);
                     Tracer.Info(context, $"{Tracer.Name}.{caller}: Error in {failingRedisDb} redis db using result from other redis db: {fasterResultTask}");
-
-                    // Avoiding task unobserved exception if the second task will fail.
-                    // TODO ST: pass the severity into this operation to trace the failure as a debug severity message (not available yet).
-                    slowerResultTask.FireAndForget(context);
 
                     if (fasterResultTask == primaryResultTask)
                     {

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/RedisGlobalStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/RedisGlobalStore.cs
@@ -157,7 +157,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
 
                     foreach (var page in contentHashes.AsIndexed().GetPages(_configuration.RedisBatchPageSize))
                     {
-                        var batchResult = await _redis.ExecuteRedisAsync(context, async redisDb =>
+                        var batchResult = await _redis.ExecuteRedisAsync(context, async (redisDb, token) =>
                         {
                             var redisBatch = redisDb.CreateBatch(RedisOperation.GetBulkGlobal);
 
@@ -190,7 +190,8 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                                 }).FireAndForget(context);
                             }
 
-                            return await redisDb.ExecuteBatchOperationAsync(context, redisBatch, context.Token);
+                            // TODO ST: now this operation may fail with TaskCancelledException. But this should be traced differently!
+                            return await redisDb.ExecuteBatchOperationAsync(context, redisBatch, token);
 
                         });
 

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/RedisGlobalStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/RedisGlobalStore.cs
@@ -193,7 +193,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                             // TODO ST: now this operation may fail with TaskCancelledException. But this should be traced differently!
                             return await redisDb.ExecuteBatchOperationAsync(context, redisBatch, token);
 
-                        });
+                        }, _configuration.RetryWindow);
 
                         if (!batchResult)
                         {
@@ -313,7 +313,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
 
                                 return await redisDb.ExecuteBatchOperationAsync(context, updateRedisBatch, token);
                             }
-                        });
+                        }, _configuration.RetryWindow);
 
                         if (!batchResult)
                         {

--- a/Public/Src/Cache/ContentStore/Distributed/NuCache/RedisGlobalStore.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/NuCache/RedisGlobalStore.cs
@@ -254,7 +254,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                 {
                     foreach (var page in contentHashes.GetPages(hashBatchSize))
                     {
-                        var batchResult = await _redis.ExecuteRedisAsync(context, async redisDb =>
+                        var batchResult = await _redis.ExecuteRedisAsync(context, async (redisDb, token) =>
                         {
                             Counters[GlobalStoreCounters.RegisterLocalLocationHashCount].Add(page.Count);
 
@@ -286,7 +286,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                                     }).FireAndForget(context);
                                 }
 
-                                var result = await redisDb.ExecuteBatchOperationAsync(context, redisBatch, context.Token);
+                                var result = await redisDb.ExecuteBatchOperationAsync(context, redisBatch, token);
                                 if (!result || requiresSetBitCount == 0)
                                 {
                                     return result;
@@ -311,7 +311,7 @@ namespace BuildXL.Cache.ContentStore.Distributed.NuCache
                                     updateRedisBatch.AddOperation(key, batch => SetLocationBitAndExpireAsync(context, batch, key, hash, machineId)).FireAndForget(context);
                                 }
 
-                                return await redisDb.ExecuteBatchOperationAsync(context, updateRedisBatch, context.Token);
+                                return await redisDb.ExecuteBatchOperationAsync(context, updateRedisBatch, token);
                             }
                         });
 

--- a/Public/Src/Cache/ContentStore/Distributed/Redis/RedisContentLocationStoreConfiguration.cs
+++ b/Public/Src/Cache/ContentStore/Distributed/Redis/RedisContentLocationStoreConfiguration.cs
@@ -112,6 +112,14 @@ namespace BuildXL.Cache.ContentStore.Distributed.Redis
         public float EvictionRemovalFraction { get; set; } = 0.015355f;
 
         /// <summary>
+        /// Time Delay given to raided redis databases to complete its result after the first redis instance has completed.
+        /// <remarks>
+        /// Default value will be set to null, and both redis instances need to be completed before moving forward.
+        /// </remarks>
+        /// </summary>
+        public TimeSpan? RetryWindow { get; set; } = null;
+
+        /// <summary>
         /// Returns true if Redis can be used for storing small files.
         /// </summary>
         public bool AreBlobsSupported => BlobExpiryTimeMinutes > 0 && MaxBlobCapacity > 0 && MaxBlobSize > 0;

--- a/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Configuration/DistributedContentSettings.cs
@@ -222,6 +222,12 @@ namespace BuildXL.Cache.Host.Configuration
         public TimeSpan EvictionMinAge { get; set; } = TimeSpan.Zero;
 
         /// <summary>
+        /// After the first raided redis instance completes, the second instance is given a window of time to complete before the retries are cancelled.
+        /// Default to always wait for both instances to complete.
+        /// </summary>
+        public TimeSpan? RetryWindow { get; set; } = null;
+
+        /// <summary>
         /// Fraction of the pool considered trusted to be in the accurate order.
         /// </summary>
         [DataMember]

--- a/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
+++ b/Public/Src/Cache/DistributedCache.Host/Service/Internal/DistributedContentStoreFactory.cs
@@ -71,6 +71,7 @@ namespace BuildXL.Cache.Host.Service.Internal
                 EvictionPoolSize = _distributedSettings.EvictionPoolSize,
                 EvictionMinAge = _distributedSettings.EvictionMinAge,
                 EvictionRemovalFraction = _distributedSettings.EvictionRemovalFraction,
+                RetryWindow = _distributedSettings.RetryWindow,
                 MemoizationExpiryTime = TimeSpan.FromMinutes(_distributedSettings.RedisMemoizationExpiryTimeMinutes)
             };
 


### PR DESCRIPTION
- Wait until one of the redis instances completes, if succeeded, there is a retry window for second instance to complete as well, otherwise, cancel second instance from retrying.
- If the first completed instance fails, wait for second instance to complete.
- Retry window is defaulted to null, meaning both instance will be waited for (previous implementation) currently until configured.