### PR TITLE
Update RocksDb package to 20191119.3

### DIFF
--- a/cg/nuget/cgmanifest.json
+++ b/cg/nuget/cgmanifest.json
@@ -2499,7 +2499,7 @@
         "Type": "NuGet",
         "NuGet": {
           "Name": "RocksDbNative",
-          "Version": "6.0.1-b20191115.2"
+          "Version": "6.0.1-b20191119.3"
         }
       }
     },
@@ -2508,7 +2508,7 @@
         "Type": "NuGet",
         "NuGet": {
           "Name": "RocksDbSharp",
-          "Version": "5.8.0-b20191115.2"
+          "Version": "5.8.0-b20191119.3"
         }
       }
     },

--- a/config.dsc
+++ b/config.dsc
@@ -140,8 +140,8 @@ config({
                 { id: "Microsoft.Windows.ProjFS", version: "1.0.19079.1" },
 
                 // RocksDb
-                { id: "RocksDbSharp", version: "5.8.0-b20191115.2", alias: "RocksDbSharpSigned" },
-                { id: "RocksDbNative", version: "6.0.1-b20191115.2" },
+                { id: "RocksDbSharp", version: "5.8.0-b20191119.3", alias: "RocksDbSharpSigned" },
+                { id: "RocksDbNative", version: "6.0.1-b20191119.3" },
 
                 { id: "JsonDiffPatch.Net", version: "2.1.0" },
 


### PR DESCRIPTION
This version has a more "correct" NuGet structure.