### PR TITLE
Remove duplicates from ObservedAccessedFileNames

### DIFF
--- a/Public/Src/Engine/Scheduler/Fingerprints/ObservedInputProcessor.cs
+++ b/Public/Src/Engine/Scheduler/Fingerprints/ObservedInputProcessor.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.ContractsLight;
-using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -892,10 +891,10 @@ namespace BuildXL.Scheduler.Fingerprints
             where TTarget : struct, IObservedInputProcessingTarget<TObservation>
         {
             using (var pooledPathSet = Pools.GetAbsolutePathSet())
-            using (var pooledStringIdSet = Pools.GetStringIdSet())
             {
-                HashSet<StringId> accessedFileNames = pooledStringIdSet.Instance;
                 HashSet<AbsolutePath> visitedPaths = pooledPathSet.Instance;
+
+                HashSet<StringId> accessedFileNames = new HashSet<StringId>(pathTable.StringTable.CaseInsensitiveEqualityComparer);
 
                 bool addFileNamesFromObservations = false;
                 if (!observedAccessedFileNames.IsValid)
@@ -942,7 +941,7 @@ namespace BuildXL.Scheduler.Fingerprints
                 {
                     observedAccessedFileNames = SortedReadOnlyArray<StringId, CaseInsensitiveStringIdComparer>.SortUnsafe(
                                                 accessedFileNames.ToArray(),
-                                                new CaseInsensitiveStringIdComparer(pathTable.StringTable));
+                                                pathTable.StringTable.CaseInsensitiveStringIdComparer);
                 }
 
                 if (searchPaths.Count == 0)

--- a/Public/Src/Engine/Scheduler/Fingerprints/PipFingerprintingVersion.cs
+++ b/Public/Src/Engine/Scheduler/Fingerprints/PipFingerprintingVersion.cs
@@ -41,7 +41,8 @@ namespace BuildXL.Scheduler.Fingerprints
         /// 67: Added SourceChangeAffectedContents
         /// 68: Added ChildProcessesToBreakawayFromSandbox
         /// 69: Added dynamic existing probe.
+        /// 70: Removed duplicates from ObservedAccessedFileNames.
         /// </remarks>
-        TwoPhaseV2 = 69,
+        TwoPhaseV2 = 70,
     }
 }

--- a/Public/Src/Engine/Scheduler/SearchPathDirectoryMembershipFilter.cs
+++ b/Public/Src/Engine/Scheduler/SearchPathDirectoryMembershipFilter.cs
@@ -18,15 +18,13 @@ namespace BuildXL.Scheduler
         /// <summary>
         /// Creates a search path membership filter based on the given accessed file names without extensions
         /// </summary>
-        public SearchPathDirectoryMembershipFilter(PathTable pathTable, IEnumerable<StringId> accessedFileNamesWithoutExtension)
+        /// <remarks>
+        /// <paramref name="accessedFileNamesWithoutExtension"/> must use case-insensitive StringId comparer.
+        /// </remarks>
+        public SearchPathDirectoryMembershipFilter(PathTable pathTable, HashSet<StringId> accessedFileNamesWithoutExtension)
         {
             m_pathTable = pathTable;
-            AccessedFileNamesWithoutExtension = new HashSet<StringId>(pathTable.StringTable.CaseInsensitiveEqualityComparer);
-
-            foreach (var fileNameWithoutExtension in accessedFileNamesWithoutExtension)
-            {
-                AccessedFileNamesWithoutExtension.Add(fileNameWithoutExtension);
-            }
+            AccessedFileNamesWithoutExtension = accessedFileNamesWithoutExtension;
         }
 
         /// <summary>

--- a/Public/Src/Utilities/Utilities/StringTable.cs
+++ b/Public/Src/Utilities/Utilities/StringTable.cs
@@ -74,6 +74,11 @@ namespace BuildXL.Utilities
         public readonly IEqualityComparer<StringId> CaseInsensitiveEqualityComparer;
 
         /// <summary>
+        /// Comparer for making case insensitive comparisons
+        /// </summary>
+        public readonly CaseInsensitiveStringIdComparer CaseInsensitiveStringIdComparer;
+
+        /// <summary>
         /// Comparer for making case-sensitive comparisons
         /// </summary>
         public readonly IComparer<StringId> OrdinalComparer;
@@ -148,6 +153,7 @@ namespace BuildXL.Utilities
 #endif
 
             CaseInsensitiveEqualityComparer = new CaseInsensitiveStringIdEqualityComparer(this);
+            CaseInsensitiveStringIdComparer = new CaseInsensitiveStringIdComparer(this);
             OrdinalComparer = new OrdinalStringIdComparer(this);
             m_stringSet = new ConcurrentBigSet<StringId>(capacity: initialCapacity);
 
@@ -169,6 +175,7 @@ namespace BuildXL.Utilities
 #endif
 
             CaseInsensitiveEqualityComparer = new CaseInsensitiveStringIdEqualityComparer(this);
+            CaseInsensitiveStringIdComparer = new CaseInsensitiveStringIdComparer(this);
             OrdinalComparer = new OrdinalStringIdComparer(this);
 
             m_byteBuffers = state.ByteBuffers;


### PR DESCRIPTION
ObservedAccessedFileNames are a part of a PathSet. Under some conditions this list might contain multiple values with different casing. As a result we might have "different" lists in subsequent runs. This PR removes any duplicates from that list.

[AB#1648383](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1648383)