### PR TITLE
Only send Environment fields in DominoInvocation telemetry event

### DIFF
--- a/Public/Src/App/Bxl/Tracing/Log.cs
+++ b/Public/Src/App/Bxl/Tracing/Log.cs
@@ -54,7 +54,7 @@ namespace BuildXL.App.Tracing
             // Prevent this from going to the log. It is only for ETW and telemetry. DominoInvocationForLocalLog is for the log.
             Keywords = (int)Keywords.SelectivelyEnabled,
             Message = AppInvocationMessage)]
-        public abstract void DominoInvocation(LoggingContext context, string commandLine, BuildInfo buildInfo, MachineInfo machineInfo, string sessionIdentifier, string relatedSessionIdentifier, string startupDirectory, string mainConfig);
+        public abstract void DominoInvocation(LoggingContext context, string commandLine, BuildInfo buildInfo, MachineInfo machineInfo, string sessionIdentifier, string relatedSessionIdentifier, string startupDirectory, string mainConfig, string environment);
 
         /// <summary>
         /// This is the event that populates the local log file. It differs from DominoInvocation in that it contains the raw commandline without any truncation
@@ -777,7 +777,7 @@ namespace BuildXL.App.Tracing
             string startupDirectory,
             string mainConfigurationFile)
         {
-            Log.DominoInvocation(context, ScrubCommandLine(commandLine, 100000, 100000), buildInfo, machineInfo, sessionIdentifier, relatedSessionIdentifier, startupDirectory, mainConfigurationFile);
+            Log.DominoInvocation(context, ScrubCommandLine(commandLine, 100000, 100000), buildInfo, machineInfo, sessionIdentifier, relatedSessionIdentifier, startupDirectory, mainConfigurationFile, context.Session.Environment);
             Log.DominoInvocationForLocalLog(context, commandLine, buildInfo, machineInfo, sessionIdentifier, relatedSessionIdentifier, startupDirectory, mainConfigurationFile);
 
             if (inCloudBuild)

--- a/Public/Src/Utilities/Instrumentation/LogGen/Generators/AriaV2.cs
+++ b/Public/Src/Utilities/Instrumentation/LogGen/Generators/AriaV2.cs
@@ -23,7 +23,6 @@ namespace BuildXL.LogGen.Generators
                 m_codeGenerator.Lns("var eventData = new {0}.AriaEvent(\"{1}\", \"{2}\", \"{3}\")", GlobalInstrumentationNamespaceCommon, site.Method.Name, m_targetFramework, m_targetRuntime);
 
                 // Save context fields that all events save
-                m_codeGenerator.Lns("eventData.SetProperty(\"Environment\", {0}.Session.Environment)", site.LoggingContextParameterName);
                 m_codeGenerator.Lns("eventData.SetProperty(\"SessionId\", {0}.Session.Id)", site.LoggingContextParameterName);
                 m_codeGenerator.Lns("eventData.SetProperty(\"RelatedSessionId\", {0}.Session.RelatedId)", site.LoggingContextParameterName);
 


### PR DESCRIPTION
This change saves redundant data from being sent to telemetry when /traceinfo flags are being utilized