### PR TITLE
Enable control flow guard by default for unmanaged binaries

### DIFF
--- a/Public/Sdk/Experimental/Msvc/Native/Tools/Cl/Cl.dsc
+++ b/Public/Sdk/Experimental/Msvc/Native/Tools/Cl/Cl.dsc
@@ -36,6 +36,7 @@ export const defaultClArguments: Arguments = {
     includes: [],
     additionalUsingDirectories: [],
     precompiledHeaderMemoryAllocationFactor: 100,
+    guardControlFlow: true,
 
     precompiledHeaderSourceFile: undefined,
     precompiledHeaderName: undefined


### PR DESCRIPTION
Secure Development Lifecycle requirement also needed by downstream dependents.