### PR TITLE
IsDirectorySymlinkOrJunction / TryGetReparsePointType cleanup for macOS

### DIFF
--- a/Public/Src/Utilities/Native/IO/FileUtilities.cs
+++ b/Public/Src/Utilities/Native/IO/FileUtilities.cs
@@ -560,8 +560,8 @@ namespace BuildXL.Native.IO
             }
         }
 
-        /// <see cref="IFileSystem.GetFileAttributes(string)"/>
-        public static FileAttributes GetFileAttributes(string path) => s_fileSystem.GetFileAttributes(path);
+        /// <see cref="IFileSystem.GetFileAttributes(string, bool)"/>
+        public static FileAttributes GetFileAttributes(string path, bool throwOnFailure = true) => s_fileSystem.GetFileAttributes(path, throwOnFailure);
 
         /// <see cref="IFileSystem.SetFileAttributes(string, FileAttributes)"/>
         public static void SetFileAttributes(string path, FileAttributes attributes)
@@ -727,13 +727,16 @@ namespace BuildXL.Native.IO
         /// </summary>
         public static bool IsDirectorySymlinkOrJunction(string path)
         {
-            if (Directory.Exists(path))
+            if (OperatingSystemHelper.IsUnixOS)
             {
                 var reparsePointType = FileUtilities.TryGetReparsePointType(path);
                 return reparsePointType.Succeeded && reparsePointType.Result == ReparsePointType.SymLink;
             }
 
-            return false;
+            FileAttributes dirSymlinkOrJunction = FileAttributes.ReparsePoint | FileAttributes.Directory;
+            FileAttributes attributes = FileUtilities.GetFileAttributes(path, throwOnFailure: false);
+
+            return (attributes & dirSymlinkOrJunction) == dirSymlinkOrJunction;
         }
 
 #endregion

--- a/Public/Src/Utilities/Native/IO/FileUtilities.cs
+++ b/Public/Src/Utilities/Native/IO/FileUtilities.cs
@@ -131,9 +131,9 @@ namespace BuildXL.Native.IO
 
         /// <see cref="IFileUtilities.DeleteDirectoryContents(string, bool, Func{string, bool}, ITempCleaner, CancellationToken?)"/>
         public static void DeleteDirectoryContents(
-            string path, 
-            bool deleteRootDirectory = false, 
-            Func<string, bool> shouldDelete = null, 
+            string path,
+            bool deleteRootDirectory = false,
+            Func<string, bool> shouldDelete = null,
             ITempCleaner tempDirectoryCleaner = null,
             CancellationToken? cancellationToken = default) =>
             s_fileUtilities.DeleteDirectoryContents(path, deleteRootDirectory, shouldDelete, tempDirectoryCleaner, cancellationToken);
@@ -156,7 +156,7 @@ namespace BuildXL.Native.IO
         {
             return s_fileSystem.EnumerateDirectoryEntries(directoryPath, recursive, pattern, handleEntry, followSymlinksToDirectories: true);
         }
-        
+
         /// <see cref="IFileSystem.EnumerateFiles(string, bool, string, Action{string, string, FileAttributes, long})"/>
         public static EnumerateDirectoryResult EnumerateFiles(
             string directoryPath,
@@ -384,7 +384,7 @@ namespace BuildXL.Native.IO
             Action<SafeFileHandle> onCompletion = null) => s_fileUtilities.WriteAllBytesAsync(filePath, bytes, predicate, onCompletion);
 
         /// <see cref="IFileUtilities.TryFindOpenHandlesToFile"/>
-        public static bool TryFindOpenHandlesToFile(string filePath, out string diagnosticInfo, bool printCurrentFilePath = true) 
+        public static bool TryFindOpenHandlesToFile(string filePath, out string diagnosticInfo, bool printCurrentFilePath = true)
             => s_fileUtilities.TryFindOpenHandlesToFile(filePath, out diagnosticInfo, printCurrentFilePath);
 
         /// <see cref="IFileUtilities.GetHardLinkCount(string)"/>
@@ -727,23 +727,13 @@ namespace BuildXL.Native.IO
         /// </summary>
         public static bool IsDirectorySymlinkOrJunction(string path)
         {
-            try
+            if (Directory.Exists(path))
             {
-                FileAttributes dirSymlinkOrJunction = FileAttributes.ReparsePoint | FileAttributes.Directory;
-                FileAttributes attributes = FileUtilities.GetFileAttributes(path);
+                var reparsePointType = FileUtilities.TryGetReparsePointType(path);
+                return reparsePointType.Succeeded && reparsePointType.Result == ReparsePointType.SymLink;
+            }
 
-                return (attributes & dirSymlinkOrJunction) == dirSymlinkOrJunction;
-            }
-            catch (NativeWin32Exception)
-            {
-                // FileSystem.Win.
-                return false;
-            }
-            catch (BuildXLException)
-            {
-                // FileSystem.Unix.
-                return false;
-            }
+            return false;
         }
 
 #endregion
@@ -987,9 +977,9 @@ namespace BuildXL.Native.IO
         /// this method simply combines A\B with D\E\F and normalizes the result, i.e., removes '.' and '..'.
         /// </remarks>
         public static Possible<string> TryResolveRelativeTarget(
-            string path, 
+            string path,
             string relativeTarget,
-            Stack<string> processed = null, 
+            Stack<string> processed = null,
             Stack<string> needToBeProcessed = null)
         {
             int rootLength = s_fileSystem.GetRootLength(path);
@@ -1026,8 +1016,8 @@ namespace BuildXL.Native.IO
         /// Tries to combine an absolute path with a relative path by resolving all the "." and ".." prefixes of the relative paths.
         /// </summary>
         private static bool TryCombinePaths(
-            string absolutePath, 
-            string relativePath, 
+            string absolutePath,
+            string relativePath,
             out string result,
             Stack<string> processed = null,
             Stack<string> needToBeProcessed = null)
@@ -1057,7 +1047,7 @@ namespace BuildXL.Native.IO
                 if (ch == '.' && index == start)
                 {
                     // Component starts with a .
-                    if ((index == relativePath.Length - 1) 
+                    if ((index == relativePath.Length - 1)
                         || s_fileSystem.IsDirectorySeparator(relativePath[index + 1]))
                     {
                         // Component is a sole . so skip it

--- a/Public/Src/Utilities/Native/IO/FileUtilities.cs
+++ b/Public/Src/Utilities/Native/IO/FileUtilities.cs
@@ -560,8 +560,8 @@ namespace BuildXL.Native.IO
             }
         }
 
-        /// <see cref="IFileSystem.GetFileAttributes(string, bool)"/>
-        public static FileAttributes GetFileAttributes(string path, bool throwOnFailure = true) => s_fileSystem.GetFileAttributes(path, throwOnFailure);
+        /// <see cref="IFileSystem.GetFileAttributes(string)"/>
+        public static FileAttributes GetFileAttributes(string path) => s_fileSystem.GetFileAttributes(path);
 
         /// <see cref="IFileSystem.SetFileAttributes(string, FileAttributes)"/>
         public static void SetFileAttributes(string path, FileAttributes attributes)
@@ -722,22 +722,8 @@ namespace BuildXL.Native.IO
             return s_fileSystem.TryGetReparsePointTarget(handle, sourcePath);
         }
 
-        /// <summary>
-        /// Checks if a path is a directory symlink or a junction.
-        /// </summary>
-        public static bool IsDirectorySymlinkOrJunction(string path)
-        {
-            if (OperatingSystemHelper.IsUnixOS)
-            {
-                var reparsePointType = FileUtilities.TryGetReparsePointType(path);
-                return reparsePointType.Succeeded && reparsePointType.Result == ReparsePointType.SymLink;
-            }
-
-            FileAttributes dirSymlinkOrJunction = FileAttributes.ReparsePoint | FileAttributes.Directory;
-            FileAttributes attributes = FileUtilities.GetFileAttributes(path, throwOnFailure: false);
-
-            return (attributes & dirSymlinkOrJunction) == dirSymlinkOrJunction;
-        }
+        /// <see cref="IFileSystem.IsDirectorySymlinkOrJunction(string)"/>
+        public static bool IsDirectorySymlinkOrJunction(string path) => s_fileSystem.IsDirectorySymlinkOrJunction(path);
 
 #endregion
 

--- a/Public/Src/Utilities/Native/IO/IFileSystem.cs
+++ b/Public/Src/Utilities/Native/IO/IFileSystem.cs
@@ -243,12 +243,12 @@ namespace BuildXL.Native.IO
         FileFlagsAndAttributes GetFileFlagsAndAttributesForPossibleReparsePoint(string expandedPath);
 
         /// <summary>
-        /// Thin wrapper for native GetFileAttributesW that throws an exception on failure by default
+        /// Thin wrapper for native GetFileAttributesW that throws an exception on failure
         /// </summary>
         /// <remarks>
         /// Supports paths greater than MAX_PATH.
         /// </remarks>
-        FileAttributes GetFileAttributes(string path, bool throwOnFailure = true);
+        FileAttributes GetFileAttributes(string path);
 
         /// <summary>
         /// Calls GetFileInformationByHandleEx on the given file handle to retrieve its attributes. This requires 'READ ATTRIBUTES' access on the handle.
@@ -623,6 +623,11 @@ namespace BuildXL.Native.IO
         /// Flag indicating if the enlistment volume supports copy on write.
         /// </summary>
         bool IsCopyOnWriteSupportedByEnlistmentVolume { get; set; }
+
+        /// <summary>
+        /// Checks if a path is a directory symlink or a junction.
+        /// </summary>
+        bool IsDirectorySymlinkOrJunction(string path);
 
         #endregion
     }

--- a/Public/Src/Utilities/Native/IO/IFileSystem.cs
+++ b/Public/Src/Utilities/Native/IO/IFileSystem.cs
@@ -101,7 +101,7 @@ namespace BuildXL.Native.IO
             Action<string /*filePath*/, string /*fileName*/, FileAttributes /*attributes*/> handleEntry,
             bool isEnumerationForDirectoryDeletion = false,
             bool followSymlinksToDirectories = false);
-        
+
         /// <summary>
         /// Enumerates the files in the given directory using a search pattern.
         /// </summary>
@@ -243,12 +243,12 @@ namespace BuildXL.Native.IO
         FileFlagsAndAttributes GetFileFlagsAndAttributesForPossibleReparsePoint(string expandedPath);
 
         /// <summary>
-        /// Thin wrapper for native GetFileAttributesW that throws an exception on failure
+        /// Thin wrapper for native GetFileAttributesW that throws an exception on failure by default
         /// </summary>
         /// <remarks>
         /// Supports paths greater than MAX_PATH.
         /// </remarks>
-        FileAttributes GetFileAttributes(string path);
+        FileAttributes GetFileAttributes(string path, bool throwOnFailure = true);
 
         /// <summary>
         /// Calls GetFileInformationByHandleEx on the given file handle to retrieve its attributes. This requires 'READ ATTRIBUTES' access on the handle.

--- a/Public/Src/Utilities/Native/IO/Unix/FileSystem.Unix.cs
+++ b/Public/Src/Utilities/Native/IO/Unix/FileSystem.Unix.cs
@@ -1174,7 +1174,7 @@ namespace BuildXL.Native.IO.Unix
             return result;
         }
 
-        private int TryGetFilePermission(string path, bool followSymlink = false, bool throwOnFailure = true)
+        private static int TryGetFilePermission(string path, bool followSymlink = false, bool throwOnFailure = true)
         {
             var statBuffer = new StatBuffer();
 

--- a/Public/Src/Utilities/Native/IO/Unix/FileSystem.Unix.cs
+++ b/Public/Src/Utilities/Native/IO/Unix/FileSystem.Unix.cs
@@ -1174,7 +1174,7 @@ namespace BuildXL.Native.IO.Unix
             return result;
         }
 
-        private static int TryGetFilePermission(string path, bool followSymlink = false, bool throwOnFailure = true)
+        private int TryGetFilePermission(string path, bool followSymlink = false, bool throwOnFailure = true)
         {
             var statBuffer = new StatBuffer();
 

--- a/Public/Src/Utilities/Native/IO/Unix/FileSystem.Unix.cs
+++ b/Public/Src/Utilities/Native/IO/Unix/FileSystem.Unix.cs
@@ -756,12 +756,12 @@ namespace BuildXL.Native.IO.Unix
         public bool TryReadSeekPenaltyProperty(SafeFileHandle driveHandle, out bool hasSeekPenalty, out int error) => throw new NotImplementedException();
 
         /// <inheritdoc />
-        public FileAttributes GetFileAttributes(string path, bool throwOnFailure = true)
+        public FileAttributes GetFileAttributes(string path)
         {
-            return TryGetFileAttributes(path, throwOnFailure);
+            return TryGetFileAttributes(path);
         }
 
-        private static FileAttributes TryGetFileAttributes(string path, bool throwOnFailure)
+        private static FileAttributes TryGetFileAttributes(string path)
         {
             try
             {
@@ -769,13 +769,8 @@ namespace BuildXL.Native.IO.Unix
             }
             catch (Exception ex)
             {
-                if (throwOnFailure)
-                {
-                    throw new BuildXLException("Getting file attributes failed", ex);
-                }
+                throw new BuildXLException("Getting file attributes failed", ex);
             }
-
-            return FileAttributes.Normal;
         }
 
         /// <inheritdoc />
@@ -1243,5 +1238,12 @@ namespace BuildXL.Native.IO.Unix
 
         /// <inheritdoc />
         public bool TryWriteFileSync(SafeFileHandle handle, byte[] content, out int nativeErrorCode) => throw new NotImplementedException();
+
+        /// <inheritdoc />
+        public bool IsDirectorySymlinkOrJunction(string path)
+        {
+            var reparsePointType = TryGetReparsePointType(path);
+            return reparsePointType.Succeeded && reparsePointType.Result == ReparsePointType.SymLink;
+        }
     }
 }

--- a/Public/Src/Utilities/Native/IO/Unix/FileSystem.Unix.cs
+++ b/Public/Src/Utilities/Native/IO/Unix/FileSystem.Unix.cs
@@ -756,12 +756,12 @@ namespace BuildXL.Native.IO.Unix
         public bool TryReadSeekPenaltyProperty(SafeFileHandle driveHandle, out bool hasSeekPenalty, out int error) => throw new NotImplementedException();
 
         /// <inheritdoc />
-        public FileAttributes GetFileAttributes(string path)
+        public FileAttributes GetFileAttributes(string path, bool throwOnFailure = true)
         {
-            return TryGetFileAttributes(path);
+            return TryGetFileAttributes(path, throwOnFailure);
         }
 
-        private static FileAttributes TryGetFileAttributes(string path)
+        private static FileAttributes TryGetFileAttributes(string path, bool throwOnFailure)
         {
             try
             {
@@ -769,8 +769,13 @@ namespace BuildXL.Native.IO.Unix
             }
             catch (Exception ex)
             {
-                throw new BuildXLException("Getting file attributes failed", ex);
+                if (throwOnFailure)
+                {
+                    throw new BuildXLException("Getting file attributes failed", ex);
+                }
             }
+
+            return FileAttributes.Normal;
         }
 
         /// <inheritdoc />
@@ -1238,6 +1243,5 @@ namespace BuildXL.Native.IO.Unix
 
         /// <inheritdoc />
         public bool TryWriteFileSync(SafeFileHandle handle, byte[] content, out int nativeErrorCode) => throw new NotImplementedException();
-
     }
 }

--- a/Public/Src/Utilities/Native/IO/Unix/FileSystem.Unix.cs
+++ b/Public/Src/Utilities/Native/IO/Unix/FileSystem.Unix.cs
@@ -582,8 +582,14 @@ namespace BuildXL.Native.IO.Unix
 
         private static bool IsSymlink(string path)
         {
-            var maybeReparsePointType = GetReparsePointType(path);
-            return maybeReparsePointType.Succeeded && maybeReparsePointType.Result == ReparsePointType.SymLink;
+            var mode = TryGetFilePermission(path, followSymlink: false, throwOnFailure: false);
+            if (mode < 0)
+            {
+                return false;
+            }
+
+            FilePermissions permissions = checked((FilePermissions)mode);
+            return permissions.HasFlag(FilePermissions.S_IFLNK);
         }
 
         /// <inheritdoc />
@@ -800,7 +806,6 @@ namespace BuildXL.Native.IO.Unix
         /// <inheritdoc />
         public bool IsReparsePointActionable(ReparsePointType reparsePointType)
         {
-            Contract.Requires(reparsePointType != ReparsePointType.MountPoint, "Currently, ReparsePointType.MountPoint is not a valid reparse point type on macOS/Unix");
             return reparsePointType == ReparsePointType.SymLink;
         }
 
@@ -812,25 +817,7 @@ namespace BuildXL.Native.IO.Unix
 
         private static Possible<ReparsePointType> GetReparsePointType(string path)
         {
-            try
-            {
-                FileAttributes attributes = File.GetAttributes(path);
-
-                if ((attributes & FileAttributes.ReparsePoint) == 0)
-                {
-                    return ReparsePointType.None;
-                }
-
-                // The only reparse type supported by CoreFX is a symlink currently, we can revisit this once the implementation changes.
-                // See: https://github.com/dotnet/corefx/blob/f25eb288a449010574a6e95fe298f3ad880ada1e/src/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
-                return ReparsePointType.SymLink;
-            }
-#pragma warning disable ERP022 // Unobserved exception in generic exception handler
-            catch
-            {
-                return ReparsePointType.None;
-            }
-#pragma warning restore ERP022 // Unobserved exception in generic exception handler
+            return IsSymlink(path) ? ReparsePointType.SymLink : ReparsePointType.None;
         }
 
         /// <inheritdoc />
@@ -1187,10 +1174,7 @@ namespace BuildXL.Native.IO.Unix
             return result;
         }
 
-        /// <summary>
-        /// Gets file permission.
-        /// </summary>
-        public int GetFilePermission(string path, bool followSymlink = false, bool throwOnFailure = true)
+        private static int TryGetFilePermission(string path, bool followSymlink = false, bool throwOnFailure = true)
         {
             var statBuffer = new StatBuffer();
 
@@ -1210,6 +1194,14 @@ namespace BuildXL.Native.IO.Unix
 
                return unchecked((int)statBuffer.Mode);
             }
+        }
+
+        /// <summary>
+        /// Gets file permission.
+        /// </summary>
+        public int GetFilePermission(string path, bool followSymlink = false, bool throwOnFailure = true)
+        {
+            return TryGetFilePermission(path, followSymlink, throwOnFailure);
         }
 
         /// <summary>
@@ -1246,6 +1238,6 @@ namespace BuildXL.Native.IO.Unix
 
         /// <inheritdoc />
         public bool TryWriteFileSync(SafeFileHandle handle, byte[] content, out int nativeErrorCode) => throw new NotImplementedException();
-      
+
     }
 }

--- a/Public/Src/Utilities/Native/IO/Unix/FileSystem.Unix.cs
+++ b/Public/Src/Utilities/Native/IO/Unix/FileSystem.Unix.cs
@@ -1243,7 +1243,7 @@ namespace BuildXL.Native.IO.Unix
         public bool IsDirectorySymlinkOrJunction(string path)
         {
             var reparsePointType = TryGetReparsePointType(path);
-            return reparsePointType.Succeeded && reparsePointType.Result == ReparsePointType.SymLink;
+            return reparsePointType.Succeeded && reparsePointType.Result == ReparsePointType.SymLink && Directory.Exists(path);
         }
     }
 }

--- a/Public/Src/Utilities/Native/IO/Windows/FileSystem.Win.cs
+++ b/Public/Src/Utilities/Native/IO/Windows/FileSystem.Win.cs
@@ -614,10 +614,10 @@ namespace BuildXL.Native.IO.Windows
         [return: MarshalAs(UnmanagedType.Bool)]
         [SuppressMessage("Microsoft.Interoperability", "CA1415:DeclarePInvokesCorrectly", Justification = "Overlapped intentionally redefined.")]
         public static extern unsafe bool WriteFile(
-            SafeFileHandle handle, 
-            byte[] buffer, 
-            int numBytesToWrite, 
-            out int numBytesWritten, 
+            SafeFileHandle handle,
+            byte[] buffer,
+            int numBytesToWrite,
+            out int numBytesWritten,
             NativeOverlapped* lpOverlapped);
 
         [SuppressMessage("Microsoft.Globalization", "CA2101:SpecifyMarshalingForPInvokeStringArguments", MessageId = "OsVersionInfoEx.CSDVersion",
@@ -764,7 +764,7 @@ namespace BuildXL.Native.IO.Windows
             Directory = 0x1,
 
             /// <summary>
-            /// Specify this flag to allow creation of symbolic links when the process is not elevated. 
+            /// Specify this flag to allow creation of symbolic links when the process is not elevated.
             /// </summary>
             AllowUnprivilegedCreate = 0x2
         }
@@ -1047,7 +1047,7 @@ namespace BuildXL.Native.IO.Windows
         /// </summary>
         /// <remarks>
         /// Not all Win 10 versions support this flag. Checking OS version for this feature is currently not advised
-        /// because the OS may have had new features added in a redistributable DLL. 
+        /// because the OS may have had new features added in a redistributable DLL.
         /// See: https://docs.microsoft.com/en-us/windows/desktop/SysInfo/operating-system-version
         /// </remarks>
         private bool CheckSupportUnprivilegedCreateSymbolicLinkFlag()
@@ -2368,7 +2368,7 @@ namespace BuildXL.Native.IO.Windows
 
             // The return value of CreateSymbolicLinkW is underspecified in its documentation.
             // In non-admin mode where Developer mode is not enabled, the return value can be greater than zero, but the last error
-            // is ERROR_PRIVILEGE_NOT_HELD, and consequently the symlink is not created. We strenghten the return value by 
+            // is ERROR_PRIVILEGE_NOT_HELD, and consequently the symlink is not created. We strenghten the return value by
             // also checking that the last error is ERROR_SUCCESS.
             int lastError = Marshal.GetLastWin32Error();
             if (res > 0 && lastError == NativeIOConstants.ErrorSuccess)
@@ -2567,7 +2567,7 @@ namespace BuildXL.Native.IO.Windows
                 Logger.Log.StorageTryOpenFileByIdFailure(Events.StaticContext, fileId.High, fileId.Low, GetVolumeSerialNumberByHandle(existingHandleOnVolume), hr);
                 handle = null;
                 Contract.Assume(hr != 0);
-                
+
                 var result = OpenFileResult.CreateForOpeningById(hr, FileMode.Open, handleIsValid: false);
                 Contract.Assume(!result.Succeeded);
                 return result;
@@ -2926,9 +2926,9 @@ namespace BuildXL.Native.IO.Windows
                 else
                 {
                     // Fall back using more expensive FindFirstFile.
-                    // Getting file attributes for probing file existence with GetFileAttributesW sometimes results in "access denied". 
-                    // This causes problem especially during file materialization. Because such a probe is interpreted as probing non-existent path, 
-                    // the materialization target is not deleted. However, cache, using .NET File.Exist, is able to determine that the file exists. 
+                    // Getting file attributes for probing file existence with GetFileAttributesW sometimes results in "access denied".
+                    // This causes problem especially during file materialization. Because such a probe is interpreted as probing non-existent path,
+                    // the materialization target is not deleted. However, cache, using .NET File.Exist, is able to determine that the file exists.
                     // Thus, cache refuses to materialize the file
                     if (!TryGetFileAttributesViaFindFirstFile(path, out fileAttributes, out hr))
                     {
@@ -3004,11 +3004,14 @@ namespace BuildXL.Native.IO.Windows
         }
 
         /// <inheritdoc />
-        public FileAttributes GetFileAttributes(string path)
+        public FileAttributes GetFileAttributes(string path, bool throwOnFailure = true)
         {
             if (!TryGetFileAttributes(path, out FileAttributes attributes, out int hr))
             {
-                ThrowForNativeFailure(hr, "FindFirstFileW", nameof(GetFileAttributes));
+                if (throwOnFailure)
+                {
+                    ThrowForNativeFailure(hr, "FindFirstFileW", nameof(GetFileAttributes));
+                }
             }
 
             return attributes;
@@ -3948,15 +3951,15 @@ namespace BuildXL.Native.IO.Windows
         }
 
         /// <summary>
-        /// Resolves the reparse points with relative target. 
+        /// Resolves the reparse points with relative target.
         /// </summary>
         /// <remarks>
         /// This method resolves reparse points that occur in the path prefix. This method should only be called when path itself
-        /// is an actionable reparse point whose target is a relative path. 
-        /// This method traverses each prefix starting from the shortest one. Every time it encounters a directory symlink, it uses GetFinalPathNameByHandle to get the final path. 
+        /// is an actionable reparse point whose target is a relative path.
+        /// This method traverses each prefix starting from the shortest one. Every time it encounters a directory symlink, it uses GetFinalPathNameByHandle to get the final path.
         /// However, if the prefix itself is a junction, then it leaves the current resolved path intact. We cannot call GetFinalPathNameByHandle on the whole path because
         /// that function resolves junctions to their target paths.
-        /// The following example show the needs for this method as a prerequisite in getting 
+        /// The following example show the needs for this method as a prerequisite in getting
         /// the immediate target of a reparse point. Suppose that we have the following file system layout:
         ///
         ///    repo
@@ -3972,7 +3975,7 @@ namespace BuildXL.Native.IO.Windows
         ///          file1.txt
         ///          file2.txt
         ///
-        /// **CASE 1**: source ==> intermediate\current is a directory symlink. 
+        /// **CASE 1**: source ==> intermediate\current is a directory symlink.
         ///
         /// If a tool accesses repo\source\symlink1.link (say 'type repo\source\symlink1.link'), then the tool should get the content of repo\target\file1.txt.
         /// If the tool accesses repo\source\symlink2.link, then the tool should get path-not-found error because the resolved path will be repo\intermediate\target\file2.txt.
@@ -3980,7 +3983,7 @@ namespace BuildXL.Native.IO.Windows
         /// which is a non-existent path. To resolve repo\source\symlink1, we need to resolve the reparse points of its prefix, i.e., repo\source. For directory symlinks,
         /// we need to resolve the prefix to its target. I.e., repo\source is resolved to repo\intermediate\current, and so, given repo\source\symlink1.link, this method returns
         /// repo\intermediate\current\symlink1.link. Combining repo\intermediate\current\symlink1.link with ..\..\target\file1.txt will give the correct path, i.e., repo\target\file1.txt.
-        /// 
+        ///
         /// Similarly, given repo\source\symlink2.link, the method returns repo\intermediate\current\symlink2.link, and combining it with ..\target\file2.txt, will give us
         /// repo\intermediate\target\file2.txt, which is a non-existent path. This corresponds to the behavior of symlink accesses above.
         ///
@@ -4079,7 +4082,7 @@ namespace BuildXL.Native.IO.Windows
         public bool TryWriteFileSync(SafeFileHandle handle, byte[] content, out int nativeErrorCode)
         {
             bool result;
-            
+
             unsafe
             {
                 // By passing null to the overlapped argument we are indicating a synchronous write

--- a/Public/Src/Utilities/Native/IO/Windows/FileSystem.Win.cs
+++ b/Public/Src/Utilities/Native/IO/Windows/FileSystem.Win.cs
@@ -3004,14 +3004,11 @@ namespace BuildXL.Native.IO.Windows
         }
 
         /// <inheritdoc />
-        public FileAttributes GetFileAttributes(string path, bool throwOnFailure = true)
+        public FileAttributes GetFileAttributes(string path)
         {
             if (!TryGetFileAttributes(path, out FileAttributes attributes, out int hr))
             {
-                if (throwOnFailure)
-                {
-                    ThrowForNativeFailure(hr, "FindFirstFileW", nameof(GetFileAttributes));
-                }
+                ThrowForNativeFailure(hr, "FindFirstFileW", nameof(GetFileAttributes));
             }
 
             return attributes;
@@ -4092,6 +4089,15 @@ namespace BuildXL.Native.IO.Windows
             nativeErrorCode = Marshal.GetLastWin32Error();
 
             return result;
+        }
+
+        /// <inheritdoc />
+        public bool IsDirectorySymlinkOrJunction(string path)
+        {
+            FileAttributes dirSymlinkOrJunction = FileAttributes.ReparsePoint | FileAttributes.Directory;
+            var success = TryGetFileAttributes(path, out FileAttributes attributes, out _);
+
+            return success && ((attributes & dirSymlinkOrJunction) == dirSymlinkOrJunction);
         }
     }
 }


### PR DESCRIPTION
Get rid of extensive try/catch blocks on the hot path when determining ReparsePoint types.

**TryGetReparsePointType**
Call interop implementation directly instead of going through the System.File.IO layers and avoid potential exception handling all together.

**IsDirectorySymlinkOrJunction**
When directories don't exist, no exception is thrown, otherwise call into TryGetReparsePointType and see if the path is a symlink via calling our interop implementation and not throwing unnecessarily.

Before vs. After (**58.45% time savings**)

SandboxedProcess.DirectorySymlinkCheckingDurationMs=**13710080**
SandboxedProcess.DirectorySymlinkCheckingDurationMs=**5696262**