### PR TITLE
Add `$schema` to `cgmanifest.json`

### DIFF
--- a/cg/nuget/cgmanifest.json
+++ b/cg/nuget/cgmanifest.json
@@ -1,31 +1,22 @@
 {
-  "Version": 1,
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Antlr4.Runtime.Standard",
-          "Version": "4.7.2"
-        }
+        "NuGet": { "Name": "Antlr4.Runtime.Standard", "Version": "4.7.2" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "AnyBuild.SDK",
-          "Version": "0.1.14"
-        }
+        "NuGet": { "Name": "AnyBuild.SDK", "Version": "0.1.14" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Aria.Cpp.SDK.win-x64",
-          "Version": "8.5.6"
-        }
+        "NuGet": { "Name": "Aria.Cpp.SDK.win-x64", "Version": "8.5.6" }
       }
     },
     {
@@ -49,28 +40,19 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "AsyncFixer",
-          "Version": "1.6.0"
-        }
+        "NuGet": { "Name": "AsyncFixer", "Version": "1.6.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Azure.Core",
-          "Version": "1.25.0"
-        }
+        "NuGet": { "Name": "Azure.Core", "Version": "1.25.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Azure.Identity",
-          "Version": "1.4.0"
-        }
+        "NuGet": { "Name": "Azure.Identity", "Version": "1.4.0" }
       }
     },
     {
@@ -94,73 +76,49 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Azure.Storage.Blobs",
-          "Version": "12.13.0"
-        }
+        "NuGet": { "Name": "Azure.Storage.Blobs", "Version": "12.13.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Azure.Storage.Blobs.Batch",
-          "Version": "12.10.0"
-        }
+        "NuGet": { "Name": "Azure.Storage.Blobs.Batch", "Version": "12.10.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Azure.Storage.Common",
-          "Version": "12.12.0"
-        }
+        "NuGet": { "Name": "Azure.Storage.Common", "Version": "12.12.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Bond.CSharp",
-          "Version": "10.0.0"
-        }
+        "NuGet": { "Name": "Bond.CSharp", "Version": "10.0.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Bond.CSharp.linux-x64",
-          "Version": "10.0.0"
-        }
+        "NuGet": { "Name": "Bond.CSharp.linux-x64", "Version": "10.0.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Bond.CSharp.osx-x64",
-          "Version": "10.0.0"
-        }
+        "NuGet": { "Name": "Bond.CSharp.osx-x64", "Version": "10.0.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Bond.Core.CSharp",
-          "Version": "10.0.0"
-        }
+        "NuGet": { "Name": "Bond.Core.CSharp", "Version": "10.0.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Bond.Runtime.CSharp",
-          "Version": "10.0.0"
-        }
+        "NuGet": { "Name": "Bond.Runtime.CSharp", "Version": "10.0.0" }
       }
     },
     {
@@ -175,28 +133,19 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "BuildXL.DeviceMap",
-          "Version": "0.0.1"
-        }
+        "NuGet": { "Name": "BuildXL.DeviceMap", "Version": "0.0.1" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "BuildXL.Tools.AppHostPatcher",
-          "Version": "1.0.0"
-        }
+        "NuGet": { "Name": "BuildXL.Tools.AppHostPatcher", "Version": "1.0.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "BuildXL.Tools.Ninjson",
-          "Version": "0.0.6"
-        }
+        "NuGet": { "Name": "BuildXL.Tools.Ninjson", "Version": "0.0.6" }
       }
     },
     {
@@ -211,46 +160,31 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "CB.QTest",
-          "Version": "22.8.24.133338"
-        }
+        "NuGet": { "Name": "CB.QTest", "Version": "22.8.24.133338" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "CLAP",
-          "Version": "4.6"
-        }
+        "NuGet": { "Name": "CLAP", "Version": "4.6" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "CLAP-DotNetCore",
-          "Version": "4.6"
-        }
+        "NuGet": { "Name": "CLAP-DotNetCore", "Version": "4.6" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "DeduplicationSigned",
-          "Version": "1.0.14"
-        }
+        "NuGet": { "Name": "DeduplicationSigned", "Version": "1.0.14" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "DotNet.Glob",
-          "Version": "2.0.3"
-        }
+        "NuGet": { "Name": "DotNet.Glob", "Version": "2.0.3" }
       }
     },
     {
@@ -283,73 +217,49 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "FSharp.Core",
-          "Version": "4.2.3"
-        }
+        "NuGet": { "Name": "FSharp.Core", "Version": "4.2.3" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "FluentAssertions",
-          "Version": "5.3.0"
-        }
+        "NuGet": { "Name": "FluentAssertions", "Version": "5.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "FsCheck",
-          "Version": "2.14.3"
-        }
+        "NuGet": { "Name": "FsCheck", "Version": "2.14.3" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "GVFS.Installers",
-          "Version": "0.3.20147.1"
-        }
+        "NuGet": { "Name": "GVFS.Installers", "Version": "0.3.20147.1" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Google.Protobuf",
-          "Version": "3.19.4"
-        }
+        "NuGet": { "Name": "Google.Protobuf", "Version": "3.19.4" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Google.Protobuf.Tools",
-          "Version": "3.19.4"
-        }
+        "NuGet": { "Name": "Google.Protobuf.Tools", "Version": "3.19.4" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Grpc.AspNetCore",
-          "Version": "2.47.0"
-        }
+        "NuGet": { "Name": "Grpc.AspNetCore", "Version": "2.47.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Grpc.AspNetCore.Server",
-          "Version": "2.47.0"
-        }
+        "NuGet": { "Name": "Grpc.AspNetCore.Server", "Version": "2.47.0" }
       }
     },
     {
@@ -364,91 +274,61 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Grpc.Core",
-          "Version": "2.46.3"
-        }
+        "NuGet": { "Name": "Grpc.Core", "Version": "2.46.3" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Grpc.Core.Api",
-          "Version": "2.47.0"
-        }
+        "NuGet": { "Name": "Grpc.Core.Api", "Version": "2.47.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Grpc.Net.Client",
-          "Version": "2.47.0"
-        }
+        "NuGet": { "Name": "Grpc.Net.Client", "Version": "2.47.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Grpc.Net.Client.Web",
-          "Version": "2.47.0"
-        }
+        "NuGet": { "Name": "Grpc.Net.Client.Web", "Version": "2.47.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Grpc.Net.ClientFactory",
-          "Version": "2.47.0"
-        }
+        "NuGet": { "Name": "Grpc.Net.ClientFactory", "Version": "2.47.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Grpc.Net.Common",
-          "Version": "2.47.0"
-        }
+        "NuGet": { "Name": "Grpc.Net.Common", "Version": "2.47.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Grpc.Tools",
-          "Version": "2.47.0"
-        }
+        "NuGet": { "Name": "Grpc.Tools", "Version": "2.47.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "GvfsTestHelpersForBuildXL",
-          "Version": "0.1.0"
-        }
+        "NuGet": { "Name": "GvfsTestHelpersForBuildXL", "Version": "0.1.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Humanizer.Core",
-          "Version": "2.2.0"
-        }
+        "NuGet": { "Name": "Humanizer.Core", "Version": "2.2.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "ILRepack",
-          "Version": "2.0.16"
-        }
+        "NuGet": { "Name": "ILRepack", "Version": "2.0.16" }
       }
     },
     {
@@ -463,28 +343,19 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "JsonDiffPatch.Net",
-          "Version": "2.1.0"
-        }
+        "NuGet": { "Name": "JsonDiffPatch.Net", "Version": "2.1.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "MessagePack",
-          "Version": "2.2.85"
-        }
+        "NuGet": { "Name": "MessagePack", "Version": "2.2.85" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "MessagePack.Annotations",
-          "Version": "2.2.85"
-        }
+        "NuGet": { "Name": "MessagePack.Annotations", "Version": "2.2.85" }
       }
     },
     {
@@ -562,10 +433,7 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.AspNet.WebApi.Core",
-          "Version": "5.2.3"
-        }
+        "NuGet": { "Name": "Microsoft.AspNet.WebApi.Core", "Version": "5.2.3" }
       }
     },
     {
@@ -580,28 +448,19 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.AspNetCore.App.Ref",
-          "Version": "3.1.10"
-        }
+        "NuGet": { "Name": "Microsoft.AspNetCore.App.Ref", "Version": "3.1.10" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.AspNetCore.App.Ref",
-          "Version": "5.0.0"
-        }
+        "NuGet": { "Name": "Microsoft.AspNetCore.App.Ref", "Version": "5.0.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.AspNetCore.App.Ref",
-          "Version": "6.0.4"
-        }
+        "NuGet": { "Name": "Microsoft.AspNetCore.App.Ref", "Version": "6.0.4" }
       }
     },
     {
@@ -688,37 +547,25 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Azure.Amqp",
-          "Version": "2.5.10"
-        }
+        "NuGet": { "Name": "Microsoft.Azure.Amqp", "Version": "2.5.10" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Azure.EventHubs",
-          "Version": "4.3.2"
-        }
+        "NuGet": { "Name": "Microsoft.Azure.EventHubs", "Version": "4.3.2" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Azure.KeyVault",
-          "Version": "3.0.1"
-        }
+        "NuGet": { "Name": "Microsoft.Azure.KeyVault", "Version": "3.0.1" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Azure.KeyVault.Core",
-          "Version": "1.0.0"
-        }
+        "NuGet": { "Name": "Microsoft.Azure.KeyVault.Core", "Version": "1.0.0" }
       }
     },
     {
@@ -751,10 +598,7 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Azure.Kusto.Data",
-          "Version": "6.1.8"
-        }
+        "NuGet": { "Name": "Microsoft.Azure.Kusto.Data", "Version": "6.1.8" }
       }
     },
     {
@@ -769,10 +613,7 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Azure.Kusto.Ingest",
-          "Version": "6.1.8"
-        }
+        "NuGet": { "Name": "Microsoft.Azure.Kusto.Ingest", "Version": "6.1.8" }
       }
     },
     {
@@ -787,10 +628,7 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Azure.Kusto.Tools",
-          "Version": "2.2.2"
-        }
+        "NuGet": { "Name": "Microsoft.Azure.Kusto.Tools", "Version": "2.2.2" }
       }
     },
     {
@@ -1084,91 +922,61 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Bcl",
-          "Version": "1.1.10"
-        }
+        "NuGet": { "Name": "Microsoft.Bcl", "Version": "1.1.10" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Bcl.Async",
-          "Version": "1.0.168"
-        }
+        "NuGet": { "Name": "Microsoft.Bcl.Async", "Version": "1.0.168" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Bcl.AsyncInterfaces",
-          "Version": "5.0.0"
-        }
+        "NuGet": { "Name": "Microsoft.Bcl.AsyncInterfaces", "Version": "5.0.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Bcl.Build",
-          "Version": "1.0.14"
-        }
+        "NuGet": { "Name": "Microsoft.Bcl.Build", "Version": "1.0.14" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Bcl.HashCode",
-          "Version": "1.1.1"
-        }
+        "NuGet": { "Name": "Microsoft.Bcl.HashCode", "Version": "1.1.1" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Build",
-          "Version": "17.0.0"
-        }
+        "NuGet": { "Name": "Microsoft.Build", "Version": "17.0.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Build.Framework",
-          "Version": "17.0.0"
-        }
+        "NuGet": { "Name": "Microsoft.Build.Framework", "Version": "17.0.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Build.Prediction",
-          "Version": "0.3.0"
-        }
+        "NuGet": { "Name": "Microsoft.Build.Prediction", "Version": "0.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Build.Runtime",
-          "Version": "17.0.0"
-        }
+        "NuGet": { "Name": "Microsoft.Build.Runtime", "Version": "17.0.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Build.Tasks.Core",
-          "Version": "17.0.0"
-        }
+        "NuGet": { "Name": "Microsoft.Build.Tasks.Core", "Version": "17.0.0" }
       }
     },
     {
@@ -1183,19 +991,13 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.CSharp",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "Microsoft.CSharp", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Caching.Redis",
-          "Version": "3.0.57"
-        }
+        "NuGet": { "Name": "Microsoft.Caching.Redis", "Version": "3.0.57" }
       }
     },
     {
@@ -1237,19 +1039,13 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.CodeAnalysis.CSharp",
-          "Version": "3.5.0"
-        }
+        "NuGet": { "Name": "Microsoft.CodeAnalysis.CSharp", "Version": "3.5.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.CodeAnalysis.CSharp",
-          "Version": "3.8.0"
-        }
+        "NuGet": { "Name": "Microsoft.CodeAnalysis.CSharp", "Version": "3.8.0" }
       }
     },
     {
@@ -1282,19 +1078,13 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.CodeAnalysis.Common",
-          "Version": "3.5.0"
-        }
+        "NuGet": { "Name": "Microsoft.CodeAnalysis.Common", "Version": "3.5.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.CodeAnalysis.Common",
-          "Version": "3.8.0"
-        }
+        "NuGet": { "Name": "Microsoft.CodeAnalysis.Common", "Version": "3.8.0" }
       }
     },
     {
@@ -1363,10 +1153,7 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.CodeCoverage",
-          "Version": "15.9.0"
-        }
+        "NuGet": { "Name": "Microsoft.CodeCoverage", "Version": "15.9.0" }
       }
     },
     {
@@ -1390,10 +1177,7 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Composition",
-          "Version": "1.0.30"
-        }
+        "NuGet": { "Name": "Microsoft.Composition", "Version": "1.0.30" }
       }
     },
     {
@@ -1408,10 +1192,7 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Data.Sqlite",
-          "Version": "1.1.1"
-        }
+        "NuGet": { "Name": "Microsoft.Data.Sqlite", "Version": "1.1.1" }
       }
     },
     {
@@ -1507,19 +1288,13 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Extensions.Http",
-          "Version": "3.1.0"
-        }
+        "NuGet": { "Name": "Microsoft.Extensions.Http", "Version": "3.1.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Extensions.Logging",
-          "Version": "2.2.0"
-        }
+        "NuGet": { "Name": "Microsoft.Extensions.Logging", "Version": "2.2.0" }
       }
     },
     {
@@ -1552,10 +1327,7 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Extensions.Options",
-          "Version": "2.2.0"
-        }
+        "NuGet": { "Name": "Microsoft.Extensions.Options", "Version": "2.2.0" }
       }
     },
     {
@@ -1588,19 +1360,13 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.IO.Redist",
-          "Version": "4.7.1"
-        }
+        "NuGet": { "Name": "Microsoft.IO.Redist", "Version": "4.7.1" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Identity.Client",
-          "Version": "4.30.1"
-        }
+        "NuGet": { "Name": "Microsoft.Identity.Client", "Version": "4.30.1" }
       }
     },
     {
@@ -1651,10 +1417,7 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Internal.Analyzers",
-          "Version": "2.6.11"
-        }
+        "NuGet": { "Name": "Microsoft.Internal.Analyzers", "Version": "2.6.11" }
       }
     },
     {
@@ -1669,28 +1432,19 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.ManifestInterface",
-          "Version": "2.1.35"
-        }
+        "NuGet": { "Name": "Microsoft.ManifestInterface", "Version": "2.1.35" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.NET.StringTools",
-          "Version": "1.0.0"
-        }
+        "NuGet": { "Name": "Microsoft.NET.StringTools", "Version": "1.0.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.NET.Test.Sdk",
-          "Version": "15.9.0"
-        }
+        "NuGet": { "Name": "Microsoft.NET.Test.Sdk", "Version": "15.9.0" }
       }
     },
     {
@@ -1777,28 +1531,19 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.NETCore.App.Ref",
-          "Version": "3.1.0"
-        }
+        "NuGet": { "Name": "Microsoft.NETCore.App.Ref", "Version": "3.1.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.NETCore.App.Ref",
-          "Version": "5.0.0"
-        }
+        "NuGet": { "Name": "Microsoft.NETCore.App.Ref", "Version": "5.0.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.NETCore.App.Ref",
-          "Version": "6.0.2"
-        }
+        "NuGet": { "Name": "Microsoft.NETCore.App.Ref", "Version": "6.0.2" }
       }
     },
     {
@@ -1885,10 +1630,7 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.NETCore.Compilers",
-          "Version": "4.0.1"
-        }
+        "NuGet": { "Name": "Microsoft.NETCore.Compilers", "Version": "4.0.1" }
       }
     },
     {
@@ -1975,37 +1717,25 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.NETCore.Platforms",
-          "Version": "3.1.0"
-        }
+        "NuGet": { "Name": "Microsoft.NETCore.Platforms", "Version": "3.1.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.NETCore.Platforms",
-          "Version": "5.0.0"
-        }
+        "NuGet": { "Name": "Microsoft.NETCore.Platforms", "Version": "5.0.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.NETCore.Platforms",
-          "Version": "6.0.2"
-        }
+        "NuGet": { "Name": "Microsoft.NETCore.Platforms", "Version": "6.0.2" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.NETCore.Targets",
-          "Version": "2.0.0"
-        }
+        "NuGet": { "Name": "Microsoft.NETCore.Targets", "Version": "2.0.0" }
       }
     },
     {
@@ -2020,19 +1750,13 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Net.Compilers",
-          "Version": "4.0.1"
-        }
+        "NuGet": { "Name": "Microsoft.Net.Compilers", "Version": "4.0.1" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Net.Http",
-          "Version": "2.2.29"
-        }
+        "NuGet": { "Name": "Microsoft.Net.Http", "Version": "2.2.29" }
       }
     },
     {
@@ -2074,10 +1798,7 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Rest.ClientRuntime",
-          "Version": "2.3.21"
-        }
+        "NuGet": { "Name": "Microsoft.Rest.ClientRuntime", "Version": "2.3.21" }
       }
     },
     {
@@ -2101,28 +1822,19 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.SBOM.Adapters",
-          "Version": "2.1.35"
-        }
+        "NuGet": { "Name": "Microsoft.SBOM.Adapters", "Version": "2.1.35" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.SBOMCore",
-          "Version": "2.1.35"
-        }
+        "NuGet": { "Name": "Microsoft.SBOMCore", "Version": "2.1.35" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Sbom.Contracts",
-          "Version": "2.1.35"
-        }
+        "NuGet": { "Name": "Microsoft.Sbom.Contracts", "Version": "2.1.35" }
       }
     },
     {
@@ -2173,19 +1885,13 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Tpl.Dataflow",
-          "Version": "4.5.24"
-        }
+        "NuGet": { "Name": "Microsoft.Tpl.Dataflow", "Version": "4.5.24" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.TypeScript.Compiler",
-          "Version": "1.8"
-        }
+        "NuGet": { "Name": "Microsoft.TypeScript.Compiler", "Version": "1.8" }
       }
     },
     {
@@ -2650,19 +2356,13 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Win32.Primitives",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "Microsoft.Win32.Primitives", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Microsoft.Win32.Registry",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "Microsoft.Win32.Registry", "Version": "4.3.0" }
       }
     },
     {
@@ -2695,253 +2395,169 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Minimatch",
-          "Version": "1.1.0.0"
-        }
+        "NuGet": { "Name": "Minimatch", "Version": "1.1.0.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "NETStandard.Library",
-          "Version": "2.0.3"
-        }
+        "NuGet": { "Name": "NETStandard.Library", "Version": "2.0.3" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "NLog",
-          "Version": "4.7.7"
-        }
+        "NuGet": { "Name": "NLog", "Version": "4.7.7" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Nerdbank.Streams",
-          "Version": "2.6.81"
-        }
+        "NuGet": { "Name": "Nerdbank.Streams", "Version": "2.6.81" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Newtonsoft.Json",
-          "Version": "13.0.1"
-        }
+        "NuGet": { "Name": "Newtonsoft.Json", "Version": "13.0.1" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Newtonsoft.Json.Bson",
-          "Version": "1.0.1"
-        }
+        "NuGet": { "Name": "Newtonsoft.Json.Bson", "Version": "1.0.1" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "NuGet.CommandLine",
-          "Version": "6.2.1"
-        }
+        "NuGet": { "Name": "NuGet.CommandLine", "Version": "6.2.1" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "NuGet.Common",
-          "Version": "5.11.0"
-        }
+        "NuGet": { "Name": "NuGet.Common", "Version": "5.11.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "NuGet.Configuration",
-          "Version": "5.11.0"
-        }
+        "NuGet": { "Name": "NuGet.Configuration", "Version": "5.11.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "NuGet.Frameworks",
-          "Version": "5.11.0"
-        }
+        "NuGet": { "Name": "NuGet.Frameworks", "Version": "5.11.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "NuGet.Packaging",
-          "Version": "5.11.0"
-        }
+        "NuGet": { "Name": "NuGet.Packaging", "Version": "5.11.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "NuGet.Protocol",
-          "Version": "5.11.0"
-        }
+        "NuGet": { "Name": "NuGet.Protocol", "Version": "5.11.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "NuGet.Versioning",
-          "Version": "5.11.0"
-        }
+        "NuGet": { "Name": "NuGet.Versioning", "Version": "5.11.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "PackageUrl",
-          "Version": "1.0.0"
-        }
+        "NuGet": { "Name": "PackageUrl", "Version": "1.0.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Pipelines.Sockets.Unofficial",
-          "Version": "2.2.0"
-        }
+        "NuGet": { "Name": "Pipelines.Sockets.Unofficial", "Version": "2.2.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Polly",
-          "Version": "7.2.1"
-        }
+        "NuGet": { "Name": "Polly", "Version": "7.2.1" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Polly.Contrib.WaitAndRetry",
-          "Version": "1.1.1"
-        }
+        "NuGet": { "Name": "Polly.Contrib.WaitAndRetry", "Version": "1.1.1" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "PowerShell.Core",
-          "Version": "6.1.0"
-        }
+        "NuGet": { "Name": "PowerShell.Core", "Version": "6.1.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "RocksDbNative",
-          "Version": "6.10.2-b20220621.2"
-        }
+        "NuGet": { "Name": "RocksDbNative", "Version": "6.10.2-b20220621.2" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "RocksDbSharp",
-          "Version": "6.10.2-b20220621.2"
-        }
+        "NuGet": { "Name": "RocksDbSharp", "Version": "6.10.2-b20220621.2" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "RuntimeContracts",
-          "Version": "0.3.0"
-        }
+        "NuGet": { "Name": "RuntimeContracts", "Version": "0.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "RuntimeContracts.Analyzer",
-          "Version": "0.3.2"
-        }
+        "NuGet": { "Name": "RuntimeContracts.Analyzer", "Version": "0.3.2" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "SQLite",
-          "Version": "3.13.0"
-        }
+        "NuGet": { "Name": "SQLite", "Version": "3.13.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "SharpZipLib",
-          "Version": "1.3.3"
-        }
+        "NuGet": { "Name": "SharpZipLib", "Version": "1.3.3" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "StackExchange.Redis",
-          "Version": "2.2.4"
-        }
+        "NuGet": { "Name": "StackExchange.Redis", "Version": "2.2.4" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "StreamJsonRpc",
-          "Version": "2.8.28"
-        }
+        "NuGet": { "Name": "StreamJsonRpc", "Version": "2.8.28" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "StructRecordGenerator",
-          "Version": "0.4.0"
-        }
+        "NuGet": { "Name": "StructRecordGenerator", "Version": "0.4.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "StyleCop.Analyzers",
-          "Version": "1.1.0-beta004"
-        }
+        "NuGet": { "Name": "StyleCop.Analyzers", "Version": "1.1.0-beta004" }
       }
     },
     {
@@ -2965,73 +2581,49 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.AppContext",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.AppContext", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Buffers",
-          "Version": "4.5.1"
-        }
+        "NuGet": { "Name": "System.Buffers", "Version": "4.5.1" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.CodeDom",
-          "Version": "4.4.0"
-        }
+        "NuGet": { "Name": "System.CodeDom", "Version": "4.4.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Collections",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Collections", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Collections.Concurrent",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Collections.Concurrent", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Collections.Immutable",
-          "Version": "1.5.0"
-        }
+        "NuGet": { "Name": "System.Collections.Immutable", "Version": "1.5.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Collections.Immutable",
-          "Version": "5.0.0"
-        }
+        "NuGet": { "Name": "System.Collections.Immutable", "Version": "5.0.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Collections.NonGeneric",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Collections.NonGeneric", "Version": "4.3.0" }
       }
     },
     {
@@ -3046,10 +2638,7 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.ComponentModel",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.ComponentModel", "Version": "4.3.0" }
       }
     },
     {
@@ -3118,19 +2707,13 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Composition.Hosting",
-          "Version": "1.0.31"
-        }
+        "NuGet": { "Name": "System.Composition.Hosting", "Version": "1.0.31" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Composition.Runtime",
-          "Version": "1.0.31"
-        }
+        "NuGet": { "Name": "System.Composition.Runtime", "Version": "1.0.31" }
       }
     },
     {
@@ -3154,46 +2737,31 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Console",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Console", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Data.Common",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Data.Common", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Data.SqlClient",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Data.SqlClient", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Diagnostics.Contracts",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Diagnostics.Contracts", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Diagnostics.Debug",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Diagnostics.Debug", "Version": "4.3.0" }
       }
     },
     {
@@ -3235,19 +2803,13 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Diagnostics.Process",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Diagnostics.Process", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Diagnostics.StackTrace",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Diagnostics.StackTrace", "Version": "4.3.0" }
       }
     },
     {
@@ -3262,10 +2824,7 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Diagnostics.Tools",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Diagnostics.Tools", "Version": "4.3.0" }
       }
     },
     {
@@ -3280,37 +2839,25 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Diagnostics.Tracing",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Diagnostics.Tracing", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Drawing.Primitives",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Drawing.Primitives", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Dynamic.Runtime",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Dynamic.Runtime", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Globalization",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Globalization", "Version": "4.3.0" }
       }
     },
     {
@@ -3334,37 +2881,25 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.IO",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.IO", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.IO.Compression",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.IO.Compression", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.IO.Compression.ZipFile",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.IO.Compression.ZipFile", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.IO.FileSystem",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.IO.FileSystem", "Version": "4.3.0" }
       }
     },
     {
@@ -3406,64 +2941,43 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.IO.FileSystem.Watcher",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.IO.FileSystem.Watcher", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.IO.Hashing",
-          "Version": "6.0.0"
-        }
+        "NuGet": { "Name": "System.IO.Hashing", "Version": "6.0.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.IO.IsolatedStorage",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.IO.IsolatedStorage", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.IO.MemoryMappedFiles",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.IO.MemoryMappedFiles", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.IO.Pipelines",
-          "Version": "6.0.2"
-        }
+        "NuGet": { "Name": "System.IO.Pipelines", "Version": "6.0.2" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.IO.Pipes",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.IO.Pipes", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.IO.Pipes.AccessControl",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.IO.Pipes.AccessControl", "Version": "4.3.0" }
       }
     },
     {
@@ -3487,145 +3001,97 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Linq",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Linq", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Linq.Async",
-          "Version": "4.0.0"
-        }
+        "NuGet": { "Name": "System.Linq.Async", "Version": "4.0.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Linq.Expressions",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Linq.Expressions", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Linq.Parallel",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Linq.Parallel", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Linq.Queryable",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Linq.Queryable", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Management",
-          "Version": "4.7.0"
-        }
+        "NuGet": { "Name": "System.Management", "Version": "4.7.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Memory",
-          "Version": "4.5.4"
-        }
+        "NuGet": { "Name": "System.Memory", "Version": "4.5.4" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Memory.Data",
-          "Version": "6.0.0"
-        }
+        "NuGet": { "Name": "System.Memory.Data", "Version": "6.0.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Net.Http",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Net.Http", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Net.NameResolution",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Net.NameResolution", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Net.NetworkInformation",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Net.NetworkInformation", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Net.Ping",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Net.Ping", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Net.Primitives",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Net.Primitives", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Net.Requests",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Net.Requests", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Net.Security",
-          "Version": "4.3.1"
-        }
+        "NuGet": { "Name": "System.Net.Security", "Version": "4.3.1" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Net.Sockets",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Net.Sockets", "Version": "4.3.0" }
       }
     },
     {
@@ -3640,46 +3106,31 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Net.WebSockets",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Net.WebSockets", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Net.WebSockets.Client",
-          "Version": "4.3.1"
-        }
+        "NuGet": { "Name": "System.Net.WebSockets.Client", "Version": "4.3.1" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Numerics.Vectors",
-          "Version": "4.4.0"
-        }
+        "NuGet": { "Name": "System.Numerics.Vectors", "Version": "4.4.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Numerics.Vectors",
-          "Version": "4.5.0"
-        }
+        "NuGet": { "Name": "System.Numerics.Vectors", "Version": "4.5.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.ObjectModel",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.ObjectModel", "Version": "4.3.0" }
       }
     },
     {
@@ -3694,37 +3145,25 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Private.ServiceModel",
-          "Version": "4.7.0"
-        }
+        "NuGet": { "Name": "System.Private.ServiceModel", "Version": "4.7.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Private.Uri",
-          "Version": "4.3.2"
-        }
+        "NuGet": { "Name": "System.Private.Uri", "Version": "4.3.2" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Reactive",
-          "Version": "4.4.1"
-        }
+        "NuGet": { "Name": "System.Reactive", "Version": "4.4.1" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Reflection",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Reflection", "Version": "4.3.0" }
       }
     },
     {
@@ -3739,10 +3178,7 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Reflection.Emit",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Reflection.Emit", "Version": "4.3.0" }
       }
     },
     {
@@ -3766,37 +3202,25 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Reflection.Extensions",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Reflection.Extensions", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Reflection.Metadata",
-          "Version": "1.6.0"
-        }
+        "NuGet": { "Name": "System.Reflection.Metadata", "Version": "1.6.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Reflection.Metadata",
-          "Version": "5.0.0"
-        }
+        "NuGet": { "Name": "System.Reflection.Metadata", "Version": "5.0.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Reflection.Primitives",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Reflection.Primitives", "Version": "4.3.0" }
       }
     },
     {
@@ -3820,10 +3244,7 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Resources.Reader",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Resources.Reader", "Version": "4.3.0" }
       }
     },
     {
@@ -3838,28 +3259,19 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Resources.Writer",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Resources.Writer", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Runtime",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Runtime", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Runtime.Analyzers",
-          "Version": "1.0.1"
-        }
+        "NuGet": { "Name": "System.Runtime.Analyzers", "Version": "1.0.1" }
       }
     },
     {
@@ -3892,19 +3304,13 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Runtime.Extensions",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Runtime.Extensions", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Runtime.Handles",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Runtime.Handles", "Version": "4.3.0" }
       }
     },
     {
@@ -3946,19 +3352,13 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Runtime.Loader",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Runtime.Loader", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Runtime.Numerics",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Runtime.Numerics", "Version": "4.3.0" }
       }
     },
     {
@@ -4000,37 +3400,25 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Runtime.WindowsRuntime",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Runtime.WindowsRuntime", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Security.AccessControl",
-          "Version": "4.7.0"
-        }
+        "NuGet": { "Name": "System.Security.AccessControl", "Version": "4.7.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Security.AccessControl",
-          "Version": "6.0.0"
-        }
+        "NuGet": { "Name": "System.Security.AccessControl", "Version": "6.0.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Security.Claims",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Security.Claims", "Version": "4.3.0" }
       }
     },
     {
@@ -4135,19 +3523,13 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Security.Permissions",
-          "Version": "4.5.0"
-        }
+        "NuGet": { "Name": "System.Security.Permissions", "Version": "4.5.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Security.Principal",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Security.Principal", "Version": "4.3.0" }
       }
     },
     {
@@ -4180,19 +3562,13 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Security.SecureString",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Security.SecureString", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.ServiceModel.Http",
-          "Version": "4.7.0"
-        }
+        "NuGet": { "Name": "System.ServiceModel.Http", "Version": "4.7.0" }
       }
     },
     {
@@ -4207,19 +3583,13 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Spatial",
-          "Version": "5.8.2"
-        }
+        "NuGet": { "Name": "System.Spatial", "Version": "5.8.2" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Text.Encoding",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Text.Encoding", "Version": "4.3.0" }
       }
     },
     {
@@ -4243,37 +3613,25 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Text.Encodings.Web",
-          "Version": "4.7.2"
-        }
+        "NuGet": { "Name": "System.Text.Encodings.Web", "Version": "4.7.2" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Text.Encodings.Web",
-          "Version": "5.0.1"
-        }
+        "NuGet": { "Name": "System.Text.Encodings.Web", "Version": "5.0.1" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Text.Json",
-          "Version": "4.7.0"
-        }
+        "NuGet": { "Name": "System.Text.Json", "Version": "4.7.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Text.Json",
-          "Version": "5.0.0"
-        }
+        "NuGet": { "Name": "System.Text.Json", "Version": "5.0.0" }
       }
     },
     {
@@ -4288,10 +3646,7 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Threading",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Threading", "Version": "4.3.0" }
       }
     },
     {
@@ -4306,28 +3661,19 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Threading.Channels",
-          "Version": "6.0.0"
-        }
+        "NuGet": { "Name": "System.Threading.Channels", "Version": "6.0.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Threading.Overlapped",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Threading.Overlapped", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Threading.Tasks",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Threading.Tasks", "Version": "4.3.0" }
       }
     },
     {
@@ -4360,109 +3706,73 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Threading.Thread",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Threading.Thread", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Threading.ThreadPool",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Threading.ThreadPool", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Threading.Timer",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Threading.Timer", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.ValueTuple",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.ValueTuple", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Xml.ReaderWriter",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Xml.ReaderWriter", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Xml.XDocument",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Xml.XDocument", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Xml.XPath",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Xml.XPath", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Xml.XPath.XDocument",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Xml.XPath.XDocument", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Xml.XPath.XmlDocument",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Xml.XPath.XmlDocument", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Xml.XmlDocument",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Xml.XmlDocument", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "System.Xml.XmlSerializer",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "System.Xml.XmlSerializer", "Version": "4.3.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Text.Analyzers",
-          "Version": "2.3.0-beta1"
-        }
+        "NuGet": { "Name": "Text.Analyzers", "Version": "2.3.0-beta1" }
       }
     },
     {
@@ -4477,10 +3787,7 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "Validation",
-          "Version": "2.5.42"
-        }
+        "NuGet": { "Name": "Validation", "Version": "2.5.42" }
       }
     },
     {
@@ -4495,73 +3802,49 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "WindowsAzure.Storage",
-          "Version": "9.3.3"
-        }
+        "NuGet": { "Name": "WindowsAzure.Storage", "Version": "9.3.3" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "WindowsSdk.Corext",
-          "Version": "10.0.16299.1"
-        }
+        "NuGet": { "Name": "WindowsSdk.Corext", "Version": "10.0.16299.1" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "boost",
-          "Version": "1.71.0.0"
-        }
+        "NuGet": { "Name": "boost", "Version": "1.71.0.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "packageurl-dotnet",
-          "Version": "1.0.0"
-        }
+        "NuGet": { "Name": "packageurl-dotnet", "Version": "1.0.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "protobuf-net",
-          "Version": "3.0.101"
-        }
+        "NuGet": { "Name": "protobuf-net", "Version": "3.0.101" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "protobuf-net.BuildTools",
-          "Version": "3.0.101"
-        }
+        "NuGet": { "Name": "protobuf-net.BuildTools", "Version": "3.0.101" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "protobuf-net.Core",
-          "Version": "3.0.101"
-        }
+        "NuGet": { "Name": "protobuf-net.Core", "Version": "3.0.101" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "protobuf-net.Grpc",
-          "Version": "1.0.152"
-        }
+        "NuGet": { "Name": "protobuf-net.Grpc", "Version": "1.0.152" }
       }
     },
     {
@@ -4576,10 +3859,7 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "protobuf-net.Grpc.Native",
-          "Version": "1.0.152"
-        }
+        "NuGet": { "Name": "protobuf-net.Grpc.Native", "Version": "1.0.152" }
       }
     },
     {
@@ -4675,10 +3955,7 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.native.System",
-          "Version": "4.3.0"
-        }
+        "NuGet": { "Name": "runtime.native.System", "Version": "4.3.0" }
       }
     },
     {
@@ -4756,10 +4033,7 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "runtime.osx-x64.BuildXL",
-          "Version": "3.8.99"
-        }
+        "NuGet": { "Name": "runtime.osx-x64.BuildXL", "Version": "3.8.99" }
       }
     },
     {
@@ -4945,73 +4219,49 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "stdole",
-          "Version": "7.0.3303"
-        }
+        "NuGet": { "Name": "stdole", "Version": "7.0.3303" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "xunit.abstractions",
-          "Version": "2.0.3"
-        }
+        "NuGet": { "Name": "xunit.abstractions", "Version": "2.0.3" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "xunit.analyzers",
-          "Version": "0.10.0"
-        }
+        "NuGet": { "Name": "xunit.analyzers", "Version": "0.10.0" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "xunit.assert",
-          "Version": "2.4.1-ms"
-        }
+        "NuGet": { "Name": "xunit.assert", "Version": "2.4.1-ms" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "xunit.core",
-          "Version": "2.4.1-ms"
-        }
+        "NuGet": { "Name": "xunit.core", "Version": "2.4.1-ms" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "xunit.extensibility.core",
-          "Version": "2.4.1"
-        }
+        "NuGet": { "Name": "xunit.extensibility.core", "Version": "2.4.1" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "xunit.extensibility.execution",
-          "Version": "2.4.1"
-        }
+        "NuGet": { "Name": "xunit.extensibility.execution", "Version": "2.4.1" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "xunit.runner.console",
-          "Version": "2.4.1"
-        }
+        "NuGet": { "Name": "xunit.runner.console", "Version": "2.4.1" }
       }
     },
     {
@@ -5026,20 +4276,15 @@
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "xunit.runner.utility",
-          "Version": "2.4.1"
-        }
+        "NuGet": { "Name": "xunit.runner.utility", "Version": "2.4.1" }
       }
     },
     {
       "Component": {
         "Type": "NuGet",
-        "NuGet": {
-          "Name": "xunit.runner.visualstudio",
-          "Version": "2.4.1"
-        }
+        "NuGet": { "Name": "xunit.runner.visualstudio", "Version": "2.4.1" }
       }
     }
-  ]
+  ],
+  "Version": 1
 }


### PR DESCRIPTION
This pull request adds the JSON schema for `cgmanifest.json`.

## FAQ

### Why?

A JSON schema helps you to ensure that your `cgmanifest.json` file is valid.
JSON schema validation is a build-in feature in most modern IDEs like Visual Studio and Visual Studio Code.
Most modern IDEs also provide code-completion for JSON schemas.

### How can I validate my `cgmanifest.json` file?

Most modern IDEs like Visual Studio and Visual Studio Code have a built-in feature to validate JSON files.
You can also use [this small script](https://github.com/JamieMagee/verify-cgmanifest) to validate your `cgmanifest.json` file.

### Why does it suggest camel case for the properties?

Component Detection is able to read camel case and pascal case properties.
However, the JSON schema doesn't have a case-insensitive mode.
We therefore suggest camel case as it's the most common format for JSON.

### Why is the diff so large?

To deserialize the `cgmanifest.json` file, we use [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
However, to serialize the JSON again we use [`prettier`](https://prettier.io/).
We found that, in general, it gave smaller diffs than the default [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function.