### PR TITLE
clean up to handle consuming source files

### DIFF
--- a/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/CosineJsonExport.cs
+++ b/Public/Src/Tools/Execution.Analyzer/Analyzers.Partner/CosineJsonExport.cs
@@ -188,7 +188,8 @@ namespace BuildXL.Execution.Analyzer
         /// </summary>
         public const int FormatVersion = 4;
         private readonly JsonTextWriter m_writer;
-        private Dictionary<AbsolutePath, int> m_fileIds = new Dictionary<AbsolutePath, int>(capacity: 10 * 1000);
+        private Dictionary<string, int> m_fileIds = new Dictionary<string, int>(capacity: 10 * 1000);
+        private int m_nextId;
 
         /// <summary>
         /// Creates a JSON writer which writes text to <paramref name="output" />
@@ -234,8 +235,7 @@ namespace BuildXL.Execution.Analyzer
             // Observed execution info may get queued up for when we begin draining the queue (below).
 
             // Don't overlap pip ids with file/directory ids
-            int nextId = graph.PipCount + 1;
-            var directoryIds = new Dictionary<DirectoryArtifact, int>(capacity: 1000);
+            m_nextId = graph.PipCount + 1;
 
             m_writer.WriteStartObject(); // Outermost object
 
@@ -248,35 +248,33 @@ namespace BuildXL.Execution.Analyzer
             // we hold pips alive between the various passes.
             var pips = new List<Pip>();
             {
-                var directoryPips = new List<SealDirectory>();
-
                 // TODO: This is pretty expensive, as it loads all pips in memory
                 foreach (Pip pip in graph.RetrieveScheduledPips())
                 {
                     pips.Add(pip);
 
-                    // We retrieve outputs rather than inputs since we do not expect duplicate outputs among pips
-                    // (not true with inputs). This means the ID assignment work is linear in the number of artifacts.
+                    // Add all of the inputs to the file list
+                    PipArtifacts.ForEachInput(pip, dependency =>
+                    {
+                        if (dependency.IsFile)
+                        {
+                            // Use producerId=0, if first referenced will indicate consumed source file
+                            AssignFileIdAndWriteFileEntry(dependency.FileArtifact.Path.ToString(context.PathTable));
+                        }
+                        return true;
+                    }, includeLazyInputs: true);
+
+                    // Now add all of the outputs
                     PipArtifacts.ForEachOutput(pip, output =>
                     {
                         if (output.IsFile)
                         {
-                            AssignFileIdAndWriteFileEntry(output.FileArtifact, context, ref nextId);
+                            AssignFileIdAndWriteFileEntry(output.FileArtifact.Path.ToString(context.PathTable));
                         }
 
                         return true;
                     },
                     includeUncacheable: true);
-
-                    // SealDirectory pips are the only ones with directory outputs. As part of the artifact entry for the directory output,
-                    // we want to capture the membership of the directory. This means we want to have assigned IDs to all member files before
-                    // writing out that list (for easier parsing). So, we defer writing out seal directory pips until all file artifacts have been visited.
-                    if (pip.PipType == PipType.SealDirectory)
-                    {
-                        var directoryPip = (SealDirectory)pip;
-                        Contract.Assume(directoryPip.IsInitialized);
-                        directoryPips.Add(directoryPip);
-                    }
 
                     // Record files that are written into SharedOpaqueDirectories
                     if (directoryOutputContent.TryGetValue(pip.PipId, out var pipOutput))
@@ -288,20 +286,32 @@ namespace BuildXL.Execution.Analyzer
 
                             foreach (var file in content)
                             {
-                                AssignFileIdAndWriteFileEntry(file, context, ref nextId);
+                                AssignFileIdAndWriteFileEntry(file.Path.ToString(context.PathTable));
                             }
                         }
                     }
-                }
 
-                foreach (SealDirectory directoryPip in directoryPips)
-                {
-                    AssignDirectoryIdAndWriteDirectoryEntry(directoryPip.Directory, context, directoryPip.Contents, directoryIds, ref nextId);
+                    // SealDirectory pips are the only ones with directory outputs. As part of the artifact entry for the directory output,
+                    // we want to capture the membership of the directory. This means we want to have assigned IDs to all member files before
+                    // writing out that list (for easier parsing). So, we defer writing out seal directory pips until all file artifacts have been visited.
+                    if (pip.PipType == PipType.SealDirectory)
+                    {
+                        var directoryPip = (SealDirectory)pip;
+                        Contract.Assume(directoryPip.IsInitialized);
+
+                        // Add any file artifacts from the sealed directory, many will be
+                        // outputs of process pips but some will be source files
+                        foreach (FileArtifact directoryMember in directoryPip.Contents)
+                        {
+                            AssignFileIdAndWriteFileEntry(directoryMember.Path.ToString(context.PathTable));
+                        }
+                    }
                 }
             }
 
             m_writer.WriteEndArray();
 
+            m_writer.WriteWhitespace(Environment.NewLine);
             m_writer.WritePropertyName("graph");
             m_writer.WriteStartArray();
             {
@@ -313,20 +323,15 @@ namespace BuildXL.Execution.Analyzer
                         continue;
                     }
 
-                    WriteGraphNodeEntry(pip, graph, context, directoryIds, directoryInputContent, directoryOutputContent);
+                    WriteGraphNodeEntry(pip, graph, context, directoryInputContent, directoryOutputContent);
                 }
             }
 
             m_writer.WriteEndArray();
 
-            // Avoid holding a reference to this map if it isn't later needed by the special file details exporter
-            if (fileData == null)
-            {
-                m_fileIds = null;
-            }
-
             if (executionData != null)
             {
+                m_writer.WriteWhitespace(Environment.NewLine);
                 m_writer.WritePropertyName("execution");
                 m_writer.WriteStartArray();
 
@@ -343,15 +348,18 @@ namespace BuildXL.Execution.Analyzer
 
             if (workers != null)
             {
+                m_writer.WriteWhitespace(Environment.NewLine);
                 ExportWorkerDetails(workers);
             }
 
             if (fileData != null)
             {
-                ExportFileDetails(fileData);
+                m_writer.WriteWhitespace(Environment.NewLine);
+                ExportFileDetails(fileData, context);
             }
 
             // End the outermost object
+            m_writer.WriteWhitespace(Environment.NewLine);
             m_writer.WriteEndObject();
             m_writer.Flush();
         }
@@ -383,7 +391,9 @@ namespace BuildXL.Execution.Analyzer
             m_writer.WriteEndArray();
         }
 
-        private void ExportFileDetails(IEnumerable<KeyValuePair<FileArtifact, FileContentInfo>> fileData)
+        private void ExportFileDetails(
+            IEnumerable<KeyValuePair<FileArtifact, FileContentInfo>> fileData,
+            PipExecutionContext context)
         {
             Contract.Assert(fileData != null);
 
@@ -396,7 +406,7 @@ namespace BuildXL.Execution.Analyzer
                 // from opaque directories are not currently represented in the graph and thus have not corresponding
                 // fileid
                 int fileId;
-                if (m_fileIds.TryGetValue(kvp.Key.Path, out fileId))
+                if (m_fileIds.TryGetValue(kvp.Key.Path.ToString(context.PathTable), out fileId))
                 {
                     m_writer.WriteWhitespace(Environment.NewLine);
                     m_writer.WriteStartObject();
@@ -415,21 +425,18 @@ namespace BuildXL.Execution.Analyzer
             m_writer.WriteEndArray();
         }
 
-        private void AssignFileIdAndWriteFileEntry(
-            FileArtifact artifact,
-            PipExecutionContext context,
-            ref int nextId)
+        private void AssignFileIdAndWriteFileEntry(string fullPath)
         {
             int fileId;
-            if (!m_fileIds.TryGetValue(artifact.Path, out fileId))
+            if (!m_fileIds.TryGetValue(fullPath, out fileId))
             {
-                fileId = nextId++;
-                m_fileIds.Add(artifact.Path, fileId);
+                fileId = m_nextId++;
+                //Console.WriteLine("Adding file " + fullPath + " ID=" + fileId.ToString());
+                m_fileIds.Add(fullPath, fileId);
             }
-            else
+             else
             {
-                Contract.Assume(false, "Multiple producers for file artifact " + artifact.Path.ToString(context.PathTable));
-                throw new InvalidOperationException("Unreachable");
+                return;
             }
 
             m_writer.WriteWhitespace(Environment.NewLine);
@@ -439,56 +446,7 @@ namespace BuildXL.Execution.Analyzer
             m_writer.WriteValue(fileId);
 
             m_writer.WritePropertyName("file");
-            string path = artifact.Path.ToString(context.PathTable);
-            m_writer.WriteValue(path);
-            m_writer.WriteEndObject();
-        }
-
-        private void AssignDirectoryIdAndWriteDirectoryEntry(
-            DirectoryArtifact artifact,
-            PipExecutionContext context,
-            ReadOnlyArray<FileArtifact> contents,
-            Dictionary<DirectoryArtifact, int> directoryIds,
-            ref int nextId)
-        {
-            int directoryId;
-            if (!directoryIds.TryGetValue(artifact, out directoryId))
-            {
-                directoryId = nextId++;
-                directoryIds.Add(artifact, directoryId);
-            }
-            else
-            {
-                Contract.Assume(false, "Multiple producers for directory artifact " + artifact.Path.ToString(context.PathTable));
-                throw new InvalidOperationException("Unreachable");
-            }
-
-            m_writer.WriteWhitespace(Environment.NewLine);
-            m_writer.WriteStartObject();
-
-            m_writer.WritePropertyName("id");
-            m_writer.WriteValue(directoryId);
-
-            m_writer.WritePropertyName("directory");
-            m_writer.WriteValue(artifact.Path.ToString(context.PathTable));
-
-            m_writer.WritePropertyName("contents");
-            m_writer.WriteStartArray();
-
-            foreach (FileArtifact directoryMember in contents)
-            {
-                int dependencyId;
-                if (!m_fileIds.TryGetValue(directoryMember.Path, out dependencyId))
-                {
-                    Contract.Assume(false, "Expected file artifact already written (member of a directory) " + directoryMember.Path.ToString(context.PathTable));
-                    throw new InvalidOperationException("Unreachable");
-                }
-
-                m_writer.WriteValue(dependencyId);
-            }
-
-            m_writer.WriteEndArray();
-
+            m_writer.WriteValue(fullPath);
             m_writer.WriteEndObject();
         }
 
@@ -514,7 +472,6 @@ namespace BuildXL.Execution.Analyzer
             Pip pip,
             IPipScheduleTraversal graph,
             PipExecutionContext context,
-            Dictionary<DirectoryArtifact, int> directoryIds,
             Dictionary<PipId, ProcessExecutionMonitoringReportedEventData> directoryInputContent,
             Dictionary<PipId, PipExecutionDirectoryOutputs> directoryOutputContent)
         {
@@ -556,30 +513,23 @@ namespace BuildXL.Execution.Analyzer
                         int dependencyId;
                         if (dependency.IsFile)
                         {
-                            if (!m_fileIds.TryGetValue(dependency.FileArtifact.Path, out dependencyId))
+                            if (!m_fileIds.TryGetValue(dependency.FileArtifact.Path.ToString(context.PathTable), out dependencyId))
                             {
                                 Contract.Assume(false, "Expected file artifact already written (dependency of pip) " + dependency.Path.ToString(context.PathTable));
                                 throw new InvalidOperationException("Unreachable");
                             }
-                        }
-                        else
-                        {
-                            if (!directoryIds.TryGetValue(dependency.DirectoryArtifact, out dependencyId))
+
+                            if (!writtenHeader)
                             {
-                                Contract.Assume(false, "Expected directory artifact already written (input of pip) " + dependency.Path.ToString(context.PathTable));
-                                throw new InvalidOperationException("Unreachable");
+                                m_writer.WritePropertyName("consumes");
+                                m_writer.WriteStartArray();
+
+                                writtenHeader = true;
                             }
+
+                            m_writer.WriteValue(dependencyId);
                         }
 
-                        if (!writtenHeader)
-                        {
-                            m_writer.WritePropertyName("consumes");
-                            m_writer.WriteStartArray();
-
-                            writtenHeader = true;
-                        }
-
-                        m_writer.WriteValue(dependencyId);
                         return true;
                     }, includeLazyInputs: true);
                     
@@ -589,7 +539,7 @@ namespace BuildXL.Execution.Analyzer
                         foreach (var input in pipInput.ReportedFileAccesses)
                         {
                             int dependencyId;
-                            if (!m_fileIds.TryGetValue(input.ManifestPath, out dependencyId))
+                            if (!m_fileIds.TryGetValue(input.ManifestPath.ToString(context.PathTable), out dependencyId))
                             {
                                 // Ignore unrecognized reads (these are usually directories / files that aren't produced, so we don't have their ID)
                                 continue;
@@ -608,29 +558,22 @@ namespace BuildXL.Execution.Analyzer
                     m_writer.WritePropertyName("produces");
                     m_writer.WriteStartArray();
 
-                    SortedSet<int> reads = new SortedSet<int>();
+                    SortedSet<int> writes = new SortedSet<int>();
 
                     PipArtifacts.ForEachOutput(pip, dependency =>
                     {
                         int dependencyId;
                         if (dependency.IsFile)
                         {
-                            if (!m_fileIds.TryGetValue(dependency.FileArtifact.Path, out dependencyId))
+                            if (!m_fileIds.TryGetValue(dependency.FileArtifact.Path.ToString(context.PathTable), out dependencyId))
                             {
                                 Contract.Assume(false, "Expected file artifact already written (output of pip) " + dependency.Path.ToString(context.PathTable));
                                 throw new InvalidOperationException("Unreachable");
                             }
-                        }
-                        else
-                        {
-                            if (!directoryIds.TryGetValue(dependency.DirectoryArtifact, out dependencyId))
-                            {
-                                Contract.Assume(false, "Expected directory artifact already written (output of pip) " + dependency.Path.ToString(context.PathTable));
-                                throw new InvalidOperationException("Unreachable");
-                            }
+
+                            writes.Add(dependencyId);
                         }
 
-                        reads.Add(dependencyId);
                         return true;
                     }, includeUncacheable: true);
 
@@ -645,17 +588,17 @@ namespace BuildXL.Execution.Analyzer
                             foreach (var file in content)
                             {
                                 int dependencyId;
-                                if (!m_fileIds.TryGetValue(file.Path, out dependencyId))
+                                if (!m_fileIds.TryGetValue(file.Path.ToString(context.PathTable), out dependencyId))
                                 {
                                     Contract.Assume(false, "Expected file artifact not found in fileId table " + file.Path.ToString(context.PathTable));
                                     throw new InvalidOperationException("Unreachable");
                                 }
-                                reads.Add(dependencyId);
+                                writes.Add(dependencyId);
                             }
                         }
                     }
 
-                    foreach (int dependencyId in reads)
+                    foreach (int dependencyId in writes)
                     {
                         m_writer.WriteValue(dependencyId);
                     }


### PR DESCRIPTION
analyzer was throwing an exception on reads from enlistment <source> files.  Also was not reporting directory consumption properly.  Added all consumed files properly and removed some nonfunctioning code