### PR TITLE
QTest: Add support for Flaky Suppression File

### DIFF
--- a/Public/Sdk/Public/Tools/QTest/Tool.QTestRunner.dsc
+++ b/Public/Sdk/Public/Tools/QTest/Tool.QTestRunner.dsc
@@ -112,9 +112,9 @@ function validateArguments(args: QTestArguments): void {
  * Find Flaky Supression file from the .config directory of source code
  */
 function findFlakyFile(): File {
-    let configDir = d`${Context.getMount("SourceRoot").path}\.config`;
-    let flakyDir = d`${configDir}\flakytests`;
-    let flakyFileName = 'CloudBuild.FlakyTests.json';
+    let configDir = d`${Context.getMount("SourceRoot").path}/.config`;
+    let flakyDir = d`${configDir}/flakytests`;
+    let flakyFileName = a`CloudBuild.FlakyTests.json`;
 
     if (File.exists(f`${flakyDir}/${flakyFileName}`)) {
         return f`${flakyDir}/${flakyFileName}`;
@@ -123,6 +123,7 @@ function findFlakyFile(): File {
     if (File.exists(f`${configDir}/${flakyFileName}`)) {
         return f`${configDir}/${flakyFileName}`;
     }
+    return undefined;
 }
 
 /**
@@ -236,14 +237,14 @@ export function runQTest(args: QTestArguments): Result {
         Cmd.flag("--zipSandbox", Environment.hasVariable("BUILDXL_IS_IN_CLOUDBUILD")),
         Cmd.flag("--debug", Environment.hasVariable("[Sdk.BuildXL]debugQTest")),
         Cmd.flag("--qTestIgnoreQTestSkip", args.qTestIgnoreQTestSkip),
-        Cmd.option("--qTestAdditionalOptions ", args.qTestAdditionalOptions, args.qTestAdditionalOptions ? true : false),
+        Cmd.option("--qTestAdditionalOptions ", args.qTestAdditionalOptions),
         Cmd.option("--qTestContextInfo ", qTestContextInfoFilePath),
         Cmd.option("--qTestBuildType ", args.qTestBuildType || "unset"),
         Cmd.option("--testSourceDir ", args.testSourceDir),
         Cmd.option("--buildSystem ", "BuildXL"),
         Cmd.option("--QTestCcTargetsFile  ", changeAffectedInputListWrittenFile),       
         Cmd.option("--qTestExcludeCcTargetsFile ", args.qTestExcludeCcTargetsFile),
-        Cmd.option("--QTestFlakyTestManagementSuppressionFile ", Artifact.input(flakyFile), flakyFile ? true : false),
+        Cmd.option("--QTestFlakyTestManagementSuppressionFile ", Artifact.input(flakyFile)),
     ];          
 
     let unsafeOptions = {

--- a/Public/Sdk/Public/Tools/QTest/Tool.QTestRunner.dsc
+++ b/Public/Sdk/Public/Tools/QTest/Tool.QTestRunner.dsc
@@ -113,10 +113,15 @@ function validateArguments(args: QTestArguments): void {
  */
 function findFlakyFile(): File {
     let configDir = d`${Context.getMount("SourceRoot").path}\.config`;
+    let flakyDir = d`${configDir}\flakytests`;
     let flakyFileName = 'CloudBuild.FlakyTests.json';
-    let flakyFiles = globR(configDir, flakyFileName);
-    if (flakyFiles.length > 0) {
-        return flakyFiles[0];
+
+    if (File.exists(f`${flakyDir}/${flakyFileName}`)) {
+        return f`${flakyDir}/${flakyFileName}`;
+    }
+
+    if (File.exists(f`${configDir}/${flakyFileName}`)) {
+        return f`${configDir}/${flakyFileName}`;
     }
 }
 

--- a/Public/Sdk/Public/Tools/QTest/Tool.QTestRunner.dsc
+++ b/Public/Sdk/Public/Tools/QTest/Tool.QTestRunner.dsc
@@ -238,7 +238,7 @@ export function runQTest(args: QTestArguments): Result {
         Cmd.option("--buildSystem ", "BuildXL"),
         Cmd.option("--QTestCcTargetsFile  ", changeAffectedInputListWrittenFile),       
         Cmd.option("--qTestExcludeCcTargetsFile ", args.qTestExcludeCcTargetsFile),
-        Cmd.option("--flakyTestManagementSuppressionFile ", Artifact.input(flakyFile), flakyFile ? true : false),
+        Cmd.option("--QTestFlakyTestManagementSuppressionFile ", Artifact.input(flakyFile), flakyFile ? true : false),
     ];          
 
     let unsafeOptions = {

--- a/cg/nuget/cgmanifest.json
+++ b/cg/nuget/cgmanifest.json
@@ -123,7 +123,7 @@
         "Type": "NuGet",
         "NuGet": {
           "Name": "CB.QTest",
-          "Version": "19.11.5.170405"
+          "Version": "19.11.19.200954"
         }
       }
     },

--- a/config.microsoftInternal.dsc
+++ b/config.microsoftInternal.dsc
@@ -14,7 +14,7 @@ export const pkgs = isMicrosoftInternal ? [
     { id: "runtime.osx-x64.BuildXL", version: "2.9.99" },
     { id: "Aria.Cpp.SDK", version: "8.5.6" },
 
-    { id: "CB.QTest", version: "19.11.5.170405" },
+    { id: "CB.QTest", version: "19.11.19.200954" },
 
     { id: "BuildXL.Tracing.AriaTenantToken", version: "1.0.0" },
 


### PR DESCRIPTION
QTest flaky test suppression feature requires access to the suppression file stored in source repository.
This change adds this file to as an artifact to QTest.

[AB#1638043](https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_workitems/edit/1638043)

Testing: Confirmed that the flaky suppression file gets passed to QTestExe and marks a flaky test as flaky as in in the QTest log:
`2019-11-20 12:47:35,655 DEBUG [QTestSourceRepoFlakyTestManagementClient] In target: Public\Src\FrontEnd\UnitTests\Core_release_X64, marking test: Test.BuildXL.FrontEnd.Core.FrontEndHostControllerTests.DownloadFileTestWithHash as flaky`