### PR TITLE
Reset counters on overflow exception in IOCounters

### DIFF
--- a/Public/Src/Utilities/Native/IO/IOCounters.cs
+++ b/Public/Src/Utilities/Native/IO/IOCounters.cs
@@ -157,9 +157,21 @@ namespace BuildXL.Native.IO
         [Pure]
         public IOTypeCounters GetAggregateIO()
         {
+            ulong operationsCount;
+            ulong transferCount;
+            try
+            {
+                operationsCount = ReadCounters.OperationCount + WriteCounters.OperationCount + OtherCounters.OperationCount;
+                transferCount = ReadCounters.TransferCount + WriteCounters.TransferCount + OtherCounters.TransferCount;
+            }
+            catch (OverflowException)
+            {
+                operationsCount = transferCount = 0;
+            }
+            
             return new IOTypeCounters(
-                operationCount: ReadCounters.OperationCount + WriteCounters.OperationCount + OtherCounters.OperationCount,
-                transferCount: ReadCounters.TransferCount + WriteCounters.TransferCount + OtherCounters.TransferCount);
+                operationCount: operationsCount,
+                transferCount: transferCount);
         }
 
         /// <nodoc />


### PR DESCRIPTION
The accumulated operation and transfer count is calculated by adding up several `ulong` variables and can overflow. In this case, we reset the data and continue gracefully instead of crashing.