### PR TITLE
Ensure that tests involving pip executions have directory translator

### DIFF
--- a/Public/Src/Engine/UnitTests/Processes.TestPrograms/DetoursCrossBitTests/DetoursCrossBitTests.dsc
+++ b/Public/Src/Engine/UnitTests/Processes.TestPrograms/DetoursCrossBitTests/DetoursCrossBitTests.dsc
@@ -25,6 +25,7 @@ namespace Processes.TestPrograms.DetoursCrossBitTests {
             importFrom("BuildXL.Engine").Scheduler.dll,
             importFrom("BuildXL.Utilities").dll,
             importFrom("BuildXL.Utilities").Ipc.dll,
+            importFrom("BuildXL.Utilities").Native.dll,
             importFrom("BuildXL.Utilities").Storage.dll,
             importFrom("BuildXL.Utilities").Collections.dll,
             importFrom("BuildXL.Utilities").Configuration.dll,

--- a/Public/Src/Engine/UnitTests/Scheduler/PipExecutorTest.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/PipExecutorTest.cs
@@ -2293,7 +2293,7 @@ EXIT /b 3
             return string.Format(DefaultInMemoryJsonConfigString, cacheId);
         }
 
-        private static Task WithCachingExecutionEnvironmentForCacheConvergence(
+        private Task WithCachingExecutionEnvironmentForCacheConvergence(
             string cacheDir,
             Func<DummyPipExecutionEnvironment, Task> act,
             Func<PathTable, SemanticPathExpander> createMountExpander = null,
@@ -2303,7 +2303,7 @@ EXIT /b 3
             return WithExecutionEnvironmentForCacheConvergence(act, createMountExpander, config: config, whitelistCreator: whitelistCreator);
         }
 
-        private static Task WithCachingExecutionEnvironment(
+        private Task WithCachingExecutionEnvironment(
             string cacheDir,
             Func<DummyPipExecutionEnvironment, Task> act,
             Func<PathTable, SemanticPathExpander> createMountExpander = null,
@@ -2314,7 +2314,7 @@ EXIT /b 3
             return WithExecutionEnvironment(act, InMemoryCacheFactory.Create, createMountExpander, config: config, whitelistCreator: whitelistCreator);
         }
 
-        private static Task WithExecutionEnvironmentForCacheConvergence(
+        private Task WithExecutionEnvironmentForCacheConvergence(
             Func<DummyPipExecutionEnvironment, Task> act,
             Func<PathTable, SemanticPathExpander> createMountExpander = null,
             Func<PathTable, IConfiguration> config = null,
@@ -2332,7 +2332,7 @@ EXIT /b 3
                         fileAccessWhitelist: fileAccessWhitelist));
         }
 
-        private static Task WithExecutionEnvironmentAndIpcServer(
+        private Task WithExecutionEnvironmentAndIpcServer(
             IIpcProvider ipcProvider,
             IIpcOperationExecutor ipcExecutor,
             Func<DummyPipExecutionEnvironment, IIpcMoniker, IServer, Task> act,
@@ -2358,7 +2358,7 @@ EXIT /b 3
                 ipcProvider: ipcProvider);
         }
 
-        private static Task WithExecutionEnvironment(
+        private Task WithExecutionEnvironment(
             Func<DummyPipExecutionEnvironment, Task> act,
             Func<EngineCache> cache = null,
             Func<PathTable, SemanticPathExpander> createMountExpander = null,
@@ -2429,7 +2429,7 @@ EXIT /b 3
             return config;
         }
 
-        private static DummyPipExecutionEnvironment CreateExecutionEnvironmentForCacheConvergence(
+        private DummyPipExecutionEnvironment CreateExecutionEnvironmentForCacheConvergence(
             BuildXLContext context,
             SemanticPathExpander mountExpander = null,
             Func<PathTable, IConfiguration> config = null,
@@ -2450,12 +2450,15 @@ EXIT /b 3
                 semanticPathExpander: mountExpander,
                 fileAccessWhitelist: fileAccessWhitelist,
                 allowUnspecifiedSealedDirectories: false,
+                subst: TryGetSubstSourceAndTarget(out var substSource, out var substTarget)
+                    ? (substSource, substTarget)
+                    : default((string, string)?),
                 sandboxConnection: GetSandboxConnection());
             env.ContentFingerprinter.FingerprintTextEnabled = true;
             return env;
         }
 
-        private static DummyPipExecutionEnvironment CreateExecutionEnvironment(
+        private DummyPipExecutionEnvironment CreateExecutionEnvironment(
             BuildXLContext context,
             Func<EngineCache> cache = null,
             SemanticPathExpander mountExpander = null,
@@ -2482,6 +2485,9 @@ EXIT /b 3
                 fileAccessWhitelist: fileAccessWhitelist,
                 allowUnspecifiedSealedDirectories: false,
                 ipcProvider: ipcProvider,
+                subst: TryGetSubstSourceAndTarget(out var substSource, out var substTarget) 
+                    ? (substSource, substTarget) 
+                    : default((string, string)?),
                 sandboxConnection: GetSandboxConnection());
             env.ContentFingerprinter.FingerprintTextEnabled = true;
 

--- a/Public/Src/Engine/UnitTests/Scheduler/PipFileSystemViewTests.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/PipFileSystemViewTests.cs
@@ -125,7 +125,14 @@ namespace Test.BuildXL.Scheduler
             {
                 Context = BuildXLContext.CreateInstanceForTesting();
                 var config = ConfigurationHelpers.GetDefaultForTesting(Context.PathTable, AbsolutePath.Create(Context.PathTable, System.IO.Path.Combine(testOutputDirectory, "config.dc")));
-                m_env = new DummyPipExecutionEnvironment(CreateLoggingContextForTest(), Context, config, sandboxConnection: GetSandboxConnection());
+                m_env = new DummyPipExecutionEnvironment(
+                    CreateLoggingContextForTest(),
+                    Context,
+                    config,
+                    subst: FileUtilities.TryGetSubstSourceAndTarget(testOutputDirectory, out var substSource, out var substTarget) 
+                        ? (substSource, substTarget) 
+                        : default((string, string)?),
+                    sandboxConnection: GetSandboxConnection());
                 var sealContentsCache = new ConcurrentBigMap<DirectoryArtifact, int[]>();
 
                 Table = Context.PathTable;

--- a/Public/Src/Engine/UnitTests/Scheduler/PipQueueTest.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/PipQueueTest.cs
@@ -43,13 +43,12 @@ using Xunit.Abstractions;
 using System.Diagnostics.CodeAnalysis;
 using BuildXL.Scheduler.FileSystem;
 using Test.BuildXL.Scheduler.Utils;
-using SandboxConnectionKext = BuildXL.Processes.SandboxConnectionKext;
 using BuildXL.Processes.Containers;
 using BuildXL.Utilities.VmCommandProxy;
 
 namespace Test.BuildXL.Scheduler
 {
-    public sealed class PipQueueTest : XunitBuildXLTest
+    public sealed class PipQueueTest : TemporaryStorageTestBase
     {
         public PipQueueTest(ITestOutputHelper output)
             : base(output)
@@ -97,7 +96,13 @@ namespace Test.BuildXL.Scheduler
                     maxDegreeOfParallelism: (Environment.ProcessorCount + 2) / 3,
                     debug: false))
                 {
-                    var executionEnvironment = new PipQueueTestExecutionEnvironment(context, config, pipTable, Path.Combine(TestOutputDirectory, "temp"), GetSandboxConnection());
+                    var executionEnvironment = new PipQueueTestExecutionEnvironment(
+                        context,
+                        config,
+                        pipTable,
+                        Path.Combine(TestOutputDirectory, "temp"),
+                        TryGetSubstSourceAndTarget(out string substSource, out string substTarget) ? (substSource, substTarget) : default((string, string)?),
+                        GetSandboxConnection());
 
                     Func<RunnablePip, Task<PipResult>> taskFactory = async (runnablePip) =>
                         {
@@ -282,17 +287,18 @@ namespace Test.BuildXL.Scheduler
         {
             // Some pip implementations may query for the hashes of their input files.
             private readonly ConcurrentDictionary<FileArtifact, ContentHash> m_expectedWrittenContent;
-            private readonly ConcurrentDictionary<FileArtifact, ContentHash> m_wellKnownFiles;
             private readonly ConcurrentDictionary<FileArtifact, Pip> m_producers;
             private readonly ConcurrentDictionary<Pip, Unit> m_executed = new ConcurrentDictionary<Pip, Unit>();
 
             private readonly TestPipGraphFilesystemView m_filesystemView;
-            private readonly ConcurrentBigMap<DirectoryArtifact, int[]> m_sealContentsById;
-            private readonly ISandboxConnection m_sandboxConnectionKext;
 
-            private readonly IFileMonitoringViolationAnalyzer m_disabledFileMonitoringViolationAnalyzer = new DisabledFileMonitoringViolationAnalyzer();
-            
-            public PipQueueTestExecutionEnvironment(BuildXLContext context, IConfiguration configuration, PipTable pipTable, string tempDirectory, ISandboxConnection SandboxConnection = null)
+            public PipQueueTestExecutionEnvironment(
+                BuildXLContext context,
+                IConfiguration configuration,
+                PipTable pipTable,
+                string tempDirectory,
+                (string substSource, string substTarget)? subst = default,
+                ISandboxConnection sandboxConnection = null)
             {
                 Contract.Requires(context != null);
                 Contract.Requires(configuration != null);
@@ -313,9 +319,8 @@ namespace Test.BuildXL.Scheduler
                 Cache = InMemoryCacheFactory.Create();
                 LocalDiskContentStore = new LocalDiskContentStore(LoggingContext, context.PathTable, FileContentTable, tracker);
 
-                m_sandboxConnectionKext = SandboxConnection;
+                SandboxConnection = sandboxConnection;
                 m_expectedWrittenContent = new ConcurrentDictionary<FileArtifact, ContentHash>();
-                m_wellKnownFiles = new ConcurrentDictionary<FileArtifact, ContentHash>();
                 m_producers = new ConcurrentDictionary<FileArtifact, Pip>();
                 m_filesystemView = new TestPipGraphFilesystemView(Context.PathTable);
                 var fileSystemView = new FileSystemView(Context.PathTable, m_filesystemView, LocalDiskContentStore);
@@ -334,9 +339,20 @@ namespace Test.BuildXL.Scheduler
                     fileContentManager: new FileContentManager(this, new NullOperationTracker()),
                     directoryMembershipFinterprinterRuleSet: null);
 
-                m_sealContentsById = new ConcurrentBigMap<DirectoryArtifact, int[]>();
-
                 ProcessInContainerManager = new ProcessInContainerManager(LoggingContext, context.PathTable);
+
+                DirectoryTranslator = new DirectoryTranslator();
+                foreach (var directoryToTranslate in configuration.Engine.DirectoriesToTranslate)
+                {
+                    DirectoryTranslator.AddTranslation(directoryToTranslate.FromPath.ToString(context.PathTable), directoryToTranslate.ToPath.ToString(context.PathTable));
+                }
+
+                if (subst.HasValue)
+                {
+                    DirectoryTranslator.AddTranslation(subst.Value.substSource, subst.Value.substTarget);
+                }
+
+                DirectoryTranslator.Seal();
             }
 
             public void AddExpectedWrite(Pip producer, FileArtifact file, ContentHash expectedContent)
@@ -387,7 +403,7 @@ namespace Test.BuildXL.Scheduler
 
             public SemanticPathExpander PathExpander => SemanticPathExpander.Default;
 
-            public IFileMonitoringViolationAnalyzer FileMonitoringViolationAnalyzer => m_disabledFileMonitoringViolationAnalyzer;
+            public IFileMonitoringViolationAnalyzer FileMonitoringViolationAnalyzer { get; } = new DisabledFileMonitoringViolationAnalyzer();
 
             public DirectoryFingerprint? TryComputeDirectoryFingerprint(
                 AbsolutePath directoryPath, 
@@ -511,7 +527,7 @@ namespace Test.BuildXL.Scheduler
             }
 
             /// <inheritdoc/>
-            public DirectoryTranslator DirectoryTranslator => null;
+            public DirectoryTranslator DirectoryTranslator { get; }
 
             /// <inheritdoc/>
             public LoggingContext LoggingContext { get; }
@@ -601,7 +617,7 @@ namespace Test.BuildXL.Scheduler
 
             SemanticPathExpander IFileContentManagerHost.SemanticPathExpander => PathExpander;
 
-            public ISandboxConnection SandboxConnection => m_sandboxConnectionKext;
+            public ISandboxConnection SandboxConnection { get; }
 
             public ProcessInContainerManager ProcessInContainerManager { get; }
 

--- a/Public/Src/Engine/UnitTests/Scheduler/SchedulerTest.cs
+++ b/Public/Src/Engine/UnitTests/Scheduler/SchedulerTest.cs
@@ -1290,6 +1290,15 @@ namespace Test.BuildXL.Scheduler
 
             m_scheduler?.Dispose();
 
+            var directoryTranslator = new DirectoryTranslator();
+
+            if (TryGetSubstSourceAndTarget(out string substSource, out string substTarget))
+            {
+                directoryTranslator.AddTranslation(substSource, substTarget);
+            }
+
+            directoryTranslator.Seal();
+
             m_scheduler = new TestScheduler(
                 graph: graph,
                 pipQueue: m_testQueue,
@@ -1304,6 +1313,7 @@ namespace Test.BuildXL.Scheduler
                 ipcProvider: ipcProvider,
                 journalState: m_journalState,
                 tempCleaner: MoveDeleteCleaner,
+                directoryTranslator: directoryTranslator,
                 testHooks: testHooks);
 
             bool success = m_scheduler.InitForMaster(LoggingContext, filter);
@@ -2745,6 +2755,15 @@ namespace Test.BuildXL.Scheduler
                 context,
                 Task.FromResult<SemanticPathExpander>(Expander));
 
+            var directoryTranslator = new DirectoryTranslator();
+
+            if (TryGetSubstSourceAndTarget(out string substSource, out string substTarget))
+            {
+                directoryTranslator.AddTranslation(substSource, substTarget);
+            }
+
+            directoryTranslator.Seal();
+
             var newScheduler = new TestScheduler(
                 graph,
                 pipQueue: testQueue,
@@ -2754,8 +2773,9 @@ namespace Test.BuildXL.Scheduler
                 fileAccessWhitelist: new FileAccessWhitelist(Context),
                 configuration: configuration,
                 cache: cache,
-                testHooks: new SchedulerTestHooks(),
-                tempCleaner: MoveDeleteCleaner);
+                directoryTranslator: directoryTranslator,
+                tempCleaner: MoveDeleteCleaner,
+                testHooks: new SchedulerTestHooks());
 
             newScheduler.InitForMaster(LoggingContext, filter);
 

--- a/Public/Src/Utilities/UnitTests/TestUtilities.XUnit/TemporaryStorageTestBase.cs
+++ b/Public/Src/Utilities/UnitTests/TestUtilities.XUnit/TemporaryStorageTestBase.cs
@@ -205,40 +205,7 @@ namespace Test.BuildXL.TestUtilities.Xunit
         /// </remarks>
         protected bool TryGetSubstSourceAndTarget(out string substSource, out string substTarget)
         {
-            substSource = null;
-            substTarget = null;
-
-            if (OperatingSystemHelper.IsUnixOS)
-            {
-                // There is currently no subst in non-Windows OS.
-                return false;
-            }
-
-            OpenFileResult directoryOpenResult = FileUtilities.TryOpenDirectory(
-                TemporaryDirectory,
-                FileShare.Read | FileShare.Write | FileShare.Delete,
-                out SafeFileHandle directoryHandle);
-            XAssert.IsTrue(directoryOpenResult.Succeeded);
-
-            string directoryHandlePath = FileUtilities.GetFinalPathNameByHandle(directoryHandle, volumeGuidPath: false);
-
-            if (!string.Equals(TemporaryDirectory, directoryHandlePath, StringComparison.OrdinalIgnoreCase))
-            {
-                string commonPath = TemporaryDirectory.Substring(2); // Include '\' of '<Drive>:\'  for searching.
-                substTarget = TemporaryDirectory.Substring(0, 3);    // Include '\' of '<Drive>:\' in the substTarget.
-                int commonIndex = directoryHandlePath.IndexOf(commonPath, 0, StringComparison.OrdinalIgnoreCase);
-
-                if (commonIndex == -1)
-                {
-                    substTarget = null;
-                }
-                else
-                {
-                    substSource = directoryHandlePath.Substring(0, commonIndex + 1);
-                }
-            }
-
-            return !string.IsNullOrWhiteSpace(substSource) && !string.IsNullOrWhiteSpace(substTarget);
+            return FileUtilities.TryGetSubstSourceAndTarget(TemporaryDirectory, out substSource, out substTarget);
         }
     }
 }


### PR DESCRIPTION
When running on CB, tests need directory translation due to the use of K:. Some tools like cmd can access directly the K: drive.

[AB#1648378](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1648378)