### PR TITLE
Allow null process sandbox stdout/err options

### DIFF
--- a/Public/Src/Engine/Processes/ISandboxedProcessFileStorage.cs
+++ b/Public/Src/Engine/Processes/ISandboxedProcessFileStorage.cs
@@ -4,12 +4,12 @@
 namespace BuildXL.Processes
 {
     /// <summary>
-    /// Access to file names needed by sandboxed process
+    /// Access to file names needed by sandboxed process stdout and stderr redirection.
     /// </summary>
     public interface ISandboxedProcessFileStorage
     {
         /// <summary>
-        /// Get file name needed by sandboxed process
+        /// Get a file path for a sandboxed process's stdout or stderr stream to copy into.
         /// </summary>
         /// <remarks>
         /// After the sandboxed process calls this method, it will attempt to create a file with the returned name.

--- a/Public/Src/Engine/Processes/SandboxedProcessFile.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessFile.cs
@@ -31,7 +31,7 @@ namespace BuildXL.Processes
     public static class SandboxedProcessFileExtenstions
     {
         /// <summary>
-        /// The default file name
+        /// Gets the default file name for stdout or stderr redirection.
         /// </summary>
         /// <param name="file">The output stream</param>
         /// <returns>The resulting default file name</returns>

--- a/Public/Src/Engine/Processes/SandboxedProcessInfo.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessInfo.cs
@@ -110,7 +110,6 @@ namespace BuildXL.Processes
             SidebandWriter sidebandWriter = null)
         {
             Contract.Requires(pathTable != null);
-            Contract.Requires(fileStorage != null);
             Contract.Requires(fileName != null);
 
             PathTable = pathTable;
@@ -157,7 +156,6 @@ namespace BuildXL.Processes
                   sandboxConnection)
         {
             Contract.Requires(pathTable != null);
-            Contract.Requires(fileStorage != null);
             Contract.Requires(fileName != null);
         }
 
@@ -178,7 +176,7 @@ namespace BuildXL.Processes
         public FileAccessManifest FileAccessManifest { get; }
 
         /// <summary>
-        /// Access to file storage
+        /// Optional file storage options for stdout and stderr output streams.
         /// </summary>
         public ISandboxedProcessFileStorage FileStorage { get; }
 
@@ -376,7 +374,7 @@ namespace BuildXL.Processes
         public string PipDescription { get; set; }
 
         /// <summary>
-        /// Standard output and error for sandboxed process.
+        /// Standard output and error options for the sandboxed process.
         /// </summary>
         /// <remarks>
         /// This instance of <see cref="SandboxedProcessStandardFiles"/> is used as an alternative to <see cref="FileStorage"/>.
@@ -446,7 +444,14 @@ namespace BuildXL.Processes
 
                 if (SandboxedProcessStandardFiles == null)
                 {
-                    SandboxedProcessStandardFiles.From(FileStorage).Serialize(writer);
+                    if (FileStorage != null)
+                    {
+                        SandboxedProcessStandardFiles.From(FileStorage).Serialize(writer);
+                    }
+                    else
+                    {
+                        SandboxedProcessStandardFiles.SerializeEmpty(writer);
+                    }
                 }
                 else
                 {
@@ -504,7 +509,7 @@ namespace BuildXL.Processes
 
                 return new SandboxedProcessInfo(
                     new PathTable(),
-                    new StandardFileStorage(sandboxedProcessStandardFiles),
+                    sandboxedProcessStandardFiles != null ? new StandardFileStorage(sandboxedProcessStandardFiles) : null,
                     fileName,
                     fam,
                     disableConHostSharing,

--- a/Public/Src/Engine/Processes/SandboxedProcessInfo.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessInfo.cs
@@ -82,7 +82,7 @@ namespace BuildXL.Processes
         /// compile against this assembly and already depend on this constructor.
         /// </remarks>
         public SandboxedProcessInfo(
-             ISandboxedProcessFileStorage fileStorage,
+             [CanBeNull] ISandboxedProcessFileStorage fileStorage,
              string fileName,
              bool disableConHostSharing,
              bool testRetries = false,
@@ -98,7 +98,7 @@ namespace BuildXL.Processes
         /// </summary>
         public SandboxedProcessInfo(
             PathTable pathTable,
-            ISandboxedProcessFileStorage fileStorage,
+            [CanBeNull] ISandboxedProcessFileStorage fileStorage,
             string fileName,
             FileAccessManifest fileAccessManifest,
             bool disableConHostSharing,
@@ -134,7 +134,7 @@ namespace BuildXL.Processes
         /// </summary>
         public SandboxedProcessInfo(
             PathTable pathTable,
-            ISandboxedProcessFileStorage fileStorage,
+            [CanBeNull] ISandboxedProcessFileStorage fileStorage,
             string fileName,
             bool disableConHostSharing,
             bool testRetries = false,

--- a/Public/Src/Engine/Processes/SandboxedProcessInfo.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessInfo.cs
@@ -13,6 +13,7 @@ using BuildXL.Processes.Sideband;
 using BuildXL.Utilities;
 using BuildXL.Utilities.Configuration;
 using BuildXL.Utilities.Instrumentation.Common;
+using CanBeNullAttribute = JetBrains.Annotations.CanBeNullAttribute;
 using static BuildXL.Utilities.BuildParameters;
 
 namespace BuildXL.Processes

--- a/Public/Src/Engine/Processes/SandboxedProcessOutput.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessOutput.cs
@@ -49,8 +49,7 @@ namespace BuildXL.Processes
             requires((fileName == null && length >= 0) || (fileName != null && length >= NoLength) || exception != null);
             requires(exception != null ^ (value != null ^ fileName != null));
             requires(exception != null || encoding != null);
-            requires(exception != null || (fileName != null && fileStorage != null) || (fileName == null && fileStorage == null));
-            requires(encoding != null); 
+            requires(encoding != null);
 
             m_length = length;
             m_value = value;

--- a/Public/Src/Engine/Processes/SandboxedProcessOutput.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessOutput.cs
@@ -50,7 +50,7 @@ namespace BuildXL.Processes
             requires(exception != null ^ (value != null ^ fileName != null));
             requires(exception != null || encoding != null);
             requires(exception != null || (fileName != null && fileStorage != null) || (fileName == null && fileStorage == null));
-            requires(encoding != null);
+            requires(encoding != null); 
 
             m_length = length;
             m_value = value;

--- a/Public/Src/Engine/Processes/SandboxedProcessOutput.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessOutput.cs
@@ -35,7 +35,7 @@ namespace BuildXL.Processes
         private readonly BuildXLException m_exception;
 
         /// <summary>
-        /// Creates an instances of this class.
+        /// Creates an instance of this class.
         /// </summary>
         public SandboxedProcessOutput(
             long length,
@@ -48,9 +48,8 @@ namespace BuildXL.Processes
         {
             requires((fileName == null && length >= 0) || (fileName != null && length >= NoLength) || exception != null);
             requires(exception != null ^ (value != null ^ fileName != null));
-            requires(value == null || length == value.Length);
             requires(exception != null || encoding != null);
-            requires(exception != null || fileName != null || fileStorage != null);
+            requires(exception != null || (fileName != null && fileStorage != null) || (fileName == null && fileStorage == null));
             requires(encoding != null);
 
             m_length = length;

--- a/Public/Src/Engine/Processes/SandboxedProcessOutputBuilder.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessOutputBuilder.cs
@@ -42,6 +42,7 @@ namespace BuildXL.Processes
         {
             Contract.Requires(encoding != null);
             Contract.Requires(maxMemoryLength >= 0);
+            Contract.Requires(fileStorage != null || observer != null);
 
             m_stringBuilderWrapper = Pools.GetStringBuilder();
             m_stringBuilder = m_stringBuilderWrapper.Instance;
@@ -110,7 +111,7 @@ namespace BuildXL.Processes
                 else if (m_fileStorage == null && m_stringBuilder.Length >= m_maxMemoryLength)
                 {
                     // The caller should have configured an observer, called above. If not and no backing file configured,
-                    // we stop collecting the output stream at the in-memory buffer length, dropping any remainder.
+                    // we start silently dropping the output stream at the in-memory buffer length.
                 }
                 else
                 {

--- a/Public/Src/Engine/Processes/SandboxedProcessStandardFiles.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessStandardFiles.cs
@@ -51,8 +51,8 @@ namespace BuildXL.Processes
         {
             Contract.Requires(writer != null);
 
-            writer.Write(string.Empty);
-            writer.Write(string.Empty);
+            writer.Write(string.Empty);  // StandardOutput
+            writer.Write(string.Empty);  // StandardError
         }
 
         /// <summary>

--- a/Public/Src/Engine/Processes/SandboxedProcessStandardFiles.cs
+++ b/Public/Src/Engine/Processes/SandboxedProcessStandardFiles.cs
@@ -7,17 +7,17 @@ using BuildXL.Utilities;
 namespace BuildXL.Processes
 {
     /// <summary>
-    /// Files potentially created by the sandboxed process.
+    /// Stdout and stderr stream redirection to files, potentially created by the sandboxed process.
     /// </summary>
     public class SandboxedProcessStandardFiles
     {
         /// <summary>
-        /// Standard output.
+        /// Standard output redirected file path.
         /// </summary>
         public string StandardOutput { get; }
 
         /// <summary>
-        /// Standard error.
+        /// Standard error redirected file path.
         /// </summary>
         public string StandardError { get; }
 
@@ -45,6 +45,17 @@ namespace BuildXL.Processes
         }
 
         /// <summary>
+        /// Serializes an empty instance into the given <paramref name="writer"/>.
+        /// </summary>
+        public static void SerializeEmpty(BuildXLWriter writer)
+        {
+            Contract.Requires(writer != null);
+
+            writer.Write(string.Empty);
+            writer.Write(string.Empty);
+        }
+
+        /// <summary>
         /// Deserializes an instance of <see cref="SandboxedProcessStandardFiles"/>.
         /// </summary>
         public static SandboxedProcessStandardFiles Deserialize(BuildXLReader reader)
@@ -53,6 +64,11 @@ namespace BuildXL.Processes
 
             string output = reader.ReadString();
             string error = reader.ReadString();
+
+            if (string.IsNullOrEmpty(output))
+            {
+                return null;
+            }
 
             return new SandboxedProcessStandardFiles(output, error);
         }

--- a/Public/Src/Engine/UnitTests/Processes.Detours/SandboxedProcessInfoTest.cs
+++ b/Public/Src/Engine/UnitTests/Processes.Detours/SandboxedProcessInfoTest.cs
@@ -22,8 +22,10 @@ namespace Test.BuildXL.Processes.Detours
         {
         }
 
-        [Fact]
-        public void SerializeSandboxedProcessInfo()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void SerializeSandboxedProcessInfo(bool useNullFileStorage)
         {
             var pt = new PathTable();
             var fam =
@@ -41,7 +43,17 @@ namespace Test.BuildXL.Processes.Detours
             vac.AddPath(A("C", "Source", "source.txt"), FileAccessPolicy.AllowReadAlways);
             vac.AddPath(A("C", "Out", "out.txt"), FileAccessPolicy.AllowAll);
 
-            var standardFiles = new SandboxedProcessStandardFiles(A("C", "pip", "pip.out"), A("C", "pip", "pip.err"));
+            ISandboxedProcessFileStorage fileStorage;
+            if (useNullFileStorage)
+            {
+                fileStorage = null;
+            }
+            else
+            {
+                var standardFiles = new SandboxedProcessStandardFiles(A("C", "pip", "pip.out"), A("C", "pip", "pip.err"));
+                fileStorage = new StandardFileStorage(standardFiles);
+            }
+
             var envVars = new Dictionary<string, string>()
             {
                 ["Var1"] = "Val1",
@@ -56,7 +68,7 @@ namespace Test.BuildXL.Processes.Detours
 
             SandboxedProcessInfo info = new SandboxedProcessInfo(
                 pt,
-                new StandardFileStorage(standardFiles),
+                fileStorage,
                 A("C", "tool", "tool.exe"),
                 fam,
                 true,
@@ -120,11 +132,21 @@ namespace Test.BuildXL.Processes.Detours
 
                 XAssert.AreEqual(info.NestedProcessTerminationTimeout, readInfo.NestedProcessTerminationTimeout);
                 XAssert.AreEqual(info.StandardInputSourceInfo, readInfo.StandardInputSourceInfo);
-                XAssert.IsNotNull(readInfo.SandboxedProcessStandardFiles);
-                XAssert.AreEqual(standardFiles.StandardOutput, readInfo.SandboxedProcessStandardFiles.StandardOutput);
-                XAssert.AreEqual(standardFiles.StandardError, readInfo.SandboxedProcessStandardFiles.StandardError);
-                XAssert.AreEqual(standardFiles.StandardOutput, readInfo.FileStorage.GetFileName(SandboxedProcessFile.StandardOutput));
-                XAssert.AreEqual(standardFiles.StandardError, readInfo.FileStorage.GetFileName(SandboxedProcessFile.StandardError));
+
+                if (useNullFileStorage)
+                {
+                    XAssert.IsNull(readInfo.SandboxedProcessStandardFiles);
+                    XAssert.IsNull(readInfo.FileStorage);
+                }
+                else
+                {
+                    XAssert.IsNotNull(readInfo.SandboxedProcessStandardFiles);
+                    XAssert.AreEqual(standardFiles.StandardOutput, readInfo.SandboxedProcessStandardFiles.StandardOutput);
+                    XAssert.AreEqual(standardFiles.StandardError, readInfo.SandboxedProcessStandardFiles.StandardError);
+                    XAssert.AreEqual(standardFiles.StandardOutput, readInfo.FileStorage.GetFileName(SandboxedProcessFile.StandardOutput));
+                    XAssert.AreEqual(standardFiles.StandardError, readInfo.FileStorage.GetFileName(SandboxedProcessFile.StandardError));
+                }
+
                 XAssert.IsFalse(readInfo.ContainerConfiguration.IsIsolationEnabled);
 
                 XAssert.AreEqual(sidebandLogFile, readInfo.SidebandWriter.SidebandLogFile);

--- a/Public/Src/Engine/UnitTests/Processes.Detours/SandboxedProcessInfoTest.cs
+++ b/Public/Src/Engine/UnitTests/Processes.Detours/SandboxedProcessInfoTest.cs
@@ -43,6 +43,7 @@ namespace Test.BuildXL.Processes.Detours
             vac.AddPath(A("C", "Source", "source.txt"), FileAccessPolicy.AllowReadAlways);
             vac.AddPath(A("C", "Out", "out.txt"), FileAccessPolicy.AllowAll);
 
+            SandboxedProcessStandardFiles standardFiles = null;
             ISandboxedProcessFileStorage fileStorage;
             if (useNullFileStorage)
             {
@@ -50,7 +51,7 @@ namespace Test.BuildXL.Processes.Detours
             }
             else
             {
-                var standardFiles = new SandboxedProcessStandardFiles(A("C", "pip", "pip.out"), A("C", "pip", "pip.err"));
+                standardFiles = new SandboxedProcessStandardFiles(A("C", "pip", "pip.out"), A("C", "pip", "pip.err"));
                 fileStorage = new StandardFileStorage(standardFiles);
             }
 

--- a/Public/Src/Engine/UnitTests/Processes/SandboxedProcessOutputTest.cs
+++ b/Public/Src/Engine/UnitTests/Processes/SandboxedProcessOutputTest.cs
@@ -39,7 +39,7 @@ namespace Test.BuildXL.Processes
                 var output = outputBuilder.Freeze();
                 XAssert.IsFalse(output.IsSaved);
                 XAssert.IsFalse(File.Exists(fileName));
-                XAssert.AreEqual(await output.ReadValueAsync(), content + Environment.NewLine);
+                XAssert.AreEqual(content + Environment.NewLine, await output.ReadValueAsync());
             }
         }
 
@@ -58,8 +58,8 @@ namespace Test.BuildXL.Processes
             outputBuilder.AppendLine(content);
             SandboxedProcessOutput output = outputBuilder.Freeze();
             XAssert.IsFalse(output.IsSaved);
-            XAssert.AreEqual(await output.ReadValueAsync(), string.Empty);
-            XAssert.AreEqual(observedOutput, content + Environment.NewLine);
+            XAssert.AreEqual(string.Empty, await output.ReadValueAsync());
+            XAssert.AreEqual(content, observedOutput);
         }
 
         [Fact]
@@ -82,7 +82,7 @@ namespace Test.BuildXL.Processes
                 XAssert.IsTrue(output.IsSaved);
                 XAssert.AreEqual(fileName, output.FileName);
                 XAssert.IsTrue(File.Exists(fileName));
-                XAssert.AreEqual(await output.ReadValueAsync(), content + Environment.NewLine);
+                XAssert.AreEqual(content + Environment.NewLine, await output.ReadValueAsync());
             }
         }
 

--- a/Public/Src/Engine/UnitTests/Processes/SandboxedProcessOutputTest.cs
+++ b/Public/Src/Engine/UnitTests/Processes/SandboxedProcessOutputTest.cs
@@ -58,7 +58,7 @@ namespace Test.BuildXL.Processes
             outputBuilder.AppendLine(content);
             SandboxedProcessOutput output = outputBuilder.Freeze();
             XAssert.IsFalse(output.IsSaved);
-            XAssert.AreEqual(await output.ReadValueAsync(), content + Environment.NewLine);
+            XAssert.AreEqual(await output.ReadValueAsync(), string.Empty);
             XAssert.AreEqual(observedOutput, content + Environment.NewLine);
         }
 

--- a/Public/Src/Engine/UnitTests/Processes/SandboxedProcessOutputTest.cs
+++ b/Public/Src/Engine/UnitTests/Processes/SandboxedProcessOutputTest.cs
@@ -44,6 +44,25 @@ namespace Test.BuildXL.Processes
         }
 
         [Fact]
+        public async Task ObservedOutputWithNullStorage()
+        {
+            var content = new string('S', 100);
+            string observedOutput = string.Empty;
+            var outputBuilder =
+                new SandboxedProcessOutputBuilder(
+                    Encoding.UTF8,
+                    0,
+                    null,
+                    SandboxedProcessFile.StandardOutput,
+                    writtenOutput => observedOutput += writtenOutput);
+            outputBuilder.AppendLine(content);
+            SandboxedProcessOutput output = outputBuilder.Freeze();
+            XAssert.IsFalse(output.IsSaved);
+            XAssert.AreEqual(await output.ReadValueAsync(), content + Environment.NewLine);
+            XAssert.AreEqual(observedOutput, content + Environment.NewLine);
+        }
+
+        [Fact]
         public async Task OutputOnDisk()
         {
             using (var tempFiles = new TempFileStorage(canGetFileNames: true))


### PR DESCRIPTION
To specify no file redirection for output streams. Typically used when using stream observers instead.