### PR TITLE
Update SendReport.cpp to skip files with newlines in their name

### DIFF
--- a/Public/Src/Sandbox/Windows/DetoursServices/SendReport.cpp
+++ b/Public/Src/Sandbox/Windows/DetoursServices/SendReport.cpp
@@ -81,7 +81,11 @@ void ReportFileAccess(
     else {
         fileName = policyResult.GetCanonicalizedPath().GetPathString();
     }
-
+    
+    if (wcspbrk((wchar_t*)fileName, L"\u000A\u000B\u000C\u000D\u0085\u2028\u2029")) {
+        fileName = L"";
+    }
+    
     if (fileName == nullptr) {
         fileName = L"";
     }


### PR DESCRIPTION
We have encountered a bug where the reportaccesses example breaks when a file with a newline in its name is reported by DetoursServices
The proposed solution treats any such invalid filename as an empty filename