### PR TITLE
Update Docs for CustomJavaScript resolver

### DIFF
--- a/Documentation/Wiki/Frontends/js-custom-graph.md
+++ b/Documentation/Wiki/Frontends/js-custom-graph.md
@@ -10,7 +10,7 @@ config({
         {
             kind: "CustomJavaScript",
             moduleName: "my-repo",
-            ...
+            root: d`.`,
             customProjectGraph: f`graph.json`
         }
 });
@@ -47,7 +47,7 @@ config({
         {
             kind: "CustomJavaScript",
             moduleName: "my-repo",
-            ...
+            root: d`.`,
             customProjectGraph: importFile(f`custom-definition.dsc`).getGraph()
         }
 });

--- a/Documentation/Wiki/Frontends/js-custom-scripts.md
+++ b/Documentation/Wiki/Frontends/js-custom-scripts.md
@@ -9,9 +9,9 @@ A callback can be defined when configuring a JavaScript resolver to provide scri
 config({
     resolvers: [
         {
-            kind: "Rush",
+            kind: "CustomJavaScript",
             moduleName: "my-repo",
-            ...
+            root: d`.`,
             customScripts: importFile(f`custom-scripts.dsc`).getCustomScripts
         }
 });


### PR DESCRIPTION
- bxl needs a root specified for the custom graph
- the name of a custom resolver should be 'CustomJavaScript'